### PR TITLE
Add LocalDataTrack example to JSDoc

### DIFF
--- a/lib/media/track/localdatatrack.js
+++ b/lib/media/track/localdatatrack.js
@@ -17,6 +17,34 @@ var didPrintDataTrackWarning = false;
  * @extends {Track}
  * @param {LocalTrackOptions} [options] - {@link LocalTrack} options
  * @property {Track.Kind} kind - "data"
+ * @example
+ * var Video = require('twilio-video');
+ *
+ * var localDataTrack = new Video.LocalDataTrack();
+ * window.addEventListener('mousemove', function(event) {
+ *   localDataTrack.send({
+ *     x: e.clientX,
+ *     y: e.clientY
+ *   });
+ * });
+ *
+ * var token1 = getAccessToken();
+ * Video.connect(token1, {
+ *   name: 'my-cool-room',
+ *   tracks: [localDataTrack]
+ * });
+ *
+ * var token2 = getAccessToken();
+ * Video.connect(token2, {
+ *   name: 'my-cool-room',
+ *   tracks: []
+ * }).then(function(room) {
+ *   room.on('trackSubscribed', function(track) {
+ *     track.on('message', function(message) {
+ *       console.log(message); // { x: <number>, y: <number> }
+ *     });
+ *   });
+ * });
  */
 function LocalDataTrack(options) {
   if (!(this instanceof LocalDataTrack)) {


### PR DESCRIPTION
@manjeshbhargav not quite sure about this example--it's rather large, but seems like we really want to explain both halves (local and remote).

![screen shot 2017-10-12 at 3 00 43 pm](https://user-images.githubusercontent.com/359154/31521382-2507c1fc-af5e-11e7-9411-830a556d0bd8.png)
