### PR TITLE
wait after OPTIONS check; add per-Framework timeouts

### DIFF
--- a/test/framework/index.js
+++ b/test/framework/index.js
@@ -7,8 +7,6 @@ const spawn = require('child_process').spawn;
 const waitForServer = require('./waitforserver');
 const webdriver = require('./webdriver');
 
-const TIMEOUT = 240000;
-
 /**
  * Run a Framework Test. Selenium will be used to navigate to the Test
  * Application and ensure twilio-video.js can be used.
@@ -23,9 +21,10 @@ function runFrameworkTest(options) {
   const port = options.port;
   const path = options.path;
   const start = options.start;
+  const timeout = options.timeout;
 
   describe(name, function() {
-    this.timeout(TIMEOUT);
+    this.timeout(timeout);
 
     let server;
     let driver;
@@ -36,12 +35,12 @@ function runFrameworkTest(options) {
         cwd: path,
         detached: true,
         env: Object.assign({}, start.env, process.env),
-        stdio: 'ignore'
+        stdio: 'inherit'
       });
 
       driver = webdriver.buildWebDriverForChrome();
 
-      return waitForServer(host, port, TIMEOUT);
+      return waitForServer(host, port, timeout);
     });
 
     after(() => {

--- a/test/framework/options.js
+++ b/test/framework/options.js
@@ -6,6 +6,7 @@
  * @property {string} path - the path to the Framework Test
  * @property {string} [host="localhost"] - the HTTP server host that serves the Test Application
  * @property {number} [port=3000] - the HTTP server port that serves the Test Application
+ * @property {number} [timeout=120000] - the duration in milliseconds a Framework Test is allowed to run before "timing out"
  * @property {FrameworkTestCommandOptions} [start] - options for starting the Test Application (defaults to "npm start")
  * @property {FrameworkTestCommandOptions} [test] - options for testing the Test Application (defaults to "npm test")
  */
@@ -27,6 +28,7 @@ function getOptions(options) {
   options = Object.assign({}, {
     host: 'localhost',
     port: 3000,
+    timeout: 120000,
     start: {},
     test: {}
   }, options);

--- a/test/framework/twilio-video-meteor.json
+++ b/test/framework/twilio-video-meteor.json
@@ -3,6 +3,7 @@
   "path": "./test/framework/twilio-video-meteor",
   "host": "localhost",
   "port": 5000,
+  "timeout": 240000,
   "start": {
     "args": ["start", "--", "--port", "5000"],
     "env": {

--- a/test/framework/twilio-video-no-framework/app.js
+++ b/test/framework/twilio-video-no-framework/app.js
@@ -19,7 +19,7 @@ function getQueryParameters(location) {
 
 const token = (getQueryParameters(location).get('token') || [])[0] || '';
 
-new Twilio.Video.Client().connect({ token: token }).then(room => {
+new Twilio.Video.connect({ token: token }).then(room => {
   root.innerHTML = `<p>Connected to Room ${room.sid}.</p>`;
   room.disconnect();
   root.innerHTML = `<p>Disconnected from Room ${room.sid}.</p>`;

--- a/test/framework/waitforserver.js
+++ b/test/framework/waitforserver.js
@@ -3,16 +3,28 @@
 const http = require('http');
 
 /**
+ * This function returns a Promise that resolves after a specified delay.
+ * @param {number} [delay=200] - delay in ms
+ * @returns {Promise<undefined>}
+ */
+function wait(delay) {
+  delay = delay || 200;
+  return new Promise(resolve => setTimeout(resolve, delay));
+}
+
+/**
  * This function returns a Promise that resolves once the specified HTTP server
  * responds to an OPTIONS request. The OPTIONS request will be retried until
  * a configurable timeout occurs, at which point the Promise rejects.
  * @param {string} host - the HTTP server host
  * @param {number} port - the HTTP server port
  * @param {number} [timeout=30000] - timeout in ms
+ * @param {number} [delay=200] - delay in ms
  * @returns {Promise<undefined>}
  */
-function waitForServer(host, port, timeout) {
+function waitForServer(host, port, timeout, delay) {
   timeout = timeout || 30000;
+  delay = delay || 200;
 
   return new Promise((resolve, reject) => {
     let timedout = false;
@@ -29,7 +41,7 @@ function waitForServer(host, port, timeout) {
         resolve();
       }, () => {
         if (!timedout) {
-          return sendOptionsRequest();
+          return wait(delay).then(sendOptionsRequest);
         }
       });
     }


### PR DESCRIPTION
@manjeshbhargav this PR adds

* Per-Framework Test timeouts (since we've since Meteor can take much longer),
* Waits between HTTP OPTIONS checks (in case we are spamming the server and slowing down its startup), and
* Prints stdout from the Framework Test "start" command (so that we can see if something is going wrong).