### PR TITLE
Calling new LocalTrack errors out

### DIFF
--- a/lib/media/track/localtrack.js
+++ b/lib/media/track/localtrack.js
@@ -23,7 +23,7 @@ var Track = require('./');
 function LocalTrack(Track, mediaStreamTrack, options) {
   var signaling = new LocalTrackSignaling(mediaStreamTrack);
 
-  if (!options.log) {
+  if (options && !options.log) {
     var logLevels = buildLogLevels(options.logLevel || DEFAULT_LOG_LEVEL);
     options.log = new Log('default', this, logLevels);
   }


### PR DESCRIPTION
Without an options object, this errors out.