### PR TITLE
1.2.1-rc1 Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,6 @@ Bug Fixes
   playback, even if the &lt;audio&gt; or &lt;video&gt; elements it was
   `attach`ed to were removed from the DOM
   ([#140](https://github.com/twilio/twilio-video.js/issues/140)).
-- Previously, connecting to a Room with a mixture of Chrome- and Firefox-based
-  Participants could result in receiving black frames from any Firefox
-  Participants who were not sharing audio. This issue arose due to a difference
-  in bundle behavior between Chrome and Firefox
-  ([Issue 6280](https://bugs.chromium.org/p/webrtc/issues/detail?id=6280)). We
-  now workaround this issue by adding a "dummy" audio MediaStreamTrack to the
-  underlying RTCPeerConnections in Firefox. This ensures the first media section
-  remains bundled. (JSDK-1443)
 
 1.2.0 (July 21, 2017)
 =====================

--- a/COMMON_ISSUES.md
+++ b/COMMON_ISSUES.md
@@ -57,12 +57,29 @@ on the WebRTC bug tracker.
 The suggested workaround is to always share audio from Firefox-based
 Participants when connecting to a peer-to-peer Room. If you do not intend to
 playback the audio, you can `disable` the Track before connecting. For example,
+using the microphone:
 
 ```js
 const audioTrack = await Twilio.Video.createLocalAudioTrack();
-
 audioTrack.disable();
+```
 
+Or, if you do not want to request microphone access, create a "dummy" Track
+using the [Web Audio API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API):
+
+```js
+const audioContext = typeof AudioContext !== 'undefined'
+  ? new AudioContext()
+  : new webkitAudioContext()
+const node = audioContext.createMediaStreamDestination()
+const stream = node.stream
+const dummyTrack = stream.getAudioTracks()[0]
+const audioTrack = new Twilio.Video.LocalAudioTrack(dummyTrack);
+```
+
+Then, pass the `audioTrack` to `connect`:
+
+```js
 const room = await Twilio.Video.connect(token, { tracks: [audioTrack] });
 ```
 

--- a/COMMON_ISSUES.md
+++ b/COMMON_ISSUES.md
@@ -44,6 +44,28 @@ While twilio-video.js will load in Internet Explorer and other browsers that
 do not support WebRTC, attempting to connect to a Room or attempting to acquire
 LocalTracks will fail.
 
+VideoTrack shared by Firefox appears black
+------------------------------------------
+
+This issue can occur when connecting to a peer-to-peer Room with a Firefox-based
+Participant who is not sharing audio. (If all the other Participants are
+Firefox-based, this issue will not occur.) The issue arises due to a difference
+in bundle behavior between Google and Mozilla's WebRTC implementations. For
+more information, see [Issue 6280](https://bugs.chromium.org/p/webrtc/issues/detail?id=6280)
+on the WebRTC bug tracker.
+
+The suggested workaround is to always share audio from Firefox-based
+Participants when connecting to a peer-to-peer Room. If you do not intend to
+playback the audio, you can `disable` the Track before connecting. For example,
+
+```js
+const audioTrack = await Twilio.Video.createLocalAudioTrack();
+
+audioTrack.disable();
+
+const room = await Twilio.Video.connect(token, { tracks: [audioTrack] });
+```
+
 Aggressive Browser Extensions and Plugins
 -----------------------------------------
 

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -21,6 +21,8 @@ var util = require('./util');
 // belongs to. Each call to connect() increments this counter.
 var connectCalls = 0;
 
+var didPrintSafariWarning = false;
+
 /**
  * Connect to a {@link Room}.
  *   <br><br>
@@ -122,8 +124,13 @@ function connect(token, options) {
   }
   options.log = log;
 
-  if (guessBrowser() === 'safari') {
-    log.warnOnce([
+  // NOTE(mroberts): Print the Safari warning once if the log-level is at least
+  // "warn", i.e. neither "error" nor "off".
+  if (guessBrowser() === 'safari'
+    && !didPrintSafariWarning
+    && (log.logLevel !== 'error' && log.logLevel !== 'off')) {
+    didPrintSafariWarning = true;
+    log.warn([
       'This release of twilio-video.js includes experimental support for',
       'Safari 11 and newer. Support for Safari is "experimental" because,',
       'at the time of writing, Safari does not support VP8. This means you',

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -16,23 +16,13 @@ var StatsReport = require('../../stats/statsreport');
 
 var defaults = {
   iceServers: [],
-  offerOptions: {
-    offerToReceiveVideo: true
-  },
+  offerOptions: {},
   RTCIceCandidate: DefaultRTCIceCandidate,
   RTCPeerConnection: DefaultRTCPeerConnection,
   RTCSessionDescription: DefaultRTCSessionDescription
 };
 
 var isFirefox = guessBrowser() === 'firefox';
-
-// NOTE(mroberts): Firefox doesn't need to offer to receive audio, because this
-// means something slightly different in Firefox versus Plan B clients like
-// Chrome and Firefox will already add an audio MediaStreamTrack (implying
-// "sendrecv" anyway).
-if (!isFirefox) {
-  defaults.offerOptions.offerToReceiveAudio = true;
-}
 
 /*
 PeerConnectionV2 States

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1,4 +1,3 @@
-/* globals mozRTCPeerConnection */
 'use strict';
 
 var DefaultRTCIceCandidate = require('../../webrtc/rtcicecandidate');
@@ -7,6 +6,7 @@ var DefaultRTCSessionDescription = require('../../webrtc/rtcsessiondescription')
 var flatMap = require('../../util').flatMap;
 var getMediaSections = require('../../util/sdp').getMediaSections;
 var getStatistics = require('../../webrtc/getstats');
+var guessBrowser = require('../../util').guessBrowser;
 var IceBox = require('./icebox');
 var inherits = require('util').inherits;
 var MediaClientLocalDescFailedError = require('../../util/twilio-video-errors').MediaClientLocalDescFailedError;
@@ -24,7 +24,15 @@ var defaults = {
   RTCSessionDescription: DefaultRTCSessionDescription
 };
 
-var isFirefox = typeof mozRTCPeerConnection !== 'undefined';
+var isFirefox = guessBrowser() === 'firefox';
+
+// NOTE(mroberts): Firefox doesn't need to offer to receive audio, because this
+// means something slightly different in Firefox versus Plan B clients like
+// Chrome and Firefox will already add an audio MediaStreamTrack (implying
+// "sendrecv" anyway).
+if (!isFirefox) {
+  defaults.offerOptions.offerToReceiveAudio = true;
+}
 
 /*
 PeerConnectionV2 States

--- a/lib/signaling/v2/peerconnectionmanager.js
+++ b/lib/signaling/v2/peerconnectionmanager.js
@@ -1,11 +1,12 @@
 'use strict';
 
-var AudioContextFactory = require('../../webaudio/audiocontext');
 var inherits = require('util').inherits;
 var PeerConnectionV2 = require('./peerconnection');
 var MediaStream = require('../../webrtc/mediastream');
 var QueueingEventEmitter = require('../../queueingeventemitter');
 var util = require('../../util');
+
+// var isFirefox = util.guessBrowser() === 'firefox';
 
 /**
  * Construct {@link PeerConnectionManager}.
@@ -25,16 +26,28 @@ function PeerConnectionManager(iceServerSource, options) {
   QueueingEventEmitter.call(this);
 
   options = Object.assign({
-    AudioContextFactory: AudioContextFactory,
+    // NOTE(mroberts): We're not quite ready to release the workaround for the
+    // Firefox/Chrome BUNDLE issue, so we'll leave this disabled for now. In the
+    // future, it should look something like
+    //
+    //   audioContextFactory: isFirefox
+    //     ? require('../../webaudio/audiocontext')
+    //     : null,
+    //
+    // We'll need to delay the require call since the singleton exported depends
+    // on Set, which fails our UMD tests.
+    audioContextFactory: null,
     MediaStream: MediaStream,
     PeerConnectionV2: PeerConnectionV2
   }, options);
 
-  var audioContext = options.audioContext || options.AudioContextFactory.getOrCreate(this);
+  var audioContext = options.audioContextFactory
+    ? options.audioContextFactory.getOrCreate(this)
+    : null;
 
   Object.defineProperties(this, {
-    _AudioContextFactory: {
-      value: options.AudioContextFactory
+    _audioContextFactory: {
+      value: options.audioContextFactory
     },
     _closedPeerConnectionIds: {
       value: new Set()
@@ -124,7 +137,9 @@ PeerConnectionManager.prototype.close = function close() {
   if (this._dummyAudioMediaStreamTrack) {
     this._dummyAudioMediaStreamTrack.stop();
   }
-  this._AudioContextFactory.release(this);
+  if (this._audioContextFactory) {
+    this._audioContextFactory.release(this);
+  }
   return this;
 };
 

--- a/lib/signaling/v2/peerconnectionmanager.js
+++ b/lib/signaling/v2/peerconnectionmanager.js
@@ -45,6 +45,12 @@ function PeerConnectionManager(iceServerSource, options) {
     ? options.audioContextFactory.getOrCreate(this)
     : null;
 
+  // NOTE(mroberts): If we're using an AudioContext, we don't need to specify
+  // `offerToReceiveAudio` in RTCOfferOptions.
+  var offerOptions = audioContext
+    ? { offerToReceiveVideo: true }
+    : { offerToReceiveAudio: true, offerToReceiveVideo: true };
+
   Object.defineProperties(this, {
     _audioContextFactory: {
       value: options.audioContextFactory
@@ -70,6 +76,9 @@ function PeerConnectionManager(iceServerSource, options) {
     },
     _localMediaStream: {
       value: new options.MediaStream()
+    },
+    _offerOptions: {
+      value: offerOptions
     },
     _peerConnections: {
       value: new Map()
@@ -106,7 +115,11 @@ PeerConnectionManager.prototype._getOrCreate = function _getOrCreate(id, configu
   if (!peerConnection) {
     var PeerConnectionV2 = this._PeerConnectionV2;
 
-    peerConnection = new PeerConnectionV2(id, configuration);
+    var options = Object.assign({
+      offerOptions: this._offerOptions
+    }, configuration);
+    peerConnection = new PeerConnectionV2(id, options);
+
     this._peerConnections.set(peerConnection.id, peerConnection);
     peerConnection.on('candidates', this.queue.bind(this, 'candidates'));
     peerConnection.on('description', this.queue.bind(this, 'description'));

--- a/lib/signaling/v2/peerconnectionmanager.js
+++ b/lib/signaling/v2/peerconnectionmanager.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var audioContext = require('../../webaudio/audiocontext');
+var AudioContextFactory = require('../../webaudio/audiocontext');
 var inherits = require('util').inherits;
 var PeerConnectionV2 = require('./peerconnection');
 var MediaStream = require('../../webrtc/mediastream');
@@ -25,12 +25,17 @@ function PeerConnectionManager(iceServerSource, options) {
   QueueingEventEmitter.call(this);
 
   options = Object.assign({
-    audioContext: audioContext,
+    AudioContextFactory: AudioContextFactory,
     MediaStream: MediaStream,
     PeerConnectionV2: PeerConnectionV2
   }, options);
 
+  var audioContext = options.audioContext || options.AudioContextFactory.getOrCreate(this);
+
   Object.defineProperties(this, {
+    _AudioContextFactory: {
+      value: options.AudioContextFactory
+    },
     _closedPeerConnectionIds: {
       value: new Set()
     },
@@ -43,8 +48,8 @@ function PeerConnectionManager(iceServerSource, options) {
       value: util.defer()
     },
     _dummyAudioMediaStreamTrack: {
-      value: options.audioContext
-        ? createDummyAudioMediaStreamTrack(options.audioContext)
+      value: audioContext
+        ? createDummyAudioMediaStreamTrack(audioContext)
         : null
     },
     _iceServerSource: {
@@ -119,6 +124,7 @@ PeerConnectionManager.prototype.close = function close() {
   if (this._dummyAudioMediaStreamTrack) {
     this._dummyAudioMediaStreamTrack.stop();
   }
+  this._AudioContextFactory.release(this);
   return this;
 };
 

--- a/lib/webaudio/audiocontext.js
+++ b/lib/webaudio/audiocontext.js
@@ -1,16 +1,81 @@
 /* globals webkitAudioContext, AudioContext */
 'use strict';
 
-var NativeAudioContext = null;
+var NativeAudioContext = typeof AudioContext !== 'undefined'
+  ? AudioContext
+  : typeof webkitAudioContext !== 'undefined'
+    ? webkitAudioContext
+    : null;
 
-if (typeof AudioContext !== 'undefined') {
-  NativeAudioContext = AudioContext;
-} else if (typeof webkitAudioContext !== 'undefined') {
-  NativeAudioContext = webkitAudioContext;
+/**
+ * @interface AudioContextFactoryOptions
+ * @property {AudioContext} [AudioContext] - The AudioContext constructor
+ */
+
+/**
+ * {@link AudioContextFactory} ensures we construct at most one AudioContext
+ * at a time, and that it is eventually closed when we no longer need it.
+ * @param {AudioContextFactoryOptions} [options]
+ * @property {AudioContextFactory} AudioContextFactory - The
+ *   {@link AudioContextFactory} constructor
+ */
+function AudioContextFactory(options) {
+  options = Object.assign({
+    AudioContext: NativeAudioContext
+  }, options);
+  Object.defineProperties(this, {
+    _AudioContext: {
+      value: options.AudioContext
+    },
+    _audioContext: {
+      value: null,
+      writable: true
+    },
+    _holders: {
+      value: new Set()
+    },
+    AudioContextFactory: {
+      enumerable: true,
+      value: AudioContextFactory
+    }
+  });
 }
 
-try {
-  module.exports = new NativeAudioContext();
-} catch (error) {
-  module.exports = null;
-}
+/**
+ * Each call to {@link AudioContextFactory#getOrCreate} should be paired with a
+ * call to {@link AudioContextFactory#release}. Calling this increments an
+ * internal reference count.
+ * @param {*} holder - The object to hold a reference to the AudioContext
+ * @returns {?AudioContext}
+ */
+AudioContextFactory.prototype.getOrCreate = function getOrCreate(holder) {
+  if (!this._holders.has(holder)) {
+    this._holders.add(holder);
+    if (this._AudioContext && !this._audioContext) {
+      try {
+        this._audioContext = new this._AudioContext();
+      } catch (error) {
+        // Do nothing;
+      }
+    }
+  }
+  return this._audioContext;
+};
+
+/**
+ * Decrement the internal reference count. If it reaches zero, close and destroy
+ * the AudioContext.
+ * @param {*} holder - The object that held a reference to the AudioContext
+ * @returns {void}
+ */
+AudioContextFactory.prototype.release = function release(holder) {
+  if (this._holders.has(holder)) {
+    this._holders.delete(holder);
+    if (!this._holders.size && this._audioContext) {
+      this._audioContext.close();
+      this._audioContext = null;
+    }
+  }
+};
+
+module.exports = new AudioContextFactory();

--- a/test/integration/spec/localtracks.js
+++ b/test/integration/spec/localtracks.js
@@ -20,7 +20,9 @@ const isSafari = guess === 'safari';
   (navigator.userAgent === 'Node'
     ? describe.skip
     : describe
-  )(description, () => {
+  )(description, function() {
+    this.timeout(10000);
+
     let localTrack = null;
 
     beforeEach(() => {

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -50,6 +50,8 @@ require('./spec/util/sdp');
 require('./spec/util/trackmatcher');
 require('./spec/util/twilioerror');
 
+require('./spec/webaudio/audiocontext');
+
 require('./spec/webrtc/getstats');
 
 require('./spec/stats/trackstats');

--- a/test/unit/spec/webaudio/audiocontext.js
+++ b/test/unit/spec/webaudio/audiocontext.js
@@ -1,0 +1,188 @@
+'use strict';
+
+const assert = require('assert');
+const AudioContextFactory = require('../../../../lib/webaudio/audiocontext').AudioContextFactory;
+const sinon = require('sinon');
+
+describe('AudioContextFactory', () => {
+  let audioContext;
+  let AudioContext;
+  let audioContextFactory;
+
+  beforeEach(() => {
+    audioContext = {
+      close: sinon.spy()
+    };
+    AudioContext = sinon.spy(() => audioContext);
+    audioContextFactory = new AudioContextFactory({ AudioContext });
+  });
+
+  describe('#getOrCreate(holder)', () => {
+    context('called before an AudioContext was ever constructed', () => {
+      context('with a new holder', () => {
+        let holder;
+        let result;
+
+        beforeEach(() => {
+          holder = {};
+          result = audioContextFactory.getOrCreate(holder);
+        });
+
+        it('returns a new AudioContext', () => {
+          assert.equal(result, audioContext);
+          sinon.assert.calledOnce(AudioContext);
+        });
+      });
+    });
+
+    context('called after an AudioContext was constructed', () => {
+      let holder1;
+
+      beforeEach(() => {
+        holder1 = {};
+        audioContextFactory.getOrCreate(holder1);
+        AudioContext.reset();
+      });
+
+      context('with an existing holder', () => {
+        let result;
+
+        beforeEach(() => {
+          result = audioContextFactory.getOrCreate(holder1);
+        });
+
+        it('returns the existing AudioContext', () => {
+          assert.equal(result, audioContext);
+          sinon.assert.notCalled(AudioContext);
+        });
+      });
+
+      context('with a new holder', () => {
+        let holder2;
+        let result;
+
+        beforeEach(() => {
+          holder2 = {};
+          result = audioContextFactory.getOrCreate(holder2);
+        });
+
+        it('returns the existing AudioContext', () => {
+          assert.equal(result, audioContext);
+          sinon.assert.notCalled(AudioContext);
+        });
+      });
+    });
+
+    context('called after an AudioContext was closed', () => {
+      let holder1;
+
+      beforeEach(() => {
+        holder1 = {};
+        audioContextFactory.getOrCreate(holder1);
+        audioContextFactory.release(holder1);
+        AudioContext.reset();
+      });
+
+      context('with a previous holder', () => {
+        let result;
+
+        beforeEach(() => {
+          result = audioContextFactory.getOrCreate(holder1);
+        });
+
+        it('returns a new AudioContext', () => {
+          assert.equal(result, audioContext);
+          sinon.assert.calledOnce(AudioContext);
+        });
+      });
+
+      context('with a new holder', () => {
+        let holder2;
+        let result;
+
+        beforeEach(() => {
+          holder2 = {};
+          result = audioContextFactory.getOrCreate(holder2);
+        });
+
+        it('returns a new AudioContext', () => {
+          assert.equal(result, audioContext);
+          sinon.assert.calledOnce(AudioContext);
+        });
+      });
+    });
+  });
+
+  describe('#release(holder)', () => {
+    context('called before an AudioContext was ever constructed', () => {
+      let holder;
+      let result;
+
+      beforeEach(() => {
+        holder = {};
+        audioContextFactory.release(holder);
+      });
+
+      it('returns undefined', () => {
+        assert.equal(result, undefined);
+      });
+    });
+
+    context('called after an AudioContext was constructed', () => {
+      let holder1;
+      let holder2;
+
+      beforeEach(() => {
+        holder1 = {};
+        holder2 = {};
+        audioContextFactory.getOrCreate(holder1);
+        audioContextFactory.getOrCreate(holder2);
+      });
+
+      context('with an existing holder', () => {
+        let result1;
+
+        beforeEach(() => {
+          result1 = audioContextFactory.release(holder1);
+        });
+
+        it('returns undefined', () => {
+          assert.equal(result1, undefined);
+        });
+
+        context('it returns undefined and, if the holder was the last holder,', () => {
+          let result2;
+
+          beforeEach(() => {
+            result2 = audioContextFactory.release(holder2);
+            assert.equal(result2, undefined);
+          });
+
+          it('closes the AudioContext', () => {
+            sinon.assert.calledOnce(audioContext.close);
+          });
+        });
+
+        context('it returns undefined and, if the holder was not the last holder,', () => {
+          it('does not close the AudioContext', () => {
+            sinon.assert.notCalled(audioContext.close);
+          });
+        });
+      });
+
+      context('with a non-holder', () => {
+        let holder3;
+        let result3;
+
+        beforeEach(() => {
+          result3 = audioContextFactory.release(holder3);
+        });
+
+        it('returns undefined and does not close the AudioContext', () => {
+          assert.equal(result3, undefined);
+          sinon.assert.notCalled(audioContext.close);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
@manjeshbhargav would you take a look? As you mentioned earlier, the "dummy" MediaStreamTrack shows up in `getStats`. We'll need to fix that before releasing; however, Deniss also mentioned seeing the dummy MediaStreamTrack in recordings, too. There may be some more work to do here, so here is my proposal: leave this in, but disabled. We can iterate on it in future sprints and try, e.g., filtering the MSID from the SDP, filtering the result of `getStats`, etc. Would like to get these in for 1.2.1-rc2.