### PR TITLE
Remove invalid LocalAudioTrack/LocalVideoTrack test

### DIFF
--- a/test/integration/spec/localtracks.js
+++ b/test/integration/spec/localtracks.js
@@ -83,13 +83,6 @@ const isSafari = guess === 'safari';
           return stoppedEvent;
         });
       });
-
-      context('when the underlying MediaStreamTrack ends', () => {
-        (isFirefox || isSafari ? it.skip : it)('emits "stopped"', () => {
-          localTrack.mediaStreamTrack.stop();
-          return stoppedEvent;
-        });
-      });
     });
   });
 });


### PR DESCRIPTION
@manjeshbhargav 

***

We already skip this test for Safari and Firefox. Now, with the introduction of Chrome 62, we should remove the test entirely (and possibly land a unit test for it later). The test relied on `MediaStreamTrack#stop` raising the "ended" event on the MediaStreamTrack; but, according to
[Media Capture and Streams](https://www.w3.org/TR/mediacapture-streams), this event is only raised if "a MediaStreamTrack _track_ ends for any reason other than the `stop()` method being invoked."

This was fixed in Chrome 62 via [Issue 752913](https://bugs.chromium.org/p/chromium/issues/detail?id=752913).