### PR TITLE
Fix detach behavior in Chrome (and Safari 11 Tech Preview)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Bug Fixes
 
 - In Firefox, we were raising a `peerIdentity` TypeError in the console.
   (JSDK-1372)
+- `detach`ing a Track in Chrome could result in that Track continuing to
+  playback, even if the &lt;audio&gt; or &lt;video&gt; elements it was
+  `attach`ed to were removed from the DOM
+  ([#140](https://github.com/twilio/twilio-video.js/issues/140)).
 
 1.2.0 (July 21, 2017)
 =====================

--- a/lib/media/track/index.js
+++ b/lib/media/track/index.js
@@ -215,6 +215,12 @@ Track.prototype._attach = function _attach(el) {
   });
   mediaStream.addTrack(this.mediaStreamTrack);
 
+  // NOTE(mroberts): Although we don't necessarily need to reset `srcObject`,
+  // we've been doing it here for a while, and it turns out it has allowed us
+  // to sidestep the following issue:
+  //
+  //   https://bugs.chromium.org/p/chromium/issues/detail?id=720258
+  //
   el.srcObject = mediaStream;
   el.autoplay = true;
 
@@ -295,6 +301,14 @@ Track.prototype._detachElement = function _detachElement(el) {
   var mediaStream = el.srcObject;
   if (mediaStream instanceof this._MediaStream) {
     mediaStream.removeTrack(this.mediaStreamTrack);
+    // NOTE(mroberts): It's as if, in Chrome and Safari, the <audio> element's
+    // `srcObject` setter is taking a "snapshot" of the MediaStream's
+    // MediaStreamTracks in order to playback; hence, calls to `removeTrack`
+    // don't take effect unless you set the <audio> element's `srcObject` again.
+    //
+    //   https://bugs.chromium.org/p/chromium/issues/detail?id=749928
+    //
+    el.srcObject = mediaStream;
   }
 
   this._attachments.delete(el);


### PR DESCRIPTION
Currently, in Chrome, it appears that an HTMLMediaElement's `srcObject` setter takes a "snapshot" of the MediaStream's MediaStreamTracks at the time at which it is set. This means, calls to `removeTrack` don't effect playback. Stranger, if a MediaStreamTrack is removed from the `srcObject`, and then the HTMLMediaElement is detached from the DOM, audio playback will continue. This bug is captured [here](https://bugs.chromium.org/p/chromium/issues/detail?id=749928).

A sufficient workaround is to reset the `srcObject` attribute after making changes to the MediaStream. So this PR introduces that change to `detach`. It's worth mentioning that this `srcObject` behavior also effects _adding_ MediaStreamTracks to a `srcObject`, as reported [here](https://bugs.chromium.org/p/chromium/issues/detail?id=720258); however, we've "accidentally" been working around this by always resetting the `srcObject` attribute in `attach`.

Fixes https://github.com/twilio/twilio-video.js/issues/140