### PR TITLE
Workaround adapter.js MSID behavior

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ env:
     - DBUS_SESSION_BUS_ADDRESS=/dev/null
     - DISPLAY=:99.0
     - PATH=$HOME/.meteor:$PATH
-matrix:
-  allow_failures:
-    - env: BROWSER=chrome BVER=beta
 before_script:
   - cd node_modules/travis-multirunner
   - BROWSER=chrome ./setup.sh

--- a/lib/webrtc/rtcpeerconnection/chrome.js
+++ b/lib/webrtc/rtcpeerconnection/chrome.js
@@ -12,6 +12,22 @@ var PeerConnection = typeof RTCPeerConnection !== 'undefined'
   ? RTCPeerConnection
   : webkitRTCPeerConnection;
 
+// NOTE(mroberts): If adapter.js is loaded, we're going to try to gain access
+// to the "real" RTCPeerConnection by loading an iframe.
+if (typeof adapter !== 'undefined' && typeof document !== 'undefined') {
+  try {
+    var iframe = document.createElement('iframe');
+    iframe.style.display = 'none';
+    document.documentElement.appendChild(iframe);
+    PeerConnection.prototype = iframe.contentWindow.RTCPeerConnection
+      ? iframe.contentWindow.RTCPeerConnection.prototype
+      : iframe.contentWindow.webkitRTCPeerConnection.prototype;
+    document.documentElement.removeChild(iframe);
+  } catch (error) {
+    // Do nothing.
+  }
+}
+
 // NOTE(mroberts): This class wraps Chrome's RTCPeerConnection implementation.
 // It provides some functionality not currently present in Chrome, namely the
 // abilities to
@@ -37,7 +53,6 @@ function ChromeRTCPeerConnection(configuration) {
 
   var onsignalingstatechange = null;
 
-  /* eslint new-cap:0 */
   var peerConnection = new PeerConnection(newConfiguration);
 
   Object.defineProperties(this, {
@@ -126,12 +141,16 @@ ChromeRTCPeerConnection.prototype.addStream = function addStream(stream) {
     return;
   }
   this._localStreams.add(stream);
-  this._peerConnection.addStream(stream);
+  PeerConnection.prototype.addStream.apply(this._peerConnection, [stream]);
+};
+
+ChromeRTCPeerConnection.prototype.getLocalStreams = function getLocalStreams() {
+  return Array.from(this._localStreams);
 };
 
 ChromeRTCPeerConnection.prototype.removeStream = function removeStream(stream) {
   this._localStreams.delete(stream);
-  this._peerConnection.removeStream(stream);
+  PeerConnection.prototype.removeStream.apply(this._peerConnection, [stream]);
 };
 
 ChromeRTCPeerConnection.prototype.addIceCandidate = function addIceCandidate(candidate) {


### PR DESCRIPTION
This sucks, but let's see if it works. adapter.js has shimmed `addTrack`/`addStream` in a way that changes MediaStream IDs. We can try to workaround its shims by getting access to a "fresh" RTCPeerConnection from an iframe's `contentWindow`. EDIT: We can also re-enable Chrome Beta in `.travis.yml` this way.