### PR TITLE
Safari 11 on iOS support: set playsInline to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,13 @@ New Features
 
 Please refer to the API docs for more information on both of these features.
 
+Bug Fixes
+---------
+
+- Track's `attach` method now sets the `playsInline` attribute on &lt;audio&gt;
+  and &lt;video&gt; elements. This is necessary to allow playback in Safari 11
+  on iOS.
+
 1.2.2 (August 22, 2017)
 =======================
 

--- a/lib/media/track/index.js
+++ b/lib/media/track/index.js
@@ -223,6 +223,7 @@ Track.prototype._attach = function _attach(el) {
   //
   el.srcObject = mediaStream;
   el.autoplay = true;
+  el.playsInline = true;
 
   if (!this._attachments.has(el)) {
     this._attachments.add(el);

--- a/test/unit/spec/media/track/index.js
+++ b/test/unit/spec/media/track/index.js
@@ -485,6 +485,10 @@ describe('Track', function() {
         assert(el.autoplay);
       });
 
+      it('should set the .playsInline of the HTMLMediaElement to true', () => {
+        assert(el.playsInline);
+      });
+
       it('should add the HTMLMediaElement to the ._attachments Set', () => {
         assert(track._attachments.has(el));
       });
@@ -522,6 +526,10 @@ describe('Track', function() {
 
       it('should set the .autoplay of the HTMLMediaElement to true', () => {
         assert(el.autoplay);
+      });
+
+      it('should set the .playsInline of the HTMLMediaElement to true', () => {
+        assert(el.playsInline);
       });
 
       it('should add the HTMLMediaElement to the ._attachments Set', () => {


### PR DESCRIPTION
@manjeshbhargav @ryan-rowland mind taking a look? I just tested with my iPhone and it looks good.