### PR TITLE
Update CHANGELOG.md for 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,81 @@
+1.5.0 (in progress)
+===================
+
+New Features
+------------
+
+- You can now specify Track names. Refer to the Track name guide below for more
+  information.
+
+Track Name Guide
+----------------
+
+### Setting Track names
+
+There are a few different ways you can specify Track names. For example, you can
+specify `name` as an `audio` or `video` constraint when calling any of
+`createLocalTracks`, `createLocalAudioTrack`, `createLocalVideoTrack`, or
+`connect`:
+
+```js
+createLocalTracks({
+  audio: { name: 'microphone' },
+  video: { name: 'camera' }
+});
+
+createLocalAudioTrack({ name: 'microphone' });
+createLocalVideoTrack({ name: 'camera' });
+
+connect(token, {
+  audio: { name: 'microphone' },
+  video: { name: 'camera' }
+});
+```
+
+These will create a LocalAudioTrack and a LocalVideoTrack with the names
+"microphone" and "camera", respectively. If you have a reference to a
+MediaStreamTrack, you can also pass the `name` to the LocalAudioTrack or
+LocalVideoTrack constructor:
+
+```js
+const localAudioTrack = new LocalAudioTrack(mediaStreamTrack1, { name: 'microphone' });
+const localVideoTrack = new LocalVideoTrack(mediaStreamTrack2, { name: 'camera' });
+```
+
+Similarly, for LocalDataTracks:
+
+```js
+const localDataTrack = new LocalDataTrack({ name: 'data' });
+```
+
+You can even pass these values if you use the MediaStreamTrack override for
+`publishTrack`. For example:
+
+```js
+room.localParticipant.publishTrack(mediaStreamTrack, { name: 'my-track' });
+```
+
+Please keep in mind:
+
+* If you do not specify a Track name, the Track's name will default to the
+  LocalTrack ID.
+* A single Participant cannot have two Tracks published with the same name at a
+  time.
+
+### Getting Track names
+
+You can check a LocalTrack or RemoteTrack's name by querying it's `name`
+property. For example,
+
+```js
+participant.on('trackSubscribed', track => {
+  console.log('Subscribed to Track "' + track.name + '"');
+});
+```
+
+This can be useful, for example, for distinguishing between a RemoteVideoTrack
+named "camera" and a RemoteVideoTrack named "screenshare".
+
 1.4.0 (October 2, 2017)
 =======================
 

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -104,11 +104,11 @@ var didPrintSafariWarning = false;
  * // Connect with custom names for LocalAudioTrack and LocalVideoTrack
  * Video.connect(token, {
  *   name: 'my-cool-room'
- *   audio: { name: 'my-audio' },
- *   video: { name: 'my-video' }
+ *   audio: { name: 'microphone' },
+ *   video: { name: 'camera' }
  * }).then(function(room) {
- *   room.localParticipants.tracks.forEach(function(track) {
- *     console.log('The LocalTrack "' + track.name + '" was successfully added');
+ *   room.localParticipants.trackPublications.forEach(function(publication) {
+ *     console.log('The LocalTrack "' + publication.trackName + '" was successfully published');
  *   });
  * });
  */

--- a/lib/createlocaltrack.js
+++ b/lib/createlocaltrack.js
@@ -38,7 +38,7 @@ function createLocalTrack(kind, options) {
  *
  * // Connect to the Room with just video
  * Video.connect('my-token', {
- *   name: 'my-room-name',
+ *   name: 'my-cool-room',
  *   video: true
  * }).then(function(room) {
  *   // Add audio after connecting to the Room
@@ -50,8 +50,8 @@ function createLocalTrack(kind, options) {
  * var Video = require('twilio-video');
  *
  * // Request the default LocalAudioTrack with a custom name
- * Video.createLocalAudioTrack({ name: 'my-audio' }).then(function(localTrack) {
- *   console.log(localTrack.name); // 'my-audio'
+ * Video.createLocalAudioTrack({ name: 'microphone' }).then(function(localTrack) {
+ *   console.log(localTrack.name); // 'microphone'
  * });
  */
 function createLocalAudioTrack(options) {
@@ -67,7 +67,7 @@ function createLocalAudioTrack(options) {
  *
  * // Connect to the Room with just audio
  * Video.connect('my-token', {
- *   name: 'my-room-name',
+ *   name: 'my-cool-room',
  *   audio: true
  * }).then(function(room) {
  *   // Add video after connecting to the Room
@@ -79,8 +79,8 @@ function createLocalAudioTrack(options) {
  * var Video = require('twilio-video');
  *
  * // Request the default LocalVideoTrack with a custom name
- * Video.createLocalVideoTrack({ name: 'my-video' }).then(function(localTrack) {
- *   console.log(localTrack.name); // 'my-video'
+ * Video.createLocalVideoTrack({ name: 'camera' }).then(function(localTrack) {
+ *   console.log(localTrack.name); // 'camera'
  * });
  */
 function createLocalVideoTrack(options) {

--- a/lib/createlocaltracks.js
+++ b/lib/createlocaltracks.js
@@ -34,7 +34,7 @@ var createLocalTrackCalls = 0;
  * // Request just the default audio track
  * Video.createLocalTracks({ audio: true }).then(function(localTracks) {
  *   return Video.connect('my-token', {
- *     name: 'my-room-name',
+ *     name: 'my-cool-room',
  *     tracks: localTracks
  *   });
  * });
@@ -42,8 +42,8 @@ var createLocalTrackCalls = 0;
  * var Video = require('twilio-video');
  * // Request the audio and video tracks with custom names
  * Video.createLocalTracks({
- *   audio: { name: 'my-audio' },
- *   video: { name: 'my-video' }
+ *   audio: { name: 'microphone' },
+ *   video: { name: 'camera' }
  * }).then(function(localTracks) {
  *   localTracks.forEach(function(localTrack) {
  *     console.log(localTrack.name);

--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -338,11 +338,10 @@ LocalParticipant.prototype.addTracks = function addTracks(tracks) {
  * }).then(function(room) {
  *   // Publish a video MediaStreamTrack with a custom name
  *   return room.localParticipant.publishTrack(mediaStreamTrack, {
- *     name: 'my-video'
+ *     name: 'camera'
  *   });
- * }).then(function(localTrackPublication) {
- *   var trackName = localTrackPublication.trackName;
- *   console.log('The LocalTrack: "' + trackName + '" was successfully published');
+ * }).then(function(publication) {
+ *   console.log('The LocalTrack "' + publication.trackName + '" was successfully published');
  * });
  */
 LocalParticipant.prototype.publishTrack = function publishTrack(localTrackOrMediaStreamTrack, options) {


### PR DESCRIPTION
@manjeshbhargav mind taking a look? I also combed through some of the `@example`s and

* Where the Room `name` deviated, standardized on "my-cool-room".
* Used "microphone" and "camera" for the LocalAudioTrack and LocalVideoTrack names.

My feeling is we should be prescriptive in the names, here. It also lets us standardize on future language we might use (for example, the `name` "screenshare") when we update the screensharing guide. ~~We might also want to fix https://github.com/twilio/twilio-video.js/issues/184 for this release since it looks pretty small.~~ EDIT: Actually, looks like that is now in twilio-webrtc.js.