### PR TITLE
Use RTCRtpReceivers where available

### DIFF
--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -621,6 +621,13 @@ PeerConnectionV2.prototype.getRemoteMediaStreamTracksAndDataTrackReceivers = fun
  * @returns {Array<MediaStreamTrack>} mediaStreamTracks
  */
 PeerConnectionV2.prototype.getRemoteMediaStreamTracks = function getRemoteMediaStreamTracks() {
+  if (this._peerConnection.getReceivers) {
+    return this._peerConnection.getReceivers().map(function(receiver) {
+      return receiver.track;
+    }).filter(function(track) {
+      return track;
+    });
+  }
   return flatMap(this._peerConnection.getRemoteStreams(), function(mediaStream) {
     return mediaStream.getTracks();
   });


### PR DESCRIPTION
@manjeshbhargav please take a look. Fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1405893. The `filter` should not really be necessary in spec-compliant implementations, but there _was_ [this bug](https://bugs.chromium.org/p/chromium/issues/detail?id=751785), so perhaps worth keeping the check?