### PR TITLE
Setup travis-multirunner under node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,13 @@ env:
     - DBUS_SESSION_BUS_ADDRESS=/dev/null
     - DISPLAY=:99.0
     - PATH=$HOME/.meteor:$PATH
-    - CHROME_BIN=$TRAVIS_BUILD_DIR/browsers/bin/chrome-stable
-    - FIREFOX_BIN=$TRAVIS_BUILD_DIR/browsers/bin/firefox-stable
+    - CHROME_BIN=$TRAVIS_BUILD_DIR/node_modules/travis-multirunner/browsers/bin/chrome-stable
+    - FIREFOX_BIN=$TRAVIS_BUILD_DIR/node_modules/travis-multirunner/browsers/bin/firefox-stable
 before_script:
-  - BROWSER=chrome BVER=stable ./node_modules/travis-multirunner/setup.sh
-  - BROWSER=firefox BVER=stable ./node_modules/travis-multirunner/setup.sh
+  - cd node_modules/travis-multirunner
+  - BROWSER=chrome BVER=stable ./setup.sh
+  - BROWSER=firefox BVER=stable ./setup.sh
+  - cd ../..
   - curl https://install.meteor.com | /bin/sh
   - sh -e /etc/init.d/xvfb start
   - pulseaudio --start


### PR DESCRIPTION
@manjeshbhargav travis-multirunner's `setup.sh` drops a Firefox tar.bz2 as well as the `browsers/` directory in wherever it is called from. This causes problems with our release-tool script for publishing to NPM. This change simply cds into `node_modules/travis-multirunner` before calling the `setup.sh` script (that way we don't pollute the working directory).