### PR TITLE
Stop LocalTracks on disconnect

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -70,6 +70,7 @@ function connect(token, options) {
   options = Object.assign({
     createLocalTracks: createLocalTracks,
     environment: constants.DEFAULT_ENVIRONMENT,
+    LocalParticipant: LocalParticipant,
     logLevel: constants.DEFAULT_LOG_LEVEL,
     name: null,
     realm: constants.DEFAULT_REALM,
@@ -107,7 +108,7 @@ function connect(token, options) {
   // 4 - Create the Room and then resolve the CancelablePromise.
   var cancelableRoomPromise = createCancelableRoomPromise(
     getLocalTracks.bind(null, options),
-    createLocalParticipant.bind(null, signaling, log),
+    createLocalParticipant.bind(null, signaling, log, options),
     createRoomSignaling.bind(null, token, options, signaling),
     createRoom.bind(null, options));
 
@@ -167,10 +168,10 @@ function connect(token, options) {
  * @typedef {String} LogLevel - One of ['debug', 'info', 'warn', 'error', 'off']
  */
 
-function createLocalParticipant(signaling, log, localTracks) {
+function createLocalParticipant(signaling, log, options, localTracks) {
   var localParticipantSignaling = signaling.createLocalParticipantSignaling();
   log.debug('Creating a new LocalParticipant:', localParticipantSignaling);
-  return new LocalParticipant(localParticipantSignaling, localTracks, { log: log });
+  return new options.LocalParticipant(localParticipantSignaling, localTracks, options);
 }
 
 function createRoom(options, localParticipant, roomSignaling) {

--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -26,8 +26,13 @@ function LocalParticipant(signaling, localTracks, options) {
   options = Object.assign({
     LocalAudioTrack: LocalAudioTrack,
     LocalVideoTrack: LocalVideoTrack,
+    shouldStopLocalTracks: false,
     tracks: localTracks
   }, options);
+
+  var tracksToStop = options.shouldStopLocalTracks
+    ? new Set(localTracks)
+    : new Set();
 
   Participant.call(this, signaling, options);
   Object.defineProperties(this, {
@@ -36,6 +41,9 @@ function LocalParticipant(signaling, localTracks, options) {
     },
     _LocalVideoTrack: {
       value: options.LocalVideoTrack
+    },
+    _tracksToStop: {
+      value: tracksToStop
     }
   });
 }
@@ -92,6 +100,12 @@ LocalParticipant.prototype._handleTrackSignalingEvents = function _handleTrackSi
       signaling.removeListener('stateChanged', stateChanged);
       self.removeListener('trackAdded', localTrackAdded);
       self.removeListener('trackRemoved', localTrackRemoved);
+
+      log.info('LocalParticipant disconnected. Stopping ' +
+        self._tracksToStop.size + ' automatically-acquired LocalTracks');
+      self._tracksToStop.forEach(function(track) {
+        track.stop();
+      });
     }
   });
 };


### PR DESCRIPTION
@manjeshbhargav @ryan-rowland This behavior got lost in the transition from 1.0.0-beta4 to 1.0.0-beta5. This commit adds it back with some unit tests to prevent future regression. See [here](https://github.com/twilio/twilio-video.js/blob/1.0.0-beta4/lib/room.js#L302) how it worked before. Should fix #75.