### PR TITLE
Support Safari 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 1.2.1 (in progress)
 ===================
 
+In addition to the following bug fixes, this release introduces experimental
+support for Safari 11 and newer. Support for Safari is "experimental" because,
+at the time of writing, Safari does not support VP8. This means you may
+experience codec issues in Group Rooms. You may also experience codec issues in
+Peer-to-Peer (P2P) Rooms containing Android- or iOS-based Participants who do
+not support H.264. However, P2P Rooms with browser-based Participants should
+work.
+
+twilio-video.js will log these same caveats as a warning if you call `connect`
+in Safari 11. You can disable this warning by setting the `logLevel` to "warn".
+
 Bug Fixes
 ---------
 

--- a/karma/makeconf.js
+++ b/karma/makeconf.js
@@ -17,10 +17,22 @@ function makeConf(defaultFile, browserNoActivityTimeout, requires) {
       return Object.assign({ [file]: 'browserify' });
     }, {});
 
-    const browsers = {
+    let browsers = {
       chrome: ['ChromeWebRTC'],
-      firefox: ['FirefoxWebRTC']
-    }[process.env.BROWSER] || ['ChromeWebRTC', 'FirefoxWebRTC'];
+      firefox: ['FirefoxWebRTC'],
+      safari: ['SafariTechPreview']
+    };
+
+    if (process.env.BROWSER) {
+      browsers = browsers[process.env.BROWSER];
+      if (!browsers) {
+        throw new Error('Unknown browser');
+      }
+    } else if (process.platform === 'darwin') {
+      browsers = ['ChromeWebRTC', 'FirefoxWebRTC', 'SafariTechPreview'];
+    } else {
+      browsers = ['ChromeWebRTC', 'FirefoxWebRTC'];
+    }
 
     config.set({
       basePath: '',

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -7,6 +7,7 @@ var ConstantIceServerSource = require('./iceserversource/constant');
 var constants = require('./util/constants');
 var Room = require('./room');
 var E = require('./util/constants').typeErrors;
+var guessBrowser = require('./util').guessBrowser;
 var LocalAudioTrack = require('./media/track/localaudiotrack');
 var LocalParticipant = require('./localparticipant');
 var LocalVideoTrack = require('./media/track/localvideotrack');
@@ -120,6 +121,19 @@ function connect(token, options) {
     return CancelablePromise.reject(error);
   }
   options.log = log;
+
+  if (guessBrowser() === 'safari') {
+    log.warnOnce([
+      'This release of twilio-video.js includes experimental support for',
+      'Safari 11 and newer. Support for Safari is "experimental" because,',
+      'at the time of writing, Safari does not support VP8. This means you',
+      'may experience codec issues in Group Rooms. You may also experience',
+      'codec issues in Peer-to-Peer (P2P) Rooms containing Android- or',
+      'iOS-based Participants who do not support H.264. However, P2P Rooms',
+      'with browser-based Participants should work. Please test this release',
+      'and report any issues to https://github.com/twilio/twilio-video.js'
+    ].join(' '));
+  }
 
   if (typeof token !== 'string') {
     return CancelablePromise.reject(new E.INVALID_TYPE('token', 'string'));

--- a/lib/createlocaltracks.js
+++ b/lib/createlocaltracks.js
@@ -72,7 +72,7 @@ function createLocalTracks(options) {
     audio: options.audio,
     video: options.video
   }).then(function(mediaStream) {
-    var mediaStreamTracks = mediaStream.getTracks();
+    var mediaStreamTracks = mediaStream.getAudioTracks().concat(mediaStream.getVideoTracks());
 
     log.info('Call to getUserMedia successful; got MediaStreamTracks:',
       mediaStreamTracks);

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -64,6 +64,21 @@ function flatMap(list, mapFn) {
 }
 
 /**
+ * Guess the browser.
+ * @returns {?string} browser - "chrome", "firefox", "safari", or null
+ */
+function guessBrowser() {
+  if (typeof webkitRTCPeerConnection !== 'undefined') {
+    return 'chrome';
+  } else if (typeof mozRTCPeerConnection !== 'undefined') {
+    return 'firefox';
+  } if (typeof navigator !== 'undefined' && navigator.userAgent.match(/AppleWebKit\/(\d+)\./)) {
+    return 'safari';
+  }
+  return null;
+}
+
+/**
  * Construct the SIP URI for a client.
  * @returns {string}
  */
@@ -328,6 +343,7 @@ module.exports.constants = constants;
 module.exports.asLocalTrack = asLocalTrack;
 module.exports.difference = difference;
 module.exports.flatMap = flatMap;
+module.exports.guessBrowser = guessBrowser;
 module.exports.makeClientSIPURI = makeClientSIPURI;
 module.exports.makeServerSIPURI = makeServerSIPURI;
 module.exports.makeUUID = makeUUID;

--- a/lib/util/log.js
+++ b/lib/util/log.js
@@ -46,6 +46,9 @@ function Log(moduleName, component, logLevels) {
     _logLevels: {
       value: logLevels
     },
+    _warnings: {
+      value: new Set()
+    },
     logLevel: {
       get: function get() {
         return Log.getLevelByName(logLevels[moduleName] || DEFAULT_LOG_LEVEL);
@@ -201,6 +204,20 @@ Log.prototype.info = function info() {
  */
 Log.prototype.warn = function warn() {
   return this.log(Log.WARN, [].slice.call(arguments));
+};
+
+/**
+ * Log a warning once.
+ * @param {String} warning
+ * @returns {Log} This instance of {@link Log}
+ * @public
+ */
+Log.prototype.warnOnce = function warnOnce(warning) {
+  if (this._warnings.has(warning)) {
+    return this;
+  }
+  this._warnings.add(warning);
+  return this.warn(warning);
 };
 
 /**

--- a/lib/util/log.js
+++ b/lib/util/log.js
@@ -40,6 +40,9 @@ function Log(moduleName, component, logLevels) {
 
   /* istanbul ignore next */
   Object.defineProperties(this, {
+    _deprecationWarnings: {
+      value: new Set()
+    },
     _logLevels: {
       value: logLevels
     },
@@ -163,6 +166,21 @@ Log.prototype.log = function log(logLevel, message) {
  */
 Log.prototype.debug = function debug() {
   return this.log(Log.DEBUG, [].slice.call(arguments));
+};
+
+/**
+ * Log a deprecation warning. Deprecation warnings are logged as warnings and
+ * they are only ever logged once.
+ * @param {String} deprecationWarning - The deprecation warning
+ * @returns {Log} This instance of {@link Log}
+ * @public
+ */
+Log.prototype.deprecated = function deprecated(deprecationWarning) {
+  if (this._deprecationWarnings.has(deprecationWarning)) {
+    return this;
+  }
+  this._deprecationWarnings.add(deprecationWarning);
+  return this.warn(deprecationWarning);
 };
 
 /**

--- a/lib/util/sdp.js
+++ b/lib/util/sdp.js
@@ -59,15 +59,18 @@ function getPlanBSSRCs(sdp, trackId) {
 /**
  * Get the m= sections of a particular kind and direction from an sdp.
  * @param {string} sdp -  sdp string
- * @param {string} kind - 'audio'|'video'
- * @param {string} direction - Pattern for matching direction
- * @returns {Array<string>} matched mediaSections
+ * @param {string} [kind] - Pattern for matching kind
+ * @param {string} [direction] - Pattern for matching direction
+ * @returns {Array<string>} mediaSections
  */
 function getMediaSections(sdp, kind, direction) {
-  return sdp.split('\r\nm=').slice(1).filter(function(mediaSection) {
+  kind = kind || '.*';
+  direction = direction || '.*';
+  return sdp.split('\r\nm=').slice(1).map(function(mediaSection) {
+    return 'm=' + mediaSection;
+  }).filter(function(mediaSection) {
     var kindPattern = new RegExp('m=' + kind, 'gm');
     var directionPattern = new RegExp('a=' + direction, 'gm');
-    mediaSection = 'm=' + mediaSection;
     return kindPattern.test(mediaSection) && directionPattern.test(mediaSection);
   });
 }
@@ -88,7 +91,7 @@ function getMediaSectionSSRCs(mediaSection) {
  * @returns {Set<string>}
  */
 function getUnifiedPlanSSRCs(sdp, trackId) {
-  var mediaSections = sdp.split('\r\nm=').slice(1);
+  var mediaSections = getMediaSections(sdp);
 
   var msidAttrRegExp = new RegExp('^a=msid:[^ ]+ +' + trackId + ' *$', 'gm');
   var matchingMediaSections = mediaSections.filter(function(mediaSection) {

--- a/lib/util/trackmatcher.js
+++ b/lib/util/trackmatcher.js
@@ -1,0 +1,133 @@
+'use strict';
+
+var util = require('./');
+
+// NOTE(mroberts): TrackMatcher is meant to solve the problem identified in
+//
+//   https://bugs.webkit.org/show_bug.cgi?id=174519
+//
+// Namely that, without MIDs, we cannot "correctly" identify MediaStreamTracks
+// in Safari's current WebRTC implementation. So, this module tries to hack
+// around this by making a possibly dangerous assumption: "track" events will
+// be raised for MediaStreamTracks of a particular kind in the same order that
+// those kinds' MSIDs appear in the SDP. By calling `update` with an
+// RTCPeerConnection's `localDescription` and then invoking `match`, we ought
+// to be able to dequeue MediaStreamTrack IDs in the correct order to be
+// assigned to "track" events.
+
+/**
+ * @typedef {string} ID
+ */
+
+/**
+ * @interface MatchedAndUnmatched
+ * @property {Set<ID>} matched
+ * @property {Set<ID>} unmatched
+ */
+
+/**
+ * Create a new instance of {@link MatchedAndUnmatched}.
+ * @returns {MatchedAndUnmatched}
+ */
+function create() {
+  return {
+    matched: new Set(),
+    unmatched: new Set()
+  };
+}
+
+/**
+ * Attempt to match a MediaStreamTrack ID.
+ * @param {MatchedAndUnmatched} mAndM
+ * @returns {?string} id
+ */
+function match(mAndM) {
+  var unmatched = Array.from(mAndM.unmatched);
+  if (!unmatched.length) {
+    return null;
+  }
+  var id = unmatched[0];
+  mAndM.matched.add(id);
+  mAndM.unmatched.delete(id);
+  return id;
+}
+
+/**
+ * Update a {@link MatchedAndUnmatched}'s MediaStreamTrack IDs.
+ * @param {MatchedAndUnmatched} mAndM
+ * @param {Set<ID>} ids
+ * @returns {void}
+ */
+function update(mAndM, ids) {
+  ids = new Set(ids);
+  var removedMatchedIds = util.difference(mAndM.matched, ids);
+  removedMatchedIds.forEach(mAndM.matched.delete, mAndM.matched);
+  mAndM.unmatched = util.difference(ids, mAndM.matched);
+}
+
+/**
+ * Parse MediaStreamTrack IDs of a particular kind from an SDP.
+ * @param {string} kind
+ * @param {string} sdp
+ * @returns {Set<ID>} ids
+ */
+function parse(kind, sdp) {
+  var mediaSections = sdp.split('\r\nm=').slice(1).map(function(mediaSection) {
+    return 'm=' + mediaSection;
+  });
+
+  var kindSections = mediaSections.filter(function(mediaSection) {
+    return mediaSection.match(new RegExp('^m=' + kind + ' '));
+  });
+
+  var pattern = 'msid: ?(.+) +(.+) ?$';
+
+  return new Set(util.flatMap(kindSections, function(kindSection) {
+    return kindSection.match(new RegExp(pattern, 'mg')) || [];
+  }).map(function(msid) {
+    return msid.match(new RegExp(pattern))[2];
+  }));
+}
+
+/**
+ * A {@link TrackMatcher} is used to match RTCTrackEvents.
+ * @property {MatchedAndUnmatched} audio
+ * @property {MatchedAndUnmatched} video
+ */
+function TrackMatcher() {
+  if (!(this instanceof TrackMatcher)) {
+    return new TrackMatcher();
+  }
+  Object.defineProperties(this, {
+    audio: {
+      enumerable: true,
+      value: create()
+    },
+    video: {
+      enumerable: true,
+      value: create()
+    }
+  });
+}
+
+/**
+ * Attempt to match a new MediaStreamTrack ID.
+ * @param {string} kind - "audio" or "video"
+ * @returns {?ID} id
+ */
+TrackMatcher.prototype.match = function(kind) {
+  return match(this[kind]);
+};
+
+/**
+ * Update the {@link TrackMatcher} with a new SDP.
+ * @param {string} sdp
+ * @returns {void}
+ */
+TrackMatcher.prototype.update = function(sdp) {
+  ['audio', 'video'].forEach(function(kind) {
+    update(this[kind], parse(kind, sdp));
+  }, this);
+};
+
+module.exports = TrackMatcher;

--- a/lib/util/trackmatcher.js
+++ b/lib/util/trackmatcher.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var util = require('./');
+var getMediaSections = require('./sdp').getMediaSections;
 
 // NOTE(mroberts): TrackMatcher is meant to solve the problem identified in
 //
@@ -72,18 +73,10 @@ function update(mAndM, ids) {
  * @returns {Set<ID>} ids
  */
 function parse(kind, sdp) {
-  var mediaSections = sdp.split('\r\nm=').slice(1).map(function(mediaSection) {
-    return 'm=' + mediaSection;
-  });
-
-  var kindSections = mediaSections.filter(function(mediaSection) {
-    return mediaSection.match(new RegExp('^m=' + kind + ' '));
-  });
-
+  var mediaSections = getMediaSections(sdp, kind);
   var pattern = 'msid: ?(.+) +(.+) ?$';
-
-  return new Set(util.flatMap(kindSections, function(kindSection) {
-    return kindSection.match(new RegExp(pattern, 'mg')) || [];
+  return new Set(util.flatMap(mediaSections, function(mediaSection) {
+    return mediaSection.match(new RegExp(pattern, 'mg')) || [];
   }).map(function(msid) {
     return msid.match(new RegExp(pattern))[2];
   }));

--- a/lib/webrtc/rtcpeerconnection/index.js
+++ b/lib/webrtc/rtcpeerconnection/index.js
@@ -6,5 +6,9 @@ if (typeof webkitRTCPeerConnection !== 'undefined') {
 } else if (typeof mozRTCPeerConnection !== 'undefined') {
   module.exports = require('./firefox');
 } else if (typeof RTCPeerConnection !== 'undefined') {
-  module.exports = RTCPeerConnection;
+  if (typeof navigator !== 'undefined' && navigator.userAgent.match(/AppleWebKit\/(\d+)\./)) {
+    module.exports = require('./safari');
+  } else {
+    module.exports = RTCPeerConnection;
+  }
 }

--- a/lib/webrtc/rtcpeerconnection/index.js
+++ b/lib/webrtc/rtcpeerconnection/index.js
@@ -1,14 +1,20 @@
-/* globals mozRTCPeerConnection, RTCPeerConnection, webkitRTCPeerConnection */
 'use strict';
 
-if (typeof webkitRTCPeerConnection !== 'undefined') {
-  module.exports = require('./chrome');
-} else if (typeof mozRTCPeerConnection !== 'undefined') {
-  module.exports = require('./firefox');
-} else if (typeof RTCPeerConnection !== 'undefined') {
-  if (typeof navigator !== 'undefined' && navigator.userAgent.match(/AppleWebKit\/(\d+)\./)) {
+var guessBrowser = require('../../util').guessBrowser;
+
+switch (guessBrowser()) {
+  case 'chrome':
+    module.exports = require('./chrome');
+    break;
+  case 'firefox':
+    module.exports = require('./firefox');
+    break;
+  case 'safari':
     module.exports = require('./safari');
-  } else {
+    break;
+  default:
+    if (typeof RTCPeerConnection === 'undefined') {
+      break;
+    }
     module.exports = RTCPeerConnection;
-  }
 }

--- a/lib/webrtc/rtcpeerconnection/safari.js
+++ b/lib/webrtc/rtcpeerconnection/safari.js
@@ -4,6 +4,7 @@
 var EventTarget = require('../../eventtarget');
 var inherits = require('util').inherits;
 var Latch = require('../../util/latch');
+var TrackMatcher = require('../../util/trackmatcher');
 var updateTracksToSSRCs = require('../../util/sdp').updatePlanBTrackIdsToSSRCs;
 var util = require('../../util');
 
@@ -14,8 +15,11 @@ function SafariRTCPeerConnection(configuration) {
 
   EventTarget.call(this);
 
-  var onsignalingstatechange = null;
   var oniceconnectionstatechange = null;
+  var onsignalingstatechange = null;
+  var ontrack = null;
+
+  var trackMatcher = new TrackMatcher();
 
   var peerConnection = new RTCPeerConnection(configuration);
 
@@ -101,6 +105,23 @@ function SafariRTCPeerConnection(configuration) {
         }
       }
     },
+    ontrack: {
+      get: function() {
+        return ontrack;
+      },
+      set: function(_ontrack) {
+        if (ontrack) {
+          this.removeEventListener('track', ontrack);
+        }
+
+        if (typeof _ontrack === 'function') {
+          ontrack = _ontrack;
+          this.addEventListener('track', ontrack);
+        } else {
+          ontrack = null;
+        }
+      }
+    },
     iceConnectionState: {
       enumerable: true,
       get: function() {
@@ -156,6 +177,20 @@ function SafariRTCPeerConnection(configuration) {
     if (!self._pendingLocalOffer && !self._pendingRemoteOffer) {
       self.dispatchEvent.apply(self, arguments);
     }
+  });
+
+  peerConnection.addEventListener('track', function ontrack(event) {
+    var sdp = self.remoteDescription ? self.remoteDescription.sdp : null;
+    if (sdp) {
+      trackMatcher.update(sdp);
+      var id = trackMatcher.match(event.track.kind);
+      if (id) {
+        Object.defineProperty(event.track, 'id', {
+          value: id
+        });
+      }
+    }
+    self.dispatchEvent(event);
   });
 
   util.proxyProperties(RTCPeerConnection.prototype, this, peerConnection);

--- a/lib/webrtc/rtcpeerconnection/safari.js
+++ b/lib/webrtc/rtcpeerconnection/safari.js
@@ -190,6 +190,9 @@ function SafariRTCPeerConnection(configuration) {
         });
       }
     }
+    event.streams.forEach(function(stream) {
+      self._remoteStreams.add(stream);
+    });
     self.dispatchEvent(event);
   });
 
@@ -274,7 +277,12 @@ SafariRTCPeerConnection.prototype.addStream = function addStream(stream) {
   if (this._localStreams.has(stream)) {
     return;
   }
-  var tracks = stream.getTracks();
+  var tracks = new Set(stream.getTracks());
+  this._peerConnection.getSenders().forEach(function(sender) {
+    if (tracks.has(sender.track)) {
+      tracks.delete(sender.track);
+    }
+  });
   tracks.forEach(function(track) {
     try {
       this.addTrack(track, stream);

--- a/lib/webrtc/rtcpeerconnection/safari.js
+++ b/lib/webrtc/rtcpeerconnection/safari.js
@@ -1,0 +1,349 @@
+/* globals RTCPeerConnection, RTCSessionDescription */
+'use strict';
+
+var EventTarget = require('../../eventtarget');
+var inherits = require('util').inherits;
+var Latch = require('../../util/latch');
+var updateTracksToSSRCs = require('../../util/sdp').updatePlanBTrackIdsToSSRCs;
+var util = require('../../util');
+
+function SafariRTCPeerConnection(configuration) {
+  if (!(this instanceof SafariRTCPeerConnection)) {
+    return new SafariRTCPeerConnection(configuration);
+  }
+
+  EventTarget.call(this);
+
+  var onsignalingstatechange = null;
+  var oniceconnectionstatechange = null;
+
+  var peerConnection = new RTCPeerConnection(configuration);
+
+  Object.defineProperties(this, {
+    _audioTransceiver: {
+      value: null,
+      writable: true
+    },
+    _isClosed: {
+      value: false,
+      writable: true
+    },
+    _localStreams: {
+      value: new Map()
+    },
+    _peerConnection: {
+      value: peerConnection
+    },
+    _pendingLocalOffer: {
+      value: null,
+      writable: true
+    },
+    _pendingRemoteOffer: {
+      value: null,
+      writable: true
+    },
+    _remoteStreams: {
+      value: new Set()
+    },
+    _signalingStateLatch: {
+      value: new Latch()
+    },
+    _tracksToSSRCs: {
+      value: new Map()
+    },
+    _videoTransceiver: {
+      value: null,
+      writable: true
+    },
+    // NOTE(mroberts): Keep this here until the following is fixed.
+    //
+    //   https://bugs.webkit.org/show_bug.cgi?id=174323
+    //
+    localDescription: {
+      enumerable: true,
+      get: function() {
+        return this._isClosed
+          ? null
+          : this._pendingLocalOffer || this._peerConnection.localDescription;
+      }
+    },
+    oniceconnectionstatechange: {
+      get: function() {
+        return oniceconnectionstatechange;
+      },
+      set: function(_oniceconnectionstatechange) {
+        if (oniceconnectionstatechange) {
+          this.removeEventListener('iceconnectionstatechange', oniceconnectionstatechange);
+        }
+
+        if (typeof _oniceconnectionstatechange === 'function') {
+          oniceconnectionstatechange = _oniceconnectionstatechange;
+          this.addEventListener('iceconnectionstatechange', oniceconnectionstatechange);
+        } else {
+          oniceconnectionstatechange = null;
+        }
+      }
+    },
+    onsignalingstatechange: {
+      get: function() {
+        return onsignalingstatechange;
+      },
+      set: function(_onsignalingstatechange) {
+        if (onsignalingstatechange) {
+          this.removeEventListener('signalingstatechange', onsignalingstatechange);
+        }
+
+        if (typeof _onsignalingstatechange === 'function') {
+          onsignalingstatechange = _onsignalingstatechange;
+          this.addEventListener('signalingstatechange', onsignalingstatechange);
+        } else {
+          onsignalingstatechange = null;
+        }
+      }
+    },
+    iceConnectionState: {
+      enumerable: true,
+      get: function() {
+        return this._isClosed ? 'closed' : this._peerConnection.iceConnectionState;
+      }
+    },
+    iceGatheringState: {
+      enumerable: true,
+      get: function() {
+        return this._isClosed ? 'complete' : this._peerConnection.iceGatheringState;
+      }
+    },
+    // NOTE(mroberts): Keep this here until the following is fixed.
+    //
+    //   https://bugs.webkit.org/show_bug.cgi?id=174323
+    //
+    remoteDescription: {
+      enumerable: true,
+      get: function() {
+        return this._isClosed
+          ? null
+          : this._pendingRemoteOffer || this._peerConnection.remoteDescription;
+      }
+    },
+    signalingState: {
+      enumerable: true,
+      get: function() {
+        if (this._isClosed) {
+          return 'closed';
+        } else if (this._pendingLocalOffer) {
+          return 'have-local-offer';
+        } else if (this._pendingRemoteOffer) {
+          return 'have-remote-offer';
+        }
+        return this._peerConnection.signalingState;
+      }
+    }
+  });
+
+  var self = this;
+
+  peerConnection.addEventListener('iceconnectionstatechange', function oniceconnectionstatechange() {
+    if (self._isClosed) {
+      return;
+    }
+    self.dispatchEvent.apply(self, arguments);
+  });
+
+  peerConnection.addEventListener('signalingstatechange', function onsignalingstatechange() {
+    if (self._isClosed) {
+      return;
+    }
+    if (!self._pendingLocalOffer && !self._pendingRemoteOffer) {
+      self.dispatchEvent.apply(self, arguments);
+    }
+  });
+
+  util.proxyProperties(RTCPeerConnection.prototype, this, peerConnection);
+}
+
+inherits(SafariRTCPeerConnection, EventTarget);
+
+SafariRTCPeerConnection.prototype.addIceCandidate = function addIceCandidate(candidate) {
+  var self = this;
+  if (this.signalingState === 'have-remote-offer') {
+    return this._signalingStateLatch.when('low').then(function signalingStatesResolved() {
+      return self._peerConnection.addIceCandidate(candidate);
+    });
+  }
+  return this._peerConnection.addIceCandidate(candidate);
+};
+
+SafariRTCPeerConnection.prototype.createOffer = function createOffer(options) {
+  options = Object.assign({}, options);
+  var self = this;
+
+  // NOTE(mroberts): In general, this is not the way to do this; however, it's
+  // good enough for our application.
+  if (options.offerToReceiveAudio && !this._audioTransceiver) {
+    delete options.offerToReceiveAudio;
+    this._audioTransceiver = this.addTransceiver('audio');
+  }
+
+  if (options.offerToReceiveVideo && !this._videoTransceiver) {
+    delete options.offerToReceiveVideo;
+    this._videoTransceiver = this.addTransceiver('video');
+  }
+
+  return this._peerConnection.createOffer(options).then(function(offer) {
+    offer.sdp = updateTracksToSSRCs(self._tracksToSSRCs, offer.sdp);
+    return offer;
+  });
+};
+
+SafariRTCPeerConnection.prototype.createAnswer = function createAnswer(options) {
+  var self = this;
+
+  if (this._pendingRemoteOffer) {
+    return this._peerConnection.setRemoteDescription(this._pendingRemoteOffer).then(function setRemoteDescriptionSucceeded() {
+      self._signalingStateLatch.lower();
+      return self._peerConnection.createAnswer();
+    }).then(function createAnswerSucceeded(answer) {
+      self._pendingRemoteOffer = null;
+      return answer;
+    }, function setRemoteDescriptionOrCreateAnswerFailed(error) {
+      self._pendingRemoteOffer = null;
+      throw error;
+    });
+  }
+
+  return this._peerConnection.createAnswer(options);
+};
+
+SafariRTCPeerConnection.prototype.setLocalDescription = function setLocalDescription(description) {
+  return setDescription(this, true, description);
+};
+
+SafariRTCPeerConnection.prototype.setRemoteDescription = function setRemoteDescription(description) {
+  return setDescription(this, false, description);
+};
+
+SafariRTCPeerConnection.prototype.close = function close() {
+  if (this._isClosed) {
+    return;
+  }
+  this._isClosed = true;
+  this._peerConnection.close();
+  var self = this;
+  setTimeout(function() {
+    self.dispatchEvent(new Event('iceconnectionstatechange'));
+    self.dispatchEvent(new Event('signalingstatechange'));
+  });
+};
+
+SafariRTCPeerConnection.prototype.addStream = function addStream(stream) {
+  if (this._localStreams.has(stream)) {
+    return;
+  }
+  var tracks = stream.getTracks();
+  tracks.forEach(function(track) {
+    try {
+      this.addTrack(track, stream);
+    } catch (error) {
+      // Do nothing.
+    }
+  }, this);
+  this._localStreams.set(stream, new Set(tracks));
+};
+
+SafariRTCPeerConnection.prototype.removeStream = function removeStream(stream) {
+  // NOTE(mroberts): We can't really remove tracks right now, at least if we
+  // ever want to add them back...
+  //
+  //     https://bugs.webkit.org/show_bug.cgi?id=174327
+  //
+  // var tracks = this._localStreams.get(stream) || new Set();
+  // this.getSenders().forEach(function(sender) {
+  //   if (tracks.has(sender.track)) {
+  //     this.removeTrack(sender);
+  //   }
+  // }, this);
+  this._localStreams.delete(stream);
+};
+
+SafariRTCPeerConnection.prototype.getLocalStreams = function getLocalStreams() {
+  return Array.from(this._localStreams.keys());
+};
+
+SafariRTCPeerConnection.prototype.getRemoteStreams = function getRemoteStreams() {
+  return Array.from(this._remoteStreams);
+};
+
+util.delegateMethods(
+  RTCPeerConnection.prototype,
+  SafariRTCPeerConnection.prototype,
+  '_peerConnection');
+
+function setDescription(peerConnection, local, description) {
+  function setPendingLocalOffer(offer) {
+    if (local) {
+      peerConnection._pendingLocalOffer = offer;
+    } else {
+      peerConnection._pendingRemoteOffer = offer;
+    }
+  }
+
+  function clearPendingLocalOffer() {
+    if (local) {
+      peerConnection._pendingLocalOffer = null;
+    } else {
+      peerConnection._pendingRemoteOffer = null;
+    }
+  }
+
+  var pendingLocalOffer = local ? peerConnection._pendingLocalOffer : peerConnection._pendingRemoteOffer;
+  var pendingRemoteOffer = local ? peerConnection._pendingRemoteOffer : peerConnection._pendingLocalOffer;
+  var intermediateState = local ? 'have-local-offer' : 'have-remote-offer';
+  var setLocalDescription = local ? 'setLocalDescription' : 'setRemoteDescription';
+
+  if (!local && pendingRemoteOffer && description.type === 'answer') {
+    return setRemoteAnswer(peerConnection, description);
+  } else if (description.type === 'offer') {
+    if (peerConnection.signalingState !== intermediateState && peerConnection.signalingState !== 'stable') {
+      return Promise.reject(new Error('Cannot set ' + (local ? 'local' : 'remote') +
+        ' offer in state ' + peerConnection.signalingState));
+    }
+
+    if (!pendingLocalOffer && peerConnection._signalingStateLatch.state === 'low') {
+      peerConnection._signalingStateLatch.raise();
+    }
+    var previousSignalingState = peerConnection.signalingState;
+    setPendingLocalOffer(description);
+
+    // Only dispatch a signalingstatechange event if we transitioned.
+    if (peerConnection.signalingState !== previousSignalingState) {
+      return Promise.resolve().then(function dispatchSignalingStateChangeEvent() {
+        peerConnection.dispatchEvent(new Event('signalingstatechange'));
+      });
+    }
+
+    return Promise.resolve();
+  } else if (description.type === 'rollback') {
+    if (peerConnection.signalingState !== intermediateState) {
+      return Promise.reject(new Error('Cannot rollback ' +
+        (local ? 'local' : 'remote') + ' description in ' + peerConnection.signalingState));
+    }
+    clearPendingLocalOffer();
+    return Promise.resolve().then(function dispatchSignalingStateChangeEvent() {
+      peerConnection.dispatchEvent(new Event('signalingstatechange'));
+    });
+  }
+
+  return peerConnection._peerConnection[setLocalDescription](description);
+}
+
+function setRemoteAnswer(peerConnection, answer) {
+  var pendingLocalOffer = peerConnection._pendingLocalOffer;
+  return peerConnection._peerConnection.setLocalDescription(pendingLocalOffer).then(function setLocalOfferSucceeded() {
+    peerConnection._pendingLocalOffer = null;
+    return peerConnection.setRemoteDescription(answer);
+  }).then(function setRemoteAnswerSucceeded() {
+    peerConnection._signalingStateLatch.lower();
+  });
+}
+
+module.exports = SafariRTCPeerConnection;

--- a/lib/webrtc/rtcsessiondescription/index.js
+++ b/lib/webrtc/rtcsessiondescription/index.js
@@ -1,10 +1,17 @@
-/* globals mozRTCSessionDescription, RTCSessionDescription, webkitRTCPeerConnection */
 'use strict';
 
-if (typeof webkitRTCPeerConnection !== 'undefined') {
-  module.exports = require('./chrome');
-} else if (typeof mozRTCSessionDescription !== 'undefined') {
-  module.exports = require('./firefox');
-} else if (typeof RTCSessionDescription !== 'undefined') {
-  module.exports = RTCSessionDescription;
+var guessBrowser = require('../../util').guessBrowser;
+
+switch (guessBrowser()) {
+  case 'chrome':
+    module.exports = require('./chrome');
+    break;
+  case 'firefox':
+    module.exports = require('./firefox');
+    break;
+  default:
+    if (typeof RTCSessionDescription === 'undefined') {
+      break;
+    }
+    module.exports = RTCSessionDescription;
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "karma-chrome-launcher": "^2.0.0",
     "karma-firefox-launcher": "^1.0.1",
     "karma-mocha": "^1.3.0",
+    "karma-safaritechpreview-launcher": "0.0.6",
     "karma-spec-reporter": "^0.0.31",
     "mocha": "^3.2.0",
     "mock-browser": "^0.92.14",

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -7,7 +7,7 @@ if (typeof window === 'undefined') {
 const assert = require('assert');
 const getToken = require('../../lib/token');
 const env = require('../../env');
-const { flatMap } = require('../../../lib/util');
+const { flatMap, guessBrowser } = require('../../../lib/util');
 const Track = require('../../../lib/media/track');
 
 const {
@@ -35,9 +35,10 @@ const defaultOptions = ['ecsServer', 'logLevel', 'wsServer', 'wsServerInsights']
   return defaultOptions;
 }, {});
 
-const isChrome = typeof webkitRTCPeerConnection !== 'undefined';
-const isFirefox = typeof mozRTCPeerConnection !== 'undefined';
-const isSafari = !isChrome && !isFirefox && navigator.userAgent.match(/AppleWebKit\/(\d+)\./);
+const guess = guessBrowser();
+const isChrome = guess === 'chrome';
+const isFirefox = guess === 'firefox';
+const isSafari = guess === 'safari';
 
 (navigator.userAgent === 'Node'
   ? describe.skip

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -35,7 +35,9 @@ const defaultOptions = ['ecsServer', 'logLevel', 'wsServer', 'wsServerInsights']
   return defaultOptions;
 }, {});
 
-const isFirefox = navigator.userAgent.indexOf("Firefox") > 0;
+const isChrome = typeof webkitRTCPeerConnection !== 'undefined';
+const isFirefox = typeof mozRTCPeerConnection !== 'undefined';
+const isSafari = !isChrome && !isFirefox && navigator.userAgent.match(/AppleWebKit\/(\d+)\./);
 
 (navigator.userAgent === 'Node'
   ? describe.skip
@@ -321,7 +323,7 @@ const isFirefox = navigator.userAgent.indexOf("Firefox") > 0;
       assert.equal(thatTrack1.id, thisTrack1.id);
       assert.equal(thatTrack1.kind, thisTrack1.kind);
       assert.equal(thatTrack1.enabled, thisTrack1.enabled);
-      if (!isFirefox) {
+      if (!isFirefox && !isSafari) {
         assert.equal(thatTrack1.mediaStreamTrack.readyState, 'ended');
       }
     });

--- a/test/integration/spec/localtracks.js
+++ b/test/integration/spec/localtracks.js
@@ -6,10 +6,12 @@ if (typeof window === 'undefined') {
 
 const assert = require('assert');
 const createLocalTracks = require('../../../lib/createlocaltrack');
+const { guessBrowser } = require('../../../lib/util');
 
-const isChrome = typeof webkitRTCPeerConnection !== 'undefined';
-const isFirefox = typeof mozRTCPeerConnection !== 'undefined';
-const isSafari = !isChrome && !isFirefox && navigator.userAgent.match(/AppleWebKit\/(\d+)\./);
+const guess = guessBrowser();
+const isChrome = guess === 'chrome';
+const isFirefox = guess === 'firefox';
+const isSafari = guess === 'safari';
 
 ['audio', 'video'].forEach(kind => {
   const createLocalTrack = createLocalTracks[kind];

--- a/test/integration/spec/localtracks.js
+++ b/test/integration/spec/localtracks.js
@@ -7,7 +7,9 @@ if (typeof window === 'undefined') {
 const assert = require('assert');
 const createLocalTracks = require('../../../lib/createlocaltrack');
 
-const isFirefox = navigator.userAgent.indexOf("Firefox") > 0;
+const isChrome = typeof webkitRTCPeerConnection !== 'undefined';
+const isFirefox = typeof mozRTCPeerConnection !== 'undefined';
+const isSafari = !isChrome && !isFirefox && navigator.userAgent.match(/AppleWebKit\/(\d+)\./);
 
 ['audio', 'video'].forEach(kind => {
   const createLocalTrack = createLocalTracks[kind];
@@ -79,7 +81,7 @@ const isFirefox = navigator.userAgent.indexOf("Firefox") > 0;
       });
 
       context('when the underlying MediaStreamTrack ends', () => {
-        (isFirefox ? it.skip : it)('emits "stopped"', () => {
+        (isFirefox || isSafari ? it.skip : it)('emits "stopped"', () => {
           localTrack.mediaStreamTrack.stop();
           return stoppedEvent;
         });

--- a/test/integration/spec/webrtc/rtcsessiondescription.js
+++ b/test/integration/spec/webrtc/rtcsessiondescription.js
@@ -5,7 +5,9 @@ const ChromeRTCSessionDescription = require('../../../../lib/webrtc/rtcsessionde
 const SessionDescription = require('../../../../lib/webrtc/rtcsessiondescription');
 const { combinationContext } = require('../../../lib/util');
 
-const isSafari = navigator.userAgent.match(/Version\/(\d+).(\d+)/);
+const isChrome = typeof webkitRTCPeerConnection !== 'undefined';
+const isFirefox = typeof mozRTCPeerConnection !== 'undefined';
+const isSafari = !isChrome && !isFirefox && navigator.userAgent.match(/AppleWebKit\/(\d+)\./);
 
 describe('RTCSessionDescription', () => {
   describe('constructor', () => {

--- a/test/integration/spec/webrtc/rtcsessiondescription.js
+++ b/test/integration/spec/webrtc/rtcsessiondescription.js
@@ -5,6 +5,8 @@ const ChromeRTCSessionDescription = require('../../../../lib/webrtc/rtcsessionde
 const SessionDescription = require('../../../../lib/webrtc/rtcsessiondescription');
 const { combinationContext } = require('../../../lib/util');
 
+const isSafari = navigator.userAgent.match(/Version\/(\d+).(\d+)/);
+
 describe('RTCSessionDescription', () => {
   describe('constructor', () => {
     var description;
@@ -88,7 +90,8 @@ describe('RTCSessionDescription', () => {
         assert.equal(description.type, 'rollback');
       });
 
-      context('setting .sdp', () => {
+      (isSafari ? context.skip : context)
+      ('setting .sdp', () => {
         var newSdp = 'new fake sdp';
 
         beforeEach(() => {
@@ -104,7 +107,8 @@ describe('RTCSessionDescription', () => {
         });
       });
 
-      context('setting .type to', () => {
+      (isSafari ? context.skip : context)
+      ('setting .type to', () => {
         combinationContext([
           [
             ['offer', 'answer', 'pranswer', 'rollback'],
@@ -214,7 +218,8 @@ describe('RTCSessionDescription', () => {
         });
       }
 
-      context('setting .sdp', () => {
+      (isSafari ? context.skip : context)
+      ('setting .sdp', () => {
         var newSdp = 'new fake sdp';
 
         beforeEach(() => {
@@ -232,7 +237,8 @@ describe('RTCSessionDescription', () => {
         }
       });
 
-      context('setting .type to', () => {
+      (isSafari ? context.skip : context)
+      ('setting .type to', () => {
         combinationContext([
           [
             ['offer', 'answer', 'pranswer'],

--- a/test/integration/spec/webrtc/rtcsessiondescription.js
+++ b/test/integration/spec/webrtc/rtcsessiondescription.js
@@ -3,11 +3,13 @@
 const assert = require('assert');
 const ChromeRTCSessionDescription = require('../../../../lib/webrtc/rtcsessiondescription/chrome');
 const SessionDescription = require('../../../../lib/webrtc/rtcsessiondescription');
+const { guessBrowser } = require('../../../../lib/util');
 const { combinationContext } = require('../../../lib/util');
 
-const isChrome = typeof webkitRTCPeerConnection !== 'undefined';
-const isFirefox = typeof mozRTCPeerConnection !== 'undefined';
-const isSafari = !isChrome && !isFirefox && navigator.userAgent.match(/AppleWebKit\/(\d+)\./);
+const guess = guessBrowser();
+const isChrome = guess === 'chrome';
+const isFirefox = guess === 'firefox';
+const isSafari = guess === 'safari';
 
 describe('RTCSessionDescription', () => {
   describe('constructor', () => {

--- a/test/lib/sdp.js
+++ b/test/lib/sdp.js
@@ -1,0 +1,61 @@
+'use strict';
+
+/**
+ * @interface TracksByKind
+ * @property {Array<string>} [audio]
+ * @property {Array<string>} [video]
+ */
+
+/**
+ * @typedef {string|TrackAndSSRC} Track
+ */
+
+/**
+ * @interface TrackAndSSRC
+ * @property {string} id
+ * @property {string} ssrc
+ */
+
+/**
+ * @param {TracksByKind} kinds
+ * @returns {string} sdp
+ */
+function makeSdpWithTracks(kinds) {
+  const session = `\
+v=0\r
+o=- 0 1 IN IP4 0.0.0.0\r
+s=-\r
+t=0 0\r
+a=ice-ufrag:0000\r
+a=ice-pwd:0000000000000000000000\r
+a=fingerprint:sha-256 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00\r
+`;
+  return ['audio', 'video'].reduce((sdp, kind) => {
+    const codecs = {
+      audio: '0',
+      video: '99'
+    }[kind];
+
+    const media = `\
+m=${kind} 9 UDP/TLS/RTP/SAVPF ${codecs}\r
+c=IN IP4 0.0.0.0\r
+a=sendrecv\r
+${kind === 'video'
+ ? 'a=rtpmap:99 H264/90000\r\n'
+ : ''}\
+a=rtcp-mux\r
+`;
+    const tracks = kinds[kind] || [];
+    return tracks.reduce((sdp, trackAndSSRC) => {
+      const { id, ssrc } = typeof trackAndSSRC === 'string'
+        ? { id: trackAndSSRC, ssrc: 1 }
+        : trackAndSSRC;
+      return sdp + `\
+a=ssrc:${ssrc} cname:0\r
+a=ssrc:${ssrc} msid:stream ${id}\r
+`;
+    }, sdp + media);
+  }, session);
+}
+
+exports.makeSdpWithTracks = makeSdpWithTracks;

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -47,6 +47,7 @@ require('./spec/util/index');
 require('./spec/util/insightspublisher');
 require('./spec/util/log');
 require('./spec/util/sdp');
+require('./spec/util/trackmatcher');
 require('./spec/util/twilioerror');
 
 require('./spec/webrtc/getstats');

--- a/test/unit/spec/util/log.js
+++ b/test/unit/spec/util/log.js
@@ -165,6 +165,25 @@ describe('Log', function() {
     });
   });
 
+  describe('#deprecated(deprecationWarning)', function() {
+    context('the first time the deprecationWarning is passed', function() {
+      it('should call #log(Log.WARN, message)', function() {
+        var log = Log('foo', component('bar'), { foo: 'warn' });
+        log.deprecated('baz');
+        sinon.assert.calledWith(log.log, Log.WARN, ['baz']);
+      });
+    });
+
+    context('subsequent times the deprecationWarning is passed', function() {
+      it('should call #log(Log.WARN, message)', function() {
+        var log = Log('foo', component('bar'), { foo: 'warn' });
+        log.deprecated('baz');
+        log.deprecated('baz');
+        sinon.assert.calledOnce(log.log);
+      });
+    });
+  });
+
   describe('#info(messages)', function() {
     it('should call #log(Log.INFO, message)', function() {
       var log = Log('foo', component('bar'), { foo: 'info' });

--- a/test/unit/spec/util/log.js
+++ b/test/unit/spec/util/log.js
@@ -200,6 +200,25 @@ describe('Log', function() {
     });
   });
 
+  describe('#warnOnce(deprecationWarning)', function() {
+    context('the first time the warning is passed', function() {
+      it('should call #log(Log.WARN, message)', function() {
+        var log = Log('foo', component('bar'), { foo: 'warn' });
+        log.warnOnce('baz');
+        sinon.assert.calledWith(log.log, Log.WARN, ['baz']);
+      });
+    });
+
+    context('subsequent times the warning is passed', function() {
+      it('should call #log(Log.WARN, message)', function() {
+        var log = Log('foo', component('bar'), { foo: 'warn' });
+        log.warnOnce('baz');
+        log.warnOnce('baz');
+        sinon.assert.calledOnce(log.log);
+      });
+    });
+  });
+
   describe('#error(messages)', function() {
     it('should call #log(Log.ERROR, message)', function() {
       var log = Log('foo', component('bar'), { foo: 'error' });

--- a/test/unit/spec/util/trackmatcher.js
+++ b/test/unit/spec/util/trackmatcher.js
@@ -1,44 +1,8 @@
 'use strict';
 
 const assert = require('assert');
+const { makeSdpWithTracks } = require('../../../lib/sdp');
 const TrackMatcher = require('../../../../lib/util/trackmatcher');
-
-/**
- * @interface TracksByKind
- * @property {Array<string>} [audio]
- * @property {Array<string>} [video]
- */
-
-/**
- * @param {TracksByKind} kinds
- * @returns {string} sdp
- */
-function makeSdpWithTracks(kinds) {
-  const session = `\
-v=0\r
-o=- 0 1 IN IP4 0.0.0.0\r
-s=-\r
-t=0 0\r
-a=ice-ufrag:0000\r
-a=ice-pwd:0000000000000000000000\r
-a=fingerprint:sha-256 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00\r
-`;
-  return ['audio', 'video'].reduce((sdp, kind) => {
-    const media = `\
-m=${kind} 9 UDP/TLS/RTP/SAVPF 0\r
-c=IN IP4 0.0.0.0\r
-a=sendrecv\r
-a=rtcp-mux\r
-`;
-    const ids = kinds[kind] || [];
-    return ids.reduce((sdp, id) => {
-      return sdp + `\
-a=ssrc:1 cname:0\r
-a=ssrc:1 msid:stream ${id}\r
-`;
-    }, sdp + media);
-  }, session);
-}
 
 /**
  * @interface TrackMatcherTest

--- a/test/unit/spec/util/trackmatcher.js
+++ b/test/unit/spec/util/trackmatcher.js
@@ -1,0 +1,157 @@
+'use strict';
+
+const assert = require('assert');
+const TrackMatcher = require('../../../../lib/util/trackmatcher');
+
+/**
+ * @interface TracksByKind
+ * @property {Array<string>} [audio]
+ * @property {Array<string>} [video]
+ */
+
+/**
+ * @param {TracksByKind} kinds
+ * @returns {string} sdp
+ */
+function makeSdpWithTracks(kinds) {
+  const session = `\
+v=0\r
+o=- 0 1 IN IP4 0.0.0.0\r
+s=-\r
+t=0 0\r
+a=ice-ufrag:0000\r
+a=ice-pwd:0000000000000000000000\r
+a=fingerprint:sha-256 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00\r
+`;
+  return ['audio', 'video'].reduce((sdp, kind) => {
+    const media = `\
+m=${kind} 9 UDP/TLS/RTP/SAVPF 0\r
+c=IN IP4 0.0.0.0\r
+a=sendrecv\r
+a=rtcp-mux\r
+`;
+    const ids = kinds[kind] || [];
+    return ids.reduce((sdp, id) => {
+      return sdp + `\
+a=ssrc:1 cname:0\r
+a=ssrc:1 msid:stream ${id}\r
+`;
+    }, sdp + media);
+  }, session);
+}
+
+/**
+ * @interface TrackMatcherTest
+ * @property {Array<TracksByKind>} sdps
+ * @property {Array<Matches>} matches
+ */
+
+/**
+ * @interface Matches
+ * @property {Array<string>} [audio]
+ * @property {Array<string>} [video]
+ */
+
+describe('TrackMatcher', () => {
+  const tests = [
+    // Add a first, then a second, and then two more audio MediaStreamTracks
+    {
+      sdps: [
+        { audio: ['track1'] },
+        { audio: ['track1', 'track2'] },
+        { audio: ['track1', 'track2', 'track3', 'track4'] }
+      ],
+      matches: [
+        { audio: ['track1'] },
+        { audio: ['track2'] },
+        { audio: ['track3', 'track4'] }
+      ]
+    },
+    // Add a first, then a second, and then two more video MediaStreamTracks
+    {
+      sdps: [
+        { video: ['track1'] },
+        { video: ['track1', 'track2'] },
+        { video: ['track1', 'track2', 'track3', 'track4'] }
+      ],
+      matches: [
+        { video: ['track1'] },
+        { video: ['track2'] },
+        { video: ['track3', 'track4'] }
+      ]
+    },
+    // First add an audio MediaStreamTrack, then add a video MediaStreamTrack
+    {
+      sdps: [
+        { audio: ['track1'] },
+        { audio: ['track1'], video: ['track2'] }
+      ],
+      matches: [
+        { audio: ['track1'] },
+        { audio: [], video: ['track2'] }
+      ]
+    },
+    // First add an video MediaStreamTrack, then add a audio MediaStreamTrack
+    {
+      sdps: [
+        { video: ['track1'] },
+        { video: ['track1'], audio: ['track2'] }
+      ],
+      matches: [
+        { video: ['track1'] },
+        { video: [], audio: ['track2'] }
+      ]
+    },
+    // Add two audio MediaStreamTracks, remove the first one, then add it back
+    {
+      sdps: [
+        { audio: ['track1'] },
+        { audio: ['track1', 'track2'] },
+        { audio: ['track2'] },
+        { audio: ['track1'] }
+      ],
+      matches: [
+        { audio: ['track1'] },
+        { audio: ['track2'] },
+        { audio: [] },
+        { audio: ['track1'] }
+      ]
+    },
+    // Add two video MediaStreamTracks, remove the first one, then add it back
+    {
+      sdps: [
+        { video: ['track1'] },
+        { video: ['track1', 'track2'] },
+        { video: ['track2'] },
+        { video: ['track1'] }
+      ],
+      matches: [
+        { video: ['track1'] },
+        { video: ['track2'] },
+        { video: [] },
+        { video: ['track1'] }
+      ]
+    }
+  ];
+
+  it('should match new MediaStreamTrack IDs in the order in which they appear in the SDP', () => {
+    tests.forEach(test => {
+      const trackMatcher = new TrackMatcher();
+
+      test.sdps.forEach((tracksByKind, i) => {
+        const sdp = makeSdpWithTracks(tracksByKind);
+        trackMatcher.update(sdp);
+
+        const matchesByKind = test.matches[i];
+        ['audio', 'video'].forEach(kind => {
+          const matches = matchesByKind[kind] || [];
+          matches.forEach(match => {
+            assert.equal(trackMatcher.match(kind), match);
+          });
+
+          assert.equal(trackMatcher.match(kind), null);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
_Not ready to merge._

This adds a SafariRTCPeerConnection wrapper to handle Safari 11 Tech Preview quirks. Currently, this PR only passes the WebRTC tests we have. You can check this with

```
BROWSER=safari npm run test:webrtc
```

Integration tests are currently hanging. I'll need to investigate that next.