### PR TITLE
chromedriver dependency should resolve to the exact version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "browserify": "^9.0.8",
     "cheerio": "^0.18.0",
-    "chromedriver": "^2.26.1",
+    "chromedriver": "2.26.1",
     "eslint": "^2.12.0",
     "ink-docstrap": "^1.3.0",
     "istanbul": "^0.4.5",


### PR DESCRIPTION
@markandrus ,

Newer versions of chromedriver require Chrome 55 or higher. So restricting chromedriver's version to 2.26.1