### PR TITLE
Fix incorrect parameters being passed to LocalTrack

### DIFF
--- a/lib/media/track/localvideotrack.js
+++ b/lib/media/track/localvideotrack.js
@@ -18,7 +18,7 @@ function LocalVideoTrack(mediaStream, mediaStreamTrack, options) {
   if (!(this instanceof LocalVideoTrack)) {
     return new LocalVideoTrack(mediaStream, mediaStreamTrack, options);
   }
-  LocalTrack.call(this, VideoTrack, mediaStream, mediaStreamTrack, options);
+  LocalTrack.call(this, VideoTrack, mediaStreamTrack, options);
 }
 
 inherits(LocalVideoTrack, VideoTrack);


### PR DESCRIPTION
The API for LocalTrack is `LocalTrack(Track, mediaStreamTrack, options)`.

The current `LocalVideoTrack` implementation passes a `mediaStream` object instead of `mediaStreamTrack` as the 2nd parameter which causes an error to be thrown.