### PR TITLE
fix RTCSessionDescription and RTCPeerConnection not defined errors on…

### DIFF
--- a/lib/webrtc/rtcpeerconnection/firefox.js
+++ b/lib/webrtc/rtcpeerconnection/firefox.js
@@ -8,7 +8,7 @@ var MediaStream = require('../mediastream');
 var updateTracksToSSRCs = require('../../util/sdp').updateUnifiedPlanTrackIdsToSSRCs;
 var util = require('../../util');
 
-var PeerConnection = RTCPeerConnection || mozRTCPeerConnection;
+var PeerConnection = mozRTCPeerConnection || RTCPeerConnection;
 
 // NOTE(mroberts): This class wraps Firefox's RTCPeerConnection implementation.
 // It provides some functionality not currently present in Firefox, namely the

--- a/lib/webrtc/rtcsessiondescription/firefox.js
+++ b/lib/webrtc/rtcsessiondescription/firefox.js
@@ -1,4 +1,4 @@
 /* globals mozRTCSessionDescription, RTCSessionDescription */
 'use strict';
 
-module.exports = RTCSessionDescription || mozRTCSessionDescription;
+module.exports = mozRTCSessionDescription ||  RTCSessionDescription;


### PR DESCRIPTION
when using twilio-video on Firefox, you get a 'RTCSessinDescription not defined' or 'RTCPeerConnection not defined' error in the console.  This fixes that by prefering the 'mox' prefixed versions of those interfaces