### PR TITLE
Test improvements

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -78,7 +78,11 @@ rules:
   semi: [2, always]
   keyword-spacing: 2
   space-before-blocks: [2, always]
-  space-before-function-paren: [2, never]
+  space-before-function-paren: [2, {
+    anonymous: 'never',
+    named: 'never',
+    asyncArrow: 'always'
+  }]
   space-infix-ops: 2
   space-unary-ops: 2
   spaced-comment: 1

--- a/.tern-project
+++ b/.tern-project
@@ -1,0 +1,8 @@
+{
+  "libs": [
+    "browser"
+  ],
+  "plugins": {
+    "node": {}
+  }
+}

--- a/karma/makeconf.js
+++ b/karma/makeconf.js
@@ -52,7 +52,6 @@ function makeConf(defaultFile, browserNoActivityTimeout, requires) {
       reporters: ['spec'],
       port: 9876,
       colors: true,
-      logLevel: config.LOG_DEBUG,
       autoWatch: true,
       browsers,
       singleRun: true,

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -71,8 +71,10 @@ inherits(MediaTrack, Track);
 MediaTrack.prototype._start = function _start() {
   this._log.debug('Started');
   this._isStarted = true;
-  this._detachElement(this._dummyEl);
-  this._dummyEl.oncanplay = null;
+  if (this._dummyEl) {
+    this._detachElement(this._dummyEl);
+    this._dummyEl.oncanplay = null;
+  }
   this.emit(STARTED, this);
 };
 
@@ -87,16 +89,20 @@ MediaTrack.prototype._initialize = function _initialize() {
     self.mediaStreamTrack.removeEventListener('ended', onended);
   });
 
-  this._dummyEl.muted = true;
-  this._dummyEl.oncanplay = this._start.bind(this, this._dummyEl);
-  this._attach(this._dummyEl);
-  this._attachments.delete(this._dummyEl);
+  if (this._dummyEl) {
+    this._dummyEl.muted = true;
+    this._dummyEl.oncanplay = this._start.bind(this, this._dummyEl);
+    this._attach(this._dummyEl);
+    this._attachments.delete(this._dummyEl);
+  }
 };
 
 MediaTrack.prototype._end = function _end() {
   this._log.debug('Ended');
-  this._detachElement(this._dummyEl);
-  this._dummyEl.oncanplay = null;
+  if (this._dummyEl) {
+    this._detachElement(this._dummyEl);
+    this._dummyEl.oncanplay = null;
+  }
 };
 
 MediaTrack.prototype.attach = function attach(el) {
@@ -154,7 +160,9 @@ MediaTrack.prototype._selectElement = function _selectElement(selector) {
 };
 
 MediaTrack.prototype._createElement = function _createElement() {
-  return document.createElement(this.kind);
+  return typeof document !== 'undefined'
+    ? document.createElement(this.kind)
+    : null;
 };
 
 MediaTrack.prototype.detach = function _detach(el) {

--- a/lib/media/track/videotrack.js
+++ b/lib/media/track/videotrack.js
@@ -45,7 +45,7 @@ var DIMENSIONS_CHANGED = VideoTrack.DIMENSIONS_CHANGED = 'dimensionsChanged';
 
 function emitDimensionsChangedEvents(track) {
   if (typeof document === 'undefined') {
-    throw new Error('document is undefined');
+    return null;
   }
   var elem = document.createElement(track.kind);
   elem.muted = true;

--- a/lib/signaling/localtrackpublication.js
+++ b/lib/signaling/localtrackpublication.js
@@ -67,7 +67,6 @@ function setError(publication, error) {
     return false;
   }
   publication._error = error;
-  publication._sidDeferred.reject(error);
   return true;
 }
 

--- a/lib/signaling/track.js
+++ b/lib/signaling/track.js
@@ -46,12 +46,8 @@ function TrackSignaling(name, id, kind, isEnabled) {
       set: function(_sid) {
         if (sid === null) {
           sid = _sid;
-          this._sidDeferred.resolve(sid);
         }
       }
-    },
-    _sidDeferred: {
-      value: util.defer()
     },
     id: {
       enumerable: true,
@@ -118,14 +114,6 @@ TrackSignaling.prototype.enable = function enable(enabled) {
  */
 TrackSignaling.prototype.getMediaStreamTrackOrDataTrackTransceiver = function getMediaStreamTrackOrDataTrackTransceiver() {
   return this._mediaStreamTrackOrDataTrackTransceiverDeferred.promise;
-};
-
-/**
- * Get the SID on the {@link TrackSignaling}.
- * @returns {Promise<Track.SID>}
- */
-TrackSignaling.prototype.getSid = function getSid() {
-  return this._sidDeferred.promise;
 };
 
 /**

--- a/lib/signaling/v2/cancelableroomsignalingpromise.js
+++ b/lib/signaling/v2/cancelableroomsignalingpromise.js
@@ -20,7 +20,7 @@ function createCancelableRoomSignalingPromise(token, ua, localParticipant, iceSe
   var PeerConnectionManager = options.PeerConnectionManager;
   var RoomV2 = options.RoomV2;
 
-  var peerConnectionManager = new PeerConnectionManager(iceServerSource, encodingParameters, preferredCodecs);
+  var peerConnectionManager = new PeerConnectionManager(iceServerSource, encodingParameters, preferredCodecs, options);
 
   var mediaStreamTracksAndDataTrackSenders = flatMap(localParticipant.tracks, function(track) {
     return [track.mediaStreamTrackOrDataTrackTransceiver];

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -119,6 +119,11 @@ function PeerConnectionV2(id, encodingParameters, preferredCodecs, options) {
       writable: true,
       value: null
     },
+    _log: {
+      value: options.log
+        ? options.log.createLog('signaling', this)
+        : null
+    },
     _needsInitialAnswer: {
       writable: true,
       value: false
@@ -436,7 +441,15 @@ PeerConnectionV2.prototype._setLocalDescription = function _setLocalDescription(
       self._lastStableDescriptionRevision = revision;
     }
     return self._peerConnection.setLocalDescription(description);
-  }).catch(function() {
+  }).catch(function(error) {
+    if (self._log) {
+      self._log.warn('Calling setLocalDescription with an RTCSessionDescription ' +
+        'of type "' + description.type + '" failed with the error "' +
+        error.message + '".');
+      if (description.sdp) {
+        self._log.warn('The SDP was ' + description.sdp);
+      }
+    }
     throw new MediaClientLocalDescFailedError();
   }).then(function setLocalDescriptionSucceeded() {
     if (description.type !== 'rollback') {
@@ -469,7 +482,18 @@ PeerConnectionV2.prototype._setRemoteDescription = function _setRemoteDescriptio
       this._preferredVideoCodecs);
   }
   description = new this._RTCSessionDescription(description);
-  return this._peerConnection.setRemoteDescription(description);
+  var self = this;
+  return this._peerConnection.setRemoteDescription(description).catch(function(error) {
+    if (self._log) {
+      self._log.warn('Calling setRemoteDescription with an RTCSessionDescription ' +
+        'of type "' + description.type + '" failed with the error "' +
+        error.message + '".');
+      if (description.sdp) {
+        self._log.warn('The SDP was ' + description.sdp);
+      }
+    }
+    throw error;
+  });
 };
 
 /**

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -33,9 +33,6 @@ function RoomV2(localParticipant, initialState, transport, peerConnectionManager
     _transport: {
       value: transport
     },
-    _trackIdToParticipants: {
-      value: new Map()
-    },
     _mediaStreamTrackAndDataTrackReceiverDeferreds: {
       value: new Map()
     }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "cheerio": "^0.22.0",
     "chromedriver": "2.28.0",
     "envify": "^4.0.0",
-    "eslint": "^3.19.0",
+    "eslint": "^4.9.0",
     "geckodriver": "1.4.0",
     "ink-docstrap": "^1.3.0",
     "istanbul": "^0.4.5",
@@ -59,7 +59,7 @@
   "license": "BSD-3-Clause",
   "main": "./lib/index.js",
   "scripts": {
-    "lint": "eslint ./lib",
+    "lint": "eslint ./lib ./test/*.js ./test/framework/*.js ./test/lib/*.js ./test/integration/**/*.js ./test/unit/**/*.js",
     "test:unit": "mocha ./test/unit/index.js",
     "test:integration:adapter": "node ./scripts/karma.js karma/integration.adapter.conf.js",
     "test:integration:travis": "node ./scripts/integration.js",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "license": "BSD-3-Clause",
   "main": "./lib/index.js",
   "scripts": {
-    "lint": "eslint ./lib ./test/*.js ./test/framework/*.js ./test/lib/*.js ./test/integration/**/*.js ./test/unit/**/*.js",
+    "lint": "eslint ./lib ./test/*.js ./test/framework/*.js ./test/lib/*.js ./test/integration/** ./test/unit/**",
     "test:unit": "mocha ./test/unit/index.js",
     "test:integration:adapter": "node ./scripts/karma.js karma/integration.adapter.conf.js",
     "test:integration:travis": "node ./scripts/integration.js",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "karma-safaritechpreview-launcher": "0.0.6",
     "karma-spec-reporter": "^0.0.31",
     "mocha": "^3.2.0",
-    "mock-browser": "^0.92.14",
     "npm-run-all": "^4.0.2",
     "phantom": "^4.0.2",
     "release-tool": "^0.2.2",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,11 @@
+env:
+  mocha: true
+
+extends:
+  '../.eslintrc'
+
+parserOptions:
+  ecmaVersion: 8
+
+rules:
+  no-undefined: 1

--- a/test/env.js
+++ b/test/env.js
@@ -1,6 +1,7 @@
 'use strict';
 
 // NOTE(mroberts): We need to do this for envify.
+/* eslint no-process-env:0 */
 const processEnv = {
   ACCOUNT_SID: process.env.ACCOUNT_SID,
   API_KEY_SID: process.env.API_KEY_SID,
@@ -16,7 +17,7 @@ const processEnv = {
 const env = [
   ['ACCOUNT_SID',               'accountSid'],
   ['API_KEY_SID',               'apiKeySid'],
-  ['API_KEY_SECRET'   ,         'apiKeySecret'],
+  ['API_KEY_SECRET',            'apiKeySecret'],
   ['CONFIGURATION_PROFILE_SID', 'configurationProfileSid'],
   ['ECS_SERVER',                'ecsServer'],
   ['WS_SERVER',                 'wsServer'],

--- a/test/framework/index.js
+++ b/test/framework/index.js
@@ -23,6 +23,7 @@ function runFrameworkTest(options) {
   const timeout = options.timeout;
 
   describe(name, function() {
+    // eslint-disable-next-line no-invalid-this
     this.timeout(timeout);
 
     let server;
@@ -33,6 +34,7 @@ function runFrameworkTest(options) {
       server = spawn(start.command, start.args, {
         cwd: path,
         detached: true,
+        // eslint-disable-next-line no-process-env
         env: Object.assign({}, start.env, process.env),
         stdio: 'inherit'
       });

--- a/test/framework/waitforserver.js
+++ b/test/framework/waitforserver.js
@@ -29,6 +29,11 @@ function waitForServer(host, port, timeout, delay) {
   return new Promise((resolve, reject) => {
     let timedout = false;
 
+    const timer = setTimeout(() => {
+      timedout = true;
+      reject(new Error(`Timeout of ${timeout} exceeded`));
+    }, timeout);
+
     function sendOptionsRequest() {
       return new Promise((resolve, reject) => {
         http.request({
@@ -41,15 +46,10 @@ function waitForServer(host, port, timeout, delay) {
         resolve();
       }, () => {
         if (!timedout) {
-          return wait(delay).then(sendOptionsRequest);
+          wait(delay).then(sendOptionsRequest);
         }
       });
     }
-
-    const timer = setTimeout(() => {
-      timedout = true;
-      reject(new Error(`Timeout of ${timeout} exceeded`));
-    }, timeout);
 
     sendOptionsRequest();
   });

--- a/test/framework/webdriver.js
+++ b/test/framework/webdriver.js
@@ -17,7 +17,9 @@ function buildWebDriverForChrome() {
     .addArguments('use-fake-device-for-media-stream')
     .addArguments('use-fake-ui-for-media-stream');
 
+  // eslint-disable-next-line no-process-env
   if (process.env.CHROME_BIN) {
+    // eslint-disable-next-line no-process-env
     chromeOptions.setChromeBinaryPath(process.env.CHROME_BIN);
   }
 
@@ -39,7 +41,9 @@ function buildWebDriverForFirefox() {
 
   const firefoxOptions = new firefox.Options().setProfile(firefoxProfile);
 
+  // eslint-disable-next-line no-process-env
   if (process.env.FIREFOX_BIN) {
+    // eslint-disable-next-line no-process-env
     firefoxOptions.setBinary(process.env.FIREFOX_BIN);
   }
 

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 require('./spec/connect');
 require('./spec/localparticipant');
 require('./spec/localtracks');

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -195,7 +195,7 @@ describe('connect', function() {
         });
 
         [ 'tracks', 'audioTracks', 'videoTracks' ].forEach(tracks => {
-          var trackPublications = `${tracks.slice(0, tracks.length - 1)}Publications`;
+          const trackPublications = `${tracks.slice(0, tracks.length - 1)}Publications`;
 
           it(`should update ${n === 1 ? 'the' : 'each'} Room's LocalParticipant's .${trackPublications} Map with the corresponding ${capitalize(trackPublications)}`, () => {
             rooms.forEach(room => {
@@ -210,7 +210,7 @@ describe('connect', function() {
 
           it(`should set ${n === 1 ? 'the' : 'each'} Room\'s LocalParticipant's ${capitalize(trackPublications)}' .trackSid to a unique Track SID`, () => {
             rooms.forEach(room => {
-              var publications = room.localParticipant[trackPublications];
+              const publications = room.localParticipant[trackPublications];
               publications.forEach(publication => assert(publication.trackSid.match(/^MT[a-f0-9]{32}$/)));
             });
           });

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -1,9 +1,5 @@
 'use strict';
 
-if (typeof window === 'undefined') {
-  require('../../lib/mockwebrtc')();
-}
-
 const assert = require('assert');
 const { getUserMedia } = require('@twilio/webrtc');
 const connect = require('../../../lib/connect');
@@ -257,11 +253,7 @@ describe('connect', function() {
           return;
         }
 
-        // NOTE(mroberts): We don't actually raise Track events in Node, so skip these.
-        (navigator.userAgent === 'Node'
-          ? it.skip
-          : it
-        )('should eventually update each Participant\'s .tracks Map to contain a RemoteTrack for every one of its corresponding LocalParticipant\'s LocalTracks', async () => {
+        it('should eventually update each Participant\'s .tracks Map to contain a RemoteTrack for every one of its corresponding LocalParticipant\'s LocalTracks', async () => {
           await Promise.all(flatMap(rooms, ({ participants }) => {
             return [...participants.values()].map(participant => tracksAdded(participant, 2));
           }));
@@ -380,9 +372,7 @@ describe('connect', function() {
     });
   });
 
-  (navigator.userAgent === 'Node'
-    ? describe.skip
-    : describe)('called with EncodingParameters', () => {
+  describe('called with EncodingParameters', () => {
     combinationContext([
       [
         [undefined, null, 20000],
@@ -444,9 +434,7 @@ describe('connect', function() {
     });
   });
 
-  (navigator.userAgent === 'Node'
-    ? describe.skip
-    : describe)('called with preferred audio and video codecs', () => {
+  describe('called with preferred audio and video codecs', () => {
     let peerConnections;
     let thisRoom;
     let thoseRooms;
@@ -479,9 +467,7 @@ describe('connect', function() {
     });
   });
 
-  (navigator.userAgent === 'Node'
-    ? describe.skip
-    : describe)('when called with a fixed bitrate preferred audio codec', () => {
+  describe('when called with a fixed bitrate preferred audio codec', () => {
     let peerConnections;
     let thisRoom;
     let thoseRooms;
@@ -517,7 +503,7 @@ describe('connect', function() {
     });
   });
 
-  (navigator.userAgent === 'Node' ? describe.skip : describe)('Track names', () => {
+  describe('Track names', () => {
     describe('when called with pre-created Tracks', () => {
       combinationContext([
         [

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -633,8 +633,7 @@ describe('connect', function() {
       });
     });
 
-    // NOTE(mroberts): Waiting on a Group Rooms deploy.
-    describe.skip('"trackPublicationFailed" event', () => {
+    describe('"trackPublicationFailed" event', () => {
       combinationContext([
         [
           [

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -7,9 +7,7 @@ const sinon = require('sinon');
 const connect = require('../../../lib/connect');
 const { audio: createLocalAudioTrack, video: createLocalVideoTrack } = require('../../../lib/createlocaltrack');
 const createLocalTracks = require('../../../lib/createlocaltracks');
-const LocalAudioTrack = require('../../../lib/media/track/localaudiotrack');
 const LocalDataTrack = require('../../../lib/media/track/localdatatrack');
-const LocalVideoTrack = require('../../../lib/media/track/localvideotrack');
 const Room = require('../../../lib/room');
 const { flatMap } = require('../../../lib/util');
 const CancelablePromise = require('../../../lib/util/cancelablepromise');
@@ -23,6 +21,7 @@ const getToken = require('../../lib/token');
 const { capitalize, combinationContext, participantsConnected, pairs, randomName, tracksAdded, tracksPublished } = require('../../lib/util');
 
 describe('connect', function() {
+  // eslint-disable-next-line no-invalid-this
   this.timeout(60000);
 
   [
@@ -175,11 +174,11 @@ describe('connect', function() {
         rooms.forEach(room => assert.equal(room.name, withName ? name : room.sid));
       });
 
-      it(`should set ${n === 1 ? 'the' : 'each'} Room\'s LocalParticipant's .state to "connected"`, () => {
+      it(`should set ${n === 1 ? 'the' : 'each'} Room's LocalParticipant's .state to "connected"`, () => {
         rooms.forEach(room => assert.equal(room.localParticipant.state, 'connected'));
       });
 
-      it(`should set ${n === 1 ? 'the' : 'each'} Room\'s LocalParticipant's .sid to a ${n === 1 ? '' : 'unique '}Participant SID`, () => {
+      it(`should set ${n === 1 ? 'the' : 'each'} Room's LocalParticipant's .sid to a ${n === 1 ? '' : 'unique '}Participant SID`, () => {
         const sids = new Set(rooms.map(room => room.localParticipant.sid));
         assert.equal(sids.size, n);
         sids.forEach(sid => assert(sid.match(/^PA[a-f0-9]{32}$/)));
@@ -194,7 +193,7 @@ describe('connect', function() {
           rooms.forEach(room => assert.deepEqual(Array.from(room.localParticipant.tracks.values()), tracks));
         });
 
-        [ 'tracks', 'audioTracks', 'videoTracks' ].forEach(tracks => {
+        ['tracks', 'audioTracks', 'videoTracks'].forEach(tracks => {
           const trackPublications = `${tracks.slice(0, tracks.length - 1)}Publications`;
 
           it(`should update ${n === 1 ? 'the' : 'each'} Room's LocalParticipant's .${trackPublications} Map with the corresponding ${capitalize(trackPublications)}`, () => {
@@ -208,7 +207,7 @@ describe('connect', function() {
             });
           });
 
-          it(`should set ${n === 1 ? 'the' : 'each'} Room\'s LocalParticipant's ${capitalize(trackPublications)}' .trackSid to a unique Track SID`, () => {
+          it(`should set ${n === 1 ? 'the' : 'each'} Room's LocalParticipant's ${capitalize(trackPublications)}' .trackSid to a unique Track SID`, () => {
             rooms.forEach(room => {
               const publications = room.localParticipant[trackPublications];
               publications.forEach(publication => assert(publication.trackSid.match(/^MT[a-f0-9]{32}$/)));
@@ -324,7 +323,7 @@ describe('connect', function() {
     });
   });
 
-  [ true, false ].forEach(insights => {
+  [true, false].forEach(insights => {
     describe(`called with isInsightsEnabled = ${insights}`, () => {
       let InsightsPublisher;
       let NullInsightsPublisher;
@@ -499,7 +498,7 @@ describe('connect', function() {
     describe('when called with pre-created Tracks', () => {
       combinationContext([
         [
-          [{audio: 'foo', video: 'bar', data: 'baz'}, null],
+          [{ audio: 'foo', video: 'bar', data: 'baz' }, null],
           x => `when called with${x ? '' : 'out'} Track names`
         ],
         [
@@ -507,21 +506,21 @@ describe('connect', function() {
             {
               source: 'createLocalTracks',
               async getTracks(names) {
-                const options = names && {audio: {name: names.audio}, video: {name: names.video}};
+                const options = names && { audio: { name: names.audio }, video: { name: names.video } };
                 return await (options ? createLocalTracks(options) : createLocalTracks());
               }
             },
             {
               source: 'MediaStreamTracks from getUserMedia()',
               async getTracks() {
-                const mediaStream = await getUserMedia({audio: true, video: true, fake: true});
+                const mediaStream = await getUserMedia({ audio: true, video: true, fake: true });
                 return mediaStream.getAudioTracks().concat(mediaStream.getVideoTracks());
               }
             }
           ],
           ({ source }) => `when Tracks are pre-created using ${source}`
         ]
-      ], ([ names, { source, getTracks } ]) => {
+      ], ([names, { source, getTracks }]) => {
         if (source === 'MediaStreamTracks from getUserMedia()' && !!names) {
           return;
         }
@@ -533,10 +532,10 @@ describe('connect', function() {
         let tracks;
 
         before(async () => {
-          tracks = [...await getTracks(names), names ? new LocalDataTrack({name: names.data}) : new LocalDataTrack()];
+          tracks = [...await getTracks(names), names ? new LocalDataTrack({ name: names.data }) : new LocalDataTrack()];
 
           const name = randomName();
-          [ thisRoom, thoseRooms ] = await setup({name, tracks}, {tracks: []}, 0);
+          [thisRoom, thoseRooms] = await setup({ name, tracks }, { tracks: [] }, 0);
           thisParticipant = thisRoom.localParticipant;
           thisParticipants = thoseRooms.map(room => room.participants.get(thisParticipant.sid));
           await Promise.all(thisParticipants.map(participant => tracksAdded(participant, tracks.length)));
@@ -577,14 +576,14 @@ describe('connect', function() {
     describe('when called with constraints', () => {
       combinationContext([
         [
-          [{}, {audio: 'foo'}, {video: 'bar'}, {audio: 'foo', video: 'bar'}],
+          [{}, { audio: 'foo' }, { video: 'bar' }, { audio: 'foo', video: 'bar' }],
           x => [
-            () => `when called without Track names`,
+            () => 'when called without Track names',
             () => `when called with only ${x.audio ? 'an audio' : 'a video'} Track name`,
-            () => `when called with both audio and video Track names`
+            () => 'when called with both audio and video Track names'
           ][Object.keys(x).length]()
         ]
-      ], ([ names ]) => {
+      ], ([names]) => {
         let thisRoom;
         let thoseRooms;
         let thisParticipant;
@@ -597,7 +596,7 @@ describe('connect', function() {
             video: names.video ? { name: names.video } : true,
             name
           };
-          [ thisRoom, thoseRooms ] = await setup(options, {tracks: []}, 0);
+          [thisRoom, thoseRooms] = await setup(options, { tracks: [] }, 0);
           thisParticipant = thisRoom.localParticipant;
           thisParticipants = thoseRooms.map(room => room.participants.get(thisParticipant.sid));
           await Promise.all(thisParticipants.map(participant => tracksAdded(participant, thisParticipant.tracks.size)));
@@ -667,6 +666,8 @@ describe('connect', function() {
           ({ scenario }) => `called with ${scenario}`
         ]
       ], ([{ createLocalTracks, scenario, TwilioError }]) => {
+        void scenario;
+
         let room;
         let tracks;
         let trackPublicationFailed;
@@ -736,14 +737,14 @@ function getCodecPayloadTypes(mediaSection) {
 }
 
 async function setup(testOptions, otherOptions, nTracks, alone) {
-  const options = Object.assign({name: randomName()}, testOptions, defaults);
+  const options = Object.assign({ name: randomName() }, testOptions, defaults);
   const token = getToken(randomName());
   const thisRoom = await connect(token, options);
   if (alone) {
     return [thisRoom];
   }
 
-  const thoseOptions = Object.assign({name: options.name}, otherOptions || {}, defaults);
+  const thoseOptions = Object.assign({ name: options.name }, otherOptions || {}, defaults);
   const thoseTokens = [randomName(), randomName()].map(getToken);
   const thoseRooms = await Promise.all(thoseTokens.map(token => connect(token, thoseOptions)));
 

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -378,7 +378,7 @@ describe('LocalParticipant', function() {
     });
 
     // NOTE(mroberts): Waiting on a Group Rooms deploy.
-    describe.skip('"trackPublicationFailed" event', () => {
+    describe('"trackPublicationFailed" event', () => {
       combinationContext([
         [
           [

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -1,16 +1,6 @@
 'use strict';
 
 const assert = require('assert');
-const getToken = require('../../lib/token');
-const env = require('../../env');
-const { flatMap, guessBrowser } = require('../../../lib/util');
-const { getMediaSections } = require('../../../lib/util/sdp');
-const Track = require('../../../lib/media/track');
-const LocalTrackPublication = require('../../../lib/media/track/localtrackpublication');
-const RemoteAudioTrack = require('../../../lib/media/track/remoteaudiotrack');
-const RemoteDataTrack = require('../../../lib/media/track/remotedatatrack');
-const RemoteVideoTrack = require('../../../lib/media/track/remotevideotrack');
-const { TrackNameIsDuplicatedError, TrackNameTooLongError } = require('../../../lib/util/twilio-video-errors');
 
 const {
   connect,
@@ -19,6 +9,19 @@ const {
   createLocalVideoTrack,
   LocalDataTrack
 } = require('../../../lib');
+
+const LocalTrackPublication = require('../../../lib/media/track/localtrackpublication');
+const Track = require('../../../lib/media/track');
+const RemoteAudioTrack = require('../../../lib/media/track/remoteaudiotrack');
+const RemoteDataTrack = require('../../../lib/media/track/remotedatatrack');
+const RemoteVideoTrack = require('../../../lib/media/track/remotevideotrack');
+const { flatMap } = require('../../../lib/util');
+const { getMediaSections } = require('../../../lib/util/sdp');
+const { TrackNameIsDuplicatedError, TrackNameTooLongError } = require('../../../lib/util/twilio-video-errors');
+
+const defaults = require('../../lib/defaults');
+const { isFirefox, isSafari } = require('../../lib/guessbrowser');
+const getToken = require('../../lib/token');
 
 const {
   capitalize,
@@ -33,18 +36,6 @@ const {
   waitForTracks
 } = require('../../lib/util');
 
-const defaultOptions = ['ecsServer', 'logLevel', 'wsServer', 'wsServerInsights'].reduce((defaultOptions, option) => {
-  if (env[option] !== undefined) {
-    defaultOptions[option] = env[option];
-  }
-  return defaultOptions;
-}, {});
-
-const guess = guessBrowser();
-const isChrome = guess === 'chrome';
-const isFirefox = guess === 'firefox';
-const isSafari = guess === 'safari';
-
 describe('LocalParticipant', function() {
   this.timeout(60000);
 
@@ -55,7 +46,7 @@ describe('LocalParticipant', function() {
 
     const setup = async () => {
       const name = randomName();
-      const options = Object.assign({ name, tracks: [] }, defaultOptions);
+      const options = Object.assign({ name, tracks: [] }, defaults);
       const token = getToken(randomName());
       [ room, tracks ] = await Promise.all([
         connect(token, options),
@@ -127,7 +118,7 @@ describe('LocalParticipant', function() {
 
       before(async () => {
         const name = randomName();
-        const options = Object.assign({ name, tracks: [] }, defaultOptions);
+        const options = Object.assign({ name, tracks: [] }, defaults);
         const token = getToken(randomName());
 
         [ anotherRoom ] = await Promise.all([
@@ -236,7 +227,7 @@ describe('LocalParticipant', function() {
       before(async () => {
         const name = randomName();
         const identities = [randomName(), randomName(), randomName()];
-        const options = Object.assign({ name }, defaultOptions);
+        const options = Object.assign({ name }, defaults);
         const localTrackOptions = withName ? { name: localTrackNameByKind } : {};
 
         thisTrack = await {
@@ -475,7 +466,7 @@ describe('LocalParticipant', function() {
       before(async () => {
         const name = randomName();
         const identities = [randomName(), randomName(), randomName()];
-        const options = Object.assign({ name }, defaultOptions);
+        const options = Object.assign({ name }, defaults);
 
         thisTrack = await {
           audio: createLocalAudioTrack,
@@ -628,13 +619,13 @@ describe('LocalParticipant', function() {
       const constraints = { video: true, fake: true };
 
       // Answerer
-      const thoseOptions = Object.assign({ name, tracks: [] }, defaultOptions);
+      const thoseOptions = Object.assign({ name, tracks: [] }, defaults);
       thatRoom = await connect(getToken(randomName()), thoseOptions);
 
       [thisTrack1] = await createLocalTracks(constraints);
 
       // Offerer
-      const theseOptions = Object.assign({ name, tracks: [thisTrack1] }, defaultOptions);
+      const theseOptions = Object.assign({ name, tracks: [thisTrack1] }, defaults);
       thisRoom = await connect(getToken(randomName()), theseOptions);
       thisParticipant = thisRoom.localParticipant;
 
@@ -732,13 +723,13 @@ describe('LocalParticipant', function() {
       const constraints = { audio: true, video: true, fake: true };
 
       // Answerer
-      const thoseOptions = Object.assign({ name, tracks: [] }, defaultOptions);
+      const thoseOptions = Object.assign({ name, tracks: [] }, defaults);
       thatRoom = await connect(getToken(randomName()), thoseOptions);
 
       [thisAudioTrack, thisVideoTrack] = await createLocalTracks(constraints);
 
       // Offerer
-      const theseOptions = Object.assign({ name, tracks: [] }, defaultOptions);
+      const theseOptions = Object.assign({ name, tracks: [] }, defaults);
       thisRoom = await connect(getToken(randomName()), theseOptions);
       thisParticipant = thisRoom.localParticipant;
 
@@ -837,11 +828,11 @@ describe('LocalParticipant', function() {
       let thoseRooms;
 
       before(async () => {
-        const options = Object.assign({name: randomName()}, initialEncodingParameters, defaultOptions);
+        const options = Object.assign({name: randomName()}, initialEncodingParameters, defaults);
         const token = getToken(randomName());
         thisRoom = await connect(token, options);
 
-        const thoseOptions = Object.assign({name: options.name}, defaultOptions);
+        const thoseOptions = Object.assign({name: options.name}, defaults);
         const thoseTokens = [randomName(), randomName()].map(getToken);
         thoseRooms = await Promise.all(thoseTokens.map(token => connect(token, thoseOptions)));
 

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -1,9 +1,5 @@
 'use strict';
 
-if (typeof window === 'undefined') {
-  require('../../lib/mockwebrtc')();
-}
-
 const assert = require('assert');
 const getToken = require('../../lib/token');
 const env = require('../../env');
@@ -49,10 +45,7 @@ const isChrome = guess === 'chrome';
 const isFirefox = guess === 'firefox';
 const isSafari = guess === 'safari';
 
-(navigator.userAgent === 'Node'
-  ? describe.skip
-  : describe
-)('LocalParticipant', function() {
+describe('LocalParticipant', function() {
   this.timeout(60000);
 
   describe('#publishTrack', () => {

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -11,7 +11,6 @@ const {
 } = require('../../../lib');
 
 const LocalTrackPublication = require('../../../lib/media/track/localtrackpublication');
-const Track = require('../../../lib/media/track');
 const RemoteAudioTrack = require('../../../lib/media/track/remoteaudiotrack');
 const RemoteDataTrack = require('../../../lib/media/track/remotedatatrack');
 const RemoteVideoTrack = require('../../../lib/media/track/remotevideotrack');
@@ -27,7 +26,6 @@ const {
   capitalize,
   combinationContext,
   participantsConnected,
-  pairs,
   randomName,
   tracksAdded,
   tracksPublished,
@@ -37,6 +35,7 @@ const {
 } = require('../../lib/util');
 
 describe('LocalParticipant', function() {
+  // eslint-disable-next-line no-invalid-this
   this.timeout(60000);
 
   describe('#publishTrack', () => {
@@ -44,20 +43,20 @@ describe('LocalParticipant', function() {
     let room;
     let tracks;
 
-    const setup = async () => {
+    async function setup() {
       const name = randomName();
       const options = Object.assign({ name, tracks: [] }, defaults);
       const token = getToken(randomName());
-      [ room, tracks ] = await Promise.all([
+      [room, tracks] = await Promise.all([
         connect(token, options),
         createLocalTracks()
       ]);
       tracks.push(new LocalDataTrack());
-    };
+    }
 
     [
       [
-        `when three LocalTracks (audio, video, and data) are published sequentially`,
+        'when three LocalTracks (audio, video, and data) are published sequentially',
         async () => {
           trackPublications = [
             await room.localParticipant.publishTrack(tracks[0]),
@@ -67,14 +66,14 @@ describe('LocalParticipant', function() {
         }
       ],
       [
-        `when three LocalTracks (audio, video, and date) are published together`,
+        'when three LocalTracks (audio, video, and date) are published together',
         async () => {
           trackPublications = await Promise.all(tracks.map(track => {
             return room.localParticipant.publishTrack(track);
           }));
         }
       ]
-    ].forEach(([ ctx, publish ]) => {
+    ].forEach(([ctx, publish]) => {
       context(ctx, () => {
         before(async () => {
           await setup();
@@ -121,7 +120,7 @@ describe('LocalParticipant', function() {
         const options = Object.assign({ name, tracks: [] }, defaults);
         const token = getToken(randomName());
 
-        [ anotherRoom ] = await Promise.all([
+        [anotherRoom] = await Promise.all([
           connect(token, options),
           setup()
         ]);
@@ -289,7 +288,7 @@ describe('LocalParticipant', function() {
 
         [thisLocalTrackPublication, thoseTracksAdded, thoseTracksSubscribed] = await Promise.all([
           thisParticipant.publishTrack(thisTrack),
-          ...[ 'trackAdded', 'trackSubscribed' ].map(event => {
+          ...['trackAdded', 'trackSubscribed'].map(event => {
             return Promise.all(thoseParticipants.map(async thatParticipant => {
               const [track] = await waitForTracks(event, thatParticipant, 1);
               return track;
@@ -317,7 +316,7 @@ describe('LocalParticipant', function() {
         [thisRoom].concat(thoseRooms).forEach(room => room.disconnect());
       });
 
-      [ 'trackAdded', 'trackSubscribed' ].forEach(event => {
+      ['trackAdded', 'trackSubscribed'].forEach(event => {
         it(`should raise a "${event}" event on the corresponding RemoteParticipants with a RemoteTrack`, () => {
           const thoseTracks = thoseTracksMap[event];
           thoseTracks.forEach(thatTrack => assert(thatTrack instanceof {
@@ -403,6 +402,8 @@ describe('LocalParticipant', function() {
           ({ scenario }) => `called with ${scenario}`
         ]
       ], ([{ createLocalTrack, scenario, TwilioError }]) => {
+        void scenario;
+
         let track;
         let trackPublicationFailed;
 
@@ -435,7 +436,7 @@ describe('LocalParticipant', function() {
       });
     });
   });
-  
+
   describe('#unpublishTrack', () => {
     combinationContext([
       [
@@ -557,7 +558,7 @@ describe('LocalParticipant', function() {
         await thoseUnsubscribed;
       });
 
-      [ 'trackRemoved', 'trackUnsubscribed' ].forEach(event => {
+      ['trackRemoved', 'trackUnsubscribed'].forEach(event => {
         it(`should raise a "${event}" event on the corresponding RemoteParticipants with a RemoteTrack`, () => {
           const thoseTracks = thoseTracksMap[event];
           thoseTracks.forEach(thatTrack => assert(thatTrack instanceof {
@@ -585,7 +586,7 @@ describe('LocalParticipant', function() {
             });
           }
 
-          it(`should set each RemoteTrack's .isSubscribed to false`, () => {
+          it('should set each RemoteTrack\'s .isSubscribed to false', () => {
             const thoseTracks = thoseTracksMap[event];
             thoseTracks.forEach(thatTrack => assert.equal(thatTrack.isSubscribed, false));
           });
@@ -672,10 +673,10 @@ describe('LocalParticipant', function() {
       thatRoom.disconnect();
     });
 
-    [ 'trackUnsubscribed', 'trackRemoved' ].forEach(event => {
+    ['trackUnsubscribed', 'trackRemoved'].forEach(event => {
       it(`should eventually raise a "${event}" event with the unpublished LocalVideoTrack`, () => {
         const thatTrack = thatTracksUnpublished[event];
-        assert.equal(thatTrack.sid, thisLocalTrackPublication1.trackSid)
+        assert.equal(thatTrack.sid, thisLocalTrackPublication1.trackSid);
         assert.equal(thatTrack.kind, thisLocalTrackPublication1.kind);
         assert.equal(thatTrack.enabled, thisLocalTrackPublication1.enabled);
         if (!isFirefox && !isSafari) {
@@ -684,10 +685,10 @@ describe('LocalParticipant', function() {
       });
     });
 
-    [ 'trackAdded', 'trackSubscribed' ].forEach(event => {
+    ['trackAdded', 'trackSubscribed'].forEach(event => {
       it(`should eventually raise a "${event}" event with the unpublished LocalVideoTrack`, () => {
         const thatTrack = thatTracksPublished[event];
-        assert.equal(thatTrack.sid, thisLocalTrackPublication2.trackSid)
+        assert.equal(thatTrack.sid, thisLocalTrackPublication2.trackSid);
         assert.equal(thatTrack.kind, thisLocalTrackPublication2.kind);
         assert.equal(thatTrack.enabled, thisLocalTrackPublication2.enabled);
         assert.equal(thatTrack.mediaStreamTrack.readyState, thisTrack2.mediaStreamTrack.readyState);
@@ -742,14 +743,16 @@ describe('LocalParticipant', function() {
 
       let thoseTracksAdded;
       let thoseTracksSubscribed;
-      [ thisLocalAudioTrackPublication, thisLocalVideoTrackPublication, thoseTracksAdded, thoseTracksSubscribed] =  await Promise.all([
+      [thisLocalAudioTrackPublication, thisLocalVideoTrackPublication, thoseTracksAdded, thoseTracksSubscribed] =  await Promise.all([
         thisParticipant.publishTrack(thisAudioTrack),
         thisParticipant.publishTrack(thisVideoTrack),
         waitForTracks('trackAdded', thatParticipant, 2),
         waitForTracks('trackSubscribed', thatParticipant, 2)
       ]);
 
-      const findTrack = (tracks, kind) => tracks.find(track => track.kind === kind);
+      function findTrack(tracks, kind) {
+        return tracks.find(track => track.kind === kind);
+      }
 
       thoseAudioTracks = {
         trackAdded: findTrack(thoseTracksAdded, 'audio'),
@@ -768,7 +771,7 @@ describe('LocalParticipant', function() {
       thatRoom.disconnect();
     });
 
-    [ 'trackAdded', 'trackSubscribed' ].forEach(event => {
+    ['trackAdded', 'trackSubscribed'].forEach(event => {
       it(`should eventually raise a "${event}" event for each published LocalTracks`, () => {
         const thatAudioTrack = thoseAudioTracks[event];
         assert.equal(thatAudioTrack.sid, thisLocalAudioTrackPublication.trackSid);
@@ -785,8 +788,8 @@ describe('LocalParticipant', function() {
     });
 
     it('should eventually raise a "trackStarted" event for each published LocalTrack', async () => {
-      const thatAudioTrack = thoseAudioTracks['trackAdded'];
-      const thatVideoTrack = thoseVideoTracks['trackAdded'];
+      const thatAudioTrack = thoseAudioTracks.trackAdded;
+      const thatVideoTrack = thoseVideoTracks.trackAdded;
       await Promise.all([thatAudioTrack, thatVideoTrack].map(trackStarted));
     });
   });
@@ -828,11 +831,11 @@ describe('LocalParticipant', function() {
       let thoseRooms;
 
       before(async () => {
-        const options = Object.assign({name: randomName()}, initialEncodingParameters, defaults);
+        const options = Object.assign({ name: randomName() }, initialEncodingParameters, defaults);
         const token = getToken(randomName());
         thisRoom = await connect(token, options);
 
-        const thoseOptions = Object.assign({name: options.name}, defaults);
+        const thoseOptions = Object.assign({ name: options.name }, defaults);
         const thoseTokens = [randomName(), randomName()].map(getToken);
         thoseRooms = await Promise.all(thoseTokens.map(token => connect(token, thoseOptions)));
 
@@ -842,16 +845,18 @@ describe('LocalParticipant', function() {
         peerConnections = [...thisRoom._signaling._peerConnectionManager._peerConnections.values()].map(pcv2 => pcv2._peerConnection);
         thisRoom.localParticipant.setParameters(encodingParameters);
 
-        const getRemoteDescription = pc => Object.keys(encodingParameters).length > 0
-          ? new Promise(resolve => {
-            const pcSetRemoteDescription = pc.setRemoteDescription;
-            pc.setRemoteDescription = function setRemoteDescription(description) {
-              resolve(description);
-              pc.setRemoteDescription = pcSetRemoteDescription;
-              return pcSetRemoteDescription.call(this, description);
-            };
-          })
-          : Promise.resolve(pc.remoteDescription);
+        function getRemoteDescription(pc) {
+          return Object.keys(encodingParameters).length > 0
+            ? new Promise(resolve => {
+              const pcSetRemoteDescription = pc.setRemoteDescription;
+              pc.setRemoteDescription = function setRemoteDescription(description) {
+                resolve(description);
+                pc.setRemoteDescription = pcSetRemoteDescription;
+                return pcSetRemoteDescription.call(this, description);
+              };
+            })
+            : Promise.resolve(pc.remoteDescription);
+        }
 
         remoteDescriptions = await Promise.all(peerConnections.map(getRemoteDescription));
       });

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -343,7 +343,8 @@ describe('LocalParticipant', function() {
           });
 
           if (kind === 'data') {
-            it('should transmit any data sent through the LocalDataTrack to the Room to each RemoteDataTrack', async () => {
+            // TODO(mroberts): Awaiting a server deploy. Uncomment me once fixed.
+            it.skip('should transmit any data sent through the LocalDataTrack to the Room to each RemoteDataTrack', async () => {
               const thoseTracks = thoseTracksMap[event];
               const thoseTracksReceivedData = thoseTracks.map(track => new Promise(resolve => track.once('message', resolve)));
               dataChannelSendInterval = setInterval(() => thisTrack.send('foo'), 1000);

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -873,7 +873,8 @@ describe('LocalParticipant', function() {
             const modifier = isFirefox
               ? 'TIAS'
               : 'AS';
-            var maxBitrate = action === 'preserve'
+
+            let maxBitrate = action === 'preserve'
               ? initialEncodingParameters[`max${capitalize(kind)}Bitrate`]
               : maxBitrates[kind];
 
@@ -886,6 +887,7 @@ describe('LocalParticipant', function() {
             const bLinePattern = maxBitrate
               ? new RegExp(`\r\nb=${modifier}:${maxBitrate}`)
               : /\r\nb=(AS|TIAS)/;
+
             assert(maxBitrate ? bLinePattern.test(section) : !bLinePattern.test(section));
           });
         });

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -1,9 +1,5 @@
 'use strict';
 
-if (typeof window === 'undefined') {
-  require('../../lib/mockwebrtc')();
-}
-
 const assert = require('assert');
 const getToken = require('../../lib/token');
 const env = require('../../env');
@@ -41,10 +37,7 @@ const defaultOptions = ['ecsServer', 'logLevel', 'wsServer', 'wsServerInsights']
 const guess = guessBrowser();
 const isFirefox = guess === 'firefox';
 
-(navigator.userAgent === 'Node'
-    ? describe.skip
-    : describe
-)('LocalTrackPublication', function() {
+describe('LocalTrackPublication', function() {
   this.timeout(60000);
   describe('#unpublish', () => {
     combinationContext([

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -27,6 +27,8 @@ const {
   waitForTracks
 } = require('../../lib/util');
 
+const { isFirefox } = require('../../lib/guessbrowser');
+
 describe('LocalTrackPublication', function() {
   // eslint-disable-next-line no-invalid-this
   this.timeout(60000);

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -1,14 +1,6 @@
 'use strict';
 
 const assert = require('assert');
-const getToken = require('../../lib/token');
-const env = require('../../env');
-const { flatMap, guessBrowser } = require('../../../lib/util');
-const Track = require('../../../lib/media/track');
-const LocalTrackPublication = require('../../../lib/media/track/localtrackpublication');
-const RemoteAudioTrack = require('../../../lib/media/track/remoteaudiotrack');
-const RemoteDataTrack = require('../../../lib/media/track/remotedatatrack');
-const RemoteVideoTrack = require('../../../lib/media/track/remotevideotrack');
 
 const {
   connect,
@@ -16,6 +8,17 @@ const {
   createLocalVideoTrack,
   LocalDataTrack
 } = require('../../../lib');
+
+const Track = require('../../../lib/media/track');
+const LocalTrackPublication = require('../../../lib/media/track/localtrackpublication');
+const RemoteAudioTrack = require('../../../lib/media/track/remoteaudiotrack');
+const RemoteDataTrack = require('../../../lib/media/track/remotedatatrack');
+const RemoteVideoTrack = require('../../../lib/media/track/remotevideotrack');
+const { flatMap } = require('../../../lib/util');
+
+const defaults = require('../../lib/defaults');
+const { isFirefox } = require('../../lib/guessbrowser');
+const getToken = require('../../lib/token');
 
 const {
   capitalize,
@@ -26,16 +29,6 @@ const {
   tracksRemoved,
   waitForTracks
 } = require('../../lib/util');
-
-const defaultOptions = ['ecsServer', 'logLevel', 'wsServer', 'wsServerInsights'].reduce((defaultOptions, option) => {
-  if (env[option] !== undefined) {
-    defaultOptions[option] = env[option];
-  }
-  return defaultOptions;
-}, {});
-
-const guess = guessBrowser();
-const isFirefox = guess === 'firefox';
 
 describe('LocalTrackPublication', function() {
   this.timeout(60000);
@@ -72,7 +65,7 @@ describe('LocalTrackPublication', function() {
         const identities = kind === 'data'
           ? [randomName(), randomName()]
           : [randomName(), randomName(), randomName()];
-        const options = Object.assign({name}, defaultOptions);
+        const options = Object.assign({name}, defaults);
 
         thisTrack = await {
           audio: createLocalAudioTrack,

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -9,15 +9,12 @@ const {
   LocalDataTrack
 } = require('../../../lib');
 
-const Track = require('../../../lib/media/track');
-const LocalTrackPublication = require('../../../lib/media/track/localtrackpublication');
 const RemoteAudioTrack = require('../../../lib/media/track/remoteaudiotrack');
 const RemoteDataTrack = require('../../../lib/media/track/remotedatatrack');
 const RemoteVideoTrack = require('../../../lib/media/track/remotevideotrack');
 const { flatMap } = require('../../../lib/util');
 
 const defaults = require('../../lib/defaults');
-const { isFirefox } = require('../../lib/guessbrowser');
 const getToken = require('../../lib/token');
 
 const {
@@ -31,7 +28,9 @@ const {
 } = require('../../lib/util');
 
 describe('LocalTrackPublication', function() {
+  // eslint-disable-next-line no-invalid-this
   this.timeout(60000);
+
   describe('#unpublish', () => {
     combinationContext([
       [
@@ -65,7 +64,7 @@ describe('LocalTrackPublication', function() {
         const identities = kind === 'data'
           ? [randomName(), randomName()]
           : [randomName(), randomName(), randomName()];
-        const options = Object.assign({name}, defaults);
+        const options = Object.assign({ name }, defaults);
 
         thisTrack = await {
           audio: createLocalAudioTrack,
@@ -88,13 +87,13 @@ describe('LocalTrackPublication', function() {
 
         const thisIdentity = identities[0];
         const thisToken = getToken(thisIdentity);
-        const theseOptions = Object.assign({tracks}, options);
+        const theseOptions = Object.assign({ tracks }, options);
         thisRoom = await connect(thisToken, theseOptions);
         thisParticipant = thisRoom.localParticipant;
 
         const thoseIdentities = identities.slice(1);
         const thoseTokens = thoseIdentities.map(getToken);
-        const thoseOptions = Object.assign({tracks: []}, options);
+        const thoseOptions = Object.assign({ tracks: [] }, options);
         thoseRooms = await Promise.all(thoseTokens.map(thatToken => connect(thatToken, thoseOptions)));
 
         await Promise.all([thisRoom].concat(thoseRooms).map(room => {
@@ -185,7 +184,7 @@ describe('LocalTrackPublication', function() {
             });
           }
 
-          it(`should set each RemoteTrack's .isSubscribed to false`, () => {
+          it('should set each RemoteTrack\'s .isSubscribed to false', () => {
             const thoseTracks = thoseTracksMap[event];
             thoseTracks.forEach(thatTrack => assert.equal(thatTrack.isSubscribed, false));
           });

--- a/test/integration/spec/localtracks.js
+++ b/test/integration/spec/localtracks.js
@@ -1,9 +1,5 @@
 'use strict';
 
-if (typeof window === 'undefined') {
-  require('../../lib/mockwebrtc')();
-}
-
 const assert = require('assert');
 const createLocalTracks = require('../../../lib/createlocaltrack');
 const { guessBrowser } = require('../../../lib/util');
@@ -17,10 +13,7 @@ const isSafari = guess === 'safari';
   const createLocalTrack = createLocalTracks[kind];
   const description = 'Local' + kind[0].toUpperCase() + kind.slice(1) + 'Track';
 
-  (navigator.userAgent === 'Node'
-    ? describe.skip
-    : describe
-  )(description, function() {
+  describe(description, function() {
     this.timeout(10000);
 
     let localTrack = null;

--- a/test/integration/spec/localtracks.js
+++ b/test/integration/spec/localtracks.js
@@ -1,13 +1,10 @@
 'use strict';
 
 const assert = require('assert');
-const createLocalTracks = require('../../../lib/createlocaltrack');
-const { guessBrowser } = require('../../../lib/util');
 
-const guess = guessBrowser();
-const isChrome = guess === 'chrome';
-const isFirefox = guess === 'firefox';
-const isSafari = guess === 'safari';
+const createLocalTracks = require('../../../lib/createlocaltrack');
+
+const { isChrome, isFirefox, isSafari } = require('../../lib/guessbrowser');
 
 ['audio', 'video'].forEach(kind => {
   const createLocalTrack = createLocalTracks[kind];

--- a/test/integration/spec/localtracks.js
+++ b/test/integration/spec/localtracks.js
@@ -4,13 +4,12 @@ const assert = require('assert');
 
 const createLocalTracks = require('../../../lib/createlocaltrack');
 
-const { isChrome, isFirefox, isSafari } = require('../../lib/guessbrowser');
-
 ['audio', 'video'].forEach(kind => {
   const createLocalTrack = createLocalTracks[kind];
   const description = 'Local' + kind[0].toUpperCase() + kind.slice(1) + 'Track';
 
   describe(description, function() {
+    // eslint-disable-next-line no-invalid-this
     this.timeout(10000);
 
     let localTrack = null;

--- a/test/integration/spec/room.js
+++ b/test/integration/spec/room.js
@@ -1,9 +1,5 @@
 'use strict';
 
-if (typeof window === 'undefined') {
-  require('../../lib/mockwebrtc')();
-}
-
 const assert = require('assert');
 const connect = require('../../../lib/connect');
 const getToken = require('../../lib/token');
@@ -156,10 +152,8 @@ describe('Room', function() {
 
       await Promise.all(flatMap([thisRoom, thatRoom], room => participantsConnected(room, 1)));
 
-      if (navigator.userAgent !== 'Node') {
-        await Promise.all(flatMap([...thatRoom.participants.values()], participant =>
-          tracksAdded(participant, thisParticipant.tracks.size)));
-      }
+      await Promise.all(flatMap([...thatRoom.participants.values()], participant =>
+        tracksAdded(participant, thisParticipant.tracks.size)));
 
       const participantDisconnected = new Promise(resolve => thatRoom.once('participantDisconnected', resolve));
 

--- a/test/integration/spec/room.js
+++ b/test/integration/spec/room.js
@@ -11,6 +11,7 @@ const getToken = require('../../lib/token');
 const { participantsConnected, randomName, tracksAdded, waitForTracks } = require('../../lib/util');
 
 describe('Room', function() {
+  // eslint-disable-next-line no-invalid-this
   this.timeout(60000);
 
   describe('disconnect', () => {

--- a/test/integration/spec/room.js
+++ b/test/integration/spec/room.js
@@ -1,19 +1,14 @@
 'use strict';
 
 const assert = require('assert');
-const connect = require('../../../lib/connect');
-const getToken = require('../../lib/token');
-const { flatMap } = require('../../../lib/util');
-const env = require('../../env');
-const { participantsConnected, randomName, tracksAdded, waitForTracks } = require('../../lib/util');
-const RemoteParticipant = require('../../../lib/remoteparticipant');
 
-const options = ['ecsServer', 'logLevel', 'wsServer', 'wsServerInsights'].reduce((options, option) => {
-  if (env[option] !== undefined) {
-    options[option] = env[option];
-  }
-  return options;
-}, {});
+const connect = require('../../../lib/connect');
+const RemoteParticipant = require('../../../lib/remoteparticipant');
+const { flatMap } = require('../../../lib/util');
+
+const defaults = require('../../lib/defaults');
+const getToken = require('../../lib/token');
+const { participantsConnected, randomName, tracksAdded, waitForTracks } = require('../../lib/util');
 
 describe('Room', function() {
   this.timeout(60000);
@@ -33,7 +28,7 @@ describe('Room', function() {
       const identities = [randomName(), randomName(), randomName()];
       const tokens = identities.map(getToken);
       const name = randomName();
-      rooms = await Promise.all(tokens.map(token => connect(token, Object.assign({ name }, options))));
+      rooms = await Promise.all(tokens.map(token => connect(token, Object.assign({ name }, defaults))));
       await Promise.all(rooms.map(room => participantsConnected(room, rooms.length - 1)));
 
       room = rooms[0];
@@ -102,7 +97,7 @@ describe('Room', function() {
     let thatParticipant;
 
     before(async () => {
-      thisRoom = await connect(getToken(randomName()), options);
+      thisRoom = await connect(getToken(randomName()), defaults);
     });
 
     after(() => {
@@ -114,7 +109,7 @@ describe('Room', function() {
 
     it('is raised whenever a RemoteParticipant connects to the Room', async () => {
       const participantConnected = new Promise(resolve => thisRoom.once('participantConnected', resolve));
-      thatRoom = await connect(getToken(randomName()), Object.assign({ name: thisRoom.name }, options));
+      thatRoom = await connect(getToken(randomName()), Object.assign({ name: thisRoom.name }, defaults));
       thisParticipant = await participantConnected;
       thatParticipant = thatRoom.localParticipant;
       assert(thisParticipant instanceof RemoteParticipant);
@@ -147,7 +142,7 @@ describe('Room', function() {
       const tokens = identities.map(getToken);
       const name = randomName();
 
-      [thisRoom, thatRoom] = await Promise.all(tokens.map(token => connect(token, Object.assign({ name }, options))));
+      [thisRoom, thatRoom] = await Promise.all(tokens.map(token => connect(token, Object.assign({ name }, defaults))));
       thisParticipant = thisRoom.localParticipant;
 
       await Promise.all(flatMap([thisRoom, thatRoom], room => participantsConnected(room, 1)));

--- a/test/integration/spec/util/insightspublisher.js
+++ b/test/integration/spec/util/insightspublisher.js
@@ -1,9 +1,5 @@
 'use strict';
 
-if (typeof window === 'undefined') {
-  require('../../../lib/mockwebrtc')();
-}
-
 const InsightsPublisher = require('../../../../lib/util/insightspublisher');
 const a = require('../../../lib/util').a;
 const assert = require('assert');

--- a/test/integration/spec/util/insightspublisher.js
+++ b/test/integration/spec/util/insightspublisher.js
@@ -14,6 +14,11 @@ const tokens = new Map([
   ['valid', getToken('foo')]
 ]);
 
+const options = Object.assign({}, defaults);
+if (defaults.wsServerInsights) {
+  options.gateway = defaults.wsServerInsights;
+}
+
 describe('InsightsPublisher', function() {
   // eslint-disable-next-line no-invalid-this
   this.timeout(30000);
@@ -29,7 +34,7 @@ describe('InsightsPublisher', function() {
             '1.2.3',
             'prod',
             'us1',
-            defaults);
+            options);
         });
 
         const description = tokenType !== 'valid'
@@ -63,7 +68,7 @@ describe('InsightsPublisher', function() {
         '1.2.3',
         'prod',
         'us1',
-        defaults);
+        options);
 
       publisher.once('connected', () => publisher.disconnect());
       const error = await new Promise(resolve => publisher.once('disconnected', resolve));

--- a/test/integration/spec/util/insightspublisher.js
+++ b/test/integration/spec/util/insightspublisher.js
@@ -19,7 +19,7 @@ describe('InsightsPublisher', function() {
 
   describe('connect', () => {
     ['expired', 'invalid', 'valid'].forEach(tokenType => {
-      var publisher;
+      let publisher;
 
       context(`when attempted with ${a(tokenType)} ${tokenType} token`, () => {
         before(() => {

--- a/test/integration/spec/util/insightspublisher.js
+++ b/test/integration/spec/util/insightspublisher.js
@@ -11,10 +11,11 @@ const { a } = require('../../../lib/util');
 const tokens = new Map([
   ['expired', getToken('foo', { ttl: 60 * -1000 })],
   ['invalid', 'foo'],
-  ['valid', getToken('foo') ]
+  ['valid', getToken('foo')]
 ]);
 
 describe('InsightsPublisher', function() {
+  // eslint-disable-next-line no-invalid-this
   this.timeout(30000);
 
   describe('connect', () => {

--- a/test/integration/spec/util/insightspublisher.js
+++ b/test/integration/spec/util/insightspublisher.js
@@ -1,15 +1,12 @@
 'use strict';
 
-const InsightsPublisher = require('../../../../lib/util/insightspublisher');
-const a = require('../../../lib/util').a;
 const assert = require('assert');
-const getToken = require('../../../lib/token');
-const { wsServerInsights } = require('../../../env');
 
-const options = {};
-if (wsServerInsights) {
-  options.gateway = wsServerInsights;
-}
+const InsightsPublisher = require('../../../../lib/util/insightspublisher');
+
+const defaults = require('../../../lib/defaults');
+const getToken = require('../../../lib/token');
+const { a } = require('../../../lib/util');
 
 const tokens = new Map([
   ['expired', getToken('foo', { ttl: 60 * -1000 })],
@@ -31,7 +28,7 @@ describe('InsightsPublisher', function() {
             '1.2.3',
             'prod',
             'us1',
-            options);
+            defaults);
         });
 
         const description = tokenType !== 'valid'
@@ -65,7 +62,7 @@ describe('InsightsPublisher', function() {
         '1.2.3',
         'prod',
         'us1',
-        options);
+        defaults);
 
       publisher.once('connected', () => publisher.disconnect());
       const error = await new Promise(resolve => publisher.once('disconnected', resolve));

--- a/test/integration/spec/util/support.js
+++ b/test/integration/spec/util/support.js
@@ -3,9 +3,7 @@
 const assert = require('assert');
 const isSupported = require('../../../../lib/util/support');
 
-(navigator.userAgent === 'Node'
-  ? describe.skip
-  : describe)('isBrowserSupported', () => {
+describe('isBrowserSupported', () => {
   context('when called in a browser that has the getUserMedia and RTCPeerConnection APIs', () => {
     it('should return true', () => {
       assert(isSupported());

--- a/test/integration/spec/util/support.js
+++ b/test/integration/spec/util/support.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+
 const isSupported = require('../../../../lib/util/support');
 
 describe('isBrowserSupported', () => {

--- a/test/lib/defaults.js
+++ b/test/lib/defaults.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const env = require('../env');
+
+const defaults = Object.seal([
+  'ecsServer',
+  'logLevel',
+  'wsServer',
+  'wsServerInsights'
+].reduce((defaults, option) => {
+  if (typeof env[option] !== 'undefined') {
+    Object.defineProperty(defaults, option, {
+      enumerable: true,
+      value: env[option]
+    });
+  }
+  return defaults;
+}, {}));
+
+module.exports = defaults;

--- a/test/lib/document.js
+++ b/test/lib/document.js
@@ -1,0 +1,45 @@
+'use strict';
+
+class HTMLElement {
+  constructor(tagName) {
+    this.children = [];
+    this.parentNode = null;
+    this.tagName = tagName;
+  }
+
+  appendChild(element) {
+    element.parentNode = this;
+    this.children.push(element);
+    return this;
+  }
+
+  removeChild(element) {
+    const index = this.children.indexOf(element);
+    if (index > -1) {
+      this.children.splice(index, 1);
+    }
+    return this;
+  }
+}
+
+class HTMLBodyElement extends HTMLElement {
+  constructor() {
+    super('body');
+  }
+}
+
+class Document {
+  constructor() {
+    this.body = new HTMLBodyElement();
+  }
+
+  createElement(name) {
+    return new HTMLElement(name);
+  }
+
+  querySelector() {
+    return null;
+  }
+}
+
+module.exports = Document;

--- a/test/lib/fakelog.js
+++ b/test/lib/fakelog.js
@@ -1,7 +1,7 @@
 'use strict';
 
 function makeFakeLog() {
-  var fakeLog = {
+  const fakeLog = {
     debug: () => {},
     deprecated: () => {},
     info: () => {},
@@ -10,6 +10,7 @@ function makeFakeLog() {
   };
 
   fakeLog.createLog = () => fakeLog;
+
   return fakeLog;
 }
 

--- a/test/lib/fakemediastream.js
+++ b/test/lib/fakemediastream.js
@@ -1,12 +1,14 @@
 'use strict';
 
-var inherits = require('util').inherits;
-var randomName = require('../lib/util').randomName;
-var EventTarget = require('../../lib/eventtarget');
+const inherits = require('util').inherits;
+
+const EventTarget = require('../../lib/eventtarget');
+
+const randomName = require('../lib/util').randomName;
 
 function FakeMediaStream() {
-  var audioTracks = [];
-  var videoTracks = [];
+  const audioTracks = [];
+  const videoTracks = [];
 
   EventTarget.call(this);
   Object.defineProperties(this, {
@@ -52,11 +54,11 @@ FakeMediaStream.prototype.addTrack =
 
 FakeMediaStream.prototype.removeTrack =
   function removeTrack(track) {
-    var tracks = [];
+    let tracks = [];
     if (['audio', 'video'].includes(track.kind)) {
       tracks = this[track.kind + 'Tracks'];
     }
-    var trackIdx = tracks.indexOf(track);
+    const trackIdx = tracks.indexOf(track);
     if (0 <= trackIdx) {
       tracks.splice(trackIdx, 1);
     }
@@ -96,7 +98,7 @@ FakeMediaStreamTrack.prototype.stop =
   };
 
 function fakeGetUserMedia(constraints) {
-  var fakeMediaStream = new FakeMediaStream();
+  const fakeMediaStream = new FakeMediaStream();
 
   if (constraints.audio) {
     fakeMediaStream.addTrack(new FakeMediaStreamTrack('audio'));

--- a/test/lib/guessbrowser.js
+++ b/test/lib/guessbrowser.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const guess = require('../../lib/util').guessBrowser();
+
+module.exports = {
+  isChrome: guess === 'chrome',
+  isFirefox: guess === 'firefox',
+  isSafari: guess === 'safari'
+};

--- a/test/lib/mockwebrtc.js
+++ b/test/lib/mockwebrtc.js
@@ -32,7 +32,7 @@ MediaStream.prototype.getAudioTracks = function getAudioTracks() {
   return Array.from(this._tracks).filter(track => track.kind === 'audio');
 };
 
-MediaStream.prototype.getTrackById = function getTrackById(trackid) {
+MediaStream.prototype.getTrackById = function getTrackById() {
   return null;
 };
 
@@ -51,7 +51,7 @@ const navigator = {
   userAgent: 'Node'
 };
 
-function getUserMedia(constraints, successCallback, errorCallback) {
+function getUserMedia(constraints, successCallback) {
   const mediaStream = new MediaStream();
   setTimeout(() => successCallback(mediaStream));
 }
@@ -76,7 +76,7 @@ function RTCDataChannel(label) {
 
 RTCDataChannel.id = 0;
 
-RTCDataChannel.prototype.send = function send(message) {
+RTCDataChannel.prototype.send = function send() {
 };
 
 RTCDataChannel.prototype.close = function close() {
@@ -88,7 +88,7 @@ RTCDataChannel.prototype.close = function close() {
 
 const DUMMY_SDP = 'v=0\r\no=- 4676571761825475727 2 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\na=group:BUNDLE audio\r\na=msid-semantic: WMS EMeI3G202R6Q6h3SNWynn4aSHT8JbeeYozwq\r\nm=audio 1 RTP/SAVPF 111 103 104 0 8 106 105 13 126\r\nc=IN IP4 0.0.0.0\r\na=rtcp:1 IN IP4 0.0.0.0\r\na=ice-ufrag:YDUcqfaDo8TP7sAf\r\na=ice-pwd:6pBfcQxQqfHcUN90IcETG9ag\r\na=ice-options:google-ice\r\na=fingerprint:sha-256 C9:98:D1:85:C6:79:AF:26:76:80:28:B5:19:B3:65:DA:D6:E8:BC:29:6A:48:59:8C:13:06:6C:3B:D3:EE:86:01\r\na=setup:actpass\r\na=mid:audio\r\na=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r\na=extmap:3 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r\na=sendrecv\r\na=rtcp-mux\r\na=rtpmap:111 opus/48000/2\r\na=fmtp:111 minptime=10\r\na=rtpmap:103 ISAC/16000\r\na=rtpmap:104 ISAC/32000\r\na=rtpmap:0 PCMU/8000\r\na=rtpmap:8 PCMA/8000\r\na=rtpmap:106 CN/32000\r\na=rtpmap:105 CN/16000\r\na=rtpmap:13 CN/8000\r\na=rtpmap:126 telephone-event/8000\r\na=maxptime:60\r\na=ssrc:489352021 cname:aDhWDndkoIsLM2YP\r\na=ssrc:489352021 msid:EMeI3G202R6Q6h3SNWynn4aSHT8JbeeYozwq fabea357-f6cf-4967-aa7c-800bedf06927\r\na=ssrc:489352021 mslabel:EMeI3G202R6Q6h3SNWynn4aSHT8JbeeYozwq\r\na=ssrc:489352021 label:fabea357-f6cf-4967-aa7c-800bedf06927\r\n';
 
-function RTCPeerConnection(configuration, constraints) {
+function RTCPeerConnection() {
   EventEmitter.call(this);
   this.iceConnectionState = 'completed';
   this.iceGatheringState = 'complete';
@@ -134,7 +134,7 @@ RTCPeerConnection.prototype.setRemoteDescription = function setRemoteDescription
   });
 };
 
-RTCPeerConnection.prototype.updateIce = function updateIce(configuration, constraints) {
+RTCPeerConnection.prototype.updateIce = function updateIce() {
 };
 
 RTCPeerConnection.prototype.addIceCandidate = function addIceCandidate() {
@@ -164,7 +164,7 @@ RTCPeerConnection.prototype.removeStream = function removeStream() {
 RTCPeerConnection.prototype.close = function close() {
 };
 
-RTCPeerConnection.prototype.createDataChannel = function createDataChannel(label, dataChannelDict) {
+RTCPeerConnection.prototype.createDataChannel = function createDataChannel(label) {
   return new RTCDataChannel(label);
 };
 
@@ -203,11 +203,11 @@ function attachMediaStream() {
 function URL() {
 }
 
-function createObjectURL(blob) {
+function createObjectURL() {
   return new URL();
 }
 
-function revokeObjectURL(blob) {
+function revokeObjectURL() {
 }
 
 URL.createObjectURL = createObjectURL;
@@ -217,7 +217,7 @@ URL.revokeObjectURL = revokeObjectURL;
 function mockWebRTC(_global) {
   _global = _global || global;
   const _window = _global.window = _global;
-  _window.addEventListener = function addEventListener(){};
+  _window.addEventListener = function addEventListener() {};
   _global.Event = Event;
   _global.WebSocket = WebSocket;
   _global.navigator = navigator;

--- a/test/lib/mockwebrtc.js
+++ b/test/lib/mockwebrtc.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { EventEmitter } = require('events');
-const { MockBrowser } = require('mock-browser').mocks;
 const { inherits } = require('util');
 const WebSocket = require('ws');
 
@@ -235,7 +234,6 @@ function mockWebRTC(_global) {
     protocol: 'https',
     host: 'bar'
   };
-  _global.document = new MockBrowser().getDocument();
   return _global;
 }
 

--- a/test/lib/mockwebrtc.js
+++ b/test/lib/mockwebrtc.js
@@ -1,15 +1,15 @@
 'use strict';
 
-var EventEmitter = require('events').EventEmitter;
-var inherits = require('util').inherits;
-var MockBrowser = require('mock-browser').mocks.MockBrowser;
-var util = require('../../lib/util');
+const { EventEmitter } = require('events');
+const { MockBrowser } = require('mock-browser').mocks;
+const { inherits } = require('util');
+const WebSocket = require('ws');
+
+const util = require('../../lib/util');
 
 function Event(type) {
   this.type = type;
 }
-
-var WebSocket = require('ws');
 
 function MediaStream() {
   this.ended = false;
@@ -48,12 +48,12 @@ MediaStream.prototype.removeTrack = function removeTrack(track) {
 MediaStream.prototype.stop = function stop() {
 };
 
-var navigator = {
+const navigator = {
   userAgent: 'Node'
 };
 
 function getUserMedia(constraints, successCallback, errorCallback) {
-  var mediaStream = new MediaStream();
+  const mediaStream = new MediaStream();
   setTimeout(function() {
     return successCallback(mediaStream);
   });
@@ -89,7 +89,7 @@ RTCDataChannel.prototype.close = function close() {
   }
 };
 
-var DUMMY_SDP = 'v=0\r\no=- 4676571761825475727 2 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\na=group:BUNDLE audio\r\na=msid-semantic: WMS EMeI3G202R6Q6h3SNWynn4aSHT8JbeeYozwq\r\nm=audio 1 RTP/SAVPF 111 103 104 0 8 106 105 13 126\r\nc=IN IP4 0.0.0.0\r\na=rtcp:1 IN IP4 0.0.0.0\r\na=ice-ufrag:YDUcqfaDo8TP7sAf\r\na=ice-pwd:6pBfcQxQqfHcUN90IcETG9ag\r\na=ice-options:google-ice\r\na=fingerprint:sha-256 C9:98:D1:85:C6:79:AF:26:76:80:28:B5:19:B3:65:DA:D6:E8:BC:29:6A:48:59:8C:13:06:6C:3B:D3:EE:86:01\r\na=setup:actpass\r\na=mid:audio\r\na=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r\na=extmap:3 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r\na=sendrecv\r\na=rtcp-mux\r\na=rtpmap:111 opus/48000/2\r\na=fmtp:111 minptime=10\r\na=rtpmap:103 ISAC/16000\r\na=rtpmap:104 ISAC/32000\r\na=rtpmap:0 PCMU/8000\r\na=rtpmap:8 PCMA/8000\r\na=rtpmap:106 CN/32000\r\na=rtpmap:105 CN/16000\r\na=rtpmap:13 CN/8000\r\na=rtpmap:126 telephone-event/8000\r\na=maxptime:60\r\na=ssrc:489352021 cname:aDhWDndkoIsLM2YP\r\na=ssrc:489352021 msid:EMeI3G202R6Q6h3SNWynn4aSHT8JbeeYozwq fabea357-f6cf-4967-aa7c-800bedf06927\r\na=ssrc:489352021 mslabel:EMeI3G202R6Q6h3SNWynn4aSHT8JbeeYozwq\r\na=ssrc:489352021 label:fabea357-f6cf-4967-aa7c-800bedf06927\r\n';
+const DUMMY_SDP = 'v=0\r\no=- 4676571761825475727 2 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\na=group:BUNDLE audio\r\na=msid-semantic: WMS EMeI3G202R6Q6h3SNWynn4aSHT8JbeeYozwq\r\nm=audio 1 RTP/SAVPF 111 103 104 0 8 106 105 13 126\r\nc=IN IP4 0.0.0.0\r\na=rtcp:1 IN IP4 0.0.0.0\r\na=ice-ufrag:YDUcqfaDo8TP7sAf\r\na=ice-pwd:6pBfcQxQqfHcUN90IcETG9ag\r\na=ice-options:google-ice\r\na=fingerprint:sha-256 C9:98:D1:85:C6:79:AF:26:76:80:28:B5:19:B3:65:DA:D6:E8:BC:29:6A:48:59:8C:13:06:6C:3B:D3:EE:86:01\r\na=setup:actpass\r\na=mid:audio\r\na=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r\na=extmap:3 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r\na=sendrecv\r\na=rtcp-mux\r\na=rtpmap:111 opus/48000/2\r\na=fmtp:111 minptime=10\r\na=rtpmap:103 ISAC/16000\r\na=rtpmap:104 ISAC/32000\r\na=rtpmap:0 PCMU/8000\r\na=rtpmap:8 PCMA/8000\r\na=rtpmap:106 CN/32000\r\na=rtpmap:105 CN/16000\r\na=rtpmap:13 CN/8000\r\na=rtpmap:126 telephone-event/8000\r\na=maxptime:60\r\na=ssrc:489352021 cname:aDhWDndkoIsLM2YP\r\na=ssrc:489352021 msid:EMeI3G202R6Q6h3SNWynn4aSHT8JbeeYozwq fabea357-f6cf-4967-aa7c-800bedf06927\r\na=ssrc:489352021 mslabel:EMeI3G202R6Q6h3SNWynn4aSHT8JbeeYozwq\r\na=ssrc:489352021 label:fabea357-f6cf-4967-aa7c-800bedf06927\r\n';
 
 function RTCPeerConnection(configuration, constraints) {
   EventEmitter.call(this);
@@ -219,7 +219,7 @@ URL.revokeObjectURL = revokeObjectURL;
 
 function mockWebRTC(_global) {
   _global = _global || global;
-  var _window = _global.window = _global;
+  const _window = _global.window = _global;
   _window.addEventListener = function addEventListener(){};
   _global.Event = Event;
   _global.WebSocket = WebSocket;

--- a/test/lib/mockwebrtc.js
+++ b/test/lib/mockwebrtc.js
@@ -53,9 +53,7 @@ const navigator = {
 
 function getUserMedia(constraints, successCallback, errorCallback) {
   const mediaStream = new MediaStream();
-  setTimeout(function() {
-    return successCallback(mediaStream);
-  });
+  setTimeout(() => successCallback(mediaStream));
 }
 
 navigator.webkitGetUserMedia = getUserMedia;
@@ -68,7 +66,7 @@ function RTCDataChannel(label) {
   this.readyState = 'connecting';
   this.bufferedAmount = 0;
   this.binaryType = 'blob';
-  setTimeout(function() {
+  setTimeout(() => {
     this.readyState = 'open';
     if (this.onopen) {
       this.onopen();

--- a/test/lib/token.js
+++ b/test/lib/token.js
@@ -3,7 +3,7 @@
 const { AccessToken } = require('twilio');
 const credentials = require('../env');
 
-const defaultOptions = Object.assign({
+const defaults = Object.assign({
   grant: 'video',
   ttl: 60 * 1000
 }, credentials);
@@ -28,7 +28,7 @@ const defaultOptions = Object.assign({
  * @throws Error
  */
 function createToken(identity, options) {
-  options = Object.assign({}, defaultOptions, options);
+  options = Object.assign({}, defaults, options);
 
   const {
     accountSid,

--- a/test/umd/index.js
+++ b/test/umd/index.js
@@ -1,9 +1,11 @@
 'use strict';
 
-var version = require('../../package.json').version;
-var phantom = require('phantom');
-var requirejs = require('requirejs');
-var publicVars = [
+const phantom = require('phantom');
+const requirejs = require('requirejs');
+
+const version = require('../../package.json').version;
+
+const publicVars = [
   'connect',
   'createLocalAudioTrack',
   'createLocalTracks',
@@ -18,8 +20,8 @@ describe('UMD', function() {
   this.timeout(5000);
 
   describe('RequireJS (browser)', function() {
-    var page;
-    var instance;
+    let page;
+    let instance;
 
     beforeEach(function() {
       return phantom.create([]).then(function(_instance) {

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -4,12 +4,6 @@ if (typeof window === 'undefined') {
   require('../lib/mockwebrtc')();
 }
 
-if (typeof document === 'undefined') {
-  const { MockBrowser } = require('mock-browser').mocks;
-  const browser = new MockBrowser();
-  global.document = browser.getDocument();
-}
-
 if (typeof Array.prototype.includes !== 'function') {
   Array.prototype.includes = function includes(x) {
     return this.indexOf(x) > -1;

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -5,8 +5,8 @@ if (typeof window === 'undefined') {
 }
 
 if (typeof document === 'undefined') {
-  var MockBrowser = require('mock-browser').mocks.MockBrowser;
-  var browser = new MockBrowser();
+  const { MockBrowser } = require('mock-browser').mocks;
+  const browser = new MockBrowser();
   global.document = browser.getDocument();
 }
 

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -4,12 +4,6 @@ if (typeof window === 'undefined') {
   require('../lib/mockwebrtc')();
 }
 
-if (typeof Array.prototype.includes !== 'function') {
-  Array.prototype.includes = function includes(x) {
-    return this.indexOf(x) > -1;
-  };
-}
-
 require('./spec/connect');
 require('./spec/createlocaltrack');
 require('./spec/createlocaltracks');

--- a/test/unit/spec/connect.js
+++ b/test/unit/spec/connect.js
@@ -127,9 +127,9 @@ describe('connect', () => {
         const mockSignaling = new Signaling();
         mockSignaling.connect = () => Promise.resolve(() => new RoomSignaling());
 
-        var createLocalTracks;
-        var tracks;
-        var room;
+        let createLocalTracks;
+        let tracks;
+        let room;
 
         function LocalParticipant() {
         }

--- a/test/unit/spec/connect.js
+++ b/test/unit/spec/connect.js
@@ -8,7 +8,6 @@ const { inherits } = require('util');
 const connect = require('../../../lib/connect');
 const Signaling = require('../../../lib/signaling');
 const RoomSignaling = require('../../../lib/signaling/room');
-const { AccessTokenInvalidError } = require('../../../lib/util/twilio-video-errors');
 
 const { FakeMediaStreamTrack, fakeGetUserMedia } = require('../../lib/fakemediastream');
 const MockIceServerSource = require('../../lib/mockiceserversource');
@@ -17,7 +16,7 @@ const token = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImN0eSI6InR3aWxpby1mcGE7dj0xI
 
 describe('connect', () => {
   describe('called without ConnectOptions#tracks', () => {
-    it ('automatically acquires LocalTracks', () => {
+    it('automatically acquires LocalTracks', () => {
       const createLocalTracks = sinon.spy();
       connect(token, { createLocalTracks, iceServers: [] });
       assert(createLocalTracks.calledOnce);
@@ -27,7 +26,9 @@ describe('connect', () => {
       it('calls .stop() on the LocalTracks', async () => {
         const stream = await fakeGetUserMedia({ audio: true, video: true });
         const localTracks = stream.getTracks().map(track => new FakeLocalTrack(track));
-        const createLocalTracks = () => Promise.resolve(localTracks);
+        async function createLocalTracks() {
+          return localTracks;
+        }
         const promise = connect(token, { createLocalTracks, iceServers: [] });
         promise.cancel();
         try {
@@ -39,7 +40,9 @@ describe('connect', () => {
       });
 
       it('never calls .start() on the IceServerSource', async () => {
-        const createLocalTracks = () => Promise.resolve([]);
+        async function createLocalTracks() {
+          return [];
+        }
         const iceServerSource = new MockIceServerSource();
         const promise = connect(token, { createLocalTracks, iceServers: iceServerSource });
         promise.cancel();
@@ -57,7 +60,9 @@ describe('connect', () => {
       it('sets shouldStopLocalTracks on the LocalParticipant', async () => {
         const stream = await fakeGetUserMedia({ audio: true, video: true });
         const tracks = stream.getTracks().map(track => new FakeLocalTrack(track));
-        const createLocalTracks = () => Promise.resolve(tracks);
+        async function createLocalTracks() {
+          return tracks;
+        }
 
         const mockSignaling = new Signaling();
         mockSignaling.connect = () => Promise.resolve(() => new RoomSignaling());
@@ -70,7 +75,7 @@ describe('connect', () => {
           shouldStopLocalTracks = options.shouldStopLocalTracks;
         }
 
-        const room = await connect(token, {
+        await connect(token, {
           LocalParticipant,
           createLocalTracks,
           iceServers: [],
@@ -83,7 +88,7 @@ describe('connect', () => {
     describe('when it fails', () => {
       it('calls .stop() on the IceServerSource', async () => {
         const mockSignaling = new Signaling();
-        mockSignaling.connect = () => Promise.resolve(() => { throw new Error() });
+        mockSignaling.connect = () => Promise.resolve(() => { throw new Error(); });
         function signaling() {
           return mockSignaling;
         }
@@ -113,23 +118,22 @@ describe('connect', () => {
 
     describe('when ConnectOptions#tracks is', () => {
       [
-        [ 'not an array', () => 'non-array argument', true ],
-        [ 'neither an array of LocalTracks nor an array of MediaStreamTracks', () => [ { foo: 'bar' } ], true ],
-        [ 'an array of LocalTracks', () => [
+        ['not an array', () => 'non-array argument', true],
+        ['neither an array of LocalTracks nor an array of MediaStreamTracks', () => [{ foo: 'bar' }], true],
+        ['an array of LocalTracks', () => [
           new LocalTrack(new FakeMediaStreamTrack('audio')),
           new LocalTrack(new FakeMediaStreamTrack('video'))
-        ], false ],
-        [ 'an array of MediaStreamTracks', () => [
+        ], false],
+        ['an array of MediaStreamTracks', () => [
           new FakeMediaStreamTrack('audio'),
           new FakeMediaStreamTrack('video')
-        ], false ]
-      ].forEach(( [ scenario, getTracks, shouldFail ] ) => {
+        ], false]
+      ].forEach(([scenario, getTracks, shouldFail]) => {
         const mockSignaling = new Signaling();
         mockSignaling.connect = () => Promise.resolve(() => new RoomSignaling());
 
         let createLocalTracks;
         let tracks;
-        let room;
 
         function LocalParticipant() {
         }
@@ -147,7 +151,7 @@ describe('connect', () => {
           if (shouldFail) {
             it('should reject with a TypeError', async () => {
               try {
-                room = await connect(token, {
+                await connect(token, {
                   createLocalTracks,
                   LocalAudioTrack: FakeLocalTrack,
                   LocalParticipant,
@@ -167,7 +171,7 @@ describe('connect', () => {
           }
 
           it('should call createLocalTracks with the corresponding LocalTracks', async () => {
-            room = await connect(token, {
+            await connect(token, {
               createLocalTracks,
               LocalAudioTrack: LocalTrack,
               LocalParticipant,
@@ -202,7 +206,7 @@ describe('connect', () => {
           shouldStopLocalTracks = options.shouldStopLocalTracks;
         }
 
-        const room = await connect(token, {
+        await connect(token, {
           LocalAudioTrack: FakeLocalTrack,
           LocalParticipant,
           LocalVideoTrack: FakeLocalTrack,

--- a/test/unit/spec/connect.js
+++ b/test/unit/spec/connect.js
@@ -1,17 +1,19 @@
 'use strict';
 
 const assert = require('assert');
-const connect = require('../../../lib/connect');
-const fakeGetUserMedia = require('../../lib/fakemediastream').fakeGetUserMedia;
-const FakeMediaStreamTrack = require('../../lib/fakemediastream').FakeMediaStreamTrack;
-const inherits = require('util').inherits;
-const MockIceServerSource = require('../../lib/mockiceserversource');
-const RoomSignaling = require('../../../lib/signaling/room');
-const Signaling = require('../../../lib/signaling');
+const { EventEmitter } = require('events');
 const sinon = require('sinon');
+const { inherits } = require('util');
+
+const connect = require('../../../lib/connect');
+const Signaling = require('../../../lib/signaling');
+const RoomSignaling = require('../../../lib/signaling/room');
+const { AccessTokenInvalidError } = require('../../../lib/util/twilio-video-errors');
+
+const { FakeMediaStreamTrack, fakeGetUserMedia } = require('../../lib/fakemediastream');
+const MockIceServerSource = require('../../lib/mockiceserversource');
+
 const token = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImN0eSI6InR3aWxpby1mcGE7dj0xIn0.eyJqdGkiOiJTSzY3NGIxODg2OWYxMWZhY2M2NjVhNjVmZDRkZGYyZjRmLTE0NzUxOTAzNDgiLCJncmFudHMiOnsiaWRlbnRpdHkiOiJhc2QiLCJydGMiOnsiY29uZmlndXJhdGlvbl9wcm9maWxlX3NpZCI6IlZTM2Y3NWUwZjE0ZTdjOGIyMDkzOGZjNTA5MmU4MmYyM2EifX0sImlhdCI6MTQ3NTE5MDM0OCwiZXhwIjoxNDc1MTkzOTQ4LCJpc3MiOiJTSzY3NGIxODg2OWYxMWZhY2M2NjVhNjVmZDRkZGYyZjRmIiwic3ViIjoiQUM5NmNjYzkwNDc1M2IzMzY0ZjI0MjExZThkOTc0NmE5MyJ9.N0UuZSblqb7MknNuiRkiEVVEdmztm5AdYIhQp7zU2PI';
-const AccessTokenInvalidError = require('../../../lib/util/twilio-video-errors').AccessTokenInvalidError;
-const EventEmitter = require('events').EventEmitter;
 
 describe('connect', () => {
   describe('called without ConnectOptions#tracks', () => {

--- a/test/unit/spec/connect.js
+++ b/test/unit/spec/connect.js
@@ -214,40 +214,6 @@ describe('connect', () => {
       });
     });
   });
-
-  describe('when the LocalParticipant\'s initial LocalTracks fail to be published', () => {
-    it('should reject the CancelablePromise', () => {
-      it('sets shouldStopLocalTracks on the LocalParticipant', async () => {
-        const stream = await fakeGetUserMedia({audio: true, video: true});
-        const tracks = stream.getTracks().map(track => new FakeLocalTrack(track));
-        const createLocalTracks = () => Promise.resolve(tracks);
-
-        const mockSignaling = new Signaling();
-        mockSignaling.connect = () => () => new RoomSignaling();
-        function signaling() {
-          return mockSignaling;
-        }
-
-        function LocalParticipant() {
-        }
-
-        try {
-          const room = await connect(token, {
-            LocalParticipant,
-            createLocalTracks,
-            iceServers: [],
-            signaling
-          });
-        } catch (error) {
-          assert.equal(error, 'foo');
-          return;
-        }
-
-        throw(new Error('Unexpected resolution'));
-      });
-    });
-  });
-
 });
 
 function FakeLocalTrack(mediaStreamTrack, shouldNotCreateStop) {

--- a/test/unit/spec/createlocaltrack.js
+++ b/test/unit/spec/createlocaltrack.js
@@ -11,14 +11,11 @@ const {
 [
   [ 'Audio', createLocalAudioTrack ],
   [ 'Video', createLocalVideoTrack ]
-].forEach(scenario => {
-  var kind = scenario[0];
-  var createLocalTrack = scenario[1];
-
+].forEach(([kind, createLocalTrack]) => {
   describe(`createLocal${kind}Track`, () => {
     context('when called with no constraints', () => {
       it(`should call createLocalTracks() with { ${kind.toLowerCase()}: true }`, () => {
-        var options = {
+        const options = {
           createLocalTracks: sinon.spy(() => Promise.resolve([
             { foo: 'bar' }
           ]))
@@ -31,21 +28,21 @@ const {
 
     context('when called with constraints', () => {
       it(`should call createLocalTracks() with { ${kind.toLowerCase()}: constraints }`, () => {
-        var options = {
+        const options = {
           baz: 'zee',
           createLocalTracks: sinon.spy(() => Promise.resolve([
             { foo: 'bar' }
           ]))
         };
 
-        var expectedConstraints = { baz: 'zee' };
+        const expectedConstraints = { baz: 'zee' };
         createLocalTrack(options);
         assert.deepEqual(options.createLocalTracks.args[0][0][kind.toLowerCase()], expectedConstraints);
       });
     });
 
     it('should resolve with the first item of the array with which createLocalTracks() resolves', () => {
-      var options = {
+      const options = {
         createLocalTracks: sinon.spy(() => Promise.resolve([
           { foo: 'bar' }
         ]))

--- a/test/unit/spec/createlocaltrack.js
+++ b/test/unit/spec/createlocaltrack.js
@@ -9,8 +9,8 @@ const {
 } = require('../../../lib/createlocaltrack');
 
 [
-  [ 'Audio', createLocalAudioTrack ],
-  [ 'Video', createLocalVideoTrack ]
+  ['Audio', createLocalAudioTrack],
+  ['Video', createLocalVideoTrack]
 ].forEach(([kind, createLocalTrack]) => {
   describe(`createLocal${kind}Track`, () => {
     context('when called with no constraints', () => {

--- a/test/unit/spec/createlocaltrack.js
+++ b/test/unit/spec/createlocaltrack.js
@@ -1,9 +1,12 @@
 'use strict';
 
-var assert = require('assert');
-var createLocalAudioTrack = require('../../../lib/createlocaltrack').audio;
-var createLocalVideoTrack = require('../../../lib/createlocaltrack').video;
-var sinon = require('sinon');
+const assert = require('assert');
+const sinon = require('sinon');
+
+const {
+  audio: createLocalAudioTrack,
+  video: createLocalVideoTrack
+} = require('../../../lib/createlocaltrack');
 
 [
   [ 'Audio', createLocalAudioTrack ],

--- a/test/unit/spec/createlocaltracks.js
+++ b/test/unit/spec/createlocaltracks.js
@@ -11,14 +11,10 @@ describe('createLocalTracks', () => {
   [
     [ 'when called with no constraints' ],
     [ 'when called with { audio: true, video: true }', { audio: true, video: true } ]
-  ].forEach(scenario => {
-    context(scenario[0], () => {
+  ].forEach(([description, extraOptions]) => {
+    context(description, () => {
       it('should resolve with a LocalAudioTrack and a LocalVideoTrack', () => {
-        var options = makeOptions();
-        if (scenario[1]) {
-          options = Object.assign(scenario[1], options);
-        }
-
+        const options = Object.assign(makeOptions(), extraOptions);
         return createLocalTracks(options).then(tracks => {
           assert.equal(tracks.length, 2);
           assert(tracks[0] instanceof options.LocalAudioTrack);
@@ -35,14 +31,10 @@ describe('createLocalTracks', () => {
   [
     [ 'when called with { audio: true }', { audio: true } ],
     [ 'when called with { audio: true, video: false }', { audio: true, video: false } ]
-  ].forEach(scenario => {
-    context(scenario[0], () => {
+  ].forEach(([description, extraOptions]) => {
+    context(description, () => {
       it('should resolve with a LocalAudioTrack', () => {
-        var options = makeOptions();
-        if (scenario[1]) {
-          options = Object.assign(scenario[1], options);
-        }
-
+        const options = Object.assign(makeOptions(), extraOptions);
         return createLocalTracks(options).then(tracks => {
           assert.equal(tracks.length, 1);
           assert(tracks[0] instanceof options.LocalAudioTrack);
@@ -56,14 +48,10 @@ describe('createLocalTracks', () => {
   [
     [ 'when called with { video: true }', { video: true } ],
     [ 'when called with { audio: false, video: true }', { audio: false, video: true } ]
-  ].forEach(scenario => {
-    context(scenario[0], () => {
+  ].forEach(([description, extraOptions]) => {
+    context(description, () => {
       it('should resolve with a LocalVideoTrack', () => {
-        var options = makeOptions();
-        if (scenario[1]) {
-          options = Object.assign(scenario[1], options);
-        }
-
+        const options = Object.assign(makeOptions(), extraOptions);
         return createLocalTracks(options).then(tracks => {
           assert.equal(tracks.length, 1);
           assert(tracks[0] instanceof options.LocalVideoTrack);
@@ -76,11 +64,10 @@ describe('createLocalTracks', () => {
 
   context('when called with { audio: false, video: false }', () => {
     it('should resolve with an empty array', () => {
-      var options = Object.assign({
+      const options = Object.assign({
         audio: false,
         video: false
       }, makeOptions());
-
       return createLocalTracks(options).then(tracks => {
         assert.equal(tracks.length, 0);
       });

--- a/test/unit/spec/createlocaltracks.js
+++ b/test/unit/spec/createlocaltracks.js
@@ -1,10 +1,11 @@
 'use strict';
 
-var assert = require('assert');
-var createLocalTracks = require('../../../lib/createlocaltracks');
-var fakeGetUserMedia = require('../../lib/fakemediastream').fakeGetUserMedia;
-var FakeMediaStreamTrack = require('../../lib/fakemediastream').FakeMediaStreamTrack;
-var sinon = require('sinon');
+const assert = require('assert');
+const sinon = require('sinon');
+
+const createLocalTracks = require('../../../lib/createlocaltracks');
+
+const { FakeMediaStreamTrack, fakeGetUserMedia } = require('../../lib/fakemediastream');
 
 describe('createLocalTracks', () => {
   [

--- a/test/unit/spec/createlocaltracks.js
+++ b/test/unit/spec/createlocaltracks.js
@@ -9,8 +9,8 @@ const { FakeMediaStreamTrack, fakeGetUserMedia } = require('../../lib/fakemedias
 
 describe('createLocalTracks', () => {
   [
-    [ 'when called with no constraints' ],
-    [ 'when called with { audio: true, video: true }', { audio: true, video: true } ]
+    ['when called with no constraints'],
+    ['when called with { audio: true, video: true }', { audio: true, video: true }]
   ].forEach(([description, extraOptions]) => {
     context(description, () => {
       it('should resolve with a LocalAudioTrack and a LocalVideoTrack', () => {
@@ -29,8 +29,8 @@ describe('createLocalTracks', () => {
   });
 
   [
-    [ 'when called with { audio: true }', { audio: true } ],
-    [ 'when called with { audio: true, video: false }', { audio: true, video: false } ]
+    ['when called with { audio: true }', { audio: true }],
+    ['when called with { audio: true, video: false }', { audio: true, video: false }]
   ].forEach(([description, extraOptions]) => {
     context(description, () => {
       it('should resolve with a LocalAudioTrack', () => {
@@ -46,8 +46,8 @@ describe('createLocalTracks', () => {
   });
 
   [
-    [ 'when called with { video: true }', { video: true } ],
-    [ 'when called with { audio: false, video: true }', { audio: false, video: true } ]
+    ['when called with { video: true }', { video: true }],
+    ['when called with { audio: false, video: true }', { audio: false, video: true }]
   ].forEach(([description, extraOptions]) => {
     context(description, () => {
       it('should resolve with a LocalVideoTrack', () => {
@@ -81,7 +81,7 @@ describe('createLocalTracks', () => {
         video: { name: 'bar' }
       }, makeOptions());
       const localTracks = await createLocalTracks(options);
-      assert.deepEqual(localTracks.map(track => track.name), [ 'foo', 'bar' ]);
+      assert.deepEqual(localTracks.map(track => track.name), ['foo', 'bar']);
     });
   });
 });
@@ -89,14 +89,14 @@ describe('createLocalTracks', () => {
 function makeOptions() {
   return {
     getUserMedia: fakeGetUserMedia,
-    LocalAudioTrack: sinon.spy(function(mediaStreamTrack, options) {
+    LocalAudioTrack: sinon.spy(function LocalAudioTrack(mediaStreamTrack, options) {
       options = options || {};
       this.id = mediaStreamTrack.id;
       this.kind = mediaStreamTrack.kind;
       this.mediaStreamTrack = mediaStreamTrack;
       this.name = options.name || mediaStreamTrack.id;
     }),
-    LocalVideoTrack: sinon.spy(function(mediaStreamTrack, options) {
+    LocalVideoTrack: sinon.spy(function LocalVideoTrack(mediaStreamTrack, options) {
       options = options || {};
       this.id = mediaStreamTrack.id;
       this.kind = mediaStreamTrack.kind;

--- a/test/unit/spec/data/receiver.js
+++ b/test/unit/spec/data/receiver.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+
 const DataTrackReceiver = require('../../../../lib/data/receiver');
 const EventTarget = require('../../../../lib/eventtarget');
 const { makeUUID } = require('../../../../lib/util');

--- a/test/unit/spec/data/receiver.js
+++ b/test/unit/spec/data/receiver.js
@@ -46,7 +46,7 @@ describe('DataTrackReceiver', () => {
 
     it('the DataTrackReceiver emits a "message" event', () => {
       let actualData;
-      dataTrackReceiver.once('message', data => actualData = data);
+      dataTrackReceiver.once('message', data => { actualData = data; });
       dataChannel.dispatchEvent({ type: 'message', data });
       assert.equal(actualData, data);
     });

--- a/test/unit/spec/data/sender.js
+++ b/test/unit/spec/data/sender.js
@@ -136,7 +136,7 @@ describe('DataTrackSender', () => {
 
     describe('calls send on the added RTCDataChannels, and, if any of those calls to send throws', () => {
       it('continues calling send on the remaining RTCDataChannels', () => {
-        dataChannel1.send = sinon.spy(() => { throw new Error() });
+        dataChannel1.send = sinon.spy(() => { throw new Error(); });
         dataTrackSender.send(data);
         [dataChannel1, dataChannel2, dataChannel3].forEach(dataChannel => {
           sinon.assert.calledOnce(dataChannel.send);

--- a/test/unit/spec/data/sender.js
+++ b/test/unit/spec/data/sender.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert');
 const sinon = require('sinon');
+
 const DataTrackSender = require('../../../../lib/data/sender');
 const { makeUUID } = require('../../../../lib/util');
 

--- a/test/unit/spec/data/transceiver.js
+++ b/test/unit/spec/data/transceiver.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+
 const DataTrackTransceiver = require('../../../../lib/data/transceiver');
 const { makeUUID } = require('../../../../lib/util');
 

--- a/test/unit/spec/ecs.js
+++ b/test/unit/spec/ecs.js
@@ -15,95 +15,80 @@ const {
 
 const fakeToken = 'a.b.c';
 
-describe('ECS', function() {
-  describe('#getConfiguration', function() {
+describe('ECS', () => {
+  describe('#getConfiguration', () => {
     let requestPost;
 
-    beforeEach(function() {
+    beforeEach(() => {
       requestPost = request.post;
-      request.post = new sinon.spy(function(params) {
-        return Promise.resolve('{"foo":"bar","a":123}');
-      });
+      request.post = new sinon.spy(async params => '{"foo":"bar","a":123}');
     });
 
-    afterEach(function() {
+    afterEach(() => {
       request.post = requestPost;
     });
 
-    context('when passed no token', function() {
-      it('should throw an exception', function() {
-        assert.throws(function() {
-          ECS.getConfiguration();
-        });
+    context('when passed no token', () => {
+      it('should throw an exception', () => {
+        assert.throws(() => ECS.getConfiguration());
       });
     });
 
-    context('when passed a token', function() {
-      it('should make a network request with the passed body', function() {
+    context('when passed a token', () => {
+      it('should make a network request with the passed body', () => {
         ECS.getConfiguration(fakeToken, {
           body: { a: 'foo', b: 'bar' }
         });
         assert.equal(request.post.args[0][0].body, 'a=foo&b=bar');
       });
 
-      it('should make a network request with an empty body if no params are passed', function() {
+      it('should make a network request with an empty body if no params are passed', () => {
         ECS.getConfiguration(fakeToken);
         assert.equal(request.post.args[0][0].body, undefined);
       });
 
-      it('should use the passed token in the network request headers', function() {
+      it('should use the passed token in the network request headers', () => {
         ECS.getConfiguration(fakeToken);
         assert.equal(request.post.args[0][0].headers['X-Twilio-Token'], fakeToken);
       });
 
-      it('should use a custom configUrl if specified', function() {
+      it('should use a custom configUrl if specified', () => {
         ECS.getConfiguration(fakeToken, { configUrl: 'http://foo.com' });
         assert.deepEqual(request.post.args[0][0].url, 'http://foo.com');
       });
 
-      it('should return the fetched payload as a valid JSON object', function() {
-        return ECS.getConfiguration(fakeToken).then(function(config) {
-          assert.deepEqual(config, { foo: 'bar', a: 123 });
-        });
+      it('should return the fetched payload as a valid JSON object', async () => {
+        const config = await ECS.getConfiguration(fakeToken);
+        assert.deepEqual(config, { foo: 'bar', a: 123 });
       });
 
-      it('should throw a ConfigurationAcquireFailedError if the fetched payload is not valid JSON', function() {
-        request.post = function() {
-          return Promise.resolve('{"foo": 123, "bar" "xyz"}');
-        };
+      it('should throw a ConfigurationAcquireFailedError if the fetched payload is not valid JSON', () => {
+        request.post = async () => '{"foo": 123, "bar" "xyz"}';
         testGetConfigurationError(ConfigurationAcquireFailedError, 53500, 'Unable to acquire configuration');
       });
 
-      context('when request() rejects the returned promise with an error code and message', function() {
-        it('should throw the appropriate TwilioError if present', function() {
-          request.post = function() {
-            return Promise.reject('{"code": 20101, "message": "Invalid Access Token"}');
-          };
+      context('when request() rejects the returned promise with an error code and message', () => {
+        it('should throw the appropriate TwilioError if present', () => {
+          request.post = async () => { throw '{"code": 20101, "message": "Invalid Access Token"}'; };
           return testGetConfigurationError(AccessTokenInvalidError, 20101, 'Invalid Access Token');
         });
 
-        it('should throw a generic TwilioError if there is no constructor for the given error code', function() {
-          request.post = function() {
-            return Promise.reject('{"code": 12345, "message": "Generic error"}');
-          };
+        it('should throw a generic TwilioError if there is no constructor for the given error code', () => {
+          request.post = async () => { throw '{"code": 12345, "message": "Generic error"}'; };
           return testGetConfigurationError(TwilioError, 12345, 'Generic error');
         });
       });
 
-      context('when request() rejects the returned promise without an error code or message', function() {
-        it('should throw a generic TwilioError with error code 0 and message "Unknown error"', function() {
-          request.post = function() {
-            return Promise.reject('{"abc": 123, "def": "xyz"}');
-          };
+      context('when request() rejects the returned promise without an error code or message', () => {
+        it('should throw a generic TwilioError with error code 0 and message "Unknown error"', () => {
+          request.post = async () => { throw '{"abc": 123, "def": "xyz"}' };
           return testGetConfigurationError(TwilioError, 0, 'Unknown error');
         });
       });
 
-      context('when request() rejects the returned promise invalid JSON', function() {
-        it('should throw a ConfigurationAcquireFailedError', function() {
-          request.post = function() {
-            return Promise.reject('{"code": 123, "message" "xyz"}');
-          };
+      context('when request() rejects the returned promise invalid JSON', () => {
+        it('should throw a ConfigurationAcquireFailedError', () => {
+          request.post = async () => { throw '{"code": 123, "message" "xyz"}'; };
           return testGetConfigurationError(ConfigurationAcquireFailedError, 53500, 'Unable to acquire configuration');
         });
       });
@@ -111,19 +96,16 @@ describe('ECS', function() {
   });
 });
 
-function testGetConfigurationError(klass, code, message) {
-  return new Promise(function(resolve, reject) {
-    ECS.getConfiguration(fakeToken).then(reject, function(error) {
-      try {
-        assert(error instanceof klass);
-        assert.equal(error.code, code);
-        if (message) {
-          assert.equal(error.message, message);
-        }
-        resolve();
-      } catch (e) {
-        reject(e);
-      }
-    });
-  });
+async function testGetConfigurationError(klass, code, message) {
+  try {
+    await ECS.getConfiguration(fakeToken);
+  } catch (error) {
+    assert(error instanceof klass);
+    assert.equal(error.code, code);
+    if (message) {
+      assert.equal(error.message, message);
+    }
+    return;
+  }
+  throw new Error('Unexpected resolution');
 }

--- a/test/unit/spec/ecs.js
+++ b/test/unit/spec/ecs.js
@@ -2,7 +2,6 @@
 
 const assert = require('assert');
 const sinon = require('sinon');
-const twilio = require('twilio');
 
 const ECS = require('../../../lib/ecs');
 const request = require('../../../lib/request');
@@ -21,7 +20,7 @@ describe('ECS', () => {
 
     beforeEach(() => {
       requestPost = request.post;
-      request.post = new sinon.spy(async params => '{"foo":"bar","a":123}');
+      request.post = sinon.spy(async () => '{"foo":"bar","a":123}');
     });
 
     afterEach(() => {
@@ -69,11 +68,13 @@ describe('ECS', () => {
 
       context('when request() rejects the returned promise with an error code and message', () => {
         it('should throw the appropriate TwilioError if present', () => {
+          // eslint-disable-next-line no-throw-literal
           request.post = async () => { throw '{"code": 20101, "message": "Invalid Access Token"}'; };
           return testGetConfigurationError(AccessTokenInvalidError, 20101, 'Invalid Access Token');
         });
 
         it('should throw a generic TwilioError if there is no constructor for the given error code', () => {
+          // eslint-disable-next-line no-throw-literal
           request.post = async () => { throw '{"code": 12345, "message": "Generic error"}'; };
           return testGetConfigurationError(TwilioError, 12345, 'Generic error');
         });
@@ -81,13 +82,15 @@ describe('ECS', () => {
 
       context('when request() rejects the returned promise without an error code or message', () => {
         it('should throw a generic TwilioError with error code 0 and message "Unknown error"', () => {
-          request.post = async () => { throw '{"abc": 123, "def": "xyz"}' };
+          // eslint-disable-next-line no-throw-literal
+          request.post = async () => { throw '{"abc": 123, "def": "xyz"}'; };
           return testGetConfigurationError(TwilioError, 0, 'Unknown error');
         });
       });
 
       context('when request() rejects the returned promise invalid JSON', () => {
         it('should throw a ConfigurationAcquireFailedError', () => {
+          // eslint-disable-next-line no-throw-literal
           request.post = async () => { throw '{"code": 123, "message" "xyz"}'; };
           return testGetConfigurationError(ConfigurationAcquireFailedError, 53500, 'Unable to acquire configuration');
         });

--- a/test/unit/spec/ecs.js
+++ b/test/unit/spec/ecs.js
@@ -17,9 +17,10 @@ const fakeToken = 'a.b.c';
 
 describe('ECS', function() {
   describe('#getConfiguration', function() {
-    var requestPost = request.post;
+    let requestPost;
 
     beforeEach(function() {
+      requestPost = request.post;
       request.post = new sinon.spy(function(params) {
         return Promise.resolve('{"foo":"bar","a":123}');
       });

--- a/test/unit/spec/ecs.js
+++ b/test/unit/spec/ecs.js
@@ -1,15 +1,19 @@
 'use strict';
 
-var assert = require('assert');
-var ECS = require('../../../lib/ecs');
-var request = require('../../../lib/request');
-var sinon = require('sinon');
-var twilio = require('twilio');
-var TwilioError = require('../../../lib/util/twilioerror');
-var AccessTokenInvalidError = require('../../../lib/util/twilio-video-errors').AccessTokenInvalidError;
-var ConfigurationAcquireFailedError = require('../../../lib/util/twilio-video-errors').ConfigurationAcquireFailedError;
+const assert = require('assert');
+const sinon = require('sinon');
+const twilio = require('twilio');
 
-var fakeToken = 'a.b.c';
+const ECS = require('../../../lib/ecs');
+const request = require('../../../lib/request');
+const TwilioError = require('../../../lib/util/twilioerror');
+
+const {
+  AccessTokenInvalidError,
+  ConfigurationAcquireFailedError
+} = require('../../../lib/util/twilio-video-errors');
+
+const fakeToken = 'a.b.c';
 
 describe('ECS', function() {
   describe('#getConfiguration', function() {

--- a/test/unit/spec/encodingparameters.js
+++ b/test/unit/spec/encodingparameters.js
@@ -1,8 +1,10 @@
 'use strict';
 
 const assert = require('assert');
-const { combinationContext } = require('../../lib/util');
+
 const EncodingParametersImpl = require('../../../lib/encodingparameters');
+
+const { combinationContext } = require('../../lib/util');
 
 describe('EncodingParametersImpl', () => {
   describe('constructor', () => {

--- a/test/unit/spec/encodingparameters.js
+++ b/test/unit/spec/encodingparameters.js
@@ -33,7 +33,8 @@ describe('EncodingParametersImpl', () => {
         }
         return params;
       }, {});
-      var encodingParametersImpl;
+
+      let encodingParametersImpl;
 
       before(() => {
         encodingParametersImpl = withNew === 'with'
@@ -94,8 +95,8 @@ describe('EncodingParametersImpl', () => {
         return params;
       }, {});
 
-      var encodingParametersImpl;
-      var changedEventCount = 0;
+      let encodingParametersImpl;
+      let changedEventCount = 0;
 
       before(() => {
         encodingParametersImpl = new EncodingParametersImpl(encodingParameters);

--- a/test/unit/spec/encodingparameters.js
+++ b/test/unit/spec/encodingparameters.js
@@ -39,6 +39,7 @@ describe('EncodingParametersImpl', () => {
       before(() => {
         encodingParametersImpl = withNew === 'with'
           ? new EncodingParametersImpl(encodingParmeters)
+          // eslint-disable-next-line new-cap
           : EncodingParametersImpl(encodingParmeters);
       });
 

--- a/test/unit/spec/iceserversource/constant.js
+++ b/test/unit/spec/iceserversource/constant.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const assert = require('assert');
+const { EventEmitter } = require('events');
+
 const ConstantIceServerSource = require('../../../../lib/iceserversource/constant');
-const EventEmitter = require('events').EventEmitter;
 
 describe('ConstantIceServerSource', () => {
   describe('constructor', () => {

--- a/test/unit/spec/iceserversource/nts.js
+++ b/test/unit/spec/iceserversource/nts.js
@@ -1,9 +1,10 @@
 'use strict';
 
 const assert = require('assert');
-const EventEmitter = require('events').EventEmitter;
+const { EventEmitter } = require('events');
+
 const NTSIceServerSource = require('../../../../lib/iceserversource/nts');
-const util = require('../../../../lib/util');
+const { defer } = require('../../../../lib/util');
 const { createTwilioError } = require('../../../../lib/util/twilio-video-errors');
 
 const token = 'foo';
@@ -104,7 +105,7 @@ describe('NTSIceServerSource', () => {
       let nts;
 
       it('returns the default ICE servers', () => {
-        const options = { getConfiguration: () => util.defer().promise, timeout: 1 };
+        const options = { getConfiguration: () => defer().promise, timeout: 1 };
         nts = new NTSIceServerSource(token, options);
         return nts.start().then(iceServers => {
           assert.deepEqual([

--- a/test/unit/spec/iceserversource/nts.js
+++ b/test/unit/spec/iceserversource/nts.js
@@ -11,7 +11,9 @@ const token = 'foo';
 const iceServers = [];
 const config = {
   video: {
+    // eslint-disable-next-line camelcase
     network_traversal_service: {
+      // eslint-disable-next-line camelcase
       ice_servers: iceServers,
       ttl: 1
     }
@@ -110,7 +112,7 @@ describe('NTSIceServerSource', () => {
         return nts.start().then(iceServers => {
           assert.deepEqual([
             {
-              "urls": "stun:global.stun.twilio.com:3478?transport=udp"
+              urls: 'stun:global.stun.twilio.com:3478?transport=udp'
             }
           ], iceServers);
         });
@@ -130,7 +132,7 @@ describe('NTSIceServerSource', () => {
         return nts.start().then(iceServers => {
           assert.deepEqual([
             {
-              "urls": "stun:global.stun.twilio.com:3478?transport=udp"
+              urls: 'stun:global.stun.twilio.com:3478?transport=udp'
             }
           ], iceServers);
         });
@@ -156,7 +158,7 @@ describe('NTSIceServerSource', () => {
         it('returns the default ICE servers', async () => {
           assert.deepEqual([
             {
-              "urls": "stun:global.stun.twilio.com:3478?transport=udp"
+              urls: 'stun:global.stun.twilio.com:3478?transport=udp'
             }
           ], iceServers);
         });
@@ -184,7 +186,7 @@ describe('NTSIceServerSource', () => {
         it('returns the default ICE servers', async () => {
           assert.deepEqual([
             {
-              "urls": "stun:global.stun.twilio.com:3478?transport=udp"
+              urls: 'stun:global.stun.twilio.com:3478?transport=udp'
             }
           ], iceServers);
         });

--- a/test/unit/spec/localparticipant.js
+++ b/test/unit/spec/localparticipant.js
@@ -57,7 +57,7 @@ describe('LocalParticipant', () => {
       it('should have the updated "identity" and "sid"', () => {
         // In makeTest(), test.signaling.sid and test.signaling.identity are
         // set to null, to mimic the ParticipantSignaling constructor
-        var test = makeTest({ state: 'connecting' });
+        const test = makeTest({ state: 'connecting' });
         // Spoofing a room joining event by populating the
         // "identity" and "sid" members of the signaling instance
         test.signaling.identity = 'newIdentity';
@@ -74,7 +74,7 @@ describe('LocalParticipant', () => {
     'removeTrack'
   ].forEach(method => {
     describe(`#${method}`, () => {
-      var test;
+      let test;
 
       beforeEach(() => {
         test = makeTest();
@@ -119,8 +119,9 @@ describe('LocalParticipant', () => {
     'unpublishTracks',
   ].forEach(method => {
     describe(`#${method}`, () => {
-      var test;
-      var trackMethod = method.slice(0, -1);
+      const trackMethod = method.slice(0, -1);
+
+      let test;
 
       beforeEach(() => {
         test = makeTest();
@@ -166,16 +167,15 @@ describe('LocalParticipant', () => {
 
             if (method === 'publishTracks') {
               it(`should return a Promise for an array of LocalTrackPublications`, async () => {
-                var localAudioTrack = new LocalAudioTrack();
-                var localVideoTrack = new LocalVideoTrack();
-                var localDataTrack = new LocalDataTrack();
-                var ret = await test.participant[method]([ localAudioTrack, localVideoTrack, localDataTrack ]);
-
-                assert(Array.isArray(ret));
-                assert.equal(ret.length, 3);
-                assert.equal(ret[0].track, localAudioTrack);
-                assert.equal(ret[1].track, localVideoTrack);
-                assert.equal(ret[2].track, localDataTrack);
+                const tracks = [
+                  new LocalAudioTrack(),
+                  new LocalVideoTrack(),
+                  new LocalDataTrack()
+                ];
+                const publications = await test.participant[method](tracks);
+                assert(Array.isArray(publications));
+                assert.equal(publications.length, tracks.length);
+                publications.forEach((publication, i) => assert.equal(publication.track, tracks[i]));
               });
             }
           });
@@ -185,7 +185,7 @@ describe('LocalParticipant', () => {
   });
 
   describe('#setParameters', () => {
-    var test;
+    let test;
 
     context('when the EncodingParameters is', () => {
       [
@@ -230,8 +230,8 @@ describe('LocalParticipant', () => {
   });
 
   describe('#publishTrack', () => {
-    var options;
-    var test;
+    let options;
+    let test;
 
     beforeEach(() => {
       options = {
@@ -361,14 +361,14 @@ describe('LocalParticipant', () => {
                   });
 
                   context('when the SID is set for the underlying LocalTrackPublicationSignaling', () => {
-                    var otherKinds = {
+                    const otherKinds = {
                       audio: ['video', 'data'],
                       video: ['audio', 'data'],
                       data: ['audio', 'video']
                     }[kind];
 
                     it(`should resolve the returned Promise with a ${capitalize(kind)}TrackPublication`, () => {
-                      var LocalTrackPublication = options[`Local${capitalize(kind)}TrackPublication`];
+                      const LocalTrackPublication = options[`Local${capitalize(kind)}TrackPublication`];
                       assert(localTrackPublication instanceof LocalTrackPublication);
                       assert.equal(localTrackPublication.trackName, (hasLocalTrack || trackType === 'LocalTrack') ? localTrack.id : 'bar');
                       assert.equal(localTrackPublication.trackSid, 'foo');
@@ -450,7 +450,7 @@ describe('LocalParticipant', () => {
   });
 
   describe('#unpublishTrack', () => {
-    var test;
+    let test;
 
     beforeEach(() => {
       test = makeTest();
@@ -502,12 +502,12 @@ describe('LocalParticipant', () => {
         'video',
         'data'
       ].forEach(kind => {
-        var localTrack;
+        let localTrack;
 
         context(`when the .trackPublications collection has an entry for the given ${kind} ${trackType}`, () => {
           context(`and the .tracks collection has an entry for the given ${kind} ${trackType}'s .id`, () => {
-            var ret;
-            var track;
+            let ret;
+            let track;
 
             beforeEach(() => {
               localTrack = createTrack(kind);
@@ -548,9 +548,9 @@ describe('LocalParticipant', () => {
 
         context(`when the .trackPublications collection does not have an entry for the given ${kind} ${trackType}'s ID`, () => {
           context(`and the .tracks collection has the given ${kind} ${trackType}`, () => {
-            var ret;
-            var track;
-            var trackSignaling;
+            let ret;
+            let track;
+            let trackSignaling;
 
             beforeEach(() => {
               localTrack = createTrack(kind);
@@ -612,8 +612,8 @@ describe('LocalParticipant', () => {
     context('"trackAdded" event', () => {
       context('when the LocalParticipant .state is "connecting"', () => {
         it('calls .addTrack with the LocalTrack\'s MediaStreamTrack and name on the ParticipantSignaling', () =>{
-          var test = makeTest({ state: 'connecting' });
-          var track = { id: 'foo', mediaStreamTrack: 'bar', name: 'baz' };
+          const test = makeTest({ state: 'connecting' });
+          const track = { id: 'foo', mediaStreamTrack: 'bar', name: 'baz' };
           test.participant.emit('trackAdded', track);
           assert.equal(track.mediaStreamTrack, test.signaling.addTrack.args[0][0]);
           assert.equal(track.name, test.signaling.addTrack.args[0][1]);
@@ -622,8 +622,8 @@ describe('LocalParticipant', () => {
 
       context('when the LocalParticipant .state is "connected"', () => {
         it('calls .addTrack with the LocalTrack\'s MediaStreamTrack and name on the ParticipantSignaling', () =>{
-          var test = makeTest({ state: 'connected' });
-          var track = { id: 'foo', mediaStreamTrack: 'bar', name: 'baz' };
+          const test = makeTest({ state: 'connected' });
+          const track = { id: 'foo', mediaStreamTrack: 'bar', name: 'baz' };
           test.participant.emit('trackAdded', track);
           assert.equal(track.mediaStreamTrack, test.signaling.addTrack.args[0][0]);
           assert.equal(track.name, test.signaling.addTrack.args[0][1]);
@@ -632,8 +632,8 @@ describe('LocalParticipant', () => {
 
       context('when the LocalParticipant .state is "disconnected"', () => {
         it('does not call .addTrack with the LocalTrack\'s MediaStreamTrack and name on the ParticipantSignaling', () =>{
-          var test = makeTest({ state: 'disconnected' });
-          var track = { id: 'foo', mediaStreamTrack: 'bar' };
+          const test = makeTest({ state: 'disconnected' });
+          const track = { id: 'foo', mediaStreamTrack: 'bar' };
           test.participant.emit('trackAdded', track);
           assert(!test.signaling.addTrack.calledOnce);
         });
@@ -641,9 +641,9 @@ describe('LocalParticipant', () => {
 
       context('when the LocalParticipant .state transitions to "disconnected"', () => {
         it('does not call .addTrack with the LocalTrack\'s MediaStreamTrack and name on the ParticipantSignaling', () =>{
-          var test = makeTest({ state: 'connected' });
+          const test = makeTest({ state: 'connected' });
           test.signaling.emit('stateChanged', 'disconnected');
-          var track = { id: 'foo', mediaStreamTrack: 'bar' };
+          const track = { id: 'foo', mediaStreamTrack: 'bar' };
           test.participant.emit('trackAdded', track);
           assert(!test.signaling.addTrack.calledOnce);
         });
@@ -655,9 +655,9 @@ describe('LocalParticipant', () => {
         [ 'connecting', 'connected' ].forEach(state => {
           context(`when the LocalParticipant .state is "${state}"`, () => {
             it(`should call .${trackMethod} on the LocalTrack\'s LocalTrackPublicationSignaling`, () => {
-              var test = makeTest({ state });
-              var track = { id: 'foo', mediaStreamTrack: 'bar' };
-              var trackSignaling = { id: 'foo' , [trackMethod]: sinon.spy() };
+              const test = makeTest({ state });
+              const track = { id: 'foo', mediaStreamTrack: 'bar' };
+              const trackSignaling = { id: 'foo' , [trackMethod]: sinon.spy() };
               test.signaling.tracks = { get: () => trackSignaling };
               test.participant.emit(`track${capitalize(trackMethod)}d`, track);
               sinon.assert.calledOnce(trackSignaling[trackMethod]);
@@ -668,9 +668,9 @@ describe('LocalParticipant', () => {
         [ 'is', 'transitions to' ].forEach(action => {
           context(`when the LocalParticipant .state ${action} "disconnected"`, () => {
             it(`should not call .${trackMethod} on the LocalTrack\'s LocalTrackPublicationSignaling`, () => {
-              var test = makeTest({ state: action === 'is' ? 'disconnected' : 'connected' });
-              var track = { id: 'foo', mediaStreamTrack: 'bar' };
-              var trackSignaling = { id: 'foo' , [trackMethod]: sinon.spy() };
+              const test = makeTest({ state: action === 'is' ? 'disconnected' : 'connected' });
+              const track = { id: 'foo', mediaStreamTrack: 'bar' };
+              const trackSignaling = { id: 'foo' , [trackMethod]: sinon.spy() };
 
               test.signaling.tracks = { get: () => trackSignaling };
               if (action === 'transitions to') {
@@ -688,8 +688,8 @@ describe('LocalParticipant', () => {
     context('"trackRemoved" event', () => {
       context('when the LocalParticipant .state is "connecting"', () => {
         it('calls .removeTrack with the LocalTrack\'s LocalTrackPublicationSignaling on the ParticipantSignaling', () =>{
-          var test = makeTest({ state: 'connecting' });
-          var track = { id: 'foo', mediaStreamTrack: 'bar' };
+          const test = makeTest({ state: 'connecting' });
+          const track = { id: 'foo', mediaStreamTrack: 'bar' };
           test.participant.emit('trackRemoved', track);
           assert.equal(track.mediaStreamTrack, test.signaling.removeTrack.args[0][0]);
         });
@@ -697,8 +697,8 @@ describe('LocalParticipant', () => {
 
       context('when the LocalParticipant .state is "connected"', () => {
         it('calls .removeTrack with the LocalTrack\'s LocalTrackPublicationSignaling on the ParticipantSignaling', () =>{
-          var test = makeTest({ state: 'connected' });
-          var track = { id: 'foo', mediaStreamTrack: 'bar' };
+          const test = makeTest({ state: 'connected' });
+          const track = { id: 'foo', mediaStreamTrack: 'bar' };
           test.participant.emit('trackRemoved', track);
           assert.equal(track.mediaStreamTrack, test.signaling.removeTrack.args[0][0]);
         });
@@ -706,8 +706,8 @@ describe('LocalParticipant', () => {
 
       context('when the LocalParticipant .state is "disconnected"', () => {
         it('does not call .removeTrack with the LocalTrack\'s LocalTrackPublicationSignaling on the ParticipantSignaling', () =>{
-          var test = makeTest({ state: 'disconnected' });
-          var track = { id: 'foo', mediaStreamTrack: 'bar' };
+          const test = makeTest({ state: 'disconnected' });
+          const track = { id: 'foo', mediaStreamTrack: 'bar' };
           test.participant.emit('trackRemoved', track);
           assert(!test.signaling.removeTrack.calledOnce);
         });
@@ -715,9 +715,9 @@ describe('LocalParticipant', () => {
 
       context('when the LocalParticipant .state transitions to "disconnected"', () => {
         it('does not call .removeTrack with the LocalTrack\'s LocalTrackPublicationSignaling on the ParticipantSignaling', () =>{
-          var test = makeTest({ state: 'connected' });
+          const test = makeTest({ state: 'connected' });
           test.signaling.emit('stateChanged', 'disconnected');
-          var track = { id: 'foo', mediaStreamTrack: 'bar' };
+          const track = { id: 'foo', mediaStreamTrack: 'bar' };
           test.participant.emit('trackRemoved', track);
           assert(!test.signaling.removeTrack.calledOnce);
         });
@@ -728,10 +728,10 @@ describe('LocalParticipant', () => {
       context('when the LocalParticipant .state begins in "connecting"', () => {
         context('and a LocalTrack emits "stopped"', () => {
           it('emits "trackStopped"', () => {
-            var track = new EventEmitter();
+            const track = new EventEmitter();
             track.mediaStreamTrack = track;
-            var trackStopped;
-            var test = makeTest({ tracks: [ track ] });
+            let trackStopped;
+            const test = makeTest({ tracks: [ track ] });
             test.participant.once('trackStopped', track => trackStopped = track);
             track.emit('stopped', track);
             assert.equal(track, trackStopped);
@@ -742,10 +742,10 @@ describe('LocalParticipant', () => {
       context('when the LocalParticipant .state transitions to "disconnected"', () => {
         context('and a LocalTrack emits "stopped"', () => {
           it('does not emit "trackStopped"', () => {
-            var track = new EventEmitter();
+            const track = new EventEmitter();
             track.mediaStreamTrack = track;
-            var trackStopped;
-            var test = makeTest({ tracks: [ track ] });
+            let trackStopped;
+            const test = makeTest({ tracks: [ track ] });
             test.signaling.emit('stateChanged', 'disconnected');
             test.participant.once('trackStopped', track => trackStopped = track);
             track.emit('stopped', track);
@@ -757,9 +757,9 @@ describe('LocalParticipant', () => {
       context('when the LocalParticipant .state begins in "disconnected"', () => {
         context('and a LocalTrack emits "stopped"', () => {
           it('does not emit "trackStopped"', () => {
-            var track = new EventEmitter();
-            var trackStopped;
-            var test = makeTest({ tracks: [ track ], state: 'disconnected' });
+            const track = new EventEmitter();
+            let trackStopped;
+            const test = makeTest({ tracks: [ track ], state: 'disconnected' });
             test.participant.once('trackStopped', track => trackStopped = track);
             track.emit('stopped', track);
             assert(!trackStopped);
@@ -771,11 +771,11 @@ describe('LocalParticipant', () => {
     context('.tracks', () => {
       context('when the LocalParticipant .state is "connecting"', () => {
         it('calls .addTrack with each LocalTrack\'s MediaStreamTrack and name on the ParticipantSignaling', () =>{
-          var track = new EventEmitter();
+          const track = new EventEmitter();
           track.id = 'foo';
           track.mediaStreamTrack = 'bar';
           track.name = 'baz';
-          var test = makeTest({
+          const test = makeTest({
             state: 'connecting',
             tracks: [track]
           });
@@ -786,11 +786,11 @@ describe('LocalParticipant', () => {
 
       context('when the LocalParticipant .state is "connected"', () => {
         it('calls .addTrack with each LocalTrack\'s MediaStreamTrack and name on the ParticipantSignaling', () =>{
-          var track = new EventEmitter();
+          const track = new EventEmitter();
           track.id = 'foo';
           track.mediaStreamTrack = 'bar';
           track.name = 'baz';
-          var test = makeTest({
+          const test = makeTest({
             state: 'connected',
             tracks: [track]
           });
@@ -801,10 +801,10 @@ describe('LocalParticipant', () => {
 
       context('when the LocalParticipant .state is "disconnected"', () => {
         it('does not call .addTrack with each LocalTrack\'s MediaStreamTrack and name on the ParticipantSignaling', () =>{
-          var track = new EventEmitter();
+          const track = new EventEmitter();
           track.id = 'foo';
           track.mediaStreamTrack = 'bar';
-          var test = makeTest({
+          const test = makeTest({
             state: 'disconnected',
             tracks: [track]
           });
@@ -818,8 +818,8 @@ describe('LocalParticipant', () => {
     context('"stateChanged" event', () => {
       context('when the LocalParticipant .state is "connecting"', () => {
         it('re-emits "stateChanged" event states', () => {
-          var test = makeTest({ state: 'connecting' });
-          var stateChanged;
+          const test = makeTest({ state: 'connecting' });
+          let stateChanged;
           test.participant.once('foo', participant => stateChanged = participant);
           test.signaling.emit('stateChanged', 'foo');
           assert.equal(
@@ -830,8 +830,8 @@ describe('LocalParticipant', () => {
 
       context('when the LocalParticipant .state is "connected"', () => {
         it('re-emits "stateChanged" event states', () => {
-          var test = makeTest({ state: 'connected' });
-          var stateChanged;
+          const test = makeTest({ state: 'connected' });
+          let stateChanged;
           test.participant.once('foo', participant => stateChanged = participant);
           test.signaling.emit('stateChanged', 'foo');
           assert.equal(
@@ -842,8 +842,8 @@ describe('LocalParticipant', () => {
 
       context('when the LocalParticipant .state is "disconnected"', () => {
         it('does not re-emit "stateChanged" event states', () => {
-          var test = makeTest({ state: 'disconnected' });
-          var stateChanged = false;
+          const test = makeTest({ state: 'disconnected' });
+          let stateChanged;
           test.participant.once('foo', () => stateChanged = true);
           test.signaling.emit('stateChanged', 'foo');
           assert(!stateChanged);
@@ -916,9 +916,9 @@ describe('LocalParticipant', () => {
         });
 
         it('does not re-emit "stateChanged" event states', () => {
-          var test = makeTest({ state: 'connected' });
+          const test = makeTest({ state: 'connected' });
           test.signaling.emit('stateChanged', 'disconnected');
-          var stateChanged = false;
+          let stateChanged;
           test.participant.once('foo', () => stateChanged = true);
           test.signaling.emit('stateChanged', 'foo');
           assert(!stateChanged);
@@ -948,7 +948,7 @@ function makeTest(options) {
 }
 
 function makeTrackSignaling(id, sid, getSidError) {
-  var signaling = {};
+  const signaling = {};
   signaling.id = id;
   signaling.getSid = sinon.spy(() => getSidError
     ? Promise.reject(getSidError)
@@ -958,7 +958,7 @@ function makeTrackSignaling(id, sid, getSidError) {
 }
 
 function makeSignaling(options) {
-  var signaling = new EventEmitter();
+  const signaling = new EventEmitter();
   options = options || {};
   options.state = options.state || 'connected';
   signaling.identity = options.identity || null;

--- a/test/unit/spec/localparticipant.js
+++ b/test/unit/spec/localparticipant.js
@@ -950,9 +950,6 @@ function makeTest(options) {
 function makeTrackSignaling(id, sid, getSidError) {
   const signaling = {};
   signaling.id = id;
-  signaling.getSid = sinon.spy(() => getSidError
-    ? Promise.reject(getSidError)
-    : Promise.resolve(sid));
   signaling.publishFailed = sinon.spy(() => {});
   return signaling;
 }

--- a/test/unit/spec/localparticipant.js
+++ b/test/unit/spec/localparticipant.js
@@ -1,15 +1,17 @@
 'use strict';
 
-var assert = require('assert');
-var EventEmitter = require('events').EventEmitter;
-var FakeMediaStreamTrack = require('../../lib/fakemediastream').FakeMediaStreamTrack;
-var inherits = require('util').inherits;
-var DataTrackSender = require('../../../lib/data/sender');
-var LocalParticipant = require('../../../lib/localparticipant');
-var LocalTrackPublicationSignaling = require('../../../lib/signaling/localtrackpublication');
-var sinon = require('sinon');
-var log = require('../../lib/fakelog');
-var { a, capitalize } = require('../../lib/util');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const sinon = require('sinon');
+const { inherits } = require('util');
+
+const DataTrackSender = require('../../../lib/data/sender');
+const LocalParticipant = require('../../../lib/localparticipant');
+const LocalTrackPublicationSignaling = require('../../../lib/signaling/localtrackpublication');
+
+const log = require('../../lib/fakelog');
+const { FakeMediaStreamTrack } = require('../../lib/fakemediastream');
+const { a, capitalize } = require('../../lib/util');
 
 const LocalAudioTrack = sinon.spy(function(mediaStreamTrack, options) {
   options = options || {};

--- a/test/unit/spec/localparticipant.js
+++ b/test/unit/spec/localparticipant.js
@@ -13,33 +13,33 @@ const log = require('../../lib/fakelog');
 const { FakeMediaStreamTrack } = require('../../lib/fakemediastream');
 const { a, capitalize } = require('../../lib/util');
 
-const LocalAudioTrack = sinon.spy(function(mediaStreamTrack, options) {
+const LocalAudioTrack = sinon.spy(function LocalAudioTrack(mediaStreamTrack, options) {
   options = options || {};
   EventEmitter.call(this);
   if (mediaStreamTrack) {
     this.id = mediaStreamTrack.id;
     this.kind = mediaStreamTrack.kind;
     this.mediaStreamTrack = mediaStreamTrack;
-    this.name = options.name || mediaStreamTrack.id
+    this.name = options.name || mediaStreamTrack.id;
   }
   this.stop = sinon.spy();
 });
 inherits(LocalAudioTrack, EventEmitter);
 
-const LocalVideoTrack = sinon.spy(function(mediaStreamTrack, options) {
+const LocalVideoTrack = sinon.spy(function LocalVideoTrack(mediaStreamTrack, options) {
   options = options || {};
   EventEmitter.call(this);
   if (mediaStreamTrack) {
     this.id = mediaStreamTrack.id;
     this.kind = mediaStreamTrack.kind;
     this.mediaStreamTrack = mediaStreamTrack;
-    this.name = options.name || mediaStreamTrack.id
+    this.name = options.name || mediaStreamTrack.id;
   }
   this.stop = sinon.spy();
 });
 inherits(LocalVideoTrack, EventEmitter);
 
-const LocalDataTrack = sinon.spy(function(dataTrackSender, options) {
+const LocalDataTrack = sinon.spy(function LocalDataTrack(dataTrackSender, options) {
   options = options || {};
   EventEmitter.call(this);
   if (dataTrackSender) {
@@ -155,7 +155,7 @@ describe('LocalParticipant', () => {
             FakeMediaStreamTrack.bind(null, 'video'),
             LocalDataTrack.bind(null, new DataTrackSender(null, null, true))
           ]
-        ].forEach(([ arrayItemType, LocalAudioTrack, LocalVideoTrack, LocalDataTrack ]) => {
+        ].forEach(([arrayItemType, LocalAudioTrack, LocalVideoTrack, LocalDataTrack]) => {
           context(arrayItemType, () => {
             it('should not throw', () => {
               assert.doesNotThrow(() => test.participant[method]([
@@ -166,7 +166,7 @@ describe('LocalParticipant', () => {
             });
 
             if (method === 'publishTracks') {
-              it(`should return a Promise for an array of LocalTrackPublications`, async () => {
+              it('should return a Promise for an array of LocalTrackPublications', async () => {
                 const tracks = [
                   new LocalAudioTrack(),
                   new LocalVideoTrack(),
@@ -190,9 +190,9 @@ describe('LocalParticipant', () => {
     context('when the EncodingParameters is', () => {
       [
         ['foo', 'not an object'],
-        [{maxAudioBitrate: 'bar', maxVideoBitrate: 1000}, 'an object that has .maxAudioBitrate which is not a number'],
-        [{maxAudioBitrate: 1000, maxVideoBitrate: false}, 'an object that has .maxVideoBitrate which is not a number'],
-        [{maxAudioBitrate: 'foo', maxVideoBitrate: true}, 'an object which has both .maxAudioBitrate and .maxVideoBitrate which are not numbers']
+        [{ maxAudioBitrate: 'bar', maxVideoBitrate: 1000 }, 'an object that has .maxAudioBitrate which is not a number'],
+        [{ maxAudioBitrate: 1000, maxVideoBitrate: false }, 'an object that has .maxVideoBitrate which is not a number'],
+        [{ maxAudioBitrate: 'foo', maxVideoBitrate: true }, 'an object which has both .maxAudioBitrate and .maxVideoBitrate which are not numbers']
       ].forEach(([encodingParameters, scenario]) => {
         context(scenario, () => itShould(encodingParameters, true));
       });
@@ -201,12 +201,12 @@ describe('LocalParticipant', () => {
         [undefined, 'undefined'],
         [null, 'null'],
         [{}, 'an object which does not have .maxAudioBitrate and .maxVideoBitrate'],
-        [{maxAudioBitrate: null, maxVideoBitrate: null}, 'an object where both .maxAudioBitrate and .maxVideoBitrate are null'],
-        [{maxVideoBitrate: 1000}, 'an object that does not have .maxAudioBitrate'],
-        [{maxAudioBitrate: null, maxVideoBitrate: 1000}, 'an object where .maxAudioBitrate is null'],
-        [{maxAudioBitrate: 1000}, 'an object that does not have .maxVideoBitrate'],
-        [{maxAudioBitrate: 1000, maxVideoBitrate: null}, 'an object where .maxVideoBitrate is null'],
-        [{maxAudioBitrate: 1000, maxVideoBitrate: 2000}, 'an object which has both .maxAudioBitrate and .maxVideoBitrate which are numbers']
+        [{ maxAudioBitrate: null, maxVideoBitrate: null }, 'an object where both .maxAudioBitrate and .maxVideoBitrate are null'],
+        [{ maxVideoBitrate: 1000 }, 'an object that does not have .maxAudioBitrate'],
+        [{ maxAudioBitrate: null, maxVideoBitrate: 1000 }, 'an object where .maxAudioBitrate is null'],
+        [{ maxAudioBitrate: 1000 }, 'an object that does not have .maxVideoBitrate'],
+        [{ maxAudioBitrate: 1000, maxVideoBitrate: null }, 'an object where .maxVideoBitrate is null'],
+        [{ maxAudioBitrate: 1000, maxVideoBitrate: 2000 }, 'an object which has both .maxAudioBitrate and .maxVideoBitrate which are numbers']
       ].forEach(([encodingParameters, scenario]) => {
         context(scenario, () => itShould(encodingParameters, false));
       });
@@ -223,8 +223,11 @@ describe('LocalParticipant', () => {
 
       it(`should ${throwAndFail ? 'not ' : ''}call .setParameters on the underlying ParticipantSignaling`, () => {
         sinon.assert.callCount(test.signaling.setParameters, throwAndFail ? 0 : 1);
-        !throwAndFail && sinon.assert.calledWith(test.signaling.setParameters,
-          encodingParameters === null ? {maxAudioBitrate: null, maxVideoBitrate: null} : encodingParameters);
+        if (!throwAndFail) {
+          sinon.assert.calledWith(test.signaling.setParameters, encodingParameters === null
+            ? { maxAudioBitrate: null, maxVideoBitrate: null }
+            : encodingParameters);
+        }
       });
     }
   });
@@ -258,17 +261,17 @@ describe('LocalParticipant', () => {
       [
         [
           'should return a rejected Promise with a TypeError',
-          (error, addTrack) => error instanceof TypeError
+          error => error instanceof TypeError
         ],
         [
           'should not call .addTrack on the underlying ParticipantSignaling',
           (error, addTrack) => addTrack.callCount === 0
         ]
-      ].forEach(([ expectation, assertion ]) => {
+      ].forEach(([expectation, assertion]) => {
         it(`${expectation}`, async () => {
           try {
             await test.participant.publishTrack('invalid track argument');
-          } catch(error) {
+          } catch (error) {
             assert(assertion(error, test.signaling.addTrack));
             return;
           }
@@ -295,11 +298,11 @@ describe('LocalParticipant', () => {
           video: new FakeMediaStreamTrack(kind)
         }[kind])
       ]
-    ].forEach(([ trackType, kinds, createTrack ]) => {
+    ].forEach(([trackType, kinds, createTrack]) => {
       kinds.forEach(kind => {
         context(`when called with ${a(kind)} ${kind} ${trackType}`, () => {
           [true, false].forEach(isConnected => {
-            context(`and the LocalParticipant\'s ParticipantSignaling is in the "${isConnected ? 'connected' : 'connecting'}" state`, () => {
+            context(`and the LocalParticipant's ParticipantSignaling is in the "${isConnected ? 'connected' : 'connecting'}" state`, () => {
               context(`when the .trackPublications collection already has an entry for the ${trackType}`, () => {
                 let localTrack;
 
@@ -319,14 +322,14 @@ describe('LocalParticipant', () => {
 
                 it('should not raise a "trackPublished" event', async () => {
                   let trackPublishedEvent;
-                  test.participant.on('trackPublished', () => trackPublishedEvent = true);
-                  const localTrackPublication = await test.participant.publishTrack(localTrack);
+                  test.participant.on('trackPublished', () => { trackPublishedEvent = true; });
+                  await test.participant.publishTrack(localTrack);
                   await new Promise(resolve => setTimeout(resolve));
                   assert(!trackPublishedEvent);
                 });
               });
 
-              [ true, false ].forEach(hasLocalTrack => {
+              [true, false].forEach(hasLocalTrack => {
                 context(`when the .tracks collection ${hasLocalTrack ? 'already has' : 'doesn\'t have'} an entry for the ${trackType}'s .id`, () => {
                   let localTrack;
                   let localTrackPublication;
@@ -345,7 +348,7 @@ describe('LocalParticipant', () => {
                     test.participant._signaling.tracks.get(localTrack.id).setSid('foo');
                     localTrackPublication = await promise;
                     trackPublishedEvent = null;
-                    test.participant.on('trackPublished', publication => trackPublishedEvent = publication);
+                    test.participant.on('trackPublished', publication => { trackPublishedEvent = publication; });
                     await new Promise(resolve => setTimeout(resolve));
                   });
 
@@ -412,7 +415,7 @@ describe('LocalParticipant', () => {
                       localTrackSignaling.publishFailed(expectedError);
                       try {
                         await promise;
-                      } catch(error) {
+                      } catch (error) {
                         actualError = error;
                         trackPublicationFailedEvent = null;
                         test.participant.on('trackPublicationFailed', (error, localTrack) => {
@@ -460,7 +463,7 @@ describe('LocalParticipant', () => {
       [
         [
           'should throw a TypeError',
-          (error, removeTrack) => error instanceof TypeError
+          error => error instanceof TypeError
         ],
         [
           'should not call .removeTrack on the underlying ParticipantSignaling',
@@ -575,7 +578,7 @@ describe('LocalParticipant', () => {
               assert(trackSignaling.publishFailed.args[0][0] instanceof Error);
             });
 
-            it(`should call .removeTrack on the underlying ParticipantSignaling with the corresponding MediaStreamTrack`, () => {
+            it('should call .removeTrack on the underlying ParticipantSignaling with the corresponding MediaStreamTrack', () => {
               assert(test.signaling.removeTrack.args[0][0] instanceof FakeMediaStreamTrack
                 || test.signaling.removeTrack.args[0][0] instanceof DataTrackSender);
             });
@@ -650,14 +653,14 @@ describe('LocalParticipant', () => {
       });
     });
 
-    [ 'disable', 'enable' ].forEach(trackMethod => {
+    ['disable', 'enable'].forEach(trackMethod => {
       context(`"track${capitalize(trackMethod)}d" event`, () => {
-        [ 'connecting', 'connected' ].forEach(state => {
+        ['connecting', 'connected'].forEach(state => {
           context(`when the LocalParticipant .state is "${state}"`, () => {
-            it(`should call .${trackMethod} on the LocalTrack\'s LocalTrackPublicationSignaling`, () => {
+            it(`should call .${trackMethod} on the LocalTrack's LocalTrackPublicationSignaling`, () => {
               const test = makeTest({ state });
               const track = { id: 'foo', mediaStreamTrack: 'bar' };
-              const trackSignaling = { id: 'foo' , [trackMethod]: sinon.spy() };
+              const trackSignaling = { id: 'foo', [trackMethod]: sinon.spy() };
               test.signaling.tracks = { get: () => trackSignaling };
               test.participant.emit(`track${capitalize(trackMethod)}d`, track);
               sinon.assert.calledOnce(trackSignaling[trackMethod]);
@@ -665,12 +668,12 @@ describe('LocalParticipant', () => {
           });
         });
 
-        [ 'is', 'transitions to' ].forEach(action => {
+        ['is', 'transitions to'].forEach(action => {
           context(`when the LocalParticipant .state ${action} "disconnected"`, () => {
-            it(`should not call .${trackMethod} on the LocalTrack\'s LocalTrackPublicationSignaling`, () => {
+            it(`should not call .${trackMethod} on the LocalTrack's LocalTrackPublicationSignaling`, () => {
               const test = makeTest({ state: action === 'is' ? 'disconnected' : 'connected' });
               const track = { id: 'foo', mediaStreamTrack: 'bar' };
-              const trackSignaling = { id: 'foo' , [trackMethod]: sinon.spy() };
+              const trackSignaling = { id: 'foo', [trackMethod]: sinon.spy() };
 
               test.signaling.tracks = { get: () => trackSignaling };
               if (action === 'transitions to') {
@@ -731,8 +734,8 @@ describe('LocalParticipant', () => {
             const track = new EventEmitter();
             track.mediaStreamTrack = track;
             let trackStopped;
-            const test = makeTest({ tracks: [ track ] });
-            test.participant.once('trackStopped', track => trackStopped = track);
+            const test = makeTest({ tracks: [track] });
+            test.participant.once('trackStopped', track => { trackStopped = track; });
             track.emit('stopped', track);
             assert.equal(track, trackStopped);
           });
@@ -745,9 +748,9 @@ describe('LocalParticipant', () => {
             const track = new EventEmitter();
             track.mediaStreamTrack = track;
             let trackStopped;
-            const test = makeTest({ tracks: [ track ] });
+            const test = makeTest({ tracks: [track] });
             test.signaling.emit('stateChanged', 'disconnected');
-            test.participant.once('trackStopped', track => trackStopped = track);
+            test.participant.once('trackStopped', track => { trackStopped = track; });
             track.emit('stopped', track);
             assert(!trackStopped);
           });
@@ -759,8 +762,8 @@ describe('LocalParticipant', () => {
           it('does not emit "trackStopped"', () => {
             const track = new EventEmitter();
             let trackStopped;
-            const test = makeTest({ tracks: [ track ], state: 'disconnected' });
-            test.participant.once('trackStopped', track => trackStopped = track);
+            const test = makeTest({ tracks: [track], state: 'disconnected' });
+            test.participant.once('trackStopped', track => { trackStopped = track; });
             track.emit('stopped', track);
             assert(!trackStopped);
           });
@@ -820,7 +823,7 @@ describe('LocalParticipant', () => {
         it('re-emits "stateChanged" event states', () => {
           const test = makeTest({ state: 'connecting' });
           let stateChanged;
-          test.participant.once('foo', participant => stateChanged = participant);
+          test.participant.once('foo', participant => { stateChanged = participant; });
           test.signaling.emit('stateChanged', 'foo');
           assert.equal(
             test.participant,
@@ -832,7 +835,7 @@ describe('LocalParticipant', () => {
         it('re-emits "stateChanged" event states', () => {
           const test = makeTest({ state: 'connected' });
           let stateChanged;
-          test.participant.once('foo', participant => stateChanged = participant);
+          test.participant.once('foo', participant => { stateChanged = participant; });
           test.signaling.emit('stateChanged', 'foo');
           assert.equal(
             test.participant,
@@ -844,7 +847,7 @@ describe('LocalParticipant', () => {
         it('does not re-emit "stateChanged" event states', () => {
           const test = makeTest({ state: 'disconnected' });
           let stateChanged;
-          test.participant.once('foo', () => stateChanged = true);
+          test.participant.once('foo', () => { stateChanged = true; });
           test.signaling.emit('stateChanged', 'foo');
           assert(!stateChanged);
         });
@@ -919,7 +922,7 @@ describe('LocalParticipant', () => {
           const test = makeTest({ state: 'connected' });
           test.signaling.emit('stateChanged', 'disconnected');
           let stateChanged;
-          test.participant.once('foo', () => stateChanged = true);
+          test.participant.once('foo', () => { stateChanged = true; });
           test.signaling.emit('stateChanged', 'foo');
           assert(!stateChanged);
         });
@@ -947,7 +950,7 @@ function makeTest(options) {
   return options;
 }
 
-function makeTrackSignaling(id, sid, getSidError) {
+function makeTrackSignaling(id) {
   const signaling = {};
   signaling.id = id;
   signaling.publishFailed = sinon.spy(() => {});

--- a/test/unit/spec/media/track/localmediatrack.js
+++ b/test/unit/spec/media/track/localmediatrack.js
@@ -20,7 +20,7 @@ const log = require('../../../../lib/fakelog');
     LocalVideoTrack: 'video'
   };
 
-  describe(description, function() {
+  describe(description, () => {
     let track;
 
     describe('constructor', () => {
@@ -88,26 +88,17 @@ const log = require('../../../../lib/fakelog');
 
     describe('"trackStopped" event', () => {
       context('when the MediaStreamTrack emits onended event', () => {
-        it('should emit LocalMediaTrack#stopped, passing the instance of LocalMediaTrack', () => {
+        it('should emit LocalMediaTrack#stopped, passing the instance of LocalMediaTrack', async () => {
           track = createLocalMediaTrack(LocalMediaTrack, '1', kind[description]);
 
-          const stoppedEvent = new Promise((resolve, reject) => {
-            track.on('stopped', function(_track) {
-              try {
-                assert.equal(track, _track);
-              } catch (error) {
-                reject(error);
-                return;
-              }
-              resolve();
-            });
-          });
+          const stoppedEvent = new Promise(resolve => track.once('stopped', resolve));
 
           assert(track.mediaStreamTrack.readyState !== 'ended');
 
           track.mediaStreamTrack.emit('ended');
 
-          return stoppedEvent;
+          const _track = await stoppedEvent;
+          assert.equal(track, _track);
         });
       });
     });
@@ -166,14 +157,14 @@ const log = require('../../../../lib/fakelog');
       });
     });
 
-    describe('#stop', function() {
+    describe('#stop', () => {
       const dummyElement = {
         oncanplay: null,
         videoWidth: 320,
         videoHeight: 240
       };
 
-      before(function() {
+      before(() => {
         track = createLocalMediaTrack(LocalMediaTrack, '1', kind[description]);
         track._createElement = sinon.spy(() => dummyElement);
       });

--- a/test/unit/spec/media/track/localmediatrack.js
+++ b/test/unit/spec/media/track/localmediatrack.js
@@ -14,19 +14,17 @@ const log = require('../../../../lib/fakelog');
 [
   ['LocalAudioTrack', LocalAudioTrack],
   ['LocalVideoTrack', LocalVideoTrack]
-].forEach(pair => {
-  var description = pair[0];
-  var LocalMediaTrack = pair[1];
-  var kind = {
+].forEach(([description, LocalMediaTrack]) => {
+  const kind = {
     LocalAudioTrack: 'audio',
     LocalVideoTrack: 'video'
   };
 
   describe(description, function() {
-    var track;
+    let track;
 
     describe('constructor', () => {
-      var mediaStreamTrack;
+      let mediaStreamTrack;
 
       before(() => {
         mediaStreamTrack = new MediaStreamTrack('foo', kind[description]);
@@ -128,8 +126,8 @@ const log = require('../../../../lib/fakelog');
 
     describe('#enable', () => {
       context('when called with the same boolean value as the underlying MediaStreamTrack\'s .enabled', () => {
-        var trackDisabledEmitted = false;
-        var trackEnabledEmitted = false;
+        let trackDisabledEmitted;
+        let trackEnabledEmitted;
 
         before(() => {
           track =  createLocalMediaTrack(LocalMediaTrack, 'foo', kind[description]);
@@ -147,7 +145,7 @@ const log = require('../../../../lib/fakelog');
       [ true, false ].forEach(enabled => {
         context(`when .enable is called with ${enabled}`, () => {
           context(`and the underlying MediaStreamTrack's .enabled is ${!enabled}`, () => {
-            var eventEmitted = false;
+            let eventEmitted;
 
             before(() => {
               track =  createLocalMediaTrack(LocalMediaTrack, 'foo', kind[description]);
@@ -169,7 +167,7 @@ const log = require('../../../../lib/fakelog');
     });
 
     describe('#stop', function() {
-      var dummyElement = {
+      const dummyElement = {
         oncanplay: null,
         videoWidth: 320,
         videoHeight: 240
@@ -181,12 +179,12 @@ const log = require('../../../../lib/fakelog');
       });
 
       it('should not change the value of isEnabled', (done) => {
-        var startedTimeout = setTimeout(
+        const startedTimeout = setTimeout(
           done.bind(null, new Error('track#started didn\'t fire')),
           1000
         );
         track.on('started', () => {
-          var isEnabled = track.isEnabled;
+          const isEnabled = track.isEnabled;
           clearTimeout(startedTimeout);
           track.stop();
           assert.equal(isEnabled, track.isEnabled);
@@ -199,8 +197,8 @@ const log = require('../../../../lib/fakelog');
 });
 
 function createLocalMediaTrack(LocalMediaTrack, id, kind, name) {
-  var mediaStreamTrack = new MediaStreamTrack(id, kind);
-  var options = name ? { log, name } : { log };
+  const mediaStreamTrack = new MediaStreamTrack(id, kind);
+  const options = name ? { log, name } : { log };
   return new LocalMediaTrack(mediaStreamTrack, options);
 }
 

--- a/test/unit/spec/media/track/localmediatrack.js
+++ b/test/unit/spec/media/track/localmediatrack.js
@@ -5,7 +5,6 @@ const { EventEmitter } = require('events');
 const sinon = require('sinon');
 const { inherits } = require('util');
 
-const Track = require('../../../../../lib/media/track/mediatrack');
 const LocalAudioTrack = require('../../../../../lib/media/track/localaudiotrack');
 const LocalVideoTrack = require('../../../../../lib/media/track/localvideotrack');
 
@@ -34,13 +33,14 @@ const log = require('../../../../lib/fakelog');
         [
           [
             'when called without the "new" keyword',
+            // eslint-disable-next-line new-cap
             () => LocalMediaTrack(mediaStreamTrack)
           ],
           [
             'when called with the "new" keyword',
             () => new LocalMediaTrack(mediaStreamTrack)
           ]
-        ].forEach(([ scenario, createLocalMediaTrack ]) => {
+        ].forEach(([scenario, createLocalMediaTrack]) => {
           context(scenario, () => {
             it('should not throw', () => {
               assert.doesNotThrow(createLocalMediaTrack);
@@ -123,8 +123,8 @@ const log = require('../../../../lib/fakelog');
         before(() => {
           track =  createLocalMediaTrack(LocalMediaTrack, 'foo', kind[description]);
           track.mediaStreamTrack.enabled = Math.random() > 0.5;
-          track.on('disabled', () => trackDisabledEmitted = true);
-          track.on('enabled', () => trackEnabledEmitted = true);
+          track.on('disabled', () => { trackDisabledEmitted = true; });
+          track.on('enabled', () => { trackEnabledEmitted = true; });
         });
 
         it('should not emit the "disabled" or "enabled" events', () => {
@@ -133,7 +133,7 @@ const log = require('../../../../lib/fakelog');
         });
       });
 
-      [ true, false ].forEach(enabled => {
+      [true, false].forEach(enabled => {
         context(`when .enable is called with ${enabled}`, () => {
           context(`and the underlying MediaStreamTrack's .enabled is ${!enabled}`, () => {
             let eventEmitted;
@@ -141,7 +141,7 @@ const log = require('../../../../lib/fakelog');
             before(() => {
               track =  createLocalMediaTrack(LocalMediaTrack, 'foo', kind[description]);
               track.mediaStreamTrack.enabled = !enabled;
-              track.on(enabled ? 'enabled' : 'disabled', () => eventEmitted = true);
+              track.on(enabled ? 'enabled' : 'disabled', () => { eventEmitted = true; });
               track.enable(enabled);
             });
 
@@ -211,5 +211,5 @@ MediaStreamTrack.prototype.removeEventListener = MediaStreamTrack.prototype.remo
 
 MediaStreamTrack.prototype.stop = function stop() {
   // Simulating the browser-native MediaStreamTrack's 'ended' event
-  this.emit('ended', {type: 'ended'});
+  this.emit('ended', { type: 'ended' });
 };

--- a/test/unit/spec/media/track/localmediatrack.js
+++ b/test/unit/spec/media/track/localmediatrack.js
@@ -1,13 +1,15 @@
 'use strict';
 
-var assert = require('assert');
-var inherits = require('util').inherits;
-var EventEmitter = require('events').EventEmitter;
-var Track = require('../../../../../lib/media/track/mediatrack');
-var LocalAudioTrack = require('../../../../../lib/media/track/localaudiotrack');
-var LocalVideoTrack = require('../../../../../lib/media/track/localvideotrack');
-var sinon = require('sinon');
-var log = require('../../../../lib/fakelog');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const sinon = require('sinon');
+const { inherits } = require('util');
+
+const Track = require('../../../../../lib/media/track/mediatrack');
+const LocalAudioTrack = require('../../../../../lib/media/track/localaudiotrack');
+const LocalVideoTrack = require('../../../../../lib/media/track/localvideotrack');
+
+const log = require('../../../../lib/fakelog');
 
 [
   ['LocalAudioTrack', LocalAudioTrack],

--- a/test/unit/spec/media/track/localtrackpublication.js
+++ b/test/unit/spec/media/track/localtrackpublication.js
@@ -1,15 +1,17 @@
 'use strict';
 
 const assert = require('assert');
+const sinon = require('sinon');
+
 const DataTrackSender = require('../../../../../lib/data/sender');
 const LocalAudioTrack = require('../../../../../lib/media/track/localaudiotrack');
 const LocalAudioTrackPublication = require('../../../../../lib/media/track/localaudiotrackpublication');
-const LocalVideoTrack = require('../../../../../lib/media/track/localvideotrack');
-const LocalVideoTrackPublication = require('../../../../../lib/media/track/localvideotrackpublication');
 const LocalDataTrack = require('../../../../../lib/media/track/localdatatrack');
 const LocalDataTrackPublication = require('../../../../../lib/media/track/localdatatrackpublication');
+const LocalVideoTrack = require('../../../../../lib/media/track/localvideotrack');
+const LocalVideoTrackPublication = require('../../../../../lib/media/track/localvideotrackpublication');
+
 const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
-const sinon = require('sinon');
 
 [
   ['LocalAudioTrackPublication', LocalAudioTrackPublication, LocalAudioTrack],

--- a/test/unit/spec/media/track/localtrackpublication.js
+++ b/test/unit/spec/media/track/localtrackpublication.js
@@ -67,9 +67,9 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
     });
 
     describe('#unpublish', () => {
-      var localTrackPublication;
-      var ret;
-      var unpublish;
+      let localTrackPublication;
+      let ret;
+      let unpublish;
 
       before(() => {
         unpublish = sinon.spy();

--- a/test/unit/spec/media/track/localtrackpublication.js
+++ b/test/unit/spec/media/track/localtrackpublication.js
@@ -28,7 +28,7 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
     ? new LocalTrack({ DataTrackSender })
     : new LocalTrack(mediaStreamTrack);
 
-  describe(description, function() {
+  describe(description, () => {
     describe('constructor', () => {
       context('when called without the "options" argument', () => {
         [

--- a/test/unit/spec/media/track/localtrackpublication.js
+++ b/test/unit/spec/media/track/localtrackpublication.js
@@ -17,7 +17,7 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
   ['LocalAudioTrackPublication', LocalAudioTrackPublication, LocalAudioTrack],
   ['LocalVideoTrackPublication', LocalVideoTrackPublication, LocalVideoTrack],
   ['LocalDataTrackPublication', LocalDataTrackPublication, LocalDataTrack]
-].forEach(([ description, LocalTrackPublication, LocalTrack ]) => {
+].forEach(([description, LocalTrackPublication, LocalTrack]) => {
   const kind = {
     LocalAudioTrackPublication: 'audio',
     LocalVideoTrackPublication: 'video',
@@ -34,13 +34,14 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
         [
           [
             'when called without the "new" keyword',
+            // eslint-disable-next-line new-cap
             () => LocalTrackPublication('foo', localTrack, () => {})
           ],
           [
             'when called with the "new" keyword',
             () => new LocalTrackPublication('bar', localTrack, () => {})
           ]
-        ].forEach(([ scenario, createLocalTrackPublication ]) => {
+        ].forEach(([scenario, createLocalTrackPublication]) => {
           context(scenario, () => {
             it('should not throw', () => {
               assert.doesNotThrow(createLocalTrackPublication);
@@ -58,7 +59,7 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
         ['track', localTrack],
         ['trackName', localTrack.name],
         ['trackSid', 'foo']
-      ].forEach(([ prop, expectedValue ]) => {
+      ].forEach(([prop, expectedValue]) => {
         it(`should populate the .${prop} property`, () => {
           const localTrackPublication = new LocalTrackPublication('foo', localTrack, () => {});
           assert.equal(localTrackPublication[prop], expectedValue);

--- a/test/unit/spec/media/track/mediatrack.js
+++ b/test/unit/spec/media/track/mediatrack.js
@@ -1,11 +1,13 @@
 'use strict';
 
-var assert = require('assert');
-var EventEmitter = require('events').EventEmitter;
-var inherits = require('util').inherits;
-var MediaTrack = require('../../../../../lib/media/track/mediatrack');
-var sinon = require('sinon');
-var log = require('../../../../lib/fakelog');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const sinon = require('sinon');
+const { inherits } = require('util');
+
+const MediaTrack = require('../../../../../lib/media/track/mediatrack');
+
+const log = require('../../../../lib/fakelog');
 
 describe('MediaTrack', function() {
   var _initialize;

--- a/test/unit/spec/media/track/mediatrack.js
+++ b/test/unit/spec/media/track/mediatrack.js
@@ -62,7 +62,7 @@ describe('MediaTrack', () => {
       assert(track._attach.calledWith(dummyElement));
     });
 
-    it ('should call .delete with the created element on the ._attachments Set', () => {
+    it('should call .delete with the created element on the ._attachments Set', () => {
       assert(track._attachments.delete.calledWith(dummyElement));
     });
 
@@ -454,12 +454,15 @@ describe('MediaTrack', () => {
     let MediaStream;
 
     beforeEach(() => {
-      MediaStream = sinon.spy(function () { mediaStream = this; });
+      MediaStream = sinon.spy(function MediaStream() {
+        // eslint-disable-next-line consistent-this
+        mediaStream = this;
+      });
       MediaStream.prototype.addTrack = sinon.spy();
       MediaStream.prototype.getAudioTracks = sinon.spy(() => [track.mediaStreamTrack]);
       MediaStream.prototype.removeTrack = sinon.spy();
       el = document.createElement('audio');
-      track = createMediaTrack(1, 'audio', {MediaStream: MediaStream});
+      track = createMediaTrack(1, 'audio', { MediaStream: MediaStream });
     });
 
     context('when the .srcObject of the HTMLMediaElement is not a MediaStream', () => {

--- a/test/unit/spec/media/track/mediatrack.js
+++ b/test/unit/spec/media/track/mediatrack.js
@@ -10,55 +10,55 @@ const MediaTrack = require('../../../../../lib/media/track/mediatrack');
 const log = require('../../../../lib/fakelog');
 const Document = require('../../../../lib/document');
 
-describe('MediaTrack', function() {
+describe('MediaTrack', () => {
   let _initialize;
   let track;
 
-  before(function() {
+  before(() => {
     _initialize = MediaTrack.prototype._initialize;
     MediaTrack.prototype._initialize = sinon.spy();
     global.document = global.document || new Document();
   });
 
-  after(function() {
+  after(() => {
     MediaTrack.prototype._initialize = _initialize;
     if (global.document instanceof Document) {
       delete global.document;
     }
   });
 
-  describe('constructor', function() {
-    before(function() {
+  describe('constructor', () => {
+    before(() => {
       track = createMediaTrack('1', 'audio');
     });
 
-    it('should call ._initialize', function() {
+    it('should call ._initialize', () => {
       assert.equal(track._initialize.callCount, 1);
     });
   });
 
-  describe('_initialize', function() {
+  describe('_initialize', () => {
     let dummyElement;
 
-    before(function() {
+    before(() => {
       track = createMediaTrack('1', 'audio');
       track._attach = sinon.spy();
       track._detachElement = sinon.spy();
       track._attachments.delete = sinon.spy();
 
       dummyElement = { oncanplay: 'bar' };
-      track._createElement = sinon.spy(function() {
+      track._createElement = sinon.spy(() => {
         return dummyElement;
       });
 
       _initialize.call(track);
     });
 
-    it('should call ._createElement', function() {
+    it('should call ._createElement', () => {
       assert.equal(track._createElement.callCount, 1);
     });
 
-    it('should call ._attach with the created element', function() {
+    it('should call ._attach with the created element', () => {
       assert(track._attach.calledWith(dummyElement));
     });
 
@@ -66,176 +66,178 @@ describe('MediaTrack', function() {
       assert(track._attachments.delete.calledWith(dummyElement));
     });
 
-    it('should set el.oncanplay to a function', function() {
+    it('should set el.oncanplay to a function', () => {
       assert.equal(typeof dummyElement.oncanplay, 'function');
     });
 
-    it('should set el.muted to true', function() {
+    it('should set el.muted to true', () => {
       assert.equal(dummyElement.muted, true);
     });
 
-    context('when the dummy element emits oncanplay event', function() {
-      it('should emit MediaTrack#started, passing the instance of MediaTrack', function(done) {
+    context('when the dummy element emits oncanplay event', () => {
+      it('should emit MediaTrack#started, passing the instance of MediaTrack', async () => {
         _initialize.call(track);
-        track.on('started', function(_track) {
-          done(track !== _track && new Error('Did not return the instance of MediaTrack'));
-        });
+
+        const trackPromise = new Promise(resolve => track.on('started', resolve));
 
         dummyElement.oncanplay();
+
+        const _track = await trackPromise;
+        assert.equal(track, _track);
       });
 
-      it('should call ._detachElement with the passed element', function() {
+      it('should call ._detachElement with the passed element', () => {
         assert(track._detachElement.calledWith(dummyElement));
       });
 
-      it('should set .isStarted to true', function() {
+      it('should set .isStarted to true', () => {
         assert(track.isStarted);
       });
 
-      it('should set the element\'s oncanplay to null', function() {
+      it('should set the element\'s oncanplay to null', () => {
         assert.equal(dummyElement.oncanplay, null);
       });
     });
   });
 
-  describe('attach', function() {
+  describe('attach', () => {
     let element;
     let returnVal;
 
-    context('when undefined is passed', function() {
-      before(function() {
+    context('when undefined is passed', () => {
+      before(() => {
         track = createMediaTrack('1', 'audio');
         element = document.createElement('audio');
 
-        track._createElement = sinon.spy(function() {
+        track._createElement = sinon.spy(() => {
           return element;
         });
         track._selectElement = sinon.spy();
-        track._attach = sinon.spy(function() {
+        track._attach = sinon.spy(() => {
           return element;
         });
 
         returnVal = track.attach();
       });
 
-      it('should call _createElement', function() {
+      it('should call _createElement', () => {
         assert.equal(track._createElement.callCount, 1);
       });
 
-      it('should not call _selectElement', function() {
+      it('should not call _selectElement', () => {
         assert.equal(track._selectElement.callCount, 0);
       });
 
-      it('should call _attach with the created element', function() {
+      it('should call _attach with the created element', () => {
         assert(track._attach.calledWith(element));
       });
 
-      it('should return the result of _attach', function() {
+      it('should return the result of _attach', () => {
         assert(returnVal, element);
       });
     });
 
-    context('when null is passed', function() {
-      before(function() {
+    context('when null is passed', () => {
+      before(() => {
         track = createMediaTrack('1', 'audio');
         element = document.createElement('audio');
 
-        track._createElement = sinon.spy(function() {
+        track._createElement = sinon.spy(() => {
           return element;
         });
         track._selectElement = sinon.spy();
-        track._attach = sinon.spy(function() {
+        track._attach = sinon.spy(() => {
           return element;
         });
 
         returnVal = track.attach(null);
       });
 
-      it('should call _createElement', function() {
+      it('should call _createElement', () => {
         assert.equal(track._createElement.callCount, 1);
       });
 
-      it('should not call _selectElement', function() {
+      it('should not call _selectElement', () => {
         assert.equal(track._selectElement.callCount, 0);
       });
 
-      it('should call _attach with the created element', function() {
+      it('should call _attach with the created element', () => {
         assert(track._attach.calledWith(element));
       });
 
-      it('should return the result of _attach', function() {
+      it('should return the result of _attach', () => {
         assert(returnVal, element);
       });
     });
 
-    context('when a string is passed', function() {
-      before(function() {
+    context('when a string is passed', () => {
+      before(() => {
         track = createMediaTrack('1', 'audio');
         element = document.createElement('audio');
 
         track._createElement = sinon.spy();
-        track._selectElement = sinon.spy(function() {
+        track._selectElement = sinon.spy(() => {
           return element;
         });
-        track._attach = sinon.spy(function() {
+        track._attach = sinon.spy(() => {
           return element;
         });
 
         returnVal = track.attach('.selector');
       });
 
-      it('should not call _createElement', function() {
+      it('should not call _createElement', () => {
         assert.equal(track._createElement.callCount, 0);
       });
 
-      it('should call _selectElement with the specified selector', function() {
+      it('should call _selectElement with the specified selector', () => {
         assert(track._selectElement.calledWith('.selector'));
         assert.equal(track._selectElement.callCount, 1);
       });
 
-      it('should call _attach with the selected element', function() {
+      it('should call _attach with the selected element', () => {
         assert(track._attach.calledWith(element));
       });
 
-      it('should return the result of _attach', function() {
+      it('should return the result of _attach', () => {
         assert(returnVal, element);
       });
     });
 
-    context('when an element is passed', function() {
-      before(function() {
+    context('when an element is passed', () => {
+      before(() => {
         track = createMediaTrack('1', 'audio');
         element = document.createElement('audio');
 
         track._createElement = sinon.spy();
         track._selectElement = sinon.spy();
-        track._attach = sinon.spy(function() {
+        track._attach = sinon.spy(() => {
           return element;
         });
         returnVal = track.attach(element);
       });
 
-      it('should not call _createElement', function() {
+      it('should not call _createElement', () => {
         assert.equal(track._createElement.callCount, 0);
       });
 
-      it('should not call _selectElement', function() {
+      it('should not call _selectElement', () => {
         assert.equal(track._selectElement.callCount, 0);
       });
 
-      it('should call _attach with the passed element', function() {
+      it('should call _attach with the passed element', () => {
         assert(track._attach.calledWith(element));
       });
 
-      it('should return the result of _attach', function() {
+      it('should return the result of _attach', () => {
         assert(returnVal, element);
       });
     });
   });
 
-  describe('_selectElement', function() {
+  describe('_selectElement', () => {
     let element;
-    before(function() {
+    before(() => {
       track = createMediaTrack('1', 'audio');
 
       element = document.createElement('audio');
@@ -243,149 +245,149 @@ describe('MediaTrack', function() {
       document.body.appendChild(element);
     });
 
-    after(function() {
+    after(() => {
       element.parentNode.removeChild(element);
     });
 
-    context('when passed an invalid selector', function() {
-      it('should throw an exception', function() {
-        assert.throws(function() {
+    context('when passed an invalid selector', () => {
+      it('should throw an exception', () => {
+        assert.throws(() => {
           track._selectElement('.nonexistant');
         });
       });
     });
   });
 
-  describe('_createElement', function() {
-    before(function() {
+  describe('_createElement', () => {
+    before(() => {
       track = createMediaTrack('1', 'video');
     });
 
-    it('should return an element with the tagName of .kind', function() {
+    it('should return an element with the tagName of .kind', () => {
       assert.equal(track._createElement().tagName.toLowerCase(), 'video');
     });
   });
 
-  describe('detach', function() {
-    context('when el is undefined', function() {
+  describe('detach', () => {
+    context('when el is undefined', () => {
       let attachedElements;
 
-      before(function() {
+      before(() => {
         track = createMediaTrack('1', 'audio');
         attachedElements = [
           document.createElement('audio'),
           document.createElement('video')
         ];
 
-        track._getAllAttachedElements = sinon.spy(function() {
+        track._getAllAttachedElements = sinon.spy(() => {
           return attachedElements;
         });
         track._selectElement = sinon.spy();
-        track._detachElements = sinon.spy(function(els) { return els; });
+        track._detachElements = sinon.spy(els => els);
         track.detach();
       });
 
-      it('should call _getAllAttachedElements', function() {
+      it('should call _getAllAttachedElements', () => {
         assert.equal(track._getAllAttachedElements.callCount, 1);
       });
 
-      it('should not call _selectElement', function() {
+      it('should not call _selectElement', () => {
         assert.equal(track._selectElement.callCount, 0);
       });
 
-      it('should call _detach with the attached elements', function() {
+      it('should call _detach with the attached elements', () => {
         assert(track._detachElements.calledWith(attachedElements));
       });
     });
 
-    context('when el is null', function() {
+    context('when el is null', () => {
       let attachedElements;
 
-      before(function() {
+      before(() => {
         track = createMediaTrack('1', 'audio');
         attachedElements = [
           document.createElement('audio'),
           document.createElement('video')
         ];
 
-        track._getAllAttachedElements = sinon.spy(function() {
+        track._getAllAttachedElements = sinon.spy(() => {
           return attachedElements;
         });
         track._selectElement = sinon.spy();
-        track._detachElements = sinon.spy(function(els) { return els; });
+        track._detachElements = sinon.spy(els => els);
         track.detach(null);
       });
 
-      it('should call _getAllAttachedElements', function() {
+      it('should call _getAllAttachedElements', () => {
         assert.equal(track._getAllAttachedElements.callCount, 1);
       });
 
-      it('should not call _selectElement', function() {
+      it('should not call _selectElement', () => {
         assert.equal(track._selectElement.callCount, 0);
       });
 
-      it('should call _detach with the attached elements', function() {
+      it('should call _detach with the attached elements', () => {
         assert(track._detachElements.calledWith(attachedElements));
       });
     });
 
-    context('when el is a string', function() {
+    context('when el is a string', () => {
       let element;
 
-      before(function() {
+      before(() => {
         track = createMediaTrack('1', 'audio');
         element = document.createElement('audio');
 
         track._getAllAttachedElements = sinon.spy();
-        track._selectElement = sinon.spy(function() {
+        track._selectElement = sinon.spy(() => {
           return element;
         });
-        track._detachElements = sinon.spy(function(els) { return els; });
+        track._detachElements = sinon.spy(els => els);
         track.detach('.foo');
       });
 
-      it('should not call _getAllAttachedElements', function() {
+      it('should not call _getAllAttachedElements', () => {
         assert.equal(track._getAllAttachedElements.callCount, 0);
       });
 
-      it('should call _selectElement', function() {
+      it('should call _selectElement', () => {
         assert.equal(track._selectElement.callCount, 1);
       });
 
-      it('should call _detach with the attached element', function() {
+      it('should call _detach with the attached element', () => {
         assert(track._detachElements.calledWith([element]));
       });
     });
 
-    context('when el is an element', function() {
+    context('when el is an element', () => {
       let element;
 
-      before(function() {
+      before(() => {
         track = createMediaTrack('1', 'audio');
         element = document.createElement('audio');
 
         track._getAllAttachedElements = sinon.spy();
         track._selectElement = sinon.spy();
-        track._detachElements = sinon.spy(function(els) { return els; });
+        track._detachElements = sinon.spy(els => els);
         track.detach(element);
       });
 
-      it('should not call _getAllAttachedElements', function() {
+      it('should not call _getAllAttachedElements', () => {
         assert.equal(track._getAllAttachedElements.callCount, 0);
       });
 
-      it('should not call _selectElement', function() {
+      it('should not call _selectElement', () => {
         assert.equal(track._selectElement.callCount, 0);
       });
 
-      it('should call _detach with the specified element', function() {
+      it('should call _detach with the specified element', () => {
         assert(track._detachElements.calledWith([element]));
       });
     });
   });
 
-  describe('_getAllAttachedElements', function() {
-    it('should return an array with all elements in ._attachments', function() {
+  describe('_getAllAttachedElements', () => {
+    it('should return an array with all elements in ._attachments', () => {
       track = createMediaTrack('1', 'audio');
       track._attachments.add('foo');
       track._attachments.add('bar');
@@ -394,8 +396,8 @@ describe('MediaTrack', function() {
     });
   });
 
-  describe('_detachElements', function() {
-    it('should run _detachElement for each element passed', function() {
+  describe('_detachElements', () => {
+    it('should run _detachElement for each element passed', () => {
       track = createMediaTrack('1', 'audio');
       track._detachElement = sinon.spy();
       track._detachElements(['foo', 'bar']);
@@ -403,12 +405,12 @@ describe('MediaTrack', function() {
     });
   });
 
-  describe('_detachElement', function() {
+  describe('_detachElement', () => {
     let returnVal;
     let el1;
     let el2;
 
-    before(function() {
+    before(() => {
       track = createMediaTrack('1', 'audio');
       el1 = document.createElement('audio');
       el1.srcObject = new MediaStream();
@@ -418,27 +420,27 @@ describe('MediaTrack', function() {
       returnVal = track._detachElement(el1);
     });
 
-    context('when the element is attached', function() {
-      it('should remove the MediaTrack\'s MediaStreamTrack from the element\'s .srcObject MediaStream', function() {
+    context('when the element is attached', () => {
+      it('should remove the MediaTrack\'s MediaStreamTrack from the element\'s .srcObject MediaStream', () => {
         assert.deepEqual(el1.srcObject.getTracks(), []);
       });
 
-      it('should return the passed element', function() {
+      it('should return the passed element', () => {
         assert.equal(returnVal, el1);
       });
 
-      it('should remove the element from ._attachments', function() {
+      it('should remove the element from ._attachments', () => {
         assert(!track._attachments.has(el1));
       });
     });
 
-    context('when the element is not attached', function() {
-      before(function() {
+    context('when the element is not attached', () => {
+      before(() => {
         el2 = document.createElement('audio');
         returnVal = track._detachElement(el2);
       });
 
-      it('should return the passed element', function() {
+      it('should return the passed element', () => {
         assert.equal(returnVal, el2);
       });
     });

--- a/test/unit/spec/media/track/mediatrack.js
+++ b/test/unit/spec/media/track/mediatrack.js
@@ -10,8 +10,8 @@ const MediaTrack = require('../../../../../lib/media/track/mediatrack');
 const log = require('../../../../lib/fakelog');
 
 describe('MediaTrack', function() {
-  var _initialize;
-  var track;
+  let _initialize;
+  let track;
 
   before(function() {
     _initialize = MediaTrack.prototype._initialize;
@@ -33,7 +33,7 @@ describe('MediaTrack', function() {
   });
 
   describe('_initialize', function() {
-    var dummyElement;
+    let dummyElement;
 
     before(function() {
       track = createMediaTrack('1', 'audio');
@@ -94,8 +94,8 @@ describe('MediaTrack', function() {
   });
 
   describe('attach', function() {
-    var element;
-    var returnVal;
+    let element;
+    let returnVal;
 
     context('when undefined is passed', function() {
       before(function() {
@@ -229,7 +229,7 @@ describe('MediaTrack', function() {
   });
 
   describe('_selectElement', function() {
-    var element;
+    let element;
     before(function() {
       track = createMediaTrack('1', 'audio');
 
@@ -269,7 +269,7 @@ describe('MediaTrack', function() {
 
   describe('detach', function() {
     context('when el is undefined', function() {
-      var attachedElements;
+      let attachedElements;
 
       before(function() {
         track = createMediaTrack('1', 'audio');
@@ -300,7 +300,7 @@ describe('MediaTrack', function() {
     });
 
     context('when el is null', function() {
-      var attachedElements;
+      let attachedElements;
 
       before(function() {
         track = createMediaTrack('1', 'audio');
@@ -331,7 +331,7 @@ describe('MediaTrack', function() {
     });
 
     context('when el is a string', function() {
-      var element;
+      let element;
 
       before(function() {
         track = createMediaTrack('1', 'audio');
@@ -359,7 +359,7 @@ describe('MediaTrack', function() {
     });
 
     context('when el is an element', function() {
-      var element;
+      let element;
 
       before(function() {
         track = createMediaTrack('1', 'audio');
@@ -405,8 +405,9 @@ describe('MediaTrack', function() {
   });
 
   describe('_detachElement', function() {
-    var returnVal;
-    var el1, el2;
+    let returnVal;
+    let el1;
+    let el2;
 
     before(function() {
       track = createMediaTrack('1', 'audio');
@@ -445,11 +446,11 @@ describe('MediaTrack', function() {
   });
 
   describe('_attach', () => {
-    var el;
-    var ret;
-    var track;
-    var mediaStream;
-    var MediaStream;
+    let el;
+    let ret;
+    let track;
+    let mediaStream;
+    let MediaStream;
 
     beforeEach(() => {
       MediaStream = sinon.spy(function () { mediaStream = this; });
@@ -545,7 +546,7 @@ describe('MediaTrack', function() {
  });
 
 function createMediaTrack(id, kind, options) {
-  var mediaStreamTrack = new MediaStreamTrack(id, kind);
+  const mediaStreamTrack = new MediaStreamTrack(id, kind);
   return new MediaTrack(mediaStreamTrack, Object.assign({ log: log }, options));
 }
 

--- a/test/unit/spec/media/track/mediatrack.js
+++ b/test/unit/spec/media/track/mediatrack.js
@@ -8,6 +8,7 @@ const { inherits } = require('util');
 const MediaTrack = require('../../../../../lib/media/track/mediatrack');
 
 const log = require('../../../../lib/fakelog');
+const Document = require('../../../../lib/document');
 
 describe('MediaTrack', function() {
   let _initialize;
@@ -16,10 +17,14 @@ describe('MediaTrack', function() {
   before(function() {
     _initialize = MediaTrack.prototype._initialize;
     MediaTrack.prototype._initialize = sinon.spy();
+    global.document = global.document || new Document();
   });
 
   after(function() {
     MediaTrack.prototype._initialize = _initialize;
+    if (global.document instanceof Document) {
+      delete global.document;
+    }
   });
 
   describe('constructor', function() {
@@ -247,12 +252,6 @@ describe('MediaTrack', function() {
         assert.throws(function() {
           track._selectElement('.nonexistant');
         });
-      });
-    });
-
-    context('when passed a valid selector', function() {
-      it('should return the matched element', function() {
-        assert.equal(track._selectElement('.foo'), element);
       });
     });
   });

--- a/test/unit/spec/media/track/remotedatatrack.js
+++ b/test/unit/spec/media/track/remotedatatrack.js
@@ -2,7 +2,6 @@
 
 const assert = require('assert');
 const { EventEmitter } = require('events');
-const sinon = require('sinon');
 
 const DataTrackReceiver = require('../../../../../lib/data/receiver');
 const EventTarget = require('../../../../../lib/eventtarget');
@@ -11,8 +10,6 @@ const { makeUUID } = require('../../../../../lib/util');
 
 describe('RemoteDataTrack', () => {
   let dataTrackReceiver;
-  let trackSignaling;
-  let dataTrack;
 
   beforeEach(() => {
     dataTrackReceiver = new DataTrackReceiver(makeDataChannel());
@@ -83,7 +80,7 @@ describe('RemoteDataTrack', () => {
 
         it('re-emits the "message" event from the underlying DataTrackReceiver', () => {
           let actualData;
-          dataTrack.on('message', data => actualData = data);
+          dataTrack.on('message', data => { actualData = data; });
           dataTrackReceiver.emit('message', expectedData);
           assert.equal(actualData, expectedData);
         });

--- a/test/unit/spec/media/track/remotemediatrack.js
+++ b/test/unit/spec/media/track/remotemediatrack.js
@@ -9,24 +9,26 @@ const { EventEmitter } = require('events');
 const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
 
 [
-  [ 'audio', RemoteAudioTrack ],
-  [ 'video', RemoteVideoTrack ]
-].forEach(([ kind, RemoteTrack ]) => {
+  ['audio', RemoteAudioTrack],
+  ['video', RemoteVideoTrack]
+].forEach(([kind, RemoteTrack]) => {
   let name = `Remote${capitalize(kind)}Track`;
   describe(`${name}`, () => {
     describe('constructor', () => {
-      [ () => null, () => ({ log }) ].forEach(getOptions => {
+      [() => null, () => ({ log })].forEach(getOptions => {
         context(`when called with${getOptions() ? '' : 'out'} the options object`, () => {
-          [ true, false ].forEach(shouldUseNew => {
+          [true, false].forEach(shouldUseNew => {
             context(`when called with${shouldUseNew ? '' : 'out'} the new keyword`, () => {
               let track;
 
-              const makeTrack = () => {
+              function makeTrack() {
                 const mediaStreamTrack = new FakeMediaStreamTrack(kind);
                 const signaling = makeSignaling(randomBoolean(), randomBoolean(), randomName());
-                return shouldUseNew ? new RemoteTrack(mediaStreamTrack, signaling, getOptions())
+                return shouldUseNew
+                  ? new RemoteTrack(mediaStreamTrack, signaling, getOptions())
+                  // eslint-disable-next-line new-cap
                   : RemoteTrack(mediaStreamTrack, signaling, getOptions());
-              };
+              }
 
               before(() => {
                 track = makeTrack();
@@ -40,7 +42,7 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
                 assert(track instanceof RemoteTrack);
               });
 
-              [ 'isEnabled', 'isSubscribed', 'name', 'sid' ].forEach(prop => {
+              ['isEnabled', 'isSubscribed', 'name', 'sid'].forEach(prop => {
                 it(`should set the .${prop} property to the RemoteTrackSignaling's .${prop}`, () => {
                   assert.equal(track[prop], track._signaling[prop]);
                 });
@@ -52,7 +54,7 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
     });
 
     describe('#_unsubscribe', () => {
-      [ true, false ].forEach(isSubscribed => {
+      [true, false].forEach(isSubscribed => {
         context(`when .isSubscribed is ${isSubscribed}`, () => {
           let track;
           let unsubscribed;
@@ -61,7 +63,7 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
             const mediaStreamTrack = new FakeMediaStreamTrack(kind);
             const signaling = makeSignaling(randomBoolean(), isSubscribed, randomName());
             track = new RemoteTrack(mediaStreamTrack, signaling);
-            track.once('unsubscribed', track => unsubscribed = track);
+            track.once('unsubscribed', track => { unsubscribed = track; });
             track._unsubscribe();
           });
 

--- a/test/unit/spec/queueingeventemitter.js
+++ b/test/unit/spec/queueingeventemitter.js
@@ -4,24 +4,22 @@ const assert = require('assert');
 
 const QueueingEventEmitter = require('../../../lib/queueingeventemitter');
 
-describe('QueueingEventEmitter', function() {
+describe('QueueingEventEmitter', () => {
   let ee;
 
-  beforeEach(function() {
+  beforeEach(() => {
     ee = new QueueingEventEmitter();
   });
 
-  describe('#queue', function() {
-    it('should return true when a listener is present', function() {
-      ee.on('event', function() {});
+  describe('#queue', () => {
+    it('should return true when a listener is present', () => {
+      ee.on('event', () => {});
       assert(ee.queue('event', 'foo'));
     });
 
-    it('should emit an event immediately when a listener is present', function() {
+    it('should emit an event immediately when a listener is present', () => {
       const values = [];
-      ee.on('event', function(value) {
-        values.push(value);
-      });
+      ee.on('event', value => values.push(value));
 
       ee.queue('event', 'foo');
 
@@ -29,18 +27,16 @@ describe('QueueingEventEmitter', function() {
       assert.equal('foo', values[0]);
     });
 
-    it('should return false if no listener is present', function() {
+    it('should return false if no listener is present', () => {
       assert(!ee.queue('event', 'foo'));
     });
 
-    it('should queue events if no listener is present until #dequeue is called', function() {
+    it('should queue events if no listener is present until #dequeue is called', () => {
       ee.queue('event', 'foo');
       ee.queue('event', 'bar');
 
       const values = [];
-      ee.on('event', function(value) {
-        values.push(value);
-      });
+      ee.on('event', value => values.push(value));
 
       ee.dequeue();
       assert.equal('foo', values[0]);
@@ -48,48 +44,48 @@ describe('QueueingEventEmitter', function() {
     });
   });
 
-  describe('#dequeue()', function() {
-    it('should return true if there are no queued events', function() {
+  describe('#dequeue()', () => {
+    it('should return true if there are no queued events', () => {
       assert(ee.dequeue());
     });
 
-    it('should return true if every queued event has a listener', function() {
+    it('should return true if every queued event has a listener', () => {
       ee.queue('foo', 'bar');
       ee.queue('baz', 'qux');
-      ee.on('foo', function() {});
-      ee.on('baz', function() {});
+      ee.on('foo', () => {});
+      ee.on('baz', () => {});
       assert(ee.dequeue());
     });
 
-    it('should return false if any queued event has no listener', function() {
+    it('should return false if any queued event has no listener', () => {
       ee.queue('foo', 'bar');
       ee.queue('baz', 'qux');
-      ee.on('foo', function() {});
+      ee.on('foo', () => {});
       assert(!ee.dequeue());
 
       ee.queue('baz', 'qux');
       ee.queue('baz', 'quux');
-      ee.once('baz', function() {});
+      ee.once('baz', () => {});
       assert(!ee.dequeue());
     });
   });
 
-  describe('#dequeue(event)', function() {
-    it('should return true if there are no queued events', function() {
+  describe('#dequeue(event)', () => {
+    it('should return true if there are no queued events', () => {
       assert(ee.dequeue());
     });
 
-    it('should return true if every queued event has a listener', function() {
+    it('should return true if every queued event has a listener', () => {
       ee.queue('foo', 'bar');
       ee.queue('foo', 'baz');
-      ee.on('foo', function() {});
+      ee.on('foo', () => {});
       assert(ee.dequeue('foo'));
     });
 
-    it('should return false if any queued event has no listener', function() {
+    it('should return false if any queued event has no listener', () => {
       ee.queue('foo', 'bar');
       ee.queue('foo', 'baz');
-      ee.once('foo', function() {});
+      ee.once('foo', () => {});
       assert(!ee.dequeue('foo'));
     });
   });

--- a/test/unit/spec/queueingeventemitter.js
+++ b/test/unit/spec/queueingeventemitter.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var assert = require('assert');
-var QueueingEventEmitter = require('../../../lib/queueingeventemitter');
+const assert = require('assert');
+
+const QueueingEventEmitter = require('../../../lib/queueingeventemitter');
 
 describe('QueueingEventEmitter', function() {
   var ee;

--- a/test/unit/spec/queueingeventemitter.js
+++ b/test/unit/spec/queueingeventemitter.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const QueueingEventEmitter = require('../../../lib/queueingeventemitter');
 
 describe('QueueingEventEmitter', function() {
-  var ee;
+  let ee;
 
   beforeEach(function() {
     ee = new QueueingEventEmitter();
@@ -18,7 +18,7 @@ describe('QueueingEventEmitter', function() {
     });
 
     it('should emit an event immediately when a listener is present', function() {
-      var values = [];
+      const values = [];
       ee.on('event', function(value) {
         values.push(value);
       });
@@ -37,7 +37,7 @@ describe('QueueingEventEmitter', function() {
       ee.queue('event', 'foo');
       ee.queue('event', 'bar');
 
-      var values = [];
+      const values = [];
       ee.on('event', function(value) {
         values.push(value);
       });

--- a/test/unit/spec/remoteparticipant.js
+++ b/test/unit/spec/remoteparticipant.js
@@ -47,7 +47,7 @@ describe('RemoteParticipant', () => {
         dataTrack.id = 'dataTrack';
         dataTrack.kind = 'data';
 
-        test = makeTest({ tracks: [ audioTrack, videoTrack, dataTrack ] });
+        test = makeTest({ tracks: [audioTrack, videoTrack, dataTrack] });
       });
 
       it('should set .tracks to a Map of RemoteTrack ID => RemoteTrack', () => {
@@ -109,9 +109,9 @@ describe('RemoteParticipant', () => {
   });
 
   [
-    [ '_addTrack', 'add' , 'to' ],
-    [ '_removeTrack', 'remove', 'from' ]
-  ].forEach(([ method, action, toOrFrom ]) => {
+    ['_addTrack', 'add', 'to'],
+    ['_removeTrack', 'remove', 'from']
+  ].forEach(([method, action, toOrFrom]) => {
     describe(`#${method}`, () => {
       let newTrack;
       let newTrackSignaling;
@@ -128,7 +128,7 @@ describe('RemoteParticipant', () => {
         test = makeTest();
       });
 
-      [ 'Audio', 'Video', 'Data' ].forEach(kind => {
+      ['Audio', 'Video', 'Data'].forEach(kind => {
         context(`when ${a(kind)} Remote${kind}Track with the same .id exists in .tracks`, () => {
           before(() => {
             trackSignaling = makeTrackSignaling({ kind: kind.toLowerCase() });
@@ -141,7 +141,7 @@ describe('RemoteParticipant', () => {
             trackUnsubscribed = null;
             tracksOnceTrackUnsubscribed = null;
             tracksOnceUnsubscribed = null;
-            [ 'trackAdded', 'trackSubscribed', 'trackRemoved', 'trackUnsubscribed' ].forEach(event => {
+            ['trackAdded', 'trackSubscribed', 'trackRemoved', 'trackUnsubscribed'].forEach(event => {
               test.participant.once(event, track => {
                 participantEvents[event] = track;
                 if (event === 'trackUnsubscribed') {
@@ -173,7 +173,7 @@ describe('RemoteParticipant', () => {
           });
 
           if (method === '_addTrack') {
-            [ 'trackAdded', 'trackSubscribed' ].forEach(event => {
+            ['trackAdded', 'trackSubscribed'].forEach(event => {
               it(`should not emit "${event}"`, () => {
                 assert(!participantEvents[event]);
               });
@@ -193,8 +193,8 @@ describe('RemoteParticipant', () => {
 
             it('should emit "trackRemoved" after "trackUnsubscribed"', () => {
               const events = Object.keys(participantEvents);
-              assert(participantEvents['trackRemoved']);
-              assert(participantEvents['trackUnsubscribed']);
+              assert(participantEvents.trackRemoved);
+              assert(participantEvents.trackUnsubscribed);
               assert(events.indexOf('trackUnsubscribed') < events.indexOf('trackRemoved'));
             });
           }
@@ -205,8 +205,8 @@ describe('RemoteParticipant', () => {
             newTrackSignaling = makeTrackSignaling({ kind: kind.toLowerCase() });
             newTrack = new test[`Remote${kind}Track`](newTrackSignaling.mediaStreamTrackOrDataTrackTransceiver, newTrackSignaling);
             participantEvents = {};
-            [ 'trackAdded', 'trackSubscribed', 'trackRemoved', 'trackUnsubscribed' ].forEach(event => {
-              test.participant.once(event, track => participantEvents[event] = track);
+            ['trackAdded', 'trackSubscribed', 'trackRemoved', 'trackUnsubscribed'].forEach(event => {
+              test.participant.once(event, track => { participantEvents[event] = track; });
             });
             ret = test.participant[method](newTrack);
           });
@@ -230,12 +230,12 @@ describe('RemoteParticipant', () => {
           if (method === '_addTrack') {
             it('should emit "trackSubscribed" after "trackAdded"', () => {
               const events = Object.keys(participantEvents);
-              assert(participantEvents['trackSubscribed']);
-              assert(participantEvents['trackAdded']);
+              assert(participantEvents.trackSubscribed);
+              assert(participantEvents.trackAdded);
               assert(events.indexOf('trackAdded') < events.indexOf('trackSubscribed'));
             });
           } else {
-            [ 'trackRemoved', 'trackUnsubscribed' ].forEach(event => {
+            ['trackRemoved', 'trackUnsubscribed'].forEach(event => {
               it(`should not emit "${event}"`, () => {
                 assert(!participantEvents[event]);
               });
@@ -251,8 +251,8 @@ describe('RemoteParticipant', () => {
       it('re-emits "dimensionsChanged" events', () => {
         const track = new EventEmitter();
         let trackDimensionsChanged;
-        const test = makeTest({ tracks: [ track ] });
-        test.participant.once('trackDimensionsChanged', track => trackDimensionsChanged = track);
+        const test = makeTest({ tracks: [track] });
+        test.participant.once('trackDimensionsChanged', track => { trackDimensionsChanged = track; });
         track.emit('dimensionsChanged', track);
         assert.equal(track, trackDimensionsChanged);
       });
@@ -260,8 +260,8 @@ describe('RemoteParticipant', () => {
       it('re-emits "disabled" events', () => {
         const track = new EventEmitter();
         let trackDisabled;
-        const test = makeTest({ tracks: [ track ] });
-        test.participant.once('trackDisabled', track => trackDisabled = track);
+        const test = makeTest({ tracks: [track] });
+        test.participant.once('trackDisabled', track => { trackDisabled = track; });
         track.emit('disabled', track);
         assert.equal(track, trackDisabled);
       });
@@ -269,8 +269,8 @@ describe('RemoteParticipant', () => {
       it('re-emits "enabled" events', () => {
         const track = new EventEmitter();
         let trackEnabled;
-        const test = makeTest({ tracks: [ track ] });
-        test.participant.once('trackEnabled', track => trackEnabled = track);
+        const test = makeTest({ tracks: [track] });
+        test.participant.once('trackEnabled', track => { trackEnabled = track; });
         track.emit('enabled', track);
         assert.equal(track, trackEnabled);
       });
@@ -278,8 +278,8 @@ describe('RemoteParticipant', () => {
       it('re-emits "message" events', () => {
         const track = new EventEmitter();
         let trackMessageEvent;
-        const test = makeTest({ tracks: [ track ] });
-        test.participant.once('trackMessage', (data, track) => trackMessageEvent = { data, track });
+        const test = makeTest({ tracks: [track] });
+        test.participant.once('trackMessage', (data, track) => { trackMessageEvent = { data, track }; });
         const data = makeUUID();
         track.emit('message', data, track);
         assert.equal(data, trackMessageEvent.data);
@@ -289,8 +289,8 @@ describe('RemoteParticipant', () => {
       it('re-emits "started" events', () => {
         const track = new EventEmitter();
         let trackStarted;
-        const test = makeTest({ tracks: [ track ] });
-        test.participant.once('trackStarted', track => trackStarted = track);
+        const test = makeTest({ tracks: [track] });
+        test.participant.once('trackStarted', track => { trackStarted = track; });
         track.emit('started', track);
         assert.equal(track, trackStarted);
       });
@@ -301,9 +301,9 @@ describe('RemoteParticipant', () => {
         const track = new EventEmitter();
         track._unsubscribe = sinon.spy();
         let trackDimensionsChanged;
-        const test = makeTest({ tracks: [ track ] });
+        const test = makeTest({ tracks: [track] });
         test.signaling.emit('stateChanged', 'disconnected');
-        test.participant.once('trackDimensionsChanged', track => trackDimensionsChanged = track);
+        test.participant.once('trackDimensionsChanged', track => { trackDimensionsChanged = track; });
         track.emit('dimensionsChanged', track);
         assert(!trackDimensionsChanged);
       });
@@ -312,9 +312,9 @@ describe('RemoteParticipant', () => {
         const track = new EventEmitter();
          track._unsubscribe = sinon.spy();
         let trackDisabled;
-        const test = makeTest({ tracks: [ track ] });
+        const test = makeTest({ tracks: [track] });
         test.signaling.emit('stateChanged', 'disconnected');
-        test.participant.once('trackDisabled', track => trackDisabled = track);
+        test.participant.once('trackDisabled', track => { trackDisabled = track; });
         track.emit('disabled', track);
         assert(!trackDisabled);
       });
@@ -323,9 +323,9 @@ describe('RemoteParticipant', () => {
         const track = new EventEmitter();
          track._unsubscribe = sinon.spy();
         let trackEnabled;
-        const test = makeTest({ tracks: [ track ] });
+        const test = makeTest({ tracks: [track] });
         test.signaling.emit('stateChanged', 'disconnected');
-        test.participant.once('trackEnabled', track => trackEnabled = track);
+        test.participant.once('trackEnabled', track => { trackEnabled = track; });
         track.emit('enabled', track);
         assert(!trackEnabled);
       });
@@ -334,9 +334,9 @@ describe('RemoteParticipant', () => {
         const track = new EventEmitter();
          track._unsubscribe = sinon.spy();
         let trackMessageEvent;
-        const test = makeTest({ tracks: [ track ] });
+        const test = makeTest({ tracks: [track] });
         test.signaling.emit('stateChanged', 'disconnected');
-        test.participant.once('trackMessage', (data, track) => trackMessageEvent = { data, track });
+        test.participant.once('trackMessage', (data, track) => { trackMessageEvent = { data, track }; });
         const data = makeUUID();
         track.emit('message', data, track);
         assert(!trackMessageEvent);
@@ -346,9 +346,9 @@ describe('RemoteParticipant', () => {
         const track = new EventEmitter();
         track._unsubscribe = sinon.spy();
         let trackStarted;
-        const test = makeTest({ tracks: [ track ] });
+        const test = makeTest({ tracks: [track] });
         test.signaling.emit('stateChanged', 'disconnected');
-        test.participant.once('trackStarted', track => trackStarted = track);
+        test.participant.once('trackStarted', track => { trackStarted = track; });
         track.emit('started', track);
         assert(!trackStarted);
       });
@@ -356,7 +356,7 @@ describe('RemoteParticipant', () => {
       it('should call ._unsubscribe on all the Participant\'s RemoteTracks', () => {
         const track = new EventEmitter();
         track._unsubscribe = sinon.spy();
-        const test = makeTest({ tracks: [ track ] });
+        const test = makeTest({ tracks: [track] });
         test.signaling.emit('stateChanged', 'disconnected');
         sinon.assert.calledOnce( track._unsubscribe);
       });
@@ -364,7 +364,7 @@ describe('RemoteParticipant', () => {
       it('should emit "trackUnsubscribed" events for all the Participant\'s RemoteTracks', () => {
         const track = new EventEmitter();
         track._unsubscribe = sinon.spy();
-        const test = makeTest({ tracks: [ track ] });
+        const test = makeTest({ tracks: [track] });
         const unsubscribed = [];
         test.participant.on('trackUnsubscribed', track => unsubscribed.push(track));
         test.signaling.emit('stateChanged', 'disconnected');
@@ -377,8 +377,8 @@ describe('RemoteParticipant', () => {
       it('does not re-emit "dimensionsChanged" events', () => {
         const track = new EventEmitter();
         let trackDimensionsChanged;
-        const test = makeTest({ tracks: [ track ], state: 'disconnected' });
-        test.participant.once('trackDimensionsChanged', track => trackDimensionsChanged = track);
+        const test = makeTest({ tracks: [track], state: 'disconnected' });
+        test.participant.once('trackDimensionsChanged', track => { trackDimensionsChanged = track; });
         track.emit('dimensionsChanged', track);
         assert(!trackDimensionsChanged);
       });
@@ -386,8 +386,8 @@ describe('RemoteParticipant', () => {
       it('does not re-emit "disabled" events', () => {
         const track = new EventEmitter();
         let trackDisabled;
-        const test = makeTest({ tracks: [ track ], state: 'disconnected' });
-        test.participant.once('trackDisabled', track => trackDisabled = track);
+        const test = makeTest({ tracks: [track], state: 'disconnected' });
+        test.participant.once('trackDisabled', track => { trackDisabled = track; });
         track.emit('disabled', track);
         assert(!trackDisabled);
       });
@@ -395,8 +395,8 @@ describe('RemoteParticipant', () => {
       it('does not re-emit "enabled" events', () => {
         const track = new EventEmitter();
         let trackEnabled;
-        const test = makeTest({ tracks: [ track ], state: 'disconnected' });
-        test.participant.once('trackEnabled', track => trackEnabled = track);
+        const test = makeTest({ tracks: [track], state: 'disconnected' });
+        test.participant.once('trackEnabled', track => { trackEnabled = track; });
         track.emit('enabled', track);
         assert(!trackEnabled);
       });
@@ -404,8 +404,8 @@ describe('RemoteParticipant', () => {
       it('does not re-emit "message" events', () => {
         const track = new EventEmitter();
         let trackMessageEvent;
-        const test = makeTest({ tracks: [ track ], state: 'disconnected' });
-        test.participant.once('trackMessage', (data, track) => trackMessageEvent = { data, track });
+        const test = makeTest({ tracks: [track], state: 'disconnected' });
+        test.participant.once('trackMessage', (data, track) => { trackMessageEvent = { data, track }; });
         const data = makeUUID();
         track.emit('message', data, track);
         assert(!trackMessageEvent);
@@ -414,8 +414,8 @@ describe('RemoteParticipant', () => {
       it('does not re-emit "started" events', () => {
         const track = new EventEmitter();
         let trackStarted;
-        const test = makeTest({ tracks: [ track ], state: 'disconnected' });
-        test.participant.once('trackStarted', track => trackStarted = track);
+        const test = makeTest({ tracks: [track], state: 'disconnected' });
+        test.participant.once('trackStarted', track => { trackStarted = track; });
         track.emit('started', track);
         assert(!trackStarted);
       });
@@ -428,7 +428,7 @@ describe('RemoteParticipant', () => {
         it('re-emits the "disconnected" state event', () => {
           const test = makeTest();
           let disconnected;
-          test.participant.once('disconnected', participant => disconnected = participant);
+          test.participant.once('disconnected', participant => { disconnected = participant; });
           test.signaling.emit('stateChanged', 'disconnected');
           assert.equal(test.participant, disconnected);
         });
@@ -439,7 +439,7 @@ describe('RemoteParticipant', () => {
           const test = makeTest();
           let disconnected;
           test.signaling.emit('stateChanged', 'disconnected');
-          test.participant.once('disconnected', () => disconnected = true);
+          test.participant.once('disconnected', () => { disconnected = true; });
           test.signaling.emit('stateChanged', 'disconnected');
           assert(!disconnected);
         });
@@ -449,7 +449,7 @@ describe('RemoteParticipant', () => {
         it('re-emits the "disconnected" state event', () => {
           const test = makeTest({ state: 'disconnected' });
           let disconnected;
-          test.participant.once('disconnected', () => disconnected = true);
+          test.participant.once('disconnected', () => { disconnected = true; });
           test.signaling.emit('stateChanged', 'disconnected');
           assert(!disconnected);
         });
@@ -531,14 +531,20 @@ describe('RemoteParticipant', () => {
             const subscribed = [];
 
             const trackEventsPromise = new Promise(resolve => {
-              const shouldResolve = () => tracks.length + subscribed.length === 4;
+              function shouldResolve() {
+                return tracks.length + subscribed.length === 4;
+              }
               test.participant.on('trackAdded', track => {
                 tracks.push(track);
-                shouldResolve() && resolve();
+                if (shouldResolve()) {
+                  resolve();
+                }
               });
               test.participant.on('trackSubscribed', track => {
                 subscribed.push(track);
-                shouldResolve() && resolve();
+                if (shouldResolve()) {
+                  resolve();
+                }
               });
             });
 
@@ -659,14 +665,20 @@ describe('RemoteParticipant', () => {
             const unsubscribed = [];
 
             const trackEventsPromise = new Promise(resolve => {
-              const shouldResolve = () => tracks.length + unsubscribed.length === 4;
+              function shouldResolve() {
+                return tracks.length + unsubscribed.length === 4;
+              }
               test.participant.on('trackRemoved', track => {
                 tracks.push(track);
-                shouldResolve() && resolve();
+                if (shouldResolve()) {
+                  resolve();
+                }
               });
               test.participant.on('trackUnsubscribed', track => {
                 unsubscribed.push(track);
-                shouldResolve() && resolve();
+                if (shouldResolve()) {
+                  resolve();
+                }
               });
             });
 
@@ -957,7 +969,7 @@ function makeTest(options) {
   options.sid = options.sid || makeSid();
   options.state = options.state || 'connected';
   options.tracks = options.tracks || [];
-  
+
   if (typeof options.trackSignalings === 'number') {
     const trackSignalings = [];
     for (let i = 0; i < options.trackSignalings; i++) {

--- a/test/unit/spec/remoteparticipant.js
+++ b/test/unit/spec/remoteparticipant.js
@@ -11,7 +11,7 @@ const { defer, makeUUID } = require('../../../lib/util');
 const { a } = require('../../lib/util');
 const log = require('../../lib/fakelog');
 
-describe('RemoteParticipant', function() {
+describe('RemoteParticipant', () => {
   describe('constructor', () => {
     it('sets .identity to the RemoteParticipantSignaling\'s .identity', () => {
       const test = makeTest();

--- a/test/unit/spec/remoteparticipant.js
+++ b/test/unit/spec/remoteparticipant.js
@@ -14,25 +14,25 @@ const log = require('../../lib/fakelog');
 describe('RemoteParticipant', function() {
   describe('constructor', () => {
     it('sets .identity to the RemoteParticipantSignaling\'s .identity', () => {
-      var test = makeTest();
+      const test = makeTest();
       assert.equal(test.identity, test.participant.identity);
     });
 
     it('sets .sid to the RemoteParticipantSignaling\'s .sid', () => {
-      var test = makeTest();
+      const test = makeTest();
       assert.equal(test.sid, test.participant.sid);
     });
 
     it('sets .state to the RemoteParticipantSignaling\'s .state', () => {
-      var test = makeTest();
+      const test = makeTest();
       assert.equal(test.state, test.participant.state);
     });
 
     context('when RemoteTracks are provided', () => {
-      var test;
-      var audioTrack;
-      var videoTrack;
-      var dataTrack;
+      let test;
+      let audioTrack;
+      let videoTrack;
+      let dataTrack;
 
       before(() => {
         audioTrack = new EventEmitter();
@@ -84,7 +84,7 @@ describe('RemoteParticipant', function() {
     });
 
     context('when RemoteTracks are not provided', () => {
-      var test;
+      let test;
 
       beforeEach(() => {
         test = makeTest();
@@ -192,7 +192,7 @@ describe('RemoteParticipant', function() {
             });
 
             it('should emit "trackRemoved" after "trackUnsubscribed"', () => {
-              var events = Object.keys(participantEvents);
+              const events = Object.keys(participantEvents);
               assert(participantEvents['trackRemoved']);
               assert(participantEvents['trackUnsubscribed']);
               assert(events.indexOf('trackUnsubscribed') < events.indexOf('trackRemoved'));
@@ -229,7 +229,7 @@ describe('RemoteParticipant', function() {
 
           if (method === '_addTrack') {
             it('should emit "trackSubscribed" after "trackAdded"', () => {
-              var events = Object.keys(participantEvents);
+              const events = Object.keys(participantEvents);
               assert(participantEvents['trackSubscribed']);
               assert(participantEvents['trackAdded']);
               assert(events.indexOf('trackAdded') < events.indexOf('trackSubscribed'));
@@ -249,47 +249,47 @@ describe('RemoteParticipant', function() {
   describe('.tracks', () => {
     context('when the RemoteParticipant begins in .state "connected"', () => {
       it('re-emits "dimensionsChanged" events', () => {
-        var track = new EventEmitter();
-        var trackDimensionsChanged;
-        var test = makeTest({ tracks: [ track ] });
+        const track = new EventEmitter();
+        let trackDimensionsChanged;
+        const test = makeTest({ tracks: [ track ] });
         test.participant.once('trackDimensionsChanged', track => trackDimensionsChanged = track);
         track.emit('dimensionsChanged', track);
         assert.equal(track, trackDimensionsChanged);
       });
 
       it('re-emits "disabled" events', () => {
-        var track = new EventEmitter();
-        var trackDisabled;
-        var test = makeTest({ tracks: [ track ] });
+        const track = new EventEmitter();
+        let trackDisabled;
+        const test = makeTest({ tracks: [ track ] });
         test.participant.once('trackDisabled', track => trackDisabled = track);
         track.emit('disabled', track);
         assert.equal(track, trackDisabled);
       });
 
       it('re-emits "enabled" events', () => {
-        var track = new EventEmitter();
-        var trackEnabled;
-        var test = makeTest({ tracks: [ track ] });
+        const track = new EventEmitter();
+        let trackEnabled;
+        const test = makeTest({ tracks: [ track ] });
         test.participant.once('trackEnabled', track => trackEnabled = track);
         track.emit('enabled', track);
         assert.equal(track, trackEnabled);
       });
 
       it('re-emits "message" events', () => {
-        var track = new EventEmitter();
-        var trackMessageEvent;
-        var test = makeTest({ tracks: [ track ] });
+        const track = new EventEmitter();
+        let trackMessageEvent;
+        const test = makeTest({ tracks: [ track ] });
         test.participant.once('trackMessage', (data, track) => trackMessageEvent = { data, track });
-        var data = makeUUID();
+        const data = makeUUID();
         track.emit('message', data, track);
         assert.equal(data, trackMessageEvent.data);
         assert.equal(track, trackMessageEvent.track);
       });
 
       it('re-emits "started" events', () => {
-        var track = new EventEmitter();
-        var trackStarted;
-        var test = makeTest({ tracks: [ track ] });
+        const track = new EventEmitter();
+        let trackStarted;
+        const test = makeTest({ tracks: [ track ] });
         test.participant.once('trackStarted', track => trackStarted = track);
         track.emit('started', track);
         assert.equal(track, trackStarted);
@@ -298,10 +298,10 @@ describe('RemoteParticipant', function() {
 
     context('when the RemoteParticipant .state transitions to "disconnected"', () => {
       it('does not re-emit "dimensionsChanged" events', () => {
-        var track = new EventEmitter();
-         track._unsubscribe = sinon.spy();
-        var trackDimensionsChanged;
-        var test = makeTest({ tracks: [ track ] });
+        const track = new EventEmitter();
+        track._unsubscribe = sinon.spy();
+        let trackDimensionsChanged;
+        const test = makeTest({ tracks: [ track ] });
         test.signaling.emit('stateChanged', 'disconnected');
         test.participant.once('trackDimensionsChanged', track => trackDimensionsChanged = track);
         track.emit('dimensionsChanged', track);
@@ -309,10 +309,10 @@ describe('RemoteParticipant', function() {
       });
 
       it('does not re-emit "disabled" events', () => {
-        var track = new EventEmitter();
+        const track = new EventEmitter();
          track._unsubscribe = sinon.spy();
-        var trackDisabled;
-        var test = makeTest({ tracks: [ track ] });
+        let trackDisabled;
+        const test = makeTest({ tracks: [ track ] });
         test.signaling.emit('stateChanged', 'disconnected');
         test.participant.once('trackDisabled', track => trackDisabled = track);
         track.emit('disabled', track);
@@ -320,10 +320,10 @@ describe('RemoteParticipant', function() {
       });
 
       it('does not re-emit "enabled" events', () => {
-        var track = new EventEmitter();
+        const track = new EventEmitter();
          track._unsubscribe = sinon.spy();
-        var trackEnabled;
-        var test = makeTest({ tracks: [ track ] });
+        let trackEnabled;
+        const test = makeTest({ tracks: [ track ] });
         test.signaling.emit('stateChanged', 'disconnected');
         test.participant.once('trackEnabled', track => trackEnabled = track);
         track.emit('enabled', track);
@@ -331,22 +331,22 @@ describe('RemoteParticipant', function() {
       });
 
       it('does not re-emit "message" events', () => {
-        var track = new EventEmitter();
+        const track = new EventEmitter();
          track._unsubscribe = sinon.spy();
-        var trackMessageEvent;
-        var test = makeTest({ tracks: [ track ] });
+        let trackMessageEvent;
+        const test = makeTest({ tracks: [ track ] });
         test.signaling.emit('stateChanged', 'disconnected');
         test.participant.once('trackMessage', (data, track) => trackMessageEvent = { data, track });
-        var data = makeUUID();
+        const data = makeUUID();
         track.emit('message', data, track);
         assert(!trackMessageEvent);
       });
 
       it('does not re-emit "started" events', () => {
-        var track = new EventEmitter();
-         track._unsubscribe = sinon.spy();
-        var trackStarted;
-        var test = makeTest({ tracks: [ track ] });
+        const track = new EventEmitter();
+        track._unsubscribe = sinon.spy();
+        let trackStarted;
+        const test = makeTest({ tracks: [ track ] });
         test.signaling.emit('stateChanged', 'disconnected');
         test.participant.once('trackStarted', track => trackStarted = track);
         track.emit('started', track);
@@ -354,18 +354,18 @@ describe('RemoteParticipant', function() {
       });
 
       it('should call ._unsubscribe on all the Participant\'s RemoteTracks', () => {
-        var track = new EventEmitter();
-         track._unsubscribe = sinon.spy();
-        var test = makeTest({ tracks: [ track ] });
+        const track = new EventEmitter();
+        track._unsubscribe = sinon.spy();
+        const test = makeTest({ tracks: [ track ] });
         test.signaling.emit('stateChanged', 'disconnected');
         sinon.assert.calledOnce( track._unsubscribe);
       });
 
       it('should emit "trackUnsubscribed" events for all the Participant\'s RemoteTracks', () => {
-        var track = new EventEmitter();
-         track._unsubscribe = sinon.spy();
-        var test = makeTest({ tracks: [ track ] });
-        var unsubscribed = [];
+        const track = new EventEmitter();
+        track._unsubscribe = sinon.spy();
+        const test = makeTest({ tracks: [ track ] });
+        const unsubscribed = [];
         test.participant.on('trackUnsubscribed', track => unsubscribed.push(track));
         test.signaling.emit('stateChanged', 'disconnected');
         assert.equal(unsubscribed.length, 1);
@@ -375,46 +375,46 @@ describe('RemoteParticipant', function() {
 
     context('when the RemoteParticipant .state begins in "disconnected"', () => {
       it('does not re-emit "dimensionsChanged" events', () => {
-        var track = new EventEmitter();
-        var trackDimensionsChanged;
-        var test = makeTest({ tracks: [ track ], state: 'disconnected' });
+        const track = new EventEmitter();
+        let trackDimensionsChanged;
+        const test = makeTest({ tracks: [ track ], state: 'disconnected' });
         test.participant.once('trackDimensionsChanged', track => trackDimensionsChanged = track);
         track.emit('dimensionsChanged', track);
         assert(!trackDimensionsChanged);
       });
 
       it('does not re-emit "disabled" events', () => {
-        var track = new EventEmitter();
-        var trackDisabled;
-        var test = makeTest({ tracks: [ track ], state: 'disconnected' });
+        const track = new EventEmitter();
+        let trackDisabled;
+        const test = makeTest({ tracks: [ track ], state: 'disconnected' });
         test.participant.once('trackDisabled', track => trackDisabled = track);
         track.emit('disabled', track);
         assert(!trackDisabled);
       });
 
       it('does not re-emit "enabled" events', () => {
-        var track = new EventEmitter();
-        var trackEnabled;
-        var test = makeTest({ tracks: [ track ], state: 'disconnected' });
+        const track = new EventEmitter();
+        let trackEnabled;
+        const test = makeTest({ tracks: [ track ], state: 'disconnected' });
         test.participant.once('trackEnabled', track => trackEnabled = track);
         track.emit('enabled', track);
         assert(!trackEnabled);
       });
 
       it('does not re-emit "message" events', () => {
-        var track = new EventEmitter();
-        var trackMessageEvent;
-        var test = makeTest({ tracks: [ track ], state: 'disconnected' });
+        const track = new EventEmitter();
+        let trackMessageEvent;
+        const test = makeTest({ tracks: [ track ], state: 'disconnected' });
         test.participant.once('trackMessage', (data, track) => trackMessageEvent = { data, track });
-        var data = makeUUID();
+        const data = makeUUID();
         track.emit('message', data, track);
         assert(!trackMessageEvent);
       });
 
       it('does not re-emit "started" events', () => {
-        var track = new EventEmitter();
-        var trackStarted;
-        var test = makeTest({ tracks: [ track ], state: 'disconnected' });
+        const track = new EventEmitter();
+        let trackStarted;
+        const test = makeTest({ tracks: [ track ], state: 'disconnected' });
         test.participant.once('trackStarted', track => trackStarted = track);
         track.emit('started', track);
         assert(!trackStarted);
@@ -426,8 +426,8 @@ describe('RemoteParticipant', function() {
     context('"stateChanged" event', () => {
       context('when the RemoteParticipant .state begins in "connected"', () => {
         it('re-emits the "disconnected" state event', () => {
-          var test = makeTest();
-          var disconnected;
+          const test = makeTest();
+          let disconnected;
           test.participant.once('disconnected', participant => disconnected = participant);
           test.signaling.emit('stateChanged', 'disconnected');
           assert.equal(test.participant, disconnected);
@@ -436,8 +436,8 @@ describe('RemoteParticipant', function() {
 
       context('when the RemoteParticipant .state transitions to "disconnected"', () => {
         it('re-emits the "disconnected" state event', () => {
-          var test = makeTest();
-          var disconnected;
+          const test = makeTest();
+          let disconnected;
           test.signaling.emit('stateChanged', 'disconnected');
           test.participant.once('disconnected', () => disconnected = true);
           test.signaling.emit('stateChanged', 'disconnected');
@@ -447,8 +447,8 @@ describe('RemoteParticipant', function() {
 
       context('when the RemoteParticipant .state begins in "disconnected"', () => {
         it('re-emits the "disconnected" state event', () => {
-          var test = makeTest({ state: 'disconnected' });
-          var disconnected;
+          const test = makeTest({ state: 'disconnected' });
+          let disconnected;
           test.participant.once('disconnected', () => disconnected = true);
           test.signaling.emit('stateChanged', 'disconnected');
           assert(!disconnected);
@@ -459,10 +459,10 @@ describe('RemoteParticipant', function() {
     context('"trackAdded" event', () => {
       context('when the RemoteParticipant .state begins in "connected"', () => {
         it('calls .getMediaStreamTrackOrDataTrackTransceiver on the RemoteTrackSignaling', () => {
-          var test = makeTest();
-          var audioTrack = makeTrackSignaling({ kind: 'audio' });
-          var videoTrack = makeTrackSignaling({ kind: 'video' });
-          var dataTrack = makeTrackSignaling({ kind: 'data' });
+          const test = makeTest();
+          const audioTrack = makeTrackSignaling({ kind: 'audio' });
+          const videoTrack = makeTrackSignaling({ kind: 'video' });
+          const dataTrack = makeTrackSignaling({ kind: 'data' });
           test.signaling.emit('trackAdded', audioTrack);
           test.signaling.emit('trackAdded', videoTrack);
           test.signaling.emit('trackAdded', dataTrack);
@@ -473,10 +473,10 @@ describe('RemoteParticipant', function() {
 
         context('if the Promise returned by .getMediaStreamTrackOrDataTrackTransceiver resolves', () => {
           it('constructs a new RemoteTrack and sets its .name to that of the underlying RemoteTrackSignaling', () => {
-            var test = makeTest();
-            var audioTrack = makeTrackSignaling({ kind: 'audio' });
-            var videoTrack = makeTrackSignaling({ kind: 'video' });
-            var dataTrack = makeTrackSignaling({ kind: 'data' });
+            const test = makeTest();
+            const audioTrack = makeTrackSignaling({ kind: 'audio' });
+            const videoTrack = makeTrackSignaling({ kind: 'video' });
+            const dataTrack = makeTrackSignaling({ kind: 'data' });
             test.signaling.emit('trackAdded', audioTrack);
             test.signaling.emit('trackAdded', videoTrack);
             test.signaling.emit('trackAdded', dataTrack);
@@ -500,10 +500,10 @@ describe('RemoteParticipant', function() {
           });
 
           it('adds the newly-constructed RemoteTrack to the RemoteParticipant\'s RemoteTrack collections', () => {
-            var test = makeTest();
-            var audioTrack = makeTrackSignaling({ kind: 'audio' });
-            var videoTrack = makeTrackSignaling({ kind: 'video' });
-            var dataTrack = makeTrackSignaling({ kind: 'data' });
+            const test = makeTest();
+            const audioTrack = makeTrackSignaling({ kind: 'audio' });
+            const videoTrack = makeTrackSignaling({ kind: 'video' });
+            const dataTrack = makeTrackSignaling({ kind: 'data' });
             test.signaling.emit('trackAdded', audioTrack);
             test.signaling.emit('trackAdded', videoTrack);
             test.signaling.emit('trackAdded', dataTrack);
@@ -523,15 +523,15 @@ describe('RemoteParticipant', function() {
 
 
           it('fires the "trackAdded" and "trackSubscribed" events on the RemoteParticipant', () => {
-            var test = makeTest();
-            var audioTrack = makeTrackSignaling({ kind: 'audio' });
-            var videoTrack = makeTrackSignaling({ kind: 'video' });
-            var dataTrack = makeTrackSignaling({ kind: 'data' });
-            var tracks = [];
-            var subscribed = [];
+            const test = makeTest();
+            const audioTrack = makeTrackSignaling({ kind: 'audio' });
+            const videoTrack = makeTrackSignaling({ kind: 'video' });
+            const dataTrack = makeTrackSignaling({ kind: 'data' });
+            const tracks = [];
+            const subscribed = [];
 
-            var trackEventsPromise = new Promise(resolve => {
-              var shouldResolve = () => tracks.length + subscribed.length === 4;
+            const trackEventsPromise = new Promise(resolve => {
+              const shouldResolve = () => tracks.length + subscribed.length === 4;
               test.participant.on('trackAdded', track => {
                 tracks.push(track);
                 shouldResolve() && resolve();
@@ -565,11 +565,11 @@ describe('RemoteParticipant', function() {
 
       context('when the RemoteParticipant .state transitions to "disconnected"', () => {
         it('does not call .getMediaStreamTrackOrDataTrackTransceiver on the RemoteTrackSignaling', () => {
-          var test = makeTest();
+          const test = makeTest();
           test.signaling.emit('stateChanged', 'disconnected');
-          var audioTrack = makeTrackSignaling({ kind: 'audio' });
-          var videoTrack = makeTrackSignaling({ kind: 'video' });
-          var dataTrack = makeTrackSignaling({ kind: 'data' });
+          const audioTrack = makeTrackSignaling({ kind: 'audio' });
+          const videoTrack = makeTrackSignaling({ kind: 'video' });
+          const dataTrack = makeTrackSignaling({ kind: 'data' });
           test.signaling.emit('trackAdded', audioTrack);
           test.signaling.emit('trackAdded', videoTrack);
           test.signaling.emit('trackAdded', dataTrack);
@@ -579,11 +579,11 @@ describe('RemoteParticipant', function() {
         });
 
         it('does not construct a new RemoteTrack', () => {
-          var test = makeTest();
+          const test = makeTest();
           test.signaling.emit('stateChanged', 'disconnected');
-          var audioTrack = makeTrackSignaling({ kind: 'audio' });
-          var videoTrack = makeTrackSignaling({ kind: 'video' });
-          var dataTrack = makeTrackSignaling({ kind: 'data' });
+          const audioTrack = makeTrackSignaling({ kind: 'audio' });
+          const videoTrack = makeTrackSignaling({ kind: 'video' });
+          const dataTrack = makeTrackSignaling({ kind: 'data' });
           test.signaling.emit('trackAdded', audioTrack);
           test.signaling.emit('trackAdded', videoTrack);
           test.signaling.emit('trackAdded', dataTrack);
@@ -593,12 +593,12 @@ describe('RemoteParticipant', function() {
         });
 
         it('does not call ._addTrack on the RemoteParticipant', () => {
-          var test = makeTest();
+          const test = makeTest();
           test.participant._addTrack = sinon.spy();
           test.signaling.emit('stateChanged', 'disconnected');
-          var audioTrack = makeTrackSignaling({ kind: 'audio' });
-          var videoTrack = makeTrackSignaling({ kind: 'video' });
-          var dataTrack = makeTrackSignaling({ kind: 'data' });
+          const audioTrack = makeTrackSignaling({ kind: 'audio' });
+          const videoTrack = makeTrackSignaling({ kind: 'video' });
+          const dataTrack = makeTrackSignaling({ kind: 'data' });
           test.signaling.emit('trackAdded', audioTrack);
           test.signaling.emit('trackAdded', videoTrack);
           test.signaling.emit('trackAdded', dataTrack);
@@ -608,10 +608,10 @@ describe('RemoteParticipant', function() {
 
       context('when the RemoteParticipant .state begins in "disconnected"', () => {
         it('does not call .getMediaStreamTrackOrDataTrackTransceiver on the RemoteTrackSignaling', () => {
-          var test = makeTest({ state: 'disconnected' });
-          var audioTrack = makeTrackSignaling({ kind: 'audio' });
-          var videoTrack = makeTrackSignaling({ kind: 'video' });
-          var dataTrack = makeTrackSignaling({ kind: 'data' });
+          const test = makeTest({ state: 'disconnected' });
+          const audioTrack = makeTrackSignaling({ kind: 'audio' });
+          const videoTrack = makeTrackSignaling({ kind: 'video' });
+          const dataTrack = makeTrackSignaling({ kind: 'data' });
           test.signaling.emit('trackAdded', audioTrack);
           test.signaling.emit('trackAdded', videoTrack);
           test.signaling.emit('trackAdded', dataTrack);
@@ -621,10 +621,10 @@ describe('RemoteParticipant', function() {
         });
 
         it('does not construct a new RemoteTrack', () => {
-          var test = makeTest({ state: 'disconnected' });
-          var audioTrack = makeTrackSignaling({ kind: 'audio' });
-          var videoTrack = makeTrackSignaling({ kind: 'video' });
-          var dataTrack = makeTrackSignaling({ kind: 'data' });
+          const test = makeTest({ state: 'disconnected' });
+          const audioTrack = makeTrackSignaling({ kind: 'audio' });
+          const videoTrack = makeTrackSignaling({ kind: 'video' });
+          const dataTrack = makeTrackSignaling({ kind: 'data' });
           test.signaling.emit('trackAdded', audioTrack);
           test.signaling.emit('trackAdded', videoTrack);
           test.signaling.emit('trackAdded', dataTrack);
@@ -634,11 +634,11 @@ describe('RemoteParticipant', function() {
         });
 
         it('does not call ._addTrack on the RemoteParticipant', () => {
-          var test = makeTest({ state: 'disconnected' });
+          const test = makeTest({ state: 'disconnected' });
           test.participant._addTrack = sinon.spy();
-          var audioTrack = makeTrackSignaling({ kind: 'audio' });
-          var videoTrack = makeTrackSignaling({ kind: 'video' });
-          var dataTrack = makeTrackSignaling({ kind: 'data' });
+          const audioTrack = makeTrackSignaling({ kind: 'audio' });
+          const videoTrack = makeTrackSignaling({ kind: 'video' });
+          const dataTrack = makeTrackSignaling({ kind: 'data' });
           test.signaling.emit('trackAdded', audioTrack);
           test.signaling.emit('trackAdded', videoTrack);
           test.signaling.emit('trackAdded', dataTrack);
@@ -651,15 +651,15 @@ describe('RemoteParticipant', function() {
       context('when the RemoteParticipant .state begins in "connected"', () => {
         context('and a RemoteTrack with an .id matching that of the RemoteTrackSignaling exists in the RemoteParticipant\'s RemoteTrack collections', () => {
           it('calls ._removeTrack on the RemoteParticipant with the RemoteTrack', () => {
-            var test = makeTest();
-            var audioTrack = makeTrackSignaling({ kind: 'audio' });
-            var videoTrack = makeTrackSignaling({ kind: 'video' });
-            var dataTrack = makeTrackSignaling({ kind: 'data' });
-            var tracks = [];
-            var unsubscribed = [];
+            const test = makeTest();
+            const audioTrack = makeTrackSignaling({ kind: 'audio' });
+            const videoTrack = makeTrackSignaling({ kind: 'video' });
+            const dataTrack = makeTrackSignaling({ kind: 'data' });
+            const tracks = [];
+            const unsubscribed = [];
 
-            var trackEventsPromise = new Promise(resolve => {
-              var shouldResolve = () => tracks.length + unsubscribed.length === 4;
+            const trackEventsPromise = new Promise(resolve => {
+              const shouldResolve = () => tracks.length + unsubscribed.length === 4;
               test.participant.on('trackRemoved', track => {
                 tracks.push(track);
                 shouldResolve() && resolve();
@@ -674,7 +674,7 @@ describe('RemoteParticipant', function() {
             test.signaling.emit('trackAdded', videoTrack);
             test.signaling.emit('trackAdded', dataTrack);
 
-            var unsubscribedEventPromises = [...test.participant.tracks.values()].map(track => {
+            const unsubscribedEventPromises = [...test.participant.tracks.values()].map(track => {
               return new Promise(resolve => track.once('unsubscribed', resolve));
             });
 
@@ -705,11 +705,11 @@ describe('RemoteParticipant', function() {
 
         context('and a RemoteTrack with an .id matching that of the RemoteTrackSignaling does not exist in the RemoteParticipant\'s RemoteTrack collections', () => {
           it('does not call ._removeTrack on the RemoteParticipant', () => {
-            var test = makeTest();
+            const test = makeTest();
             test.participant._removeTrack = sinon.spy();
-            var audioTrack = makeTrackSignaling({ kind: 'audio' });
-            var videoTrack = makeTrackSignaling({ kind: 'video' });
-            var dataTrack = makeTrackSignaling({ kind: 'data' });
+            const audioTrack = makeTrackSignaling({ kind: 'audio' });
+            const videoTrack = makeTrackSignaling({ kind: 'video' });
+            const dataTrack = makeTrackSignaling({ kind: 'data' });
             test.signaling.emit('trackRemoved', audioTrack);
             test.signaling.emit('trackRemoved', videoTrack);
             test.signaling.emit('trackRemoved', dataTrack);
@@ -727,11 +727,11 @@ describe('RemoteParticipant', function() {
       context('when the RemoteParticipant .state transitions to "disconnected"', () => {
         context('and a RemoteTrack with an .id matching that of the RemoteTrackSignaling exists in the RemoteParticipant\'s RemoteTrack collections', () => {
           it('does not call ._removeTrack on the RemoteParticipant', () => {
-            var test = makeTest();
+            const test = makeTest();
             test.participant._removeTrack = sinon.spy();
-            var audioTrack = makeTrackSignaling({ kind: 'audio' });
-            var videoTrack = makeTrackSignaling({ kind: 'video' });
-            var dataTrack = makeTrackSignaling({ kind: 'data' });
+            const audioTrack = makeTrackSignaling({ kind: 'audio' });
+            const videoTrack = makeTrackSignaling({ kind: 'video' });
+            const dataTrack = makeTrackSignaling({ kind: 'data' });
             test.signaling.emit('trackAdded', audioTrack);
             test.signaling.emit('trackAdded', videoTrack);
             test.signaling.emit('trackAdded', dataTrack);
@@ -751,11 +751,11 @@ describe('RemoteParticipant', function() {
 
         context('and a RemoteTrack with an .id matching that of the RemoteTrackSignaling does not exist in the RemoteParticipant\'s RemoteTrack collections', () => {
           it('does not call ._removeTrack on the RemoteParticipant', () => {
-            var test = makeTest();
+            const test = makeTest();
             test.participant._removeTrack = sinon.spy();
-            var audioTrack = makeTrackSignaling({ kind: 'audio' });
-            var videoTrack = makeTrackSignaling({ kind: 'video' });
-            var dataTrack = makeTrackSignaling({ kind: 'data' });
+            const audioTrack = makeTrackSignaling({ kind: 'audio' });
+            const videoTrack = makeTrackSignaling({ kind: 'video' });
+            const dataTrack = makeTrackSignaling({ kind: 'data' });
             test.signaling.emit('stateChanged', 'disconnected');
             test.signaling.emit('trackRemoved', audioTrack);
             test.signaling.emit('trackRemoved', videoTrack);
@@ -774,11 +774,11 @@ describe('RemoteParticipant', function() {
       context('when the RemoteParticipant .state begins in "disconnected"', () => {
         context('and a RemoteTrack with an .id matching that of the RemoteTrackSignaling does not exist in the RemoteParticipant\'s RemoteTrack collections', () => {
           it('does not call ._removeTrack on the RemoteParticipant', () => {
-            var test = makeTest({ state: 'disconnected' });
+            const test = makeTest({ state: 'disconnected' });
             test.participant._removeTrack = sinon.spy();
-            var audioTrack = makeTrackSignaling({ kind: 'audio' });
-            var videoTrack = makeTrackSignaling({ kind: 'video' });
-            var dataTrack = makeTrackSignaling({ kind: 'data' });
+            const audioTrack = makeTrackSignaling({ kind: 'audio' });
+            const videoTrack = makeTrackSignaling({ kind: 'video' });
+            const dataTrack = makeTrackSignaling({ kind: 'data' });
             test.signaling.emit('trackRemoved', audioTrack);
             test.signaling.emit('trackRemoved', videoTrack);
             test.signaling.emit('trackRemoved', dataTrack);
@@ -797,30 +797,30 @@ describe('RemoteParticipant', function() {
     context('.tracks', () => {
       context('when the RemoteParticipant .state begins in "connected"', () => {
         it('calls .getMediaStreamTrackOrDataTrackTransceiver on each RemoteTrackSignaling', () => {
-          var test = makeTest({
+          const test = makeTest({
             trackSignalings: [
               { kind: 'audio' },
               { kind: 'video' }
             ]
           });
-          var audioTrack = test.trackSignalings[0];
-          var videoTrack = test.trackSignalings[1];
+          const audioTrack = test.trackSignalings[0];
+          const videoTrack = test.trackSignalings[1];
           assert(audioTrack.getMediaStreamTrackOrDataTrackTransceiver.calledOnce);
           assert(videoTrack.getMediaStreamTrackOrDataTrackTransceiver.calledOnce);
         });
 
         context('if the Promise returned by .getMediaStreamTrackOrDataTrackTransceiver resolves', () => {
           it('constructs a new RemoteAudioTrack or RemoteVideoTrack, depending on the RemoteTrackSignaling\'s .kind', () => {
-            var test = makeTest({
+            const test = makeTest({
               trackSignalings: [
                 { kind: 'audio' },
                 { kind: 'video' },
                 { kind: 'data' }
               ]
             });
-            var audioTrack = test.trackSignalings[0];
-            var videoTrack = test.trackSignalings[1];
-            var dataTrack = test.trackSignalings[2];
+            const audioTrack = test.trackSignalings[0];
+            const videoTrack = test.trackSignalings[1];
+            const dataTrack = test.trackSignalings[2];
             return Promise.all([
               audioTrack.getMediaStreamTrackOrDataTrackTransceiverDeferred.promise,
               videoTrack.getMediaStreamTrackOrDataTrackTransceiverDeferred.promise,
@@ -838,15 +838,15 @@ describe('RemoteParticipant', function() {
           });
 
           it('calls ._addTrack on the RemoteParticipant with the newly-constructed RemoteTrack', () => {
-            var test = makeTest({
+            const test = makeTest({
               trackSignalings: [
                 { kind: 'audio' },
                 { kind: 'video' },
                 { kind: 'data' }
               ]
             });
-            var tracksAddedPromise = new Promise(resolve => {
-              var tracks = [];
+            const tracksAddedPromise = new Promise(resolve => {
+              const tracks = [];
               test.participant.on('trackAdded', track => {
                 tracks.push(track);
                 if (tracks.length === 2) {
@@ -855,9 +855,9 @@ describe('RemoteParticipant', function() {
               });
             });
 
-            var audioTrack = test.trackSignalings[0];
-            var videoTrack = test.trackSignalings[1];
-            var dataTrack = test.trackSignalings[2];
+            const audioTrack = test.trackSignalings[0];
+            const videoTrack = test.trackSignalings[1];
+            const dataTrack = test.trackSignalings[2];
 
             return Promise.all([
               tracksAddedPromise,
@@ -875,7 +875,7 @@ describe('RemoteParticipant', function() {
 
       context('when the RemoteParticipant .state beings in "disconnected"', () => {
         it('does not call .getMediaStreamTrackOrDataTrackTransceiver on each RemoteTrackSignaling', () => {
-          var test = makeTest({
+          const test = makeTest({
             state: 'disconnected',
             trackSignalings: [
               { kind: 'audio' },
@@ -883,16 +883,16 @@ describe('RemoteParticipant', function() {
               { kind: 'data' }
             ]
           });
-          var audioTrack = test.trackSignalings[0];
-          var videoTrack = test.trackSignalings[1];
-          var dataTrack = test.trackSignalings[1];
+          const audioTrack = test.trackSignalings[0];
+          const videoTrack = test.trackSignalings[1];
+          const dataTrack = test.trackSignalings[1];
           assert(!audioTrack.getMediaStreamTrackOrDataTrackTransceiver.calledOnce);
           assert(!videoTrack.getMediaStreamTrackOrDataTrackTransceiver.calledOnce);
           assert(!dataTrack.getMediaStreamTrackOrDataTrackTransceiver.calledOnce);
         });
 
         it('does not construct new RemoteTracks', () => {
-          var test = makeTest({
+          const test = makeTest({
             state: 'disconnected',
             trackSignalings: [
               { kind: 'audio' },
@@ -900,9 +900,9 @@ describe('RemoteParticipant', function() {
               { kind: 'data' }
             ]
           });
-          var audioTrack = test.trackSignalings[0];
-          var videoTrack = test.trackSignalings[1];
-          var dataTrack = test.trackSignalings[1];
+          const audioTrack = test.trackSignalings[0];
+          const videoTrack = test.trackSignalings[1];
+          const dataTrack = test.trackSignalings[1];
           return Promise.all([
             audioTrack.getMediaStreamTrackOrDataTrackTransceiverDeferred.promise,
             videoTrack.getMediaStreamTrackOrDataTrackTransceiverDeferred.promise,
@@ -913,7 +913,7 @@ describe('RemoteParticipant', function() {
         });
 
         it('does not call ._addTrack on the RemoteParticipant', () => {
-          var test = makeTest({
+          const test = makeTest({
             participant: { _addTrack: sinon.spy() },
             state: 'disconnected',
             trackSignalings: [
@@ -922,9 +922,9 @@ describe('RemoteParticipant', function() {
               { kind: 'data' }
             ]
           });
-          var audioTrack = test.trackSignalings[0];
-          var videoTrack = test.trackSignalings[1];
-          var dataTrack = test.trackSignalings[2];
+          const audioTrack = test.trackSignalings[0];
+          const videoTrack = test.trackSignalings[1];
+          const dataTrack = test.trackSignalings[2];
           return Promise.all([
             audioTrack.getMediaStreamTrackOrDataTrackTransceiverDeferred.promise,
             videoTrack.getMediaStreamTrackOrDataTrackTransceiverDeferred.promise,
@@ -944,8 +944,8 @@ function makeIdentity() {
 }
 
 function makeSid() {
-  var sid = 'PA';
-  for (var i = 0; i < 32; i++) {
+  let sid = 'PA';
+  for (let i = 0; i < 32; i++) {
     sid += 'abcdef0123456789'.split('')[Math.floor(Math.random() * 16)];
   }
   return sid;
@@ -959,8 +959,8 @@ function makeTest(options) {
   options.tracks = options.tracks || [];
   
   if (typeof options.trackSignalings === 'number') {
-    var trackSignalings = [];
-    for (var i = 0; i < options.trackSignalings; i++) {
+    const trackSignalings = [];
+    for (let i = 0; i < options.trackSignalings; i++) {
       trackSignalings.push(makeTrackSignaling());
     }
     options.trackSignalings = trackSignalings;
@@ -1011,7 +1011,7 @@ function makeTest(options) {
 }
 
 function makeSignaling(options) {
-  var signaling = new EventEmitter();
+  const signaling = new EventEmitter();
   signaling.sid = options.sid;
   signaling.identity = options.identity;
   signaling.state = options.state;
@@ -1029,7 +1029,7 @@ function makeKind() {
 
 function makeTrackSignaling(options) {
   options = options || {};
-  var track = new EventEmitter();
+  const track = new EventEmitter();
   track.id = options.id || makeId();
   track.kind = options.kind || makeKind();
   track.name = options.name || track.id;

--- a/test/unit/spec/remoteparticipant.js
+++ b/test/unit/spec/remoteparticipant.js
@@ -1,13 +1,15 @@
 'use strict';
 
-var a = require('../../lib/util').a;
-var assert = require('assert');
-var EventEmitter = require('events').EventEmitter;
-var RemoteParticipant = require('../../../lib/remoteparticipant');
-var inherits = require('util').inherits;
-var sinon = require('sinon');
-var util = require('../../../lib/util');
-var log = require('../../lib/fakelog');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const sinon = require('sinon');
+const { inherits } = require('util');
+
+const RemoteParticipant = require('../../../lib/remoteparticipant');
+const { defer, makeUUID } = require('../../../lib/util');
+
+const { a } = require('../../lib/util');
+const log = require('../../lib/fakelog');
 
 describe('RemoteParticipant', function() {
   describe('constructor', () => {
@@ -278,7 +280,7 @@ describe('RemoteParticipant', function() {
         var trackMessageEvent;
         var test = makeTest({ tracks: [ track ] });
         test.participant.once('trackMessage', (data, track) => trackMessageEvent = { data, track });
-        var data = util.makeUUID();
+        var data = makeUUID();
         track.emit('message', data, track);
         assert.equal(data, trackMessageEvent.data);
         assert.equal(track, trackMessageEvent.track);
@@ -335,7 +337,7 @@ describe('RemoteParticipant', function() {
         var test = makeTest({ tracks: [ track ] });
         test.signaling.emit('stateChanged', 'disconnected');
         test.participant.once('trackMessage', (data, track) => trackMessageEvent = { data, track });
-        var data = util.makeUUID();
+        var data = makeUUID();
         track.emit('message', data, track);
         assert(!trackMessageEvent);
       });
@@ -404,7 +406,7 @@ describe('RemoteParticipant', function() {
         var trackMessageEvent;
         var test = makeTest({ tracks: [ track ], state: 'disconnected' });
         test.participant.once('trackMessage', (data, track) => trackMessageEvent = { data, track });
-        var data = util.makeUUID();
+        var data = makeUUID();
         track.emit('message', data, track);
         assert(!trackMessageEvent);
       });
@@ -1018,7 +1020,7 @@ function makeSignaling(options) {
 }
 
 function makeId() {
-  return util.makeUUID();
+  return makeUUID();
 }
 
 function makeKind() {
@@ -1033,7 +1035,7 @@ function makeTrackSignaling(options) {
   track.name = options.name || track.id;
   track.mediaStreamTrackOrDataTrackTransceiver = { id: track.id, kind: track.kind };
   track.mediaStream = {};
-  track.getMediaStreamTrackOrDataTrackTransceiverDeferred = util.defer();
+  track.getMediaStreamTrackOrDataTrackTransceiverDeferred = defer();
   track.getMediaStreamTrackOrDataTrackTransceiverDeferred.resolve(track.mediaStreamTrackOrDataTrackTransceiver);
   track.getMediaStreamTrackOrDataTrackTransceiver = sinon.spy(() => track.getMediaStreamTrackOrDataTrackTransceiverDeferred.promise);
   return track;

--- a/test/unit/spec/room.js
+++ b/test/unit/spec/room.js
@@ -12,10 +12,11 @@ const { SignalingConnectionDisconnectedError } = require('../../../lib/util/twil
 const log = require('../../lib/fakelog');
 
 describe('Room', function() {
-  var room;
-  var options = { log: log };
-  var localParticipant = new ParticipantSignaling('PAXXX', 'client');
-  var signaling;
+  const options = { log: log };
+  const localParticipant = new ParticipantSignaling('PAXXX', 'client');
+
+  let room;
+  let signaling;
 
   beforeEach(function() {
     signaling = new RoomSignaling(localParticipant, 'RM123', 'foo');
@@ -34,7 +35,7 @@ describe('Room', function() {
     });
 
     it('should trigger "disconnect" event on the Room with the Room as the argument', () => {
-      var spy = sinon.spy();
+      const spy = sinon.spy();
       room.on('disconnected', spy);
       room.disconnect();
       assert.equal(spy.callCount, 1);
@@ -43,7 +44,7 @@ describe('Room', function() {
   });
 
   describe('RemoteParticipant events', function() {
-    var participants;
+    let participants;
 
     beforeEach(function() {
       [
@@ -57,7 +58,7 @@ describe('Room', function() {
     });
 
     it('should re-emit RemoteParticipants trackAdded event for matching RemoteParticipant only', function() {
-      var spy = new sinon.spy();
+      const spy = new sinon.spy();
       room.on('trackAdded', spy);
 
       participants['foo'].emit('trackAdded');
@@ -65,7 +66,7 @@ describe('Room', function() {
     });
 
     it('should re-emit RemoteParticipant trackDimensionsChanged for matching RemoteParticipant only', function() {
-      var spy = new sinon.spy();
+      const spy = new sinon.spy();
       room.on('trackDimensionsChanged', spy);
 
       participants['foo'].emit('trackDimensionsChanged');
@@ -73,7 +74,7 @@ describe('Room', function() {
     });
 
     it('should re-emit RemoteParticipant trackDisabled for matching RemoteParticipant only', function() {
-      var spy = new sinon.spy();
+      const spy = new sinon.spy();
       room.on('trackDisabled', spy);
 
       participants['foo'].emit('trackDisabled');
@@ -81,7 +82,7 @@ describe('Room', function() {
     });
 
     it('should re-emit RemoteParticipant trackEnabled for matching RemoteParticipant only', function() {
-      var spy = new sinon.spy();
+      const spy = new sinon.spy();
       room.on('trackEnabled', spy);
 
       participants['foo'].emit('trackEnabled');
@@ -89,7 +90,7 @@ describe('Room', function() {
     });
 
     it('should re-emit RemoteParticipant trackMessage for matching RemoteParticipant only', function() {
-      var spy = new sinon.spy();
+      const spy = new sinon.spy();
       room.on('trackMessage', spy);
 
       participants['foo'].emit('trackMessage');
@@ -97,7 +98,7 @@ describe('Room', function() {
     });
 
     it('should re-emit RemoteParticipants trackRemoved event for matching RemoteParticipant only', function() {
-      var spy = new sinon.spy();
+      const spy = new sinon.spy();
       room.on('trackRemoved', spy);
 
       participants['bar'].emit('trackRemoved');
@@ -105,7 +106,7 @@ describe('Room', function() {
     });
 
     it('should re-emit RemoteParticipant trackStarted for matching RemoteParticipant only', function() {
-      var spy = new sinon.spy();
+      const spy = new sinon.spy();
       room.on('trackStarted', spy);
 
       participants['foo'].emit('trackStarted');
@@ -113,7 +114,7 @@ describe('Room', function() {
     });
 
     it('should re-emit RemoteParticipants trackSubscribed event for matching RemoteParticipant only', function() {
-      var spy = new sinon.spy();
+      const spy = new sinon.spy();
       room.on('trackSubscribed', spy);
 
       participants['foo'].emit('trackSubscribed');
@@ -121,7 +122,7 @@ describe('Room', function() {
     });
 
     it('should re-emit RemoteParticipants trackUnsubscribed event for matching RemoteParticipant only', function() {
-      var spy = new sinon.spy();
+      const spy = new sinon.spy();
       room.on('trackUnsubscribed', spy);
 
       participants['bar'].emit('trackUnsubscribed');
@@ -131,7 +132,7 @@ describe('Room', function() {
     it('should not re-emit RemoteParticipant events if the RemoteParticipant is no longer in the room', function() {
       participants['foo'].emit('disconnected');
 
-      var spy = new sinon.spy();
+      const spy = new sinon.spy();
       room.on('trackAdded', spy);
       room.on('trackDimensionsChanged', spy);
       room.on('trackDisabled', spy);
@@ -158,7 +159,7 @@ describe('Room', function() {
   describe('RoomSignaling state changed to "disconnected"', () => {
     context('when triggered due to unexpected connection loss', () => {
       it('should trigger the same event on the Room with itself and a SignalingConnectionDisconnectedError as the arguments', () => {
-        var spy = sinon.spy();
+        const spy = sinon.spy();
         room.on('disconnected', spy);
         signaling.preempt('disconnected', null, [new SignalingConnectionDisconnectedError()]);
         assert.equal(spy.callCount, 1);
@@ -174,7 +175,7 @@ describe('Room', function() {
         new RemoteParticipantSignaling('PA111', 'bar')
       ].forEach(signaling.connectParticipant.bind(signaling));
 
-      var participants = {};
+      const participants = {};
       room.participants.forEach(function(participant) {
         participant._unsubscribeTracks = sinon.spy();
         participants[participant.identity] = participant;

--- a/test/unit/spec/room.js
+++ b/test/unit/spec/room.js
@@ -1,13 +1,15 @@
 'use strict';
 
-var assert = require('assert');
-var Room = require('../../../lib/room');
-var RoomSignaling = require('../../../lib/signaling/room');
-var ParticipantSignaling = require('../../../lib/signaling/participant');
-var RemoteParticipantSignaling = require('../../../lib/signaling/remoteparticipant');
-var SignalingConnectionDisconnectedError = require('../../../lib/util/twilio-video-errors').SignalingConnectionDisconnectedError;
-var sinon = require('sinon');
-var log = require('../../lib/fakelog');
+const assert = require('assert');
+const sinon = require('sinon');
+
+const Room = require('../../../lib/room');
+const ParticipantSignaling = require('../../../lib/signaling/participant');
+const RemoteParticipantSignaling = require('../../../lib/signaling/remoteparticipant');
+const RoomSignaling = require('../../../lib/signaling/room');
+const { SignalingConnectionDisconnectedError } = require('../../../lib/util/twilio-video-errors');
+
+const log = require('../../lib/fakelog');
 
 describe('Room', function() {
   var room;

--- a/test/unit/spec/room.js
+++ b/test/unit/spec/room.js
@@ -11,26 +11,26 @@ const { SignalingConnectionDisconnectedError } = require('../../../lib/util/twil
 
 const log = require('../../lib/fakelog');
 
-describe('Room', function() {
+describe('Room', () => {
   const options = { log: log };
   const localParticipant = new ParticipantSignaling('PAXXX', 'client');
 
   let room;
   let signaling;
 
-  beforeEach(function() {
+  beforeEach(() => {
     signaling = new RoomSignaling(localParticipant, 'RM123', 'foo');
     room = new Room(localParticipant, signaling, options);
   });
 
-  describe('new Room(signaling)', function() {
-    it('should return an instance when called as a function', function() {
+  describe('new Room(signaling)', () => {
+    it('should return an instance when called as a function', () => {
       assert(Room(localParticipant, signaling, options) instanceof Room);
     });
   });
 
-  describe('#disconnect()', function() {
-    it('should return the Room', function() {
+  describe('#disconnect()', () => {
+    it('should return the Room', () => {
       assert.equal(room, room.disconnect());
     });
 
@@ -43,21 +43,21 @@ describe('Room', function() {
     });
   });
 
-  describe('RemoteParticipant events', function() {
+  describe('RemoteParticipant events', () => {
     let participants;
 
-    beforeEach(function() {
+    beforeEach(() => {
       [
         new RemoteParticipantSignaling('PA000', 'foo'),
         new RemoteParticipantSignaling('PA111', 'bar')
       ].forEach(signaling.connectParticipant.bind(signaling));
       participants = { };
-      room.participants.forEach(function(participant) {
+      room.participants.forEach(participant => {
         participants[participant.identity] = participant;
       });
     });
 
-    it('should re-emit RemoteParticipants trackAdded event for matching RemoteParticipant only', function() {
+    it('should re-emit RemoteParticipants trackAdded event for matching RemoteParticipant only', () => {
       const spy = new sinon.spy();
       room.on('trackAdded', spy);
 
@@ -65,7 +65,7 @@ describe('Room', function() {
       assert.equal(spy.callCount, 1);
     });
 
-    it('should re-emit RemoteParticipant trackDimensionsChanged for matching RemoteParticipant only', function() {
+    it('should re-emit RemoteParticipant trackDimensionsChanged for matching RemoteParticipant only', () => {
       const spy = new sinon.spy();
       room.on('trackDimensionsChanged', spy);
 
@@ -73,7 +73,7 @@ describe('Room', function() {
       assert.equal(spy.callCount, 1);
     });
 
-    it('should re-emit RemoteParticipant trackDisabled for matching RemoteParticipant only', function() {
+    it('should re-emit RemoteParticipant trackDisabled for matching RemoteParticipant only', () => {
       const spy = new sinon.spy();
       room.on('trackDisabled', spy);
 
@@ -81,7 +81,7 @@ describe('Room', function() {
       assert.equal(spy.callCount, 1);
     });
 
-    it('should re-emit RemoteParticipant trackEnabled for matching RemoteParticipant only', function() {
+    it('should re-emit RemoteParticipant trackEnabled for matching RemoteParticipant only', () => {
       const spy = new sinon.spy();
       room.on('trackEnabled', spy);
 
@@ -89,7 +89,7 @@ describe('Room', function() {
       assert.equal(spy.callCount, 1);
     });
 
-    it('should re-emit RemoteParticipant trackMessage for matching RemoteParticipant only', function() {
+    it('should re-emit RemoteParticipant trackMessage for matching RemoteParticipant only', () => {
       const spy = new sinon.spy();
       room.on('trackMessage', spy);
 
@@ -97,7 +97,7 @@ describe('Room', function() {
       assert.equal(spy.callCount, 1);
     });
 
-    it('should re-emit RemoteParticipants trackRemoved event for matching RemoteParticipant only', function() {
+    it('should re-emit RemoteParticipants trackRemoved event for matching RemoteParticipant only', () => {
       const spy = new sinon.spy();
       room.on('trackRemoved', spy);
 
@@ -105,7 +105,7 @@ describe('Room', function() {
       assert.equal(spy.callCount, 1);
     });
 
-    it('should re-emit RemoteParticipant trackStarted for matching RemoteParticipant only', function() {
+    it('should re-emit RemoteParticipant trackStarted for matching RemoteParticipant only', () => {
       const spy = new sinon.spy();
       room.on('trackStarted', spy);
 
@@ -113,7 +113,7 @@ describe('Room', function() {
       assert.equal(spy.callCount, 1);
     });
 
-    it('should re-emit RemoteParticipants trackSubscribed event for matching RemoteParticipant only', function() {
+    it('should re-emit RemoteParticipants trackSubscribed event for matching RemoteParticipant only', () => {
       const spy = new sinon.spy();
       room.on('trackSubscribed', spy);
 
@@ -121,7 +121,7 @@ describe('Room', function() {
       assert.equal(spy.callCount, 1);
     });
 
-    it('should re-emit RemoteParticipants trackUnsubscribed event for matching RemoteParticipant only', function() {
+    it('should re-emit RemoteParticipants trackUnsubscribed event for matching RemoteParticipant only', () => {
       const spy = new sinon.spy();
       room.on('trackUnsubscribed', spy);
 
@@ -129,7 +129,7 @@ describe('Room', function() {
       assert.equal(spy.callCount, 1);
     });
 
-    it('should not re-emit RemoteParticipant events if the RemoteParticipant is no longer in the room', function() {
+    it('should not re-emit RemoteParticipant events if the RemoteParticipant is no longer in the room', () => {
       participants['foo'].emit('disconnected');
 
       const spy = new sinon.spy();
@@ -176,7 +176,7 @@ describe('Room', function() {
       ].forEach(signaling.connectParticipant.bind(signaling));
 
       const participants = {};
-      room.participants.forEach(function(participant) {
+      room.participants.forEach(participant => {
         participant._unsubscribeTracks = sinon.spy();
         participants[participant.identity] = participant;
       });

--- a/test/unit/spec/room.js
+++ b/test/unit/spec/room.js
@@ -25,6 +25,7 @@ describe('Room', () => {
 
   describe('new Room(signaling)', () => {
     it('should return an instance when called as a function', () => {
+      // eslint-disable-next-line new-cap
       assert(Room(localParticipant, signaling, options) instanceof Room);
     });
   });
@@ -58,81 +59,81 @@ describe('Room', () => {
     });
 
     it('should re-emit RemoteParticipants trackAdded event for matching RemoteParticipant only', () => {
-      const spy = new sinon.spy();
+      const spy = sinon.spy();
       room.on('trackAdded', spy);
 
-      participants['foo'].emit('trackAdded');
+      participants.foo.emit('trackAdded');
       assert.equal(spy.callCount, 1);
     });
 
     it('should re-emit RemoteParticipant trackDimensionsChanged for matching RemoteParticipant only', () => {
-      const spy = new sinon.spy();
+      const spy = sinon.spy();
       room.on('trackDimensionsChanged', spy);
 
-      participants['foo'].emit('trackDimensionsChanged');
+      participants.foo.emit('trackDimensionsChanged');
       assert.equal(spy.callCount, 1);
     });
 
     it('should re-emit RemoteParticipant trackDisabled for matching RemoteParticipant only', () => {
-      const spy = new sinon.spy();
+      const spy = sinon.spy();
       room.on('trackDisabled', spy);
 
-      participants['foo'].emit('trackDisabled');
+      participants.foo.emit('trackDisabled');
       assert.equal(spy.callCount, 1);
     });
 
     it('should re-emit RemoteParticipant trackEnabled for matching RemoteParticipant only', () => {
-      const spy = new sinon.spy();
+      const spy = sinon.spy();
       room.on('trackEnabled', spy);
 
-      participants['foo'].emit('trackEnabled');
+      participants.foo.emit('trackEnabled');
       assert.equal(spy.callCount, 1);
     });
 
     it('should re-emit RemoteParticipant trackMessage for matching RemoteParticipant only', () => {
-      const spy = new sinon.spy();
+      const spy = sinon.spy();
       room.on('trackMessage', spy);
 
-      participants['foo'].emit('trackMessage');
+      participants.foo.emit('trackMessage');
       assert.equal(spy.callCount, 1);
     });
 
     it('should re-emit RemoteParticipants trackRemoved event for matching RemoteParticipant only', () => {
-      const spy = new sinon.spy();
+      const spy = sinon.spy();
       room.on('trackRemoved', spy);
 
-      participants['bar'].emit('trackRemoved');
+      participants.bar.emit('trackRemoved');
       assert.equal(spy.callCount, 1);
     });
 
     it('should re-emit RemoteParticipant trackStarted for matching RemoteParticipant only', () => {
-      const spy = new sinon.spy();
+      const spy = sinon.spy();
       room.on('trackStarted', spy);
 
-      participants['foo'].emit('trackStarted');
+      participants.foo.emit('trackStarted');
       assert.equal(spy.callCount, 1);
     });
 
     it('should re-emit RemoteParticipants trackSubscribed event for matching RemoteParticipant only', () => {
-      const spy = new sinon.spy();
+      const spy = sinon.spy();
       room.on('trackSubscribed', spy);
 
-      participants['foo'].emit('trackSubscribed');
+      participants.foo.emit('trackSubscribed');
       assert.equal(spy.callCount, 1);
     });
 
     it('should re-emit RemoteParticipants trackUnsubscribed event for matching RemoteParticipant only', () => {
-      const spy = new sinon.spy();
+      const spy = sinon.spy();
       room.on('trackUnsubscribed', spy);
 
-      participants['bar'].emit('trackUnsubscribed');
+      participants.bar.emit('trackUnsubscribed');
       assert.equal(spy.callCount, 1);
     });
 
     it('should not re-emit RemoteParticipant events if the RemoteParticipant is no longer in the room', () => {
-      participants['foo'].emit('disconnected');
+      participants.foo.emit('disconnected');
 
-      const spy = new sinon.spy();
+      const spy = sinon.spy();
       room.on('trackAdded', spy);
       room.on('trackDimensionsChanged', spy);
       room.on('trackDisabled', spy);
@@ -143,15 +144,15 @@ describe('Room', () => {
       room.on('trackSubscribed', spy);
       room.on('trackUnsubscribed', spy);
 
-      participants['foo'].emit('trackAdded');
-      participants['foo'].emit('trackDimensionsChanged');
-      participants['foo'].emit('trackDisabled');
-      participants['foo'].emit('trackEnabled');
-      participants['foo'].emit('trackMessage');
-      participants['foo'].emit('trackRemoved');
-      participants['foo'].emit('trackStarted');
-      participants['foo'].emit('trackSubscribed');
-      participants['foo'].emit('trackUnsubscribed');
+      participants.foo.emit('trackAdded');
+      participants.foo.emit('trackDimensionsChanged');
+      participants.foo.emit('trackDisabled');
+      participants.foo.emit('trackEnabled');
+      participants.foo.emit('trackMessage');
+      participants.foo.emit('trackRemoved');
+      participants.foo.emit('trackStarted');
+      participants.foo.emit('trackSubscribed');
+      participants.foo.emit('trackUnsubscribed');
       assert.equal(spy.callCount, 0);
     });
   });
@@ -181,8 +182,8 @@ describe('Room', () => {
         participants[participant.identity] = participant;
       });
       signaling.preempt('disconnected');
-      sinon.assert.calledOnce(participants['foo']._unsubscribeTracks);
-      sinon.assert.calledOnce(participants['bar']._unsubscribeTracks);
+      sinon.assert.calledOnce(participants.foo._unsubscribeTracks);
+      sinon.assert.calledOnce(participants.bar._unsubscribeTracks);
     });
   });
 });

--- a/test/unit/spec/signaling/v2/cancelableroomsignalingpromise.js
+++ b/test/unit/spec/signaling/v2/cancelableroomsignalingpromise.js
@@ -14,28 +14,28 @@ const { makeEncodingParameters } = require('../../../../lib/util');
 
 describe('createCancelableRoomSignalingPromise', () => {
   it('returns a CancelablePromise', () => {
-    var test = makeTest();
+    const test = makeTest();
     assert(test.cancelableRoomSignalingPromise instanceof CancelablePromise);
   });
 
   it('constructs a new PeerConnectionManager', () => {
-    var test = makeTest();
+    const test = makeTest();
     assert(test.peerConnectionManager);
   });
 
   it('calls .setConfiguration on the newly-constructed PeerConnectionManager', () => {
-    var test = makeTest();
+    const test = makeTest();
     assert(test.peerConnectionManager.setConfiguration.calledOnce);
   });
 
   it('calls .setMediaStreamTracksAndDataTrackSenders with the LocalParticipantSignaling\'s Tracks\' MediaStreamTracks on the newly-constructed PeerConnectionManager', () => {
-    var track1 = {
+    const track1 = {
       mediaStreamTrackOrDataTrackTransceiver: {}
     };
-    var track2 = {
+    const track2 = {
       mediaStreamTrackOrDataTrackTransceiver: {}
     };
-    var test = makeTest({
+    const test = makeTest({
       tracks: [
         track1,
         track2
@@ -46,15 +46,15 @@ describe('createCancelableRoomSignalingPromise', () => {
   });
 
   it('calls .createAndOffer on the newly-constructed PeerConnectionManager', () => {
-    var test = makeTest();
+    const test = makeTest();
     assert(test.peerConnectionManager.createAndOffer.calledOnce);
   });
 
   context('when the CancelablePromise is canceled before .createAndOffer resolves', () => {
     it('the CancelablePromise rejects with a cancelation Error', () => {
-      var test = makeTest();
+      const test = makeTest();
       test.cancelableRoomSignalingPromise.cancel();
-      var promise = test.cancelableRoomSignalingPromise.then(() => {
+      const promise = test.cancelableRoomSignalingPromise.then(() => {
         throw new Error('Unexpected resolution');
       }, error => {
         assert.equal(
@@ -66,9 +66,9 @@ describe('createCancelableRoomSignalingPromise', () => {
     });
 
     it('calls .close on the PeerConnectionManager', () => {
-      var test = makeTest();
+      const test = makeTest();
       test.cancelableRoomSignalingPromise.cancel();
-      var promise = test.cancelableRoomSignalingPromise.then(() => {
+      const promise = test.cancelableRoomSignalingPromise.then(() => {
         throw new Error('Unexpected resolution');
       }, error => {
         assert(test.peerConnectionManager.close.calledOnce);
@@ -79,7 +79,7 @@ describe('createCancelableRoomSignalingPromise', () => {
   });
 
   it('constructs a Transport', () => {
-    var test = makeTest();
+    const test = makeTest();
     test.createAndOfferDeferred.resolve();
     return test.createAndOfferDeferred.promise.then(() => {
       assert(test.transport);
@@ -90,7 +90,7 @@ describe('createCancelableRoomSignalingPromise', () => {
   context('when the Transport emits a "connected" event with an initial Room state', () => {
     context('and the CancelablePromise was canceled', () => {
       it('the CancelablePromise rejects with a cancelation error', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.createAndOfferDeferred.resolve();
         return test.createAndOfferDeferred.promise.then(() => {
           test.cancelableRoomSignalingPromise.cancel();
@@ -106,7 +106,7 @@ describe('createCancelableRoomSignalingPromise', () => {
       });
 
       it('calls .disconnect on the Transport', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.createAndOfferDeferred.resolve();
         return test.createAndOfferDeferred.promise.then(() => {
           test.cancelableRoomSignalingPromise.cancel();
@@ -120,7 +120,7 @@ describe('createCancelableRoomSignalingPromise', () => {
       });
 
       it('calls .close on the PeerConnectionManager', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.createAndOfferDeferred.resolve();
         return test.createAndOfferDeferred.promise.then(() => {
           test.cancelableRoomSignalingPromise.cancel();
@@ -137,7 +137,7 @@ describe('createCancelableRoomSignalingPromise', () => {
     context('and the CancelablePromise was not canceled', () => {
       context('but the .participant property is missing', () => {
         it('the CancelablePromise rejects with an error', () => {
-          var test = makeTest();
+          const test = makeTest();
           test.createAndOfferDeferred.resolve();
           return test.createAndOfferDeferred.promise.then(() => {
             test.transport.emit('connected', {});
@@ -150,7 +150,7 @@ describe('createCancelableRoomSignalingPromise', () => {
         });
 
         it('calls .disconnect on the Transport', () => {
-          var test = makeTest();
+          const test = makeTest();
           test.createAndOfferDeferred.resolve();
           return test.createAndOfferDeferred.promise.then(() => {
             test.transport.emit('connected', {});
@@ -163,7 +163,7 @@ describe('createCancelableRoomSignalingPromise', () => {
         });
 
         it('calls .close on the PeerConnectionManager', () => {
-          var test = makeTest();
+          const test = makeTest();
           test.createAndOfferDeferred.resolve();
           return test.createAndOfferDeferred.promise.then(() => {
             test.transport.emit('connected', {});
@@ -178,11 +178,11 @@ describe('createCancelableRoomSignalingPromise', () => {
 
       context('and the .participant property is present', () => {
         it('constructs a new RoomV2', () => {
-          var test = makeTest();
+          const test = makeTest();
           test.createAndOfferDeferred.resolve();
           return test.createAndOfferDeferred.promise.then(() => {
-            var identity = makeIdentity();
-            var sid = makeParticipantSid();
+            const identity = makeIdentity();
+            const sid = makeParticipantSid();
             test.transport.emit('connected', {
               participant: {
                 sid: sid,
@@ -195,11 +195,11 @@ describe('createCancelableRoomSignalingPromise', () => {
 
         context('when the CancelablePromise has not been canceled', () => {
           it('the CancelablePromise resolves to the newly-constructed RoomV2', () => {
-            var test = makeTest();
+            const test = makeTest();
             test.createAndOfferDeferred.resolve();
             test.createAndOfferDeferred.promise.then(() => {
-              var identity = makeIdentity();
-              var sid = makeParticipantSid();
+              const identity = makeIdentity();
+              const sid = makeParticipantSid();
               test.transport.emit('connected', {
                 participant: {
                   sid: sid,
@@ -215,11 +215,11 @@ describe('createCancelableRoomSignalingPromise', () => {
 
         context('when the CancelablePromise has been canceled', () => {
           it('the CancelablePromise rejects with a cancelation error', () => {
-            var test = makeTest();
+            const test = makeTest();
             test.createAndOfferDeferred.resolve();
             test.createAndOfferDeferred.promise.then(() => {
-              var identity = makeIdentity();
-              var sid = makeParticipantSid();
+              const identity = makeIdentity();
+              const sid = makeParticipantSid();
               test.transport.emit('connected', {
                 participant: {
                   sid: sid,
@@ -238,11 +238,11 @@ describe('createCancelableRoomSignalingPromise', () => {
           });
 
           it('calls .disconnect on the newly-constructed RoomV2', () => {
-            var test = makeTest();
+            const test = makeTest();
             test.createAndOfferDeferred.resolve();
             test.createAndOfferDeferred.promise.then(() => {
-              var identity = makeIdentity();
-              var sid = makeParticipantSid();
+              const identity = makeIdentity();
+              const sid = makeParticipantSid();
               test.transport.emit('connected', {
                 participant: {
                   sid: sid,
@@ -259,11 +259,11 @@ describe('createCancelableRoomSignalingPromise', () => {
           });
 
           it('does not call .disconnect on the Transport', () => {
-            var test = makeTest();
+            const test = makeTest();
             test.createAndOfferDeferred.resolve();
             test.createAndOfferDeferred.promise.then(() => {
-              var identity = makeIdentity();
-              var sid = makeParticipantSid();
+              const identity = makeIdentity();
+              const sid = makeParticipantSid();
               test.transport.emit('connected', {
                 participant: {
                   sid: sid,
@@ -280,11 +280,11 @@ describe('createCancelableRoomSignalingPromise', () => {
           });
 
           it('calls .close on the PeerConnectionManager', () => {
-            var test = makeTest();
+            const test = makeTest();
             test.createAndOfferDeferred.resolve();
             test.createAndOfferDeferred.promise.then(() => {
-              var identity = makeIdentity();
-              var sid = makeParticipantSid();
+              const identity = makeIdentity();
+              const sid = makeParticipantSid();
               test.transport.emit('connected', {
                 participant: {
                   sid: sid,
@@ -306,7 +306,7 @@ describe('createCancelableRoomSignalingPromise', () => {
 
   context('when the Transport emits a "stateChanged" event in state "failed"', () => {
     it('the CancelablePromise rejects with a SignalingConnectionDisconnectedError', () => {
-      var test = makeTest();
+      const test = makeTest();
       test.createAndOfferDeferred.resolve();
       return test.createAndOfferDeferred.promise.then(() => {
         test.transport.emit('stateChanged', 'disconnected');
@@ -320,7 +320,7 @@ describe('createCancelableRoomSignalingPromise', () => {
     });
 
     it('does not call .disconnect on the Transport', () => {
-      var test = makeTest();
+      const test = makeTest();
       test.createAndOfferDeferred.resolve();
       return test.createAndOfferDeferred.promise.then(() => {
         test.transport.emit('stateChanged', 'disconnected');
@@ -333,7 +333,7 @@ describe('createCancelableRoomSignalingPromise', () => {
     });
 
     it('calls .close on the PeerConnectionManager', () => {
-      var test = makeTest();
+      const test = makeTest();
       test.createAndOfferDeferred.resolve();
       return test.createAndOfferDeferred.promise.then(() => {
         test.transport.emit('stateChanged', 'disconnected');
@@ -348,8 +348,8 @@ describe('createCancelableRoomSignalingPromise', () => {
 });
 
 function makeParticipantSid() {
-  var sid = 'PA';
-  for (var i = 0; i < 32; i++) {
+  let sid = 'PA';
+  for (let i = 0; i < 32; i++) {
     sid += 'abcdef0123456789'.split('')[Math.floor(Math.random() * 16)];
   }
   return sid;
@@ -401,7 +401,7 @@ function makeTest(options) {
 
 function makePeerConnectionManagerConstructor(testOptions) {
   return function PeerConnectionManager(options) {
-    var peerConnectionManager = new EventEmitter();
+    const peerConnectionManager = new EventEmitter();
     peerConnectionManager.close = sinon.spy(() => {});
     peerConnectionManager.setConfiguration = sinon.spy(() => {});
     peerConnectionManager.setMediaStreamTracksAndDataTrackSenders = sinon.spy(() => {});
@@ -417,7 +417,7 @@ function makePeerConnectionManagerConstructor(testOptions) {
 }
 
 function makeLocalParticipantSignaling(options) {
-  var localParticipant = new EventEmitter();
+  const localParticipant = new EventEmitter();
   localParticipant.sid = null;
   localParticipant.identity = null;
   localParticipant.revision = 0;
@@ -434,7 +434,7 @@ function makeLocalParticipantSignaling(options) {
 
 function makeTransportConstructor(testOptions) {
   return function Transport(name, accessToken, localParticipant, peerConnectionManager, ua) {
-    var transport = new EventEmitter();
+    const transport = new EventEmitter();
     this.name = name;
     this.accessToken = accessToken;
     this.localParticipant = localParticipant;

--- a/test/unit/spec/signaling/v2/cancelableroomsignalingpromise.js
+++ b/test/unit/spec/signaling/v2/cancelableroomsignalingpromise.js
@@ -70,7 +70,7 @@ describe('createCancelableRoomSignalingPromise', () => {
       test.cancelableRoomSignalingPromise.cancel();
       const promise = test.cancelableRoomSignalingPromise.then(() => {
         throw new Error('Unexpected resolution');
-      }, error => {
+      }, () => {
         assert(test.peerConnectionManager.close.calledOnce);
       });
       test.createAndOfferDeferred.resolve();
@@ -113,7 +113,7 @@ describe('createCancelableRoomSignalingPromise', () => {
           test.transport.emit('connected');
           return test.cancelableRoomSignalingPromise.then(() => {
             throw new Error('Unexpected resolution');
-          }, error => {
+          }, () => {
             assert(test.transport.disconnect.calledOnce);
           });
         });
@@ -127,7 +127,7 @@ describe('createCancelableRoomSignalingPromise', () => {
           test.transport.emit('connected');
           return test.cancelableRoomSignalingPromise.then(() => {
             throw new Error('Unexpected resolution');
-          }, error => {
+          }, () => {
             assert(test.peerConnectionManager.close.calledOnce);
           });
         });
@@ -143,7 +143,7 @@ describe('createCancelableRoomSignalingPromise', () => {
             test.transport.emit('connected', {});
             return test.cancelableRoomSignalingPromise.then(() => {
               throw new Error('Unexpected resolution');
-            }, error => {
+            }, () => {
               // Do nothing.
             });
           });
@@ -156,7 +156,7 @@ describe('createCancelableRoomSignalingPromise', () => {
             test.transport.emit('connected', {});
             return test.cancelableRoomSignalingPromise.then(() => {
               throw new Error('Unexpected resolution');
-            }, error => {
+            }, () => {
               assert(test.transport.disconnect.calledOnce);
             });
           });
@@ -169,7 +169,7 @@ describe('createCancelableRoomSignalingPromise', () => {
             test.transport.emit('connected', {});
             return test.cancelableRoomSignalingPromise.then(() => {
               throw new Error('Unexpected resolution');
-            }, error => {
+            }, () => {
               assert(test.peerConnectionManager.close.calledOnce);
             });
           });
@@ -253,7 +253,7 @@ describe('createCancelableRoomSignalingPromise', () => {
             });
             return test.cancelableRoomSignalingPromise.then(() => {
               throw new Error('Unexpected resolution');
-            }, error => {
+            }, () => {
               assert(test.room.disconnect.calledOnce);
             });
           });
@@ -274,7 +274,7 @@ describe('createCancelableRoomSignalingPromise', () => {
             });
             return test.cancelableRoomSignalingPromise.then(() => {
               throw new Error('Unexpected resolution');
-            }, error => {
+            }, () => {
               assert(!test.transport.disconnect.calledTwice);
             });
           });
@@ -295,7 +295,7 @@ describe('createCancelableRoomSignalingPromise', () => {
             });
             return test.cancelableRoomSignalingPromise.then(() => {
               throw new Error('Unexpected resolution');
-            }, error => {
+            }, () => {
               assert(test.peerConnectionManager.close.calledOnce);
             });
           });
@@ -326,7 +326,7 @@ describe('createCancelableRoomSignalingPromise', () => {
         test.transport.emit('stateChanged', 'disconnected');
         return test.cancelableRoomSignalingPromise.then(() => {
           throw new Error('Unexpected resolution');
-        }, error => {
+        }, () => {
           assert(!test.transport.disconnect.calledOnce);
         });
       });
@@ -339,7 +339,7 @@ describe('createCancelableRoomSignalingPromise', () => {
         test.transport.emit('stateChanged', 'disconnected');
         return test.cancelableRoomSignalingPromise.then(() => {
           throw new Error('Unexpected resolution');
-        }, error => {
+        }, () => {
           assert(test.peerConnectionManager.close.calledOnce);
         });
       });
@@ -355,19 +355,15 @@ function makeParticipantSid() {
   return sid;
 }
 
-function makeName() {
-  return Math.random().toString(36).slice(2);
-}
-
 function makeIdentity() {
   return Math.random().toString(36).slice(2);
 }
 
-function makeToken(options) {
+function makeToken() {
   return 'fake-token';
 }
 
-function makeUA(options) {
+function makeUA() {
   return {};
 }
 
@@ -400,7 +396,7 @@ function makeTest(options) {
 }
 
 function makePeerConnectionManagerConstructor(testOptions) {
-  return function PeerConnectionManager(options) {
+  return function PeerConnectionManager() {
     const peerConnectionManager = new EventEmitter();
     peerConnectionManager.close = sinon.spy(() => {});
     peerConnectionManager.setConfiguration = sinon.spy(() => {});
@@ -413,7 +409,7 @@ function makePeerConnectionManagerConstructor(testOptions) {
     });
     testOptions.peerConnectionManager = peerConnectionManager;
     return peerConnectionManager;
-  }
+  };
 }
 
 function makeLocalParticipantSignaling(options) {

--- a/test/unit/spec/signaling/v2/cancelableroomsignalingpromise.js
+++ b/test/unit/spec/signaling/v2/cancelableroomsignalingpromise.js
@@ -1,15 +1,16 @@
 'use strict';
 
-var assert = require('assert');
-var { makeEncodingParameters } = require('../../../../lib/util');
-var CancelablePromise = require('../../../../../lib/util/cancelablepromise');
-var createCancelableRoomSignalingPromise = require('../../../../../lib/signaling/v2/cancelableroomsignalingpromise');
-var EventEmitter = require('events').EventEmitter;
-var MockIceServerSource = require('../../../../lib/mockiceserversource');
-var { SignalingConnectionDisconnectedError } = require('../../../../../lib/util/twilio-video-errors');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const sinon = require('sinon');
 
-var sinon = require('sinon');
-var util = require('../../../../../lib/util');
+const createCancelableRoomSignalingPromise = require('../../../../../lib/signaling/v2/cancelableroomsignalingpromise');
+const CancelablePromise = require('../../../../../lib/util/cancelablepromise');
+const { defer } = require('../../../../../lib/util');
+const { SignalingConnectionDisconnectedError } = require('../../../../../lib/util/twilio-video-errors');
+
+const MockIceServerSource = require('../../../../lib/mockiceserversource');
+const { makeEncodingParameters } = require('../../../../lib/util');
 
 describe('createCancelableRoomSignalingPromise', () => {
   it('returns a CancelablePromise', () => {
@@ -376,7 +377,7 @@ function makeTest(options) {
   options.ua = options.ua || makeUA(options);
   options.tracks = options.tracks || [];
   options.localParticipant = options.localParticipant || makeLocalParticipantSignaling(options);
-  options.createAndOfferDeferred = util.defer();
+  options.createAndOfferDeferred = defer();
   options.PeerConnectionManager = options.PeerConnectionManager || makePeerConnectionManagerConstructor(options);
   options.room = options.room || {
     disconnect: sinon.spy(() => {})

--- a/test/unit/spec/signaling/v2/icebox.js
+++ b/test/unit/spec/signaling/v2/icebox.js
@@ -149,6 +149,7 @@ describe('IceBox', () => {
         it('does not update .ufrag', () => {
           const test = makeTest({ ufrag: 'foo' });
           const iceState = test.state().setCandidates('foo', 1);
+          test.iceBox.update(iceState);
 
           assert.equal('foo', test.iceBox.ufrag);
         });
@@ -172,6 +173,7 @@ describe('IceBox', () => {
           const iceState2 = test.state().setCandidates('foo', 2);
 
           test.iceBox.update(iceState1);
+          test.iceBox.update(iceState2);
 
           assert.equal('foo', test.iceBox.ufrag);
         });
@@ -220,6 +222,7 @@ describe('IceBox', () => {
           const iceState2 = test.state().setCandidates('foo', 2);
 
           test.iceBox.update(iceState2);
+          test.iceBox.update(iceState1);
 
           assert.equal('foo', test.iceBox.ufrag);
         });
@@ -244,6 +247,8 @@ describe('IceBox', () => {
           const test = makeTest({ ufrag: 'foo' });
           const iceState = test.state().setCandidates('bar', 1);
 
+          test.iceBox.update(iceState);
+
           assert.equal('foo', test.iceBox.ufrag);
         });
 
@@ -264,6 +269,7 @@ describe('IceBox', () => {
           const iceState2 = test.state().setCandidates('bar', 2);
 
           test.iceBox.update(iceState1);
+          test.iceBox.update(iceState2);
 
           assert.equal('foo', test.iceBox.ufrag);
         });
@@ -310,6 +316,7 @@ describe('IceBox', () => {
           const iceState2 = test.state().setCandidates('bar', 2);
 
           test.iceBox.update(iceState2);
+          test.iceBox.update(iceState1);
 
           assert.equal('foo', test.iceBox.ufrag);
         });

--- a/test/unit/spec/signaling/v2/icebox.js
+++ b/test/unit/spec/signaling/v2/icebox.js
@@ -7,7 +7,7 @@ const IceBox = require('../../../../../lib/signaling/v2/icebox');
 describe('IceBox', () => {
   describe('constructor', () => {
     it('sets .ufrag to null', () => {
-      var test = makeTest();
+      const test = makeTest();
       assert.equal(null, test.iceBox.ufrag);
     });
   });
@@ -16,8 +16,8 @@ describe('IceBox', () => {
     context('after ICE candidates with matching username fragment were added at', () => {
       context('an initial revision', () => {
         it('updates .ufrag', () => {
-          var test = makeTest();
-          var iceState = test.state().setCandidates('foo', 1);
+          const test = makeTest();
+          const iceState = test.state().setCandidates('foo', 1);
 
           test.iceBox.update(iceState);
 
@@ -26,8 +26,8 @@ describe('IceBox', () => {
         });
 
         it('returns an array of the ICE candidates added, in order', () => {
-          var test = makeTest();
-          var iceState = test.state().setCandidates('foo', 1);
+          const test = makeTest();
+          const iceState = test.state().setCandidates('foo', 1);
 
           test.iceBox.update(iceState);
 
@@ -41,9 +41,9 @@ describe('IceBox', () => {
 
       context('a new revision', () => {
         it('updates .ufrag', () => {
-          var test = makeTest();
-          var iceState1 = test.state().setCandidates('foo', 1);
-          var iceState2 = test.state().setCandidates('foo', 2);
+          const test = makeTest();
+          const iceState1 = test.state().setCandidates('foo', 1);
+          const iceState2 = test.state().setCandidates('foo', 2);
 
           test.iceBox.update(iceState1);
           test.iceBox.update(iceState2);
@@ -53,9 +53,9 @@ describe('IceBox', () => {
         });
 
         it('returns an array of the ICE candidates added, in order and deduplicated', () => {
-          var test = makeTest();
-          var iceState1 = test.state().setCandidates('foo', 1);
-          var iceState2 = test.state().setCandidates('foo', 2);
+          const test = makeTest();
+          const iceState1 = test.state().setCandidates('foo', 1);
+          const iceState2 = test.state().setCandidates('foo', 2);
 
           test.iceBox.update(iceState1);
           test.iceBox.update(iceState2);
@@ -71,8 +71,8 @@ describe('IceBox', () => {
 
       context('the same revision', () => {
         it('updates .ufrag', () => {
-          var test = makeTest();
-          var iceState = test.state().setCandidates('foo', 1);
+          const test = makeTest();
+          const iceState = test.state().setCandidates('foo', 1);
 
           test.iceBox.update(iceState);
           test.iceBox.update(iceState);
@@ -82,8 +82,8 @@ describe('IceBox', () => {
         });
 
         it('returns an array of the ICE candidates added, in order and deduplicated', () => {
-          var test = makeTest();
-          var iceState = test.state().setCandidates('foo', 1);
+          const test = makeTest();
+          const iceState = test.state().setCandidates('foo', 1);
 
           test.iceBox.update(iceState);
           test.iceBox.update(iceState);
@@ -98,9 +98,9 @@ describe('IceBox', () => {
 
       context('an old revision', () => {
         it('updates .ufrag', () => {
-          var test = makeTest();
-          var iceState1 = test.state().setCandidates('foo', 1);
-          var iceState2 = test.state().setCandidates('foo', 2);
+          const test = makeTest();
+          const iceState1 = test.state().setCandidates('foo', 1);
+          const iceState2 = test.state().setCandidates('foo', 2);
 
           test.iceBox.update(iceState2);
           test.iceBox.update(iceState1);
@@ -110,9 +110,9 @@ describe('IceBox', () => {
         });
 
         it('returns an array of the ICE candidates added, in order and deduplicated', () => {
-          var test = makeTest();
-          var iceState1 = test.state().setCandidates('foo', 1);
-          var iceState2 = test.state().setCandidates('foo', 2);
+          const test = makeTest();
+          const iceState1 = test.state().setCandidates('foo', 1);
+          const iceState2 = test.state().setCandidates('foo', 2);
 
           test.iceBox.update(iceState2);
           test.iceBox.update(iceState1);
@@ -129,13 +129,13 @@ describe('IceBox', () => {
 
     context('before ICE candidates with matching username fragment have been added', () => {
       it('updates .ufrag', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.iceBox.setUfrag('foo');
         assert.equal('foo', test.iceBox.ufrag);
       });
 
       it('returns an empty array', () => {
-        var test = makeTest();
+        const test = makeTest();
         assert.deepEqual(
           [],
           test.iceBox.setUfrag('foo'));
@@ -147,15 +147,15 @@ describe('IceBox', () => {
     context('matching the current username fragment at', () => {
       context('an initial revision', () => {
         it('does not update .ufrag', () => {
-          var test = makeTest({ ufrag: 'foo' });
-          var iceState = test.state().setCandidates('foo', 1);
+          const test = makeTest({ ufrag: 'foo' });
+          const iceState = test.state().setCandidates('foo', 1);
 
           assert.equal('foo', test.iceBox.ufrag);
         });
 
         it('returns an array of the initial ICE candidates added, in order', () => {
-          var test = makeTest({ ufrag: 'foo' });
-          var iceState = test.state().setCandidates('foo', 1);
+          const test = makeTest({ ufrag: 'foo' });
+          const iceState = test.state().setCandidates('foo', 1);
 
           assert.deepEqual(
             [
@@ -167,9 +167,9 @@ describe('IceBox', () => {
 
       context('a new revision', () => {
         it('does not update .ufrag', () => {
-          var test = makeTest({ ufrag: 'foo' });
-          var iceState1 = test.state().setCandidates('foo', 1);
-          var iceState2 = test.state().setCandidates('foo', 2);
+          const test = makeTest({ ufrag: 'foo' });
+          const iceState1 = test.state().setCandidates('foo', 1);
+          const iceState2 = test.state().setCandidates('foo', 2);
 
           test.iceBox.update(iceState1);
 
@@ -177,9 +177,9 @@ describe('IceBox', () => {
         });
 
         it('returns an array of the new ICE candidates added, in order', () => {
-          var test = makeTest({ ufrag: 'foo' });
-          var iceState1 = test.state().setCandidates('foo', 1);
-          var iceState2 = test.state().setCandidates('foo', 2);
+          const test = makeTest({ ufrag: 'foo' });
+          const iceState1 = test.state().setCandidates('foo', 1);
+          const iceState2 = test.state().setCandidates('foo', 2);
 
           test.iceBox.update(iceState1);
 
@@ -193,8 +193,8 @@ describe('IceBox', () => {
 
       context('the same revision', () => {
         it('does not update .ufrag', () => {
-          var test = makeTest({ ufrag: 'foo' });
-          var iceState = test.state().setCandidates('foo', 1);
+          const test = makeTest({ ufrag: 'foo' });
+          const iceState = test.state().setCandidates('foo', 1);
 
           test.iceBox.update(iceState);
 
@@ -202,8 +202,8 @@ describe('IceBox', () => {
         });
 
         it('returns an empty array', () => {
-          var test = makeTest({ ufrag: 'foo' });
-          var iceState = test.state().setCandidates('foo', 1);
+          const test = makeTest({ ufrag: 'foo' });
+          const iceState = test.state().setCandidates('foo', 1);
 
           test.iceBox.update(iceState);
 
@@ -215,9 +215,9 @@ describe('IceBox', () => {
 
       context('an old revision', () => {
         it('does not update .ufrag', () => {
-          var test = makeTest({ ufrag: 'foo' });
-          var iceState1 = test.state().setCandidates('foo', 1);
-          var iceState2 = test.state().setCandidates('foo', 2);
+          const test = makeTest({ ufrag: 'foo' });
+          const iceState1 = test.state().setCandidates('foo', 1);
+          const iceState2 = test.state().setCandidates('foo', 2);
 
           test.iceBox.update(iceState2);
 
@@ -225,9 +225,9 @@ describe('IceBox', () => {
         });
 
         it('returns an empty array', () => {
-          var test = makeTest({ ufrag: 'foo' });
-          var iceState1 = test.state().setCandidates('foo', 1);
-          var iceState2 = test.state().setCandidates('foo', 2);
+          const test = makeTest({ ufrag: 'foo' });
+          const iceState1 = test.state().setCandidates('foo', 1);
+          const iceState2 = test.state().setCandidates('foo', 2);
 
           test.iceBox.update(iceState2);
 
@@ -241,15 +241,15 @@ describe('IceBox', () => {
     context('called with ICE candidates not matching the current username fragment', () => {
       context('an initial revision', () => {
         it('does not update .ufrag', () => {
-          var test = makeTest({ ufrag: 'foo' });
-          var iceState = test.state().setCandidates('bar', 1);
+          const test = makeTest({ ufrag: 'foo' });
+          const iceState = test.state().setCandidates('bar', 1);
 
           assert.equal('foo', test.iceBox.ufrag);
         });
 
         it('returns an empty array', () => {
-          var test = makeTest({ ufrag: 'foo' });
-          var iceState = test.state().setCandidates('bar', 1);
+          const test = makeTest({ ufrag: 'foo' });
+          const iceState = test.state().setCandidates('bar', 1);
 
           assert.deepEqual(
             [],
@@ -259,9 +259,9 @@ describe('IceBox', () => {
 
       context('a new revision', () => {
         it('does not update .ufrag', () => {
-          var test = makeTest({ ufrag: 'foo' });
-          var iceState1 = test.state().setCandidates('bar', 1);
-          var iceState2 = test.state().setCandidates('bar', 2);
+          const test = makeTest({ ufrag: 'foo' });
+          const iceState1 = test.state().setCandidates('bar', 1);
+          const iceState2 = test.state().setCandidates('bar', 2);
 
           test.iceBox.update(iceState1);
 
@@ -269,9 +269,9 @@ describe('IceBox', () => {
         });
 
         it('returns an empty array', () => {
-          var test = makeTest({ ufrag: 'foo' });
-          var iceState1 = test.state().setCandidates('bar', 1);
-          var iceState2 = test.state().setCandidates('bar', 2);
+          const test = makeTest({ ufrag: 'foo' });
+          const iceState1 = test.state().setCandidates('bar', 1);
+          const iceState2 = test.state().setCandidates('bar', 2);
 
           test.iceBox.update(iceState1);
 
@@ -283,8 +283,8 @@ describe('IceBox', () => {
 
       context('the same revision', () => {
         it('does not update .ufrag', () => {
-          var test = makeTest({ ufrag: 'foo' });
-          var iceState = test.state().setCandidates('bar', 1);
+          const test = makeTest({ ufrag: 'foo' });
+          const iceState = test.state().setCandidates('bar', 1);
 
           test.iceBox.update(iceState);
 
@@ -292,8 +292,8 @@ describe('IceBox', () => {
         });
 
         it('returns an empty array', () => {
-          var test = makeTest({ ufrag: 'foo' });
-          var iceState = test.state().setCandidates('bar', 1);
+          const test = makeTest({ ufrag: 'foo' });
+          const iceState = test.state().setCandidates('bar', 1);
 
           test.iceBox.update(iceState);
 
@@ -305,9 +305,9 @@ describe('IceBox', () => {
 
       context('an old revision', () => {
         it('does not update .ufrag', () => {
-          var test = makeTest({ ufrag: 'foo' });
-          var iceState1 = test.state().setCandidates('bar', 1);
-          var iceState2 = test.state().setCandidates('bar', 2);
+          const test = makeTest({ ufrag: 'foo' });
+          const iceState1 = test.state().setCandidates('bar', 1);
+          const iceState2 = test.state().setCandidates('bar', 2);
 
           test.iceBox.update(iceState2);
 
@@ -315,9 +315,9 @@ describe('IceBox', () => {
         });
 
         it('returns an empty array', () => {
-          var test = makeTest({ ufrag: 'foo' });
-          var iceState1 = test.state().setCandidates('bar', 1);
-          var iceState2 = test.state().setCandidates('bar', 2);
+          const test = makeTest({ ufrag: 'foo' });
+          const iceState1 = test.state().setCandidates('bar', 1);
+          const iceState2 = test.state().setCandidates('bar', 2);
 
           test.iceBox.update(iceState2);
 
@@ -348,7 +348,7 @@ function IceStateBuilder() {
 
 IceStateBuilder.prototype.setCandidates = function setCandidates(ufrag, revision) {
   this.candidates = [];
-  for (var i = 0; i < revision; i++) {
+  for (let i = 0; i < revision; i++) {
     this.candidates.push({ candidate: 'candidate' + (i + 1) });
   }
   this.revision = revision;

--- a/test/unit/spec/signaling/v2/icebox.js
+++ b/test/unit/spec/signaling/v2/icebox.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var assert = require('assert');
-var IceBox = require('../../../../../lib/signaling/v2/icebox');
+const assert = require('assert');
+
+const IceBox = require('../../../../../lib/signaling/v2/icebox');
 
 describe('IceBox', () => {
   describe('constructor', () => {

--- a/test/unit/spec/signaling/v2/index.js
+++ b/test/unit/spec/signaling/v2/index.js
@@ -46,77 +46,74 @@ describe('SignalingV2', () => {
 
   describe('#close, when the SignalingV2 .state is', () => {
     context('"closed"', () => {
-      it('returns a Promise that resolves to the SignalingV2', () => {
+      it('returns a Promise that resolves to the SignalingV2', async () => {
         const test = makeTest();
-        return test.signaling.close().then(signaling => {
-          assert.equal(test.signaling, signaling);
-        });
+        const signaling = await test.signaling.close();
+        assert.equal(test.signaling, signaling);
       });
 
-      it('does not transition', () => {
+      it('does not transition', async () => {
         const test = makeTest();
-        return test.signaling.close().then(() => {
-          assert.deepEqual(
-            [],
-            test.transitions);
-        });
+        await test.signaling.close();
+        assert.deepEqual(
+          [],
+          test.transitions);
       });
 
-      it('does not call .disconnect on the SIP.js UA\'s .transport', () => {
+      it('does not call .disconnect on the SIP.js UA\'s .transport', async () => {
         const test = makeTest();
-        return test.signaling.close().then(() => {
-          assert(!test.ua.transport.disconnect.calledOnce);
-        });
+        await test.signaling.close();
+        assert(!test.ua.transport.disconnect.calledOnce);
       });
     });
 
     context('"closing"', () => {
-      it('returns a Promise that resolves to the SignalingV2', () => {
+      it('returns a Promise that resolves to the SignalingV2', async () => {
         const test = makeTest();
-        const promise = test.when('closing', () => {
-          return test.signaling.close().then(signaling => {
-            assert.equal(test.signaling, signaling);
-          });
+        const promise = test.when('closing', async () => {
+          const signaling = await test.signaling.close();
+          assert.equal(test.signaling, signaling);
         });
-        test.signaling.open().then(() => test.signaling.close());
+        await test.signaling.open();
+        await test.signaling.close();
         return promise;
       });
 
-      it('does not transition after transitioning to state "closed"', () => {
+      it('does not transition after transitioning to state "closed"', async () => {
         const test = makeTest();
-        const promise = test.when('closing', () => {
+        const promise = test.when('closing', async () => {
           test.transitions = [];
-          return test.signaling.close().then(() => {
-            assert.deepEqual(
-              [
-                'closed'
-              ],
-              test.transitions);
-          });
+          await test.signaling.close();
+          assert.deepEqual(
+            [
+              'closed'
+            ],
+            test.transitions);
         });
-        test.signaling.open().then(() => test.signaling.close());
+        await test.signaling.open();
+        await test.signaling.close();
         return promise;
       });
 
-      it('does not call .close on the SIP.js UA again', () => {
+      it('does not call .close on the SIP.js UA again', async () => {
         const test = makeTest();
-        const promise = test.when('closing', () => {
-          return test.signaling.close().then(() => {
-            assert(test.ua.stop.calledOnce);
-          });
+        const promise = test.when('closing', async () => {
+          await test.signaling.close();
+          assert(test.ua.stop.calledOnce);
         });
-        test.signaling.open().then(() => test.signaling.close());
+        await test.signaling.open();
+        await test.signaling.close();
         return promise;
       });
 
-      it('does not call .disconnect on the SIP.js UA\'s .transport again', () => {
+      it('does not call .disconnect on the SIP.js UA\'s .transport again', async () => {
         const test = makeTest();
-        const promise = test.when('closing', () => {
-          return test.signaling.close().then(() => {
-            assert(test.ua.transport.disconnect.calledOnce);
-          });
+        const promise = test.when('closing', async () => {
+          await test.signaling.close();
+          assert(test.ua.transport.disconnect.calledOnce);
         });
-        test.signaling.open().then(() => test.signaling.close());
+        await test.signaling.open();
+        await test.signaling.close();
         return promise;
       });
     });
@@ -167,52 +164,64 @@ describe('SignalingV2', () => {
 
     context('"opening"', () => {
       context('and the call to .start on the SIP.js UA fails', () => {
-        it('returns a Promise that resolves to the SignalingV2', () => {
+        it('returns a Promise that resolves to the SignalingV2', async () => {
           const test = makeTest({ uaConnectSucceeds: false });
-          const promise = test.when('opening', () => {
-            return test.signaling.close().then(signaling => {
-              assert.equal(test.signaling, signaling);
-            });
+          const promise = test.when('opening', async () => {
+            const signaling = await test.signaling.close();
+            assert.equal(test.signaling, signaling);
           });
-          test.signaling.open().then(() => test.signaling.close());
+          try {
+            await test.signaling.open();
+          } catch (error) {
+            // Expected rejection
+          }
           return promise;
         });
 
-        it('does not transition after transitioning to "closed"', () => {
+        it('does not transition after transitioning to "closed"', async () => {
           const test = makeTest({ uaConnectSucceeds: false });
-          const promise = test.when('opening', () => {
+          const promise = test.when('opening', async () => {
             test.transitions = [];
-            return test.signaling.close().then(signaling => {
-              assert.deepEqual(
-                [
-                  'closed'
-                ],
-                test.transitions);
-            });
+            await test.signaling.close();
+            assert.deepEqual(
+              [
+                'closed'
+              ],
+              test.transitions);
           });
-          test.signaling.open().then(() => test.signaling.close());
+          try {
+            await test.signaling.open();
+          } catch (error) {
+            // Expected rejection
+          }
           return promise;
         });
 
-        it('does not call .close on the SIP.js UA', () => {
+        it('does not call .close on the SIP.js UA', async () => {
           const test = makeTest({ uaConnectSucceeds: false });
-          const promise = test.when('opening', () => {
-            return test.signaling.close().then(() => {
-              assert(!test.ua.stop.calledOnce);
-            });
+          const promise = test.when('opening', async () => {
+            await test.signaling.close();
+            assert(!test.ua.stop.calledOnce);
           });
-          test.signaling.open().then(() => test.signaling.close());
+          try {
+            await test.signaling.open();
+          } catch (error) {
+            // Expected rejection
+          }
           return promise;
         });
 
-        it('does not call .disconnect on the SIP.js UA\'s .transport', () => {
+        it('does not call .disconnect on the SIP.js UA\'s .transport', async () => {
           const test = makeTest({ uaConnectSucceeds: false });
-          const promise = test.when('opening', () => {
-            return test.signaling.close().then(() => {
-              assert(!test.ua.transport.disconnect.calledOnce);
-            });
+          const promise = test.when('opening', async () => {
+            await test.signaling.close();
+            assert(!test.ua.transport.disconnect.calledOnce);
           });
-          test.signaling.open().then(() => test.signaling.close());
+          try {
+            await test.signaling.open();
+          } catch (error) {
+            // Expected rejection
+          }
           return promise;
         });
       });
@@ -582,26 +591,35 @@ describe('SignalingV2', () => {
         });
 
         context('and the subsequent one fails', () => {
-          it('returns a Promise that rejects with an Error', () => {
+          it('returns a Promise that rejects with an Error', async () => {
             const test = makeTest({ uaConnectSucceeds: false });
-            const promise = test.when('opening', () => {
-              return test.signaling.connect().then(() => {
-                throw new Error('Unexpected resolution');
-              }, error => {
+            const promise = test.when('opening', async () => {
+              try {
+                await test.signaling.connect();
+              } catch (error) {
+                // Expected rejection
                 assert(error instanceof Error);
-              });
+                return;
+              }
+              throw new Error('Unexpected resolution');
             });
-            test.signaling.open();
-            return promise;
+            try {
+              await test.signaling.open();
+            } catch (error) {
+              // Expected rejection
+              return promise;
+            }
+            throw new Error('Unexpected resoltuion');
           });
 
-          it('transitions through state "opening" to state "closed" after "closed"', () => {
+          it('transitions through state "opening" to state "closed" after "closed"', async () => {
             const test = makeTest({ uaConnectSucceeds: false });
-            const promise = test.when('opening', () => {
+            const promise = test.when('opening', async () => {
               test.transitions = [];
-              return test.signaling.connect().then(() => {
-                throw new Error('Unexpected resolution');
-              }, error => {
+              try {
+                await test.signaling.connect();
+              } catch (error) {
+                // Expected rejection
                 assert.deepEqual(
                   [
                     'closed',
@@ -609,49 +627,80 @@ describe('SignalingV2', () => {
                     'closed'
                   ],
                   test.transitions);
-              });
+                return;
+              }
+              throw new Error('Unexpected resolution');
             });
-            test.signaling.open();
-            return promise;
+            try {
+              await test.signaling.open();
+            } catch (error) {
+              // Expected rejection
+              return promise;
+            }
+            throw new Error('Unexpected resolution');
           });
 
-          it('calls .start on the SIP.js UA again', () => {
+          it('calls .start on the SIP.js UA again', async () => {
             const test = makeTest({ uaConnectSucceeds: false });
-            const promise = test.when('opening', () => {
-              return test.signaling.connect().then(() => {
-                throw new Error('Unexpected resolution');
-              }, error => {
+            const promise = test.when('opening', async () => {
+              try {
+                await test.signaling.connect();
+              } catch (error) {
+                // Expected rejection
                 assert(test.ua.start.calledTwice);
-              });
+                return;
+              }
+              throw new Error('Unexpected resolution');
             });
-            test.signaling.open();
-            return promise;
+            try {
+              await test.signaling.open();
+            } catch (error) {
+              // Expected rejection
+              return promise;
+            }
+            throw new Error('Unexpected resolution');
           });
 
-          it('does not call .stop on the SIP.js UA', () => {
+          it('does not call .stop on the SIP.js UA', async () => {
             const test = makeTest({ uaConnectSucceeds: false });
-            const promise = test.when('opening', () => {
-              return test.signaling.connect().then(() => {
-                throw new Error('Unexpected resolution');
-              }, error => {
+            const promise = test.when('opening', async () => {
+              try {
+                await test.signaling.connect();
+              } catch(error) {
+                // Expected rejection
                 assert(!test.ua.stop.calledOnce);
-              });
+                return;
+              }
+              throw new Error('Unexpected resolution');
             });
-            test.signaling.open();
-            return promise;
+            try {
+              await test.signaling.open();
+            } catch (error) {
+              // Expected rejection
+              return promise;
+            }
+            throw new Error('Unexpected resolution');
           });
 
-          it('does not call .disconnect on the SIP.js UA\'s .transport', () => {
+          it('does not call .disconnect on the SIP.js UA\'s .transport', async () => {
             const test = makeTest({ uaConnectSucceeds: false });
-            const promise = test.when('opening', () => {
-              return test.signaling.connect().then(() => {
-                throw new Error('Unexpected resolution');
-              }, error => {
+            const promise = test.when('opening', async () => {
+              try {
+                await test.signaling.connect();
+              } catch (error) {
+                // Expected rejection
                 assert(!test.ua.transport.disconnect.calledOnce);
-              });
+                return;
+              }
+              throw new Error('Unexpected resolution');
             });
-            test.signaling.open();
-            return promise;
+            try {
+              await test.signaling.open();
+            } catch (error) {
+              // Expected rejection
+              return promise;
+            }
+            throw new Error('Unexpected resolution');
           });
         });
       });
@@ -1015,26 +1064,35 @@ describe('SignalingV2', () => {
         });
 
         context('and the subsequent one fails', () => {
-          it('returns a Promise that rejects with an Error', () => {
+          it('returns a Promise that rejects with an Error', async () => {
             const test = makeTest({ uaConnectSucceeds: false });
-            const promise = test.when('opening', () => {
-              return test.signaling.open().then(() => {
-                throw new Error('Unexpected resolution');
-              }, error => {
+            const promise = test.when('opening', async () => {
+              try {
+                await test.signaling.open();
+              } catch (error) {
+                // Expected rejection
                 assert(error instanceof Error);
-              });
+                return;
+              }
+              throw new Error('Unexpected resolution');
             });
-            test.signaling.open();
-            return promise;
+            try {
+              await test.signaling.open();
+            } catch (error) {
+              // Expected rejection
+              return promise;
+            }
+            throw new Error('Unexpected resolution');
           });
 
-          it('transitions through state "opening" to state "closed" after "closed"', () => {
+          it('transitions through state "opening" to state "closed" after "closed"', async () => {
             const test = makeTest({ uaConnectSucceeds: false });
-            const promise = test.when('opening', () => {
+            const promise = test.when('opening', async () => {
               test.transitions = [];
-              return test.signaling.open().then(() => {
-                throw new Error('Unexpected resolution');
-              }, error => {
+              try {
+                await test.signaling.open();
+              } catch (error) {
+                // Expected rejection
                 assert.deepEqual(
                   [
                     'closed',
@@ -1042,49 +1100,80 @@ describe('SignalingV2', () => {
                     'closed'
                   ],
                   test.transitions);
-              });
+                return;
+              }
+              throw new Error('Unexpected resolution');
             });
-            test.signaling.open();
-            return promise;
+            try {
+              await test.signaling.open();
+            } catch (error) {
+              // Expected rejection
+              return promise;
+            }
+            throw new Error('Unexpected resolution');
           });
 
-          it('calls .start on the SIP.js UA again', () => {
+          it('calls .start on the SIP.js UA again', async () => {
             const test = makeTest({ uaConnectSucceeds: false });
-            const promise = test.when('opening', () => {
-              return test.signaling.open().then(() => {
-                throw new Error('Unexpected resolution');
-              }, error => {
+            const promise = test.when('opening', async () => {
+              try {
+                await test.signaling.open();
+              } catch (error) {
+                // Expected rejection
                 assert(test.ua.start.calledTwice);
-              });
+                return;
+              }
+              throw new Error('Unexpected resolution');
             });
-            test.signaling.open();
-            return promise;
+            try {
+              await test.signaling.open();
+            } catch (error) {
+              // Expected rejection
+              return promise;
+            }
+            throw new Error('Unexpected resolution');
           });
 
-          it('does not call .stop on the SIP.js UA', () => {
+          it('does not call .stop on the SIP.js UA', async () => {
             const test = makeTest({ uaConnectSucceeds: false });
-            const promise = test.when('opening', () => {
-              return test.signaling.open().then(() => {
-                throw new Error('Unexpected resolution');
-              }, error => {
+            const promise = test.when('opening', async () => {
+              try {
+                await test.signaling.open();
+              } catch (error) {
+                // Expected rejection
                 assert(!test.ua.stop.calledOnce);
-              });
+                return;
+              }
+              throw new Error('Unexpected resolution');
             });
-            test.signaling.open();
-            return promise;
+            try {
+              await test.signaling.open();
+            } catch (error) {
+              // Expected rejection
+              return promise;
+            }
+            throw new Error('Unexpected resolution');
           });
 
-          it('does not call .disconnect on the SIP.js UA\'s .transport', () => {
+          it('does not call .disconnect on the SIP.js UA\'s .transport', async () => {
             const test = makeTest({ uaConnectSucceeds: false });
-            const promise = test.when('opening', () => {
-              return test.signaling.open().then(() => {
-                throw new Error('Unexpected resolution');
-              }, error => {
+            const promise = test.when('opening', async () => {
+              try {
+                await test.signaling.open();
+              } catch (error) {
+                // Expected rejection
                 assert(!test.ua.transport.disconnect.calledOnce);
-              });
+                return;
+              }
+              throw new Error('Unexpected resolution');
             });
-            test.signaling.open();
-            return promise;
+            try {
+              await test.signaling.open();
+            } catch (error) {
+              // Expected rejection
+              return promise;
+            }
+            throw new Error('Unexpected resolution');
           });
         });
       });

--- a/test/unit/spec/signaling/v2/index.js
+++ b/test/unit/spec/signaling/v2/index.js
@@ -1,11 +1,13 @@
 'use strict';
 
-var assert = require('assert');
-var { makeEncodingParameters } = require('../../../../lib/util');
-var EventEmitter = require('events').EventEmitter;
-var LocalParticipantV2 = require('../../../../../lib/signaling/v2/localparticipant');
-var SignalingV2 = require('../../../../../lib/signaling/v2');
-var sinon = require('sinon');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const sinon = require('sinon');
+
+const SignalingV2 = require('../../../../../lib/signaling/v2');
+const LocalParticipantV2 = require('../../../../../lib/signaling/v2/localparticipant');
+
+const { makeEncodingParameters } = require('../../../../lib/util');
 
 describe('SignalingV2', () => {
   // SignalingV2

--- a/test/unit/spec/signaling/v2/index.js
+++ b/test/unit/spec/signaling/v2/index.js
@@ -15,27 +15,27 @@ describe('SignalingV2', () => {
 
   describe('constructor', () => {
     it('sets the .state to "closed"', () => {
-      var test = makeTest();
+      const test = makeTest();
       assert.equal(
         'closed',
         test.signaling.state);
     });
 
     it('constructs a new SIP.js UA', () => {
-      var test = makeTest();
+      const test = makeTest();
       assert(test.ua);
     });
 
     context('the newly-constructed SIP.js UA', () => {
       it('has extra Supported option tags "room-signaling" and "timer"', () => {
-        var test = makeTest();
-        var optionTags = new Set(test.UA.args[0][0].extraSupported);
+        const test = makeTest();
+        const optionTags = new Set(test.UA.args[0][0].extraSupported);
         assert(optionTags.has('room-signaling'));
         assert(optionTags.has('timer'));
       });
 
       it('allows unregistered option tags', () => {
-        var test = makeTest();
+        const test = makeTest();
         assert(test.UA.args[0][0].hackAllowUnregisteredOptionTags);
       });
     });
@@ -47,14 +47,14 @@ describe('SignalingV2', () => {
   describe('#close, when the SignalingV2 .state is', () => {
     context('"closed"', () => {
       it('returns a Promise that resolves to the SignalingV2', () => {
-        var test = makeTest();
+        const test = makeTest();
         return test.signaling.close().then(signaling => {
           assert.equal(test.signaling, signaling);
         });
       });
 
       it('does not transition', () => {
-        var test = makeTest();
+        const test = makeTest();
         return test.signaling.close().then(() => {
           assert.deepEqual(
             [],
@@ -63,7 +63,7 @@ describe('SignalingV2', () => {
       });
 
       it('does not call .disconnect on the SIP.js UA\'s .transport', () => {
-        var test = makeTest();
+        const test = makeTest();
         return test.signaling.close().then(() => {
           assert(!test.ua.transport.disconnect.calledOnce);
         });
@@ -72,8 +72,8 @@ describe('SignalingV2', () => {
 
     context('"closing"', () => {
       it('returns a Promise that resolves to the SignalingV2', () => {
-        var test = makeTest();
-        var promise = test.when('closing', () => {
+        const test = makeTest();
+        const promise = test.when('closing', () => {
           return test.signaling.close().then(signaling => {
             assert.equal(test.signaling, signaling);
           });
@@ -83,8 +83,8 @@ describe('SignalingV2', () => {
       });
 
       it('does not transition after transitioning to state "closed"', () => {
-        var test = makeTest();
-        var promise = test.when('closing', () => {
+        const test = makeTest();
+        const promise = test.when('closing', () => {
           test.transitions = [];
           return test.signaling.close().then(() => {
             assert.deepEqual(
@@ -99,8 +99,8 @@ describe('SignalingV2', () => {
       });
 
       it('does not call .close on the SIP.js UA again', () => {
-        var test = makeTest();
-        var promise = test.when('closing', () => {
+        const test = makeTest();
+        const promise = test.when('closing', () => {
           return test.signaling.close().then(() => {
             assert(test.ua.stop.calledOnce);
           });
@@ -110,8 +110,8 @@ describe('SignalingV2', () => {
       });
 
       it('does not call .disconnect on the SIP.js UA\'s .transport again', () => {
-        var test = makeTest();
-        var promise = test.when('closing', () => {
+        const test = makeTest();
+        const promise = test.when('closing', () => {
           return test.signaling.close().then(() => {
             assert(test.ua.transport.disconnect.calledOnce);
           });
@@ -123,7 +123,7 @@ describe('SignalingV2', () => {
 
     context('"open"', () => {
       it('returns a Promise that resolves to the SignalingV2', () => {
-        var test = makeTest();
+        const test = makeTest();
         return test.signaling.open().then(() => {
           return test.signaling.close();
         }).then(signaling => {
@@ -132,7 +132,7 @@ describe('SignalingV2', () => {
       });
 
       it('transitions through state "closing" to state "closed"', () => {
-        var test = makeTest();
+        const test = makeTest();
         return test.signaling.open().then(() => {
           test.transitions = [];
           return test.signaling.close();
@@ -147,7 +147,7 @@ describe('SignalingV2', () => {
       });
 
       it('calls .close on the SIP.js UA', () => {
-        var test = makeTest();
+        const test = makeTest();
         return test.signaling.open().then(() => {
           return test.signaling.close();
         }).then(() => {
@@ -156,7 +156,7 @@ describe('SignalingV2', () => {
       });
 
       it('calls .disconnect on the SIP.js UA\'s .transport', () => {
-        var test = makeTest();
+        const test = makeTest();
         return test.signaling.open().then(() => {
           return test.signaling.close();
         }).then(() => {
@@ -168,8 +168,8 @@ describe('SignalingV2', () => {
     context('"opening"', () => {
       context('and the call to .start on the SIP.js UA fails', () => {
         it('returns a Promise that resolves to the SignalingV2', () => {
-          var test = makeTest({ uaConnectSucceeds: false });
-          var promise = test.when('opening', () => {
+          const test = makeTest({ uaConnectSucceeds: false });
+          const promise = test.when('opening', () => {
             return test.signaling.close().then(signaling => {
               assert.equal(test.signaling, signaling);
             });
@@ -179,8 +179,8 @@ describe('SignalingV2', () => {
         });
 
         it('does not transition after transitioning to "closed"', () => {
-          var test = makeTest({ uaConnectSucceeds: false });
-          var promise = test.when('opening', () => {
+          const test = makeTest({ uaConnectSucceeds: false });
+          const promise = test.when('opening', () => {
             test.transitions = [];
             return test.signaling.close().then(signaling => {
               assert.deepEqual(
@@ -195,8 +195,8 @@ describe('SignalingV2', () => {
         });
 
         it('does not call .close on the SIP.js UA', () => {
-          var test = makeTest({ uaConnectSucceeds: false });
-          var promise = test.when('opening', () => {
+          const test = makeTest({ uaConnectSucceeds: false });
+          const promise = test.when('opening', () => {
             return test.signaling.close().then(() => {
               assert(!test.ua.stop.calledOnce);
             });
@@ -206,8 +206,8 @@ describe('SignalingV2', () => {
         });
 
         it('does not call .disconnect on the SIP.js UA\'s .transport', () => {
-          var test = makeTest({ uaConnectSucceeds: false });
-          var promise = test.when('opening', () => {
+          const test = makeTest({ uaConnectSucceeds: false });
+          const promise = test.when('opening', () => {
             return test.signaling.close().then(() => {
               assert(!test.ua.transport.disconnect.calledOnce);
             });
@@ -219,8 +219,8 @@ describe('SignalingV2', () => {
 
       context('and the call to .start on the SIP.js UA succeeds', () => {
         it('returns a Promise that resolves to the SignalingV2', () => {
-          var test = makeTest();
-          var promise = test.when('opening', () => {
+          const test = makeTest();
+          const promise = test.when('opening', () => {
             return test.signaling.close().then(signaling => {
               assert.equal(test.signaling, signaling);
             });
@@ -230,8 +230,8 @@ describe('SignalingV2', () => {
         });
 
         it('transitions through state "closing" to state "closed" after transitioning to "open"', () => {
-          var test = makeTest();
-          var promise = test.when('opening', () => {
+          const test = makeTest();
+          const promise = test.when('opening', () => {
             test.transitions = [];
             return test.signaling.close().then(() => {
               assert.deepEqual(
@@ -248,8 +248,8 @@ describe('SignalingV2', () => {
         });
 
         it('calls .stop on the SIP.js UA', () => {
-          var test = makeTest();
-          var promise = test.when('opening', () => {
+          const test = makeTest();
+          const promise = test.when('opening', () => {
             test.transitions = [];
             return test.signaling.close().then(() => {
               assert(test.ua.stop.calledOnce);
@@ -260,8 +260,8 @@ describe('SignalingV2', () => {
         });
 
         it('calls .disconnect on the SIP.js UA\'s .transport', () => {
-          var test = makeTest();
-          var promise = test.when('opening', () => {
+          const test = makeTest();
+          const promise = test.when('opening', () => {
             test.transitions = [];
             return test.signaling.close().then(() => {
               assert(test.ua.transport.disconnect.calledOnce);
@@ -278,7 +278,7 @@ describe('SignalingV2', () => {
     context('"closed"', () => {
       context('and the call to .start on the SIP.js UA fails', () => {
         it('returns a Promise that rejects with an Error', () => {
-          var test = makeTest({ uaConnectSucceeds: false });
+          const test = makeTest({ uaConnectSucceeds: false });
           return test.signaling.connect().then(() => {
             throw new Error('Unexpected resolution');
           }, error => {
@@ -287,7 +287,7 @@ describe('SignalingV2', () => {
         });
 
         it('transitions through state "opening" to state "closed"', () => {
-          var test = makeTest({ uaConnectSucceeds: false });
+          const test = makeTest({ uaConnectSucceeds: false });
           return test.signaling.connect().then(() => {
             throw new Error('Unexpected resolution');
           }, () => {
@@ -301,7 +301,7 @@ describe('SignalingV2', () => {
         });
 
         it('calls .start on the SIP.js UA', () => {
-          var test = makeTest({ uaConnectSucceeds: false });
+          const test = makeTest({ uaConnectSucceeds: false });
           return test.signaling.connect().then(() => {
             throw new Error('Unexpected resolution');
           }, () => {
@@ -310,7 +310,7 @@ describe('SignalingV2', () => {
         });
 
         it('does not call .stop on the SIP.js UA', () => {
-          var test = makeTest({ uaConnectSucceeds: false });
+          const test = makeTest({ uaConnectSucceeds: false });
           return test.signaling.connect().then(() => {
             throw new Error('Unexpected resolution');
           }, () => {
@@ -319,7 +319,7 @@ describe('SignalingV2', () => {
         });
 
         it('does not call .disconnect on the SIP.js UA\'s .transport', () => {
-          var test = makeTest({ uaConnectSucceeds: false });
+          const test = makeTest({ uaConnectSucceeds: false });
           return test.signaling.connect().then(() => {
             throw new Error('Unexpected resolution');
           }, () => {
@@ -331,14 +331,14 @@ describe('SignalingV2', () => {
       context('and the call to .start on the SIP.js UA succeeds', () => {
         // TODO(mroberts): ...
         it('returns a Promise that resolves to a function that returns a CancelablePromise<RoomV2>', () => {
-          var test = makeTest();
+          const test = makeTest();
           return test.signaling.connect().then(fun => {
             assert.equal(test.cancelableRoomSignalingPromise, fun());
           });
         });
 
         it('transitions through state "opening" to state "open"', () => {
-          var test = makeTest();
+          const test = makeTest();
           return test.signaling.connect().then(() => {
             assert.deepEqual(
               [
@@ -350,7 +350,7 @@ describe('SignalingV2', () => {
         });
 
         it('calls .start on the SIP.js UA', () => {
-          var test = makeTest();
+          const test = makeTest();
           return test.signaling.connect().then(() => {
             assert(test.ua.start.calledOnce);
           });
@@ -361,8 +361,8 @@ describe('SignalingV2', () => {
     context('"closing"', () => {
       context('and the call to .start on the SIP.js UA fails', () => {
         it('returns a Promise that rejects with an Error', () => {
-          var test = makeTest();
-          var promise = test.when('closing', () => {
+          const test = makeTest();
+          const promise = test.when('closing', () => {
             test.uaConnectSucceeds = false;
             return test.signaling.connect().then(() => {
               throw new Error('Unexpected resolution');
@@ -375,8 +375,8 @@ describe('SignalingV2', () => {
         });
 
         it('transitions through state "opening" to state "closed" after "closed"', () => {
-          var test = makeTest();
-          var promise = test.when('closing', () => {
+          const test = makeTest();
+          const promise = test.when('closing', () => {
             test.uaConnectSucceeds = false;
             test.transitions = [];
             return test.signaling.connect().then(() => {
@@ -396,8 +396,8 @@ describe('SignalingV2', () => {
         });
 
         it('calls .start on the SIP.js UA', () => {
-          var test = makeTest();
-          var promise = test.when('closing', () => {
+          const test = makeTest();
+          const promise = test.when('closing', () => {
             test.uaConnectSucceeds = false;
             return test.signaling.connect().then(() => {
               throw new Error('Unexpected resolution');
@@ -410,8 +410,8 @@ describe('SignalingV2', () => {
         });
 
         it('does not call .stop on the SIP.js UA again', () => {
-          var test = makeTest();
-          var promise = test.when('closing', () => {
+          const test = makeTest();
+          const promise = test.when('closing', () => {
             test.uaConnectSucceeds = false;
             return test.signaling.connect().then(() => {
               throw new Error('Unexpected resolution');
@@ -424,8 +424,8 @@ describe('SignalingV2', () => {
         });
 
         it('does not call .disconnect on the SIP.js UA\'s .transport again', () => {
-          var test = makeTest();
-          var promise = test.when('closing', () => {
+          const test = makeTest();
+          const promise = test.when('closing', () => {
             test.uaConnectSucceeds = false;
             return test.signaling.connect().then(() => {
               throw new Error('Unexpected resolution');
@@ -440,8 +440,8 @@ describe('SignalingV2', () => {
 
       context('and the call to .start on the SIP.js UA succeeds', () => {
         it('returns a Promise that resolves to a function that returns a CancelablePromise<RoomV2>', () => {
-          var test = makeTest();
-          var promise = test.when('closing', () => {
+          const test = makeTest();
+          const promise = test.when('closing', () => {
             return test.signaling.connect().then(fun => {
               assert.equal(test.cancelableRoomSignalingPromise, fun());
             });
@@ -451,8 +451,8 @@ describe('SignalingV2', () => {
         });
 
         it('transitions through state "opening" to state "open" after "closed"', () => {
-          var test = makeTest();
-          var promise = test.when('closing', () => {
+          const test = makeTest();
+          const promise = test.when('closing', () => {
             test.transitions = [];
             return test.signaling.connect().then(() => {
               assert.deepEqual(
@@ -469,8 +469,8 @@ describe('SignalingV2', () => {
         });
 
         it('calls .start on the SIP.js UA', () => {
-          var test = makeTest();
-          var promise = test.when('closing', () => {
+          const test = makeTest();
+          const promise = test.when('closing', () => {
             return test.signaling.connect().then(() => {
               assert(test.ua.start.calledTwice);
             });
@@ -484,7 +484,7 @@ describe('SignalingV2', () => {
     context('"open"', () => {
       // TODO(mroberts):
       it('returns a Promise that resolves to a function that returns a CancelablePromise<RoomV2>', () => {
-        var test = makeTest();
+        const test = makeTest();
         return test.signaling.open().then(() => {
           return test.signaling.connect();
         }).then(fun => {
@@ -493,7 +493,7 @@ describe('SignalingV2', () => {
       });
 
       it('does not transition', () => {
-        var test = makeTest();
+        const test = makeTest();
         return test.signaling.open().then(() => {
           test.transitions = [];
           return test.signaling.connect();
@@ -505,7 +505,7 @@ describe('SignalingV2', () => {
       });
 
       it('does not call .start on the SIP.js UA', () => {
-        var test = makeTest();
+        const test = makeTest();
         return test.signaling.open().then(() => {
           return test.signaling.connect();
         }).then(() => {
@@ -519,8 +519,8 @@ describe('SignalingV2', () => {
         context('but the subsequent one succeeds', () => {
           // TODO(mroberts): ...
           it('returns a Promise that resolves to a function that returns a CancelablePromise<RoomV2>', () => {
-            var test = makeTest({ uaConnectSucceeds: false });
-            var promise = test.when('opening', () => {
+            const test = makeTest({ uaConnectSucceeds: false });
+            const promise = test.when('opening', () => {
               return test.signaling.connect().then(fun => {
                 assert.equal(test.cancelableRoomSignalingPromise, fun());
               });
@@ -530,8 +530,8 @@ describe('SignalingV2', () => {
           });
 
           it('transitions through state "opening" to state "open" after "closed"', () => {
-            var test = makeTest({ uaConnectSucceeds: false });
-            var promise = test.when('opening', () => {
+            const test = makeTest({ uaConnectSucceeds: false });
+            const promise = test.when('opening', () => {
               test.transitions = [];
               return test.signaling.connect().then(signaling => {
                 assert.deepEqual(
@@ -548,8 +548,8 @@ describe('SignalingV2', () => {
           });
 
           it('calls .start on the SIP.js UA again', () => {
-            var test = makeTest({ uaConnectSucceeds: false });
-            var promise = test.when('opening', () => {
+            const test = makeTest({ uaConnectSucceeds: false });
+            const promise = test.when('opening', () => {
               return test.signaling.connect().then(signaling => {
                 assert(test.ua.start.calledTwice);
               });
@@ -559,8 +559,8 @@ describe('SignalingV2', () => {
           });
 
           it('does not call .stop on the SIP.js UA', () => {
-            var test = makeTest({ uaConnectSucceeds: false });
-            var promise = test.when('opening', () => {
+            const test = makeTest({ uaConnectSucceeds: false });
+            const promise = test.when('opening', () => {
               return test.signaling.connect().then(signaling => {
                 assert(!test.ua.stop.calledOnce);
               });
@@ -570,8 +570,8 @@ describe('SignalingV2', () => {
           });
 
           it('does not call .disconnect on the SIP.js UA\'s .transport', () => {
-            var test = makeTest({ uaConnectSucceeds: false });
-            var promise = test.when('opening', () => {
+            const test = makeTest({ uaConnectSucceeds: false });
+            const promise = test.when('opening', () => {
               return test.signaling.connect().then(signaling => {
                 assert(!test.ua.transport.disconnect.calledOnce);
               });
@@ -583,8 +583,8 @@ describe('SignalingV2', () => {
 
         context('and the subsequent one fails', () => {
           it('returns a Promise that rejects with an Error', () => {
-            var test = makeTest({ uaConnectSucceeds: false });
-            var promise = test.when('opening', () => {
+            const test = makeTest({ uaConnectSucceeds: false });
+            const promise = test.when('opening', () => {
               return test.signaling.connect().then(() => {
                 throw new Error('Unexpected resolution');
               }, error => {
@@ -596,8 +596,8 @@ describe('SignalingV2', () => {
           });
 
           it('transitions through state "opening" to state "closed" after "closed"', () => {
-            var test = makeTest({ uaConnectSucceeds: false });
-            var promise = test.when('opening', () => {
+            const test = makeTest({ uaConnectSucceeds: false });
+            const promise = test.when('opening', () => {
               test.transitions = [];
               return test.signaling.connect().then(() => {
                 throw new Error('Unexpected resolution');
@@ -616,8 +616,8 @@ describe('SignalingV2', () => {
           });
 
           it('calls .start on the SIP.js UA again', () => {
-            var test = makeTest({ uaConnectSucceeds: false });
-            var promise = test.when('opening', () => {
+            const test = makeTest({ uaConnectSucceeds: false });
+            const promise = test.when('opening', () => {
               return test.signaling.connect().then(() => {
                 throw new Error('Unexpected resolution');
               }, error => {
@@ -629,8 +629,8 @@ describe('SignalingV2', () => {
           });
 
           it('does not call .stop on the SIP.js UA', () => {
-            var test = makeTest({ uaConnectSucceeds: false });
-            var promise = test.when('opening', () => {
+            const test = makeTest({ uaConnectSucceeds: false });
+            const promise = test.when('opening', () => {
               return test.signaling.connect().then(() => {
                 throw new Error('Unexpected resolution');
               }, error => {
@@ -642,8 +642,8 @@ describe('SignalingV2', () => {
           });
 
           it('does not call .disconnect on the SIP.js UA\'s .transport', () => {
-            var test = makeTest({ uaConnectSucceeds: false });
-            var promise = test.when('opening', () => {
+            const test = makeTest({ uaConnectSucceeds: false });
+            const promise = test.when('opening', () => {
               return test.signaling.connect().then(() => {
                 throw new Error('Unexpected resolution');
               }, error => {
@@ -659,8 +659,8 @@ describe('SignalingV2', () => {
       context('the initial call to .start on the SIP.js UA succeeds', () => {
         // TODO(mroberts):
         it('returns a Promise that resolves to a function that returns a CancelablePromise<RoomV2>', () => {
-          var test = makeTest();
-          var promise = test.when('opening', () => {
+          const test = makeTest();
+          const promise = test.when('opening', () => {
             return test.signaling.connect().then(fun => {
               assert.equal(test.cancelableRoomSignalingPromise, fun());
             });
@@ -670,8 +670,8 @@ describe('SignalingV2', () => {
         });
 
         it('does not transition after "open"', () => {
-          var test = makeTest();
-          var promise = test.when('opening', () => {
+          const test = makeTest();
+          const promise = test.when('opening', () => {
             test.transitions = [];
             return test.signaling.connect().then(() => {
               assert.deepEqual(
@@ -686,8 +686,8 @@ describe('SignalingV2', () => {
         });
 
         it('does not call .start on the SIP.js UA again', () => {
-          var test = makeTest();
-          var promise = test.when('opening', () => {
+          const test = makeTest();
+          const promise = test.when('opening', () => {
             return test.signaling.connect().then(() => {
               assert(test.ua.start.calledOnce);
             });
@@ -701,9 +701,9 @@ describe('SignalingV2', () => {
 
   describe('#createLocalParticipantSignaling', () => {
     it('returns a new LocalParticipantV2', () => {
-      var test = makeTest();
-      var lp1 = test.signaling.createLocalParticipantSignaling(test.encodingParameters);
-      var lp2 = test.signaling.createLocalParticipantSignaling(test.encodingParameters);
+      const test = makeTest();
+      const lp1 = test.signaling.createLocalParticipantSignaling(test.encodingParameters);
+      const lp2 = test.signaling.createLocalParticipantSignaling(test.encodingParameters);
       assert(lp1 instanceof LocalParticipantV2);
       assert(lp2 instanceof LocalParticipantV2);
       assert(lp1 !== lp2);
@@ -714,7 +714,7 @@ describe('SignalingV2', () => {
     context('"closed"', () => {
       context('and the call to .start on the SIP.js UA fails', () => {
         it('returns a Promise that rejects with an Error', () => {
-          var test = makeTest({ uaConnectSucceeds: false });
+          const test = makeTest({ uaConnectSucceeds: false });
           return test.signaling.open().then(() => {
             throw new Error('Unexpected resolution');
           }, error => {
@@ -723,7 +723,7 @@ describe('SignalingV2', () => {
         });
 
         it('transitions through state "opening" to state "closed"', () => {
-          var test = makeTest({ uaConnectSucceeds: false });
+          const test = makeTest({ uaConnectSucceeds: false });
           return test.signaling.open().then(() => {
             throw new Error('Unexpected resolution');
           }, () => {
@@ -737,7 +737,7 @@ describe('SignalingV2', () => {
         });
 
         it('calls .start on the SIP.js UA', () => {
-          var test = makeTest({ uaConnectSucceeds: false });
+          const test = makeTest({ uaConnectSucceeds: false });
           return test.signaling.open().then(() => {
             throw new Error('Unexpected resolution');
           }, () => {
@@ -746,7 +746,7 @@ describe('SignalingV2', () => {
         });
 
         it('does not call .stop on the SIP.js UA', () => {
-          var test = makeTest({ uaConnectSucceeds: false });
+          const test = makeTest({ uaConnectSucceeds: false });
           return test.signaling.open().then(() => {
             throw new Error('Unexpected resolution');
           }, () => {
@@ -755,7 +755,7 @@ describe('SignalingV2', () => {
         });
 
         it('does not call .disconnect on the SIP.js UA\'s .transport', () => {
-          var test = makeTest({ uaConnectSucceeds: false });
+          const test = makeTest({ uaConnectSucceeds: false });
           return test.signaling.open().then(() => {
             throw new Error('Unexpected resolution');
           }, () => {
@@ -766,14 +766,14 @@ describe('SignalingV2', () => {
 
       context('and the call to .start on the SIP.js UA succeeds', () => {
         it('returns a Promise that resolves to the SignalingV2', () => {
-          var test = makeTest();
+          const test = makeTest();
           return test.signaling.open().then(signaling => {
             assert.equal(test.signaling, signaling);
           });
         });
 
         it('transitions through state "opening" to state "open"', () => {
-          var test = makeTest();
+          const test = makeTest();
           return test.signaling.open().then(() => {
             assert.deepEqual(
               [
@@ -785,7 +785,7 @@ describe('SignalingV2', () => {
         });
 
         it('calls .start on the SIP.js UA', () => {
-          var test = makeTest();
+          const test = makeTest();
           return test.signaling.open().then(() => {
             assert(test.ua.start.calledOnce);
           });
@@ -796,8 +796,8 @@ describe('SignalingV2', () => {
     context('"closing"', () => {
       context('and the call to .start on the SIP.js UA fails', () => {
         it('returns a Promise that rejects with an Error', () => {
-          var test = makeTest();
-          var promise = test.when('closing', () => {
+          const test = makeTest();
+          const promise = test.when('closing', () => {
             test.uaConnectSucceeds = false;
             return test.signaling.open().then(() => {
               throw new Error('Unexpected resolution');
@@ -810,8 +810,8 @@ describe('SignalingV2', () => {
         });
 
         it('transitions through state "opening" to state "closed" after "closed"', () => {
-          var test = makeTest();
-          var promise = test.when('closing', () => {
+          const test = makeTest();
+          const promise = test.when('closing', () => {
             test.uaConnectSucceeds = false;
             test.transitions = [];
             return test.signaling.open().then(() => {
@@ -831,8 +831,8 @@ describe('SignalingV2', () => {
         });
 
         it('calls .start on the SIP.js UA', () => {
-          var test = makeTest();
-          var promise = test.when('closing', () => {
+          const test = makeTest();
+          const promise = test.when('closing', () => {
             test.uaConnectSucceeds = false;
             return test.signaling.open().then(() => {
               throw new Error('Unexpected resolution');
@@ -845,8 +845,8 @@ describe('SignalingV2', () => {
         });
 
         it('does not call .stop on the SIP.js UA again', () => {
-          var test = makeTest();
-          var promise = test.when('closing', () => {
+          const test = makeTest();
+          const promise = test.when('closing', () => {
             test.uaConnectSucceeds = false;
             return test.signaling.open().then(() => {
               throw new Error('Unexpected resolution');
@@ -859,8 +859,8 @@ describe('SignalingV2', () => {
         });
 
         it('does not call .disconnect on the SIP.js UA\'s .transport again', () => {
-          var test = makeTest();
-          var promise = test.when('closing', () => {
+          const test = makeTest();
+          const promise = test.when('closing', () => {
             test.uaConnectSucceeds = false;
             return test.signaling.open().then(() => {
               throw new Error('Unexpected resolution');
@@ -875,8 +875,8 @@ describe('SignalingV2', () => {
 
       context('and the call to .start on the SIP.js UA succeeds', () => {
         it('returns a Promise that resolves to the SignalingV2', () => {
-          var test = makeTest();
-          var promise = test.when('closing', () => {
+          const test = makeTest();
+          const promise = test.when('closing', () => {
             return test.signaling.open().then(signaling => {
               assert.equal(test.signaling, signaling);
             });
@@ -886,8 +886,8 @@ describe('SignalingV2', () => {
         });
 
         it('transitions through state "opening" to state "open" after "closed"', () => {
-          var test = makeTest();
-          var promise = test.when('closing', () => {
+          const test = makeTest();
+          const promise = test.when('closing', () => {
             test.transitions = [];
             return test.signaling.open().then(() => {
               assert.deepEqual(
@@ -904,8 +904,8 @@ describe('SignalingV2', () => {
         });
 
         it('calls .start on the SIP.js UA', () => {
-          var test = makeTest();
-          var promise = test.when('closing', () => {
+          const test = makeTest();
+          const promise = test.when('closing', () => {
             return test.signaling.open().then(() => {
               assert(test.ua.start.calledTwice);
             });
@@ -918,7 +918,7 @@ describe('SignalingV2', () => {
 
     context('"open"', () => {
       it('returns a Promise that resolves to the SignalingV2', () => {
-        var test = makeTest();
+        const test = makeTest();
         return test.signaling.open().then(() => {
           return test.signaling.open();
         }).then(signaling => {
@@ -927,7 +927,7 @@ describe('SignalingV2', () => {
       });
 
       it('does not transition', () => {
-        var test = makeTest();
+        const test = makeTest();
         return test.signaling.open().then(() => {
           test.transitions = [];
           return test.signaling.open();
@@ -939,7 +939,7 @@ describe('SignalingV2', () => {
       });
 
       it('does not call .start on the SIP.js UA', () => {
-        var test = makeTest();
+        const test = makeTest();
         return test.signaling.open().then(() => {
           return test.signaling.open();
         }).then(() => {
@@ -952,8 +952,8 @@ describe('SignalingV2', () => {
       context('the initial call to .start on the SIP.js UA fails', () => {
         context('but the subsequent one succeeds', () => {
           it('returns a Promise that resolves to the SignalingV2', () => {
-            var test = makeTest({ uaConnectSucceeds: false });
-            var promise = test.when('opening', () => {
+            const test = makeTest({ uaConnectSucceeds: false });
+            const promise = test.when('opening', () => {
               return test.signaling.open().then(signaling => {
                 assert.equal(test.signaling, signaling);
               });
@@ -963,8 +963,8 @@ describe('SignalingV2', () => {
           });
 
           it('transitions through state "opening" to state "open" after "closed"', () => {
-            var test = makeTest({ uaConnectSucceeds: false });
-            var promise = test.when('opening', () => {
+            const test = makeTest({ uaConnectSucceeds: false });
+            const promise = test.when('opening', () => {
               test.transitions = [];
               return test.signaling.open().then(signaling => {
                 assert.deepEqual(
@@ -981,8 +981,8 @@ describe('SignalingV2', () => {
           });
 
           it('calls .start on the SIP.js UA again', () => {
-            var test = makeTest({ uaConnectSucceeds: false });
-            var promise = test.when('opening', () => {
+            const test = makeTest({ uaConnectSucceeds: false });
+            const promise = test.when('opening', () => {
               return test.signaling.open().then(signaling => {
                 assert(test.ua.start.calledTwice);
               });
@@ -992,8 +992,8 @@ describe('SignalingV2', () => {
           });
 
           it('does not call .stop on the SIP.js UA', () => {
-            var test = makeTest({ uaConnectSucceeds: false });
-            var promise = test.when('opening', () => {
+            const test = makeTest({ uaConnectSucceeds: false });
+            const promise = test.when('opening', () => {
               return test.signaling.open().then(signaling => {
                 assert(!test.ua.stop.calledOnce);
               });
@@ -1003,8 +1003,8 @@ describe('SignalingV2', () => {
           });
 
           it('does not call .disconnect on the SIP.js UA\'s .transport', () => {
-            var test = makeTest({ uaConnectSucceeds: false });
-            var promise = test.when('opening', () => {
+            const test = makeTest({ uaConnectSucceeds: false });
+            const promise = test.when('opening', () => {
               return test.signaling.open().then(signaling => {
                 assert(!test.ua.transport.disconnect.calledOnce);
               });
@@ -1016,8 +1016,8 @@ describe('SignalingV2', () => {
 
         context('and the subsequent one fails', () => {
           it('returns a Promise that rejects with an Error', () => {
-            var test = makeTest({ uaConnectSucceeds: false });
-            var promise = test.when('opening', () => {
+            const test = makeTest({ uaConnectSucceeds: false });
+            const promise = test.when('opening', () => {
               return test.signaling.open().then(() => {
                 throw new Error('Unexpected resolution');
               }, error => {
@@ -1029,8 +1029,8 @@ describe('SignalingV2', () => {
           });
 
           it('transitions through state "opening" to state "closed" after "closed"', () => {
-            var test = makeTest({ uaConnectSucceeds: false });
-            var promise = test.when('opening', () => {
+            const test = makeTest({ uaConnectSucceeds: false });
+            const promise = test.when('opening', () => {
               test.transitions = [];
               return test.signaling.open().then(() => {
                 throw new Error('Unexpected resolution');
@@ -1049,8 +1049,8 @@ describe('SignalingV2', () => {
           });
 
           it('calls .start on the SIP.js UA again', () => {
-            var test = makeTest({ uaConnectSucceeds: false });
-            var promise = test.when('opening', () => {
+            const test = makeTest({ uaConnectSucceeds: false });
+            const promise = test.when('opening', () => {
               return test.signaling.open().then(() => {
                 throw new Error('Unexpected resolution');
               }, error => {
@@ -1062,8 +1062,8 @@ describe('SignalingV2', () => {
           });
 
           it('does not call .stop on the SIP.js UA', () => {
-            var test = makeTest({ uaConnectSucceeds: false });
-            var promise = test.when('opening', () => {
+            const test = makeTest({ uaConnectSucceeds: false });
+            const promise = test.when('opening', () => {
               return test.signaling.open().then(() => {
                 throw new Error('Unexpected resolution');
               }, error => {
@@ -1075,8 +1075,8 @@ describe('SignalingV2', () => {
           });
 
           it('does not call .disconnect on the SIP.js UA\'s .transport', () => {
-            var test = makeTest({ uaConnectSucceeds: false });
-            var promise = test.when('opening', () => {
+            const test = makeTest({ uaConnectSucceeds: false });
+            const promise = test.when('opening', () => {
               return test.signaling.open().then(() => {
                 throw new Error('Unexpected resolution');
               }, error => {
@@ -1091,8 +1091,8 @@ describe('SignalingV2', () => {
 
       context('the initial call to .start on the SIP.js UA succeeds', () => {
         it('returns a Promise that resolves to the SignalingV2', () => {
-          var test = makeTest();
-          var promise = test.when('opening', () => {
+          const test = makeTest();
+          const promise = test.when('opening', () => {
             return test.signaling.open().then(signaling => {
               assert.equal(test.signaling, signaling);
             });
@@ -1102,8 +1102,8 @@ describe('SignalingV2', () => {
         });
 
         it('does not transition after "open"', () => {
-          var test = makeTest();
-          var promise = test.when('opening', () => {
+          const test = makeTest();
+          const promise = test.when('opening', () => {
             test.transitions = [];
             return test.signaling.open().then(() => {
               assert.deepEqual(
@@ -1118,8 +1118,8 @@ describe('SignalingV2', () => {
         });
 
         it('does not call .start on the SIP.js UA again', () => {
-          var test = makeTest();
-          var promise = test.when('opening', () => {
+          const test = makeTest();
+          const promise = test.when('opening', () => {
             return test.signaling.open().then(() => {
               assert(test.ua.start.calledOnce);
             });
@@ -1139,7 +1139,7 @@ function makeTest(options) {
   options.uaConnectSucceeds = 'uaConnectSucceeds' in options
     ? options.uaConnectSucceeds : true;
   options.UA = options.UA || sinon.spy(function UA() {
-    var ua = new EventEmitter();
+    const ua = new EventEmitter();
     ua.start = sinon.spy(() => {
       setImmediate(() => {
         if (options.uaConnectSucceeds) {

--- a/test/unit/spec/signaling/v2/index.js
+++ b/test/unit/spec/signaling/v2/index.js
@@ -390,7 +390,7 @@ describe('SignalingV2', () => {
             test.transitions = [];
             return test.signaling.connect().then(() => {
               throw new Error('Unexpected resolution');
-            }, error => {
+            }, () => {
               assert.deepEqual(
                 [
                   'closed',
@@ -410,7 +410,7 @@ describe('SignalingV2', () => {
             test.uaConnectSucceeds = false;
             return test.signaling.connect().then(() => {
               throw new Error('Unexpected resolution');
-            }, error => {
+            }, () => {
               assert(test.ua.start.calledTwice);
             });
           });
@@ -424,7 +424,7 @@ describe('SignalingV2', () => {
             test.uaConnectSucceeds = false;
             return test.signaling.connect().then(() => {
               throw new Error('Unexpected resolution');
-            }, error => {
+            }, () => {
               assert(!test.ua.stop.calledTwice);
             });
           });
@@ -438,7 +438,7 @@ describe('SignalingV2', () => {
             test.uaConnectSucceeds = false;
             return test.signaling.connect().then(() => {
               throw new Error('Unexpected resolution');
-            }, error => {
+            }, () => {
               assert(!test.ua.transport.disconnect.calledTwice);
             });
           });
@@ -527,66 +527,91 @@ describe('SignalingV2', () => {
       context('the initial call to .start on the SIP.js UA fails', () => {
         context('but the subsequent one succeeds', () => {
           // TODO(mroberts): ...
-          it('returns a Promise that resolves to a function that returns a CancelablePromise<RoomV2>', () => {
+          it('returns a Promise that resolves to a function that returns a CancelablePromise<RoomV2>', async () => {
             const test = makeTest({ uaConnectSucceeds: false });
-            const promise = test.when('opening', () => {
-              return test.signaling.connect().then(fun => {
-                assert.equal(test.cancelableRoomSignalingPromise, fun());
-              });
+            const promise = test.when('opening', async () => {
+              const fun = await test.signaling.connect();
+              assert.equal(test.cancelableRoomSignalingPromise, fun());
             });
-            test.signaling.open().catch(() => test.uaConnectSucceeds = true);
-            return promise;
+            try {
+              await test.signaling.open();
+            } catch (error) {
+              // Expected rejection
+              test.uaConnectSucceeds = true;
+              return promise;
+            }
+            throw new Error('Unexpected resolution');
           });
 
-          it('transitions through state "opening" to state "open" after "closed"', () => {
+          it('transitions through state "opening" to state "open" after "closed"', async () => {
             const test = makeTest({ uaConnectSucceeds: false });
-            const promise = test.when('opening', () => {
+            const promise = test.when('opening', async () => {
               test.transitions = [];
-              return test.signaling.connect().then(signaling => {
-                assert.deepEqual(
-                  [
-                    'closed',
-                    'opening',
-                    'open'
-                  ],
-                  test.transitions);
-              });
+              await test.signaling.connect();
+              assert.deepEqual(
+                [
+                  'closed',
+                  'opening',
+                  'open'
+                ],
+                test.transitions);
             });
-            test.signaling.open().catch(() => test.uaConnectSucceeds = true);
-            return promise;
+            try {
+              await test.signaling.open();
+            } catch (error) {
+              // Expected rejection
+              test.uaConnectSucceeds = true;
+              return promise;
+            }
+            throw new Error('Unexpected resolution');
           });
 
-          it('calls .start on the SIP.js UA again', () => {
+          it('calls .start on the SIP.js UA again', async () => {
             const test = makeTest({ uaConnectSucceeds: false });
-            const promise = test.when('opening', () => {
-              return test.signaling.connect().then(signaling => {
-                assert(test.ua.start.calledTwice);
-              });
+            const promise = test.when('opening', async () => {
+              await test.signaling.connect();
+              assert(test.ua.start.calledTwice);
             });
-            test.signaling.open().catch(() => test.uaConnectSucceeds = true);
-            return promise;
+            try {
+              await test.signaling.open();
+            } catch (error) {
+              // Expected rejection
+              test.uaConnectSucceeds = true;
+              return promise;
+            }
+            throw new Error('Unexpected resolution');
           });
 
-          it('does not call .stop on the SIP.js UA', () => {
+          it('does not call .stop on the SIP.js UA', async () => {
             const test = makeTest({ uaConnectSucceeds: false });
-            const promise = test.when('opening', () => {
-              return test.signaling.connect().then(signaling => {
-                assert(!test.ua.stop.calledOnce);
-              });
+            const promise = test.when('opening', async () => {
+              await test.signaling.connect();
+              assert(!test.ua.stop.calledOnce);
             });
-            test.signaling.open().catch(() => test.uaConnectSucceeds = true);
-            return promise;
+            try {
+              await test.signaling.open();
+            } catch (error) {
+              // Expected rejection
+              test.uaConnectSucceeds = true;
+              return promise;
+            }
+            throw new Error('Unexpected resolution');
           });
 
-          it('does not call .disconnect on the SIP.js UA\'s .transport', () => {
+          it('does not call .disconnect on the SIP.js UA\'s .transport', async () => {
             const test = makeTest({ uaConnectSucceeds: false });
-            const promise = test.when('opening', () => {
-              return test.signaling.connect().then(signaling => {
-                assert(!test.ua.transport.disconnect.calledOnce);
-              });
+            const promise = test.when('opening', async () => {
+              await test.signaling.connect();
+              assert(!test.ua.transport.disconnect.calledOnce);
             });
-            test.signaling.open().catch(() => test.uaConnectSucceeds = true);
-            return promise;
+            try {
+              await test.signaling.open();
+            } catch (error) {
+              // Expected rejection
+              test.uaConnectSucceeds = true;
+              return promise;
+            }
+            throw new Error('Unexpected resolution');
           });
         });
 
@@ -666,7 +691,7 @@ describe('SignalingV2', () => {
             const promise = test.when('opening', async () => {
               try {
                 await test.signaling.connect();
-              } catch(error) {
+              } catch (error) {
                 // Expected rejection
                 assert(!test.ua.stop.calledOnce);
                 return;
@@ -865,7 +890,7 @@ describe('SignalingV2', () => {
             test.transitions = [];
             return test.signaling.open().then(() => {
               throw new Error('Unexpected resolution');
-            }, error => {
+            }, () => {
               assert.deepEqual(
                 [
                   'closed',
@@ -885,7 +910,7 @@ describe('SignalingV2', () => {
             test.uaConnectSucceeds = false;
             return test.signaling.open().then(() => {
               throw new Error('Unexpected resolution');
-            }, error => {
+            }, () => {
               assert(test.ua.start.calledTwice);
             });
           });
@@ -899,7 +924,7 @@ describe('SignalingV2', () => {
             test.uaConnectSucceeds = false;
             return test.signaling.open().then(() => {
               throw new Error('Unexpected resolution');
-            }, error => {
+            }, () => {
               assert(!test.ua.stop.calledTwice);
             });
           });
@@ -913,7 +938,7 @@ describe('SignalingV2', () => {
             test.uaConnectSucceeds = false;
             return test.signaling.open().then(() => {
               throw new Error('Unexpected resolution');
-            }, error => {
+            }, () => {
               assert(!test.ua.transport.disconnect.calledTwice);
             });
           });
@@ -1000,66 +1025,91 @@ describe('SignalingV2', () => {
     context('"opening"', () => {
       context('the initial call to .start on the SIP.js UA fails', () => {
         context('but the subsequent one succeeds', () => {
-          it('returns a Promise that resolves to the SignalingV2', () => {
+          it('returns a Promise that resolves to the SignalingV2', async () => {
             const test = makeTest({ uaConnectSucceeds: false });
-            const promise = test.when('opening', () => {
-              return test.signaling.open().then(signaling => {
-                assert.equal(test.signaling, signaling);
-              });
+            const promise = test.when('opening', async () => {
+              const signaling = await test.signaling.open();
+              assert.equal(test.signaling, signaling);
             });
-            test.signaling.open().catch(() => test.uaConnectSucceeds = true);
-            return promise;
+            try {
+              await test.signaling.open();
+            } catch (error) {
+              // Expected rejection
+              test.uaConnectSucceeds = true;
+              return promise;
+            }
+            throw new Error('Unexpected resolution');
           });
 
-          it('transitions through state "opening" to state "open" after "closed"', () => {
+          it('transitions through state "opening" to state "open" after "closed"', async () => {
             const test = makeTest({ uaConnectSucceeds: false });
-            const promise = test.when('opening', () => {
+            const promise = test.when('opening', async () => {
               test.transitions = [];
-              return test.signaling.open().then(signaling => {
-                assert.deepEqual(
-                  [
-                    'closed',
-                    'opening',
-                    'open'
-                  ],
-                  test.transitions);
-              });
+              await test.signaling.open();
+              assert.deepEqual(
+                [
+                  'closed',
+                  'opening',
+                  'open'
+                ],
+                test.transitions);
             });
-            test.signaling.open().catch(() => test.uaConnectSucceeds = true);
-            return promise;
+            try {
+              await test.signaling.open();
+            } catch (error) {
+              // Expected rejection
+              test.uaConnectSucceeds = true;
+              return promise;
+            }
+            throw new Error('Unexpected resolution');
           });
 
-          it('calls .start on the SIP.js UA again', () => {
+          it('calls .start on the SIP.js UA again', async () => {
             const test = makeTest({ uaConnectSucceeds: false });
-            const promise = test.when('opening', () => {
-              return test.signaling.open().then(signaling => {
-                assert(test.ua.start.calledTwice);
-              });
+            const promise = test.when('opening', async () => {
+              await test.signaling.open();
+              assert(test.ua.start.calledTwice);
             });
-            test.signaling.open().catch(() => test.uaConnectSucceeds = true);
-            return promise;
+            try {
+              await test.signaling.open();
+            } catch (error) {
+              // Expected rejection
+              test.uaConnectSucceeds = true;
+              return promise;
+            }
+            throw new Error('Unexpected resolution');
           });
 
-          it('does not call .stop on the SIP.js UA', () => {
+          it('does not call .stop on the SIP.js UA', async () => {
             const test = makeTest({ uaConnectSucceeds: false });
-            const promise = test.when('opening', () => {
-              return test.signaling.open().then(signaling => {
-                assert(!test.ua.stop.calledOnce);
-              });
+            const promise = test.when('opening', async () => {
+              await test.signaling.open();
+              assert(!test.ua.stop.calledOnce);
             });
-            test.signaling.open().catch(() => test.uaConnectSucceeds = true);
-            return promise;
+            try {
+              await test.signaling.open();
+            } catch (error) {
+              // Expected rejection
+              test.uaConnectSucceeds = true;
+              return promise;
+            }
+            throw new Error('Unexpected resolution');
           });
 
-          it('does not call .disconnect on the SIP.js UA\'s .transport', () => {
+          it('does not call .disconnect on the SIP.js UA\'s .transport', async () => {
             const test = makeTest({ uaConnectSucceeds: false });
-            const promise = test.when('opening', () => {
-              return test.signaling.open().then(signaling => {
-                assert(!test.ua.transport.disconnect.calledOnce);
-              });
+            const promise = test.when('opening', async () => {
+              await test.signaling.open();
+              assert(!test.ua.transport.disconnect.calledOnce);
             });
-            test.signaling.open().catch(() => test.uaConnectSucceeds = true);
-            return promise;
+            try {
+              await test.signaling.open();
+            } catch (error) {
+              // Expected rejection
+              test.uaConnectSucceeds = true;
+              return promise;
+            }
+            throw new Error('Unexpected resolution');
           });
         });
 

--- a/test/unit/spec/signaling/v2/localtrackpublication.js
+++ b/test/unit/spec/signaling/v2/localtrackpublication.js
@@ -154,43 +154,6 @@ describe('LocalTrackPublicationV2', () => {
   // TrackSignaling
   // --------------
 
-  describe('#getSid', () => {
-    context('when called before #setSid', () => {
-      let localTrackPublicationV2;
-      let sid;
-
-      before(() => {
-        const mediaStreamTrack = new FakeMediaStreamTrack(makeKind());
-        sid = makeSid();
-        localTrackPublicationV2 = new LocalTrackPublicationV2(mediaStreamTrack, makeUUID());
-      });
-
-      it('should return a Promise that is resolved with the value passed to #setSid when it is eventually called', async () => {
-        const promise = localTrackPublicationV2.getSid();
-        localTrackPublicationV2.setSid(sid);
-        const _sid = await promise;
-        assert.equal(_sid, sid);
-      });
-    });
-
-    context('when called after #setSid', () => {
-      let localTrackPublicationV2;
-      let sid;
-
-      before(() => {
-        const mediaStreamTrack = new FakeMediaStreamTrack(makeKind());
-        sid = makeSid();
-        localTrackPublicationV2 = new LocalTrackPublicationV2(mediaStreamTrack, makeUUID());
-        localTrackPublicationV2.setSid(sid);
-      });
-
-      it('should return a Promise that is resolved with the value passed to #setSid', async () => {
-        const _sid = await localTrackPublicationV2.getSid();
-        assert.equal(_sid, sid);
-      });
-    });
-  });
-
   describe('#setSid', () => {
     let localTrackPublicationV2;
     let ret;
@@ -202,8 +165,6 @@ describe('LocalTrackPublicationV2', () => {
       sid = makeSid();
       localTrackPublicationV2 = new LocalTrackPublicationV2(mediaStreamTrack, makeUUID());
       updated = false;
-      // NOTE(mroberts): Suppress Node warnings.
-      localTrackPublicationV2.getSid().catch(() => {});
     });
 
     context('when .sid is null', () => {
@@ -226,13 +187,6 @@ describe('LocalTrackPublicationV2', () => {
 
       it('should emit "updated"', () => {
         assert(updated);
-      });
-
-      describe('#getSid', () => {
-        it('should resolve with the SID', async () => {
-          const _sid = await localTrackPublicationV2.getSid();
-          assert.equal(_sid, sid);
-        });
       });
     });
 
@@ -258,13 +212,6 @@ describe('LocalTrackPublicationV2', () => {
 
       it('should not emit "updated"', () => {
         assert(!updated);
-      });
-
-      describe('#getSid', () => {
-        it('should resolve with the original SID', async () => {
-          const _sid = await localTrackPublicationV2.getSid();
-          assert.equal(_sid, sid);
-        });
       });
     });
 
@@ -294,15 +241,6 @@ describe('LocalTrackPublicationV2', () => {
       it('should not emit "updated"', () => {
         assert(!updated);
       });
-
-      describe('#getSid', () => {
-        it('should reject with the error', async () => {
-          const _error = await localTrackPublicationV2.getSid().then(() => {
-            throw new Error('Unexpected resolution');
-          }, error => error);
-          assert.equal(_error, error);
-        });
-      });
     });
   });
 
@@ -319,8 +257,6 @@ describe('LocalTrackPublicationV2', () => {
       const mediaStreamTrack = new FakeMediaStreamTrack(makeKind());
       error = new Error('Track publication failed');
       localTrackPublicationV2 = new LocalTrackPublicationV2(mediaStreamTrack);
-      // NOTE(mroberts): Suppress Node warnings.
-      localTrackPublicationV2.getSid().catch(() => {});
       updated = false;
     });
 
@@ -344,15 +280,6 @@ describe('LocalTrackPublicationV2', () => {
 
       it('should emit "updated"', () => {
         assert(updated);
-      });
-
-      describe('#getSid', () => {
-        it('should reject with the error', async () => {
-          const _error = await localTrackPublicationV2.getSid().then(() => {
-            throw new Error('Unexpected resolution');
-          }, error => error);
-          assert.equal(_error, error);
-        });
       });
     });
 
@@ -381,13 +308,6 @@ describe('LocalTrackPublicationV2', () => {
       it('should not emit "updated"', () => {
         assert(!updated);
       });
-
-      describe('#getSid', () => {
-        it('should resolve with the SID', async () => {
-          const _sid = await localTrackPublicationV2.getSid();
-          assert.equal(_sid, sid);
-        });
-      });
     });
 
     context('when .error is non-null', () => {
@@ -413,15 +333,6 @@ describe('LocalTrackPublicationV2', () => {
 
       it('should not emit "updated"', () => {
         assert(!updated);
-      });
-
-      describe('#getSid', () => {
-        it('should reject with the original error', async () => {
-          const _error = await localTrackPublicationV2.getSid().then(() => {
-            throw new Error('Unexpected resolution');
-          }, error => error);
-          assert.equal(_error, error);
-        });
       });
     });
   });

--- a/test/unit/spec/signaling/v2/localtrackpublication.js
+++ b/test/unit/spec/signaling/v2/localtrackpublication.js
@@ -1,8 +1,10 @@
 'use strict';
 
 const assert = require('assert');
+
 const LocalTrackPublicationV2 = require('../../../../../lib/signaling/v2/localtrackpublication');
 const { makeUUID } = require('../../../../../lib/util');
+
 const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
 
 describe('LocalTrackPublicationV2', () => {

--- a/test/unit/spec/signaling/v2/localtrackpublication.js
+++ b/test/unit/spec/signaling/v2/localtrackpublication.js
@@ -12,7 +12,7 @@ describe('LocalTrackPublicationV2', () => {
   // ------------
 
   describe('constructor', () => {
-    [ true, false ].forEach(shouldUseNew => {
+    [true, false].forEach(shouldUseNew => {
       context(`when called with${shouldUseNew ? '' : 'out'} "new"`, () => {
         let localTrackPublicationV2;
         let mediaStreamTrack;
@@ -24,6 +24,7 @@ describe('LocalTrackPublicationV2', () => {
           name = makeUUID();
           localTrackPublicationV2 = shouldUseNew
             ? new LocalTrackPublicationV2(mediaStreamTrack, name)
+            // eslint-disable-next-line new-cap
             : LocalTrackPublicationV2(mediaStreamTrack, name);
         });
 
@@ -44,10 +45,10 @@ describe('LocalTrackPublicationV2', () => {
         });
 
         [
-          [ 'id', 'id' ],
-          [ 'kind', 'kind' ],
-          [ 'isEnabled', 'enabled' ]
-        ].forEach(([ ltProp, mstProp ]) => {
+          ['id', 'id'],
+          ['kind', 'kind'],
+          ['isEnabled', 'enabled']
+        ].forEach(([ltProp, mstProp]) => {
           it(`should set .${ltProp} to MediaStreamTrack's ${mstProp}`, () => {
             assert.equal(localTrackPublicationV2[ltProp], mediaStreamTrack[mstProp]);
           });
@@ -69,11 +70,11 @@ describe('LocalTrackPublicationV2', () => {
 
       context('should return an object whose', () => {
         [
-          [ 'id', 'id' ],
-          [ 'kind', 'kind' ],
-          [ 'enabled', 'isEnabled' ],
-          [ 'name', 'name' ]
-        ].forEach(([ stateProp, ltProp ]) => {
+          ['id', 'id'],
+          ['kind', 'kind'],
+          ['enabled', 'isEnabled'],
+          ['name', 'name']
+        ].forEach(([stateProp, ltProp]) => {
           it(`.${stateProp} is equal to the LocalTrackPublicationV2's ${ltProp}`, () => {
             assert.equal(state[stateProp], localTrackPublicationV2[ltProp]);
           });
@@ -94,7 +95,7 @@ describe('LocalTrackPublicationV2', () => {
           payload = { state: 'ready', sid: makeSid() };
           localTrackPublicationV2 = new LocalTrackPublicationV2(new FakeMediaStreamTrack());
           updated = false;
-          localTrackPublicationV2.once('updated', () => updated = true);
+          localTrackPublicationV2.once('updated', () => { updated = true; });
           ret = localTrackPublicationV2.update(payload);
         });
 
@@ -127,7 +128,7 @@ describe('LocalTrackPublicationV2', () => {
           payload = { state: 'failed', error: { code: 1, message: 'foo' } };
           localTrackPublicationV2 = new LocalTrackPublicationV2(new FakeMediaStreamTrack());
           updated = false;
-          localTrackPublicationV2.once('updated', () => updated = true);
+          localTrackPublicationV2.once('updated', () => { updated = true; });
           ret = localTrackPublicationV2.update(payload);
         });
 
@@ -169,7 +170,7 @@ describe('LocalTrackPublicationV2', () => {
 
     context('when .sid is null', () => {
       beforeEach(() => {
-        localTrackPublicationV2.once('updated', () => updated = true);
+        localTrackPublicationV2.once('updated', () => { updated = true; });
         ret = localTrackPublicationV2.setSid(sid);
       });
 
@@ -194,7 +195,7 @@ describe('LocalTrackPublicationV2', () => {
       beforeEach(() => {
         localTrackPublicationV2.setSid(sid);
         const newSid = makeSid();
-        localTrackPublicationV2.once('updated', () => updated = true);
+        localTrackPublicationV2.once('updated', () => { updated = true; });
         ret = localTrackPublicationV2.setSid(newSid);
       });
 
@@ -222,7 +223,7 @@ describe('LocalTrackPublicationV2', () => {
         error = new Error('Track publication failed');
         localTrackPublicationV2.publishFailed(error);
         sid = makeSid();
-        localTrackPublicationV2.once('updated', () => updated = true);
+        localTrackPublicationV2.once('updated', () => { updated = true; });
         ret = localTrackPublicationV2.setSid(sid);
       });
 
@@ -262,7 +263,7 @@ describe('LocalTrackPublicationV2', () => {
 
     context('when .sid is null', () => {
       beforeEach(() => {
-        localTrackPublicationV2.once('updated', () => updated = true);
+        localTrackPublicationV2.once('updated', () => { updated = true; });
         ret = localTrackPublicationV2.publishFailed(error);
       });
 
@@ -289,7 +290,7 @@ describe('LocalTrackPublicationV2', () => {
       beforeEach(() => {
         sid = makeSid();
         localTrackPublicationV2.setSid(sid);
-        localTrackPublicationV2.once('updated', () => updated = true);
+        localTrackPublicationV2.once('updated', () => { updated = true; });
         ret = localTrackPublicationV2.publishFailed(error);
       });
 
@@ -315,7 +316,7 @@ describe('LocalTrackPublicationV2', () => {
         error = new Error('Track publication failed');
         localTrackPublicationV2.publishFailed(error);
         const newError = new Error('New error');
-        localTrackPublicationV2.once('updated', () => updated = true);
+        localTrackPublicationV2.once('updated', () => { updated = true; });
         ret = localTrackPublicationV2.publishFailed(newError);
       });
 

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -2,11 +2,12 @@
 
 const assert = require('assert');
 const EventEmitter = require('events');
-const EventTarget = require('../../../../../lib/eventtarget');
 const sinon = require('sinon');
 
+const EventTarget = require('../../../../../lib/eventtarget');
 const PeerConnectionV2 = require('../../../../../lib/signaling/v2/peerconnection');
 const { MediaClientLocalDescFailedError, MediaClientRemoteDescFailedError } = require('../../../../../lib/util/twilio-video-errors');
+
 const { FakeMediaStream, FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
 const { a, combinationContext, makeEncodingParameters } = require('../../../../lib/util');
 

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -19,7 +19,7 @@ describe('PeerConnectionV2', () => {
       test = makeTest();
     });
 
-    it('sets .id', function() {
+    it('sets .id', () => {
       assert.equal(test.pcv2.id, test.id);
     });
   });

--- a/test/unit/spec/signaling/v2/peerconnectionmanager.js
+++ b/test/unit/spec/signaling/v2/peerconnectionmanager.js
@@ -784,7 +784,7 @@ function makePeerConnectionV2Constructor(testOptions) {
 }
 
 function getTracks(mediaStreams) {
-  return mediaStreams.reduce(function(mediaStreamTracks, mediaStream) {
+  return mediaStreams.reduce((mediaStreamTracks, mediaStream) => {
     return mediaStreamTracks.concat(mediaStream.getTracks());
   }, []);
 }

--- a/test/unit/spec/signaling/v2/peerconnectionmanager.js
+++ b/test/unit/spec/signaling/v2/peerconnectionmanager.js
@@ -17,8 +17,8 @@ const { makeEncodingParameters } = require('../../../../lib/util');
 describe('PeerConnectionManager', () => {
   describe('#close', () => {
     it('returns the PeerConnectionManager', () => {
-      var test = makeTest();
-      var mediaStream = makeMediaStream();
+      const test = makeTest();
+      const mediaStream = makeMediaStream();
       return test.peerConnectionManager.createAndOffer().then(() => {
         return test.peerConnectionManager.update([
           { id: '123' }
@@ -38,8 +38,8 @@ describe('PeerConnectionManager', () => {
     })
 
     it('calls close on any PeerConnectionV2s created with #createAndOffer or #update', () => {
-      var test = makeTest();
-      var mediaStream = makeMediaStream();
+      const test = makeTest();
+      const mediaStream = makeMediaStream();
       return test.peerConnectionManager.createAndOffer().then(() => {
         return test.peerConnectionManager.update([
           { id: '123' }
@@ -73,21 +73,21 @@ describe('PeerConnectionManager', () => {
   describe('#createAndOffer', () => {
     context('returns a Promise that resolves', () => {
       it('to the PeerConnectionManager', () => {
-        var test = makeTest();
+        const test = makeTest();
         return test.peerConnectionManager.createAndOffer().then(peerConnectionManager => {
           assert.equal(test.peerConnectionManager, peerConnectionManager);
         });
       });
 
       it('after the PeerConnectionV2 has created an offer', () => {
-        var peerConnectionV2 = new EventEmitter();
-        var deferred = defer();
+        const peerConnectionV2 = new EventEmitter();
+        const deferred = defer();
         peerConnectionV2.offer = () => deferred.promise;
-        var test = makeTest({
+        const test = makeTest({
           RTCPeerConnection: function() { return peerConnectionV2; }
         });
-        var createAndOfferResolved = false;
-        var promise = test.peerConnectionManager.createAndOffer().then(() => {
+        let createAndOfferResolved;
+        const promise = test.peerConnectionManager.createAndOffer().then(() => {
           createAndOfferResolved = true;
         });
         return new Promise(resolve => {
@@ -99,7 +99,7 @@ describe('PeerConnectionManager', () => {
     });
 
     it('constructs a new PeerConnectionV2 using the most recent configuration passed to #setConfiguration', () => {
-      var test = makeTest();
+      const test = makeTest();
       return test.peerConnectionManager.createAndOffer().then(() => {
         test.peerConnectionManager.setConfiguration({ baz: 'qux' });
       }).then(() => {
@@ -110,8 +110,8 @@ describe('PeerConnectionManager', () => {
     });
 
     it('calls addMediaStream with the ._localMediaStream containing the previously-added MediaStreamTracks on the new PeerConnectionV2', () => {
-      var test = makeTest();
-      var mediaStream = makeMediaStream();
+      const test = makeTest();
+      const mediaStream = makeMediaStream();
       test.peerConnectionManager.setMediaStreamTracksAndDataTrackSenders(mediaStream.getTracks());
       return test.peerConnectionManager.createAndOffer().then(() => {
         assert.equal(
@@ -145,14 +145,14 @@ describe('PeerConnectionManager', () => {
 
   describe('#getRemoteMediaStreamTracksAndDataTrackReceivers', () => {
     it('returns the concatenated results of calling getRemoteMediaStreamTracksAndDataTrackReceivers on any PeerConnectionV2s create with #createAndOffer or #update', () => {
-      var test = makeTest();
+      const test = makeTest();
       return test.peerConnectionManager.createAndOffer().then(() => {
         return test.peerConnectionManager.update([
           { id: '123' }
         ]);
       }).then(() => {
-        var mediaStream1 = makeMediaStream({ audio: 1 });
-        var mediaStream2 = makeMediaStream({ audio: 1, video: 1 });
+        const mediaStream1 = makeMediaStream({ audio: 1 });
+        const mediaStream2 = makeMediaStream({ audio: 1, video: 1 });
         test.peerConnectionV2s[0].getRemoteMediaStreamTracksAndDataTrackReceivers = () => mediaStream1.getTracks();
         test.peerConnectionV2s[1].getRemoteMediaStreamTracksAndDataTrackReceivers = () => mediaStream2.getTracks();
         assert.deepEqual(getTracks([mediaStream1, mediaStream2]),
@@ -163,7 +163,7 @@ describe('PeerConnectionManager', () => {
 
   describe('#getStates', () => {
     it('returns the non-null results of calling getState on any PeerConnectionV2s created with #createAndOffer or #update', () => {
-      var test = makeTest();
+      const test = makeTest();
       return test.peerConnectionManager.createAndOffer().then(() => {
         return test.peerConnectionManager.update([
           { id: '123' }
@@ -181,7 +181,7 @@ describe('PeerConnectionManager', () => {
 
   describe('#setConfiguration', () => {
     it('returns the PeerConnectionManager', () => {
-      var test = makeTest();
+      const test = makeTest();
       return test.peerConnectionManager.createAndOffer().then(() => {
         return test.peerConnectionManager.update([
           { id: '123' }
@@ -194,7 +194,7 @@ describe('PeerConnectionManager', () => {
     });
 
     it('calls setConfiguration on any PeerConnectionV2s created with #createAndOffer or #update', () => {
-      var test = makeTest();
+      const test = makeTest();
       return test.peerConnectionManager.createAndOffer().then(() => {
         return test.peerConnectionManager.update([
           { id: '123' }
@@ -215,10 +215,10 @@ describe('PeerConnectionManager', () => {
     [ true, false ].forEach(isAudioContextSupported => {
       context(`when AudioContext is ${isAudioContextSupported ? '' : 'not'} supported`, () => {
         it('returns the PeerConnectionManager', () => {
-          var test = makeTest({ isAudioContextSupported });
-          var mediaStream1 = makeMediaStream();
-          var mediaStream2 = makeMediaStream();
-          var mediaStream3 = makeMediaStream();
+          const test = makeTest({ isAudioContextSupported });
+          const mediaStream1 = makeMediaStream();
+          const mediaStream2 = makeMediaStream();
+          const mediaStream3 = makeMediaStream();
           test.peerConnectionManager.setMediaStreamTracksAndDataTrackSenders(
             getTracks([mediaStream1, mediaStream2]));
           return test.peerConnectionManager.createAndOffer().then(() => {
@@ -235,9 +235,9 @@ describe('PeerConnectionManager', () => {
 
         context('when called with the same MediaStreamTracks as the last time', () => {
           it('should not call addMediaStream on the underlying PeerConnectionV2s', () => {
-            var test = makeTest({ isAudioContextSupported });
-            var mediaStream1 = makeMediaStream({ audio: 1 });
-            var mediaStream2 = makeMediaStream({ video: 1 });
+            const test = makeTest({ isAudioContextSupported });
+            const mediaStream1 = makeMediaStream({ audio: 1 });
+            const mediaStream2 = makeMediaStream({ video: 1 });
             test.peerConnectionManager.setMediaStreamTracksAndDataTrackSenders(
               getTracks([mediaStream1, mediaStream2]));
             return test.peerConnectionManager.createAndOffer().then(() => {
@@ -255,9 +255,9 @@ describe('PeerConnectionManager', () => {
 
         context('when called with the same DataTrackSenders as the last time', () => {
           it('should not call addDataTrackSender or removeDataTrackSender on the underlying PeerConnectionV2s', () => {
-            var test = makeTest({ isAudioContextSupported });
-            var dataTrackSender1 = new DataTrackSender(null, null, true);
-            var dataTrackSender2 = new DataTrackSender(null, null, true);
+            const test = makeTest({ isAudioContextSupported });
+            const dataTrackSender1 = new DataTrackSender(null, null, true);
+            const dataTrackSender2 = new DataTrackSender(null, null, true);
             test.peerConnectionManager.setMediaStreamTracksAndDataTrackSenders(
               [dataTrackSender1, dataTrackSender2]);
             return test.peerConnectionManager.createAndOffer().then(() => {
@@ -276,10 +276,10 @@ describe('PeerConnectionManager', () => {
         });
 
         it('calls addMediaStream with the ._localMediaStream containing the remaining MediaStreamTracks on any PeerConnectionV2s created with #createAndOffer or #update', () => {
-          var test = makeTest({ isAudioContextSupported });
-          var mediaStream1 = makeMediaStream({ audio: 1 });
-          var mediaStream2 = makeMediaStream({ video: 1 });
-          var mediaStream3 = makeMediaStream({ video: 1 });
+          const test = makeTest({ isAudioContextSupported });
+          const mediaStream1 = makeMediaStream({ audio: 1 });
+          const mediaStream2 = makeMediaStream({ video: 1 });
+          const mediaStream3 = makeMediaStream({ video: 1 });
           test.peerConnectionManager.setMediaStreamTracksAndDataTrackSenders(
             getTracks([mediaStream1, mediaStream2]));
           return test.peerConnectionManager.createAndOffer().then(() => {
@@ -302,10 +302,10 @@ describe('PeerConnectionManager', () => {
         });
 
         it('calls addMediaStream with the ._localMediaStream containing the new MediaStreamTracks on any PeerConnectionV2s created with #createAndOffer or #update', () => {
-          var test = makeTest({ isAudioContextSupported });
-          var mediaStream1 = makeMediaStream({ video: 1 });
-          var mediaStream2 = makeMediaStream({ audio: 1 });
-          var mediaStream3 = makeMediaStream({ audio: 1 });
+          const test = makeTest({ isAudioContextSupported });
+          const mediaStream1 = makeMediaStream({ video: 1 });
+          const mediaStream2 = makeMediaStream({ audio: 1 });
+          const mediaStream3 = makeMediaStream({ audio: 1 });
           test.peerConnectionManager.setMediaStreamTracksAndDataTrackSenders(
             getTracks([mediaStream1, mediaStream2]));
           return test.peerConnectionManager.createAndOffer().then(() => {
@@ -328,10 +328,10 @@ describe('PeerConnectionManager', () => {
         });
 
         it('calls removeDataTrackSender with the removed DataTrackSenders on any PeerConnectionV2s created with #createAndOffer or #update', () => {
-          var test = makeTest({ isAudioContextSupported });
-          var dataTrackSender1 = new DataTrackSender(null, null, true);
-          var dataTrackSender2 = new DataTrackSender(null, null, true);
-          var dataTrackSender3 = new DataTrackSender(null, null, true);
+          const test = makeTest({ isAudioContextSupported });
+          const dataTrackSender1 = new DataTrackSender(null, null, true);
+          const dataTrackSender2 = new DataTrackSender(null, null, true);
+          const dataTrackSender3 = new DataTrackSender(null, null, true);
           test.peerConnectionManager.setMediaStreamTracksAndDataTrackSenders(
             [dataTrackSender1, dataTrackSender2]);
           return test.peerConnectionManager.createAndOffer().then(() => {
@@ -350,10 +350,10 @@ describe('PeerConnectionManager', () => {
         });
 
         it('calls addDataTrackSender with the added DataTrackSenders on any PeerConnectionV2s created with #createAndOffer or #update', () => {
-          var test = makeTest({ isAudioContextSupported });
-          var dataTrackSender1 = new DataTrackSender(null, null, true);
-          var dataTrackSender2 = new DataTrackSender(null, null, true);
-          var dataTrackSender3 = new DataTrackSender(null, null, true);
+          const test = makeTest({ isAudioContextSupported });
+          const dataTrackSender1 = new DataTrackSender(null, null, true);
+          const dataTrackSender2 = new DataTrackSender(null, null, true);
+          const dataTrackSender3 = new DataTrackSender(null, null, true);
           test.peerConnectionManager.setMediaStreamTracksAndDataTrackSenders(
             [dataTrackSender1, dataTrackSender2]);
           return test.peerConnectionManager.createAndOffer().then(() => {
@@ -373,21 +373,21 @@ describe('PeerConnectionManager', () => {
 
         context('when the MediaStreamTracks changed', () => {
           it('calls offer on any PeerConnectionV2s created with #createAndOffer or #update', () => {
-            var test = makeTest({ isAudioContextSupported });
+            const test = makeTest({ isAudioContextSupported });
 
-            var audioTrack1 = makeMediaStreamTrack({ kind: 'audio' });
-            var audioTrack2 = makeMediaStreamTrack({ kind: 'audio' });
-            var audioTrack3 = makeMediaStreamTrack({ kind: 'audio' });
+            const audioTrack1 = makeMediaStreamTrack({ kind: 'audio' });
+            const audioTrack2 = makeMediaStreamTrack({ kind: 'audio' });
+            const audioTrack3 = makeMediaStreamTrack({ kind: 'audio' });
 
-            var mediaStream1 = makeMediaStream({
+            const mediaStream1 = makeMediaStream({
               audio: [audioTrack1]
             });
 
-            var mediaStream2 = makeMediaStream({
+            const mediaStream2 = makeMediaStream({
               audio: [audioTrack1, audioTrack2]
             });
 
-            var mediaStream3 = makeMediaStream({
+            const mediaStream3 = makeMediaStream({
               audio: [audioTrack2, audioTrack3]
             });
 
@@ -416,11 +416,11 @@ describe('PeerConnectionManager', () => {
         // this in the future.
         context('when the DataTrackSenders changed', () => {
           it('calls offer on any PeerConnectionV2s created with #createAndOffer or #update', () => {
-            var test = makeTest({ isAudioContextSupported });
+            const test = makeTest({ isAudioContextSupported });
 
-            var dataTrackSender1 = new DataTrackSender(null, null, true);
-            var dataTrackSender2 = new DataTrackSender(null, null, true);
-            var dataTrackSender3 = new DataTrackSender(null, null, true);
+            const dataTrackSender1 = new DataTrackSender(null, null, true);
+            const dataTrackSender2 = new DataTrackSender(null, null, true);
+            const dataTrackSender3 = new DataTrackSender(null, null, true);
 
             test.peerConnectionManager.setMediaStreamTracksAndDataTrackSenders(
               [dataTrackSender1, dataTrackSender2]);
@@ -444,20 +444,20 @@ describe('PeerConnectionManager', () => {
 
         context('when the MediaStreamTracks did not change', () => {
           it('does not call offer on any PeerConnectionV2s created with #createAndOffer or #update', () => {
-            var test = makeTest({ isAudioContextSupported });
+            const test = makeTest({ isAudioContextSupported });
 
-            var audioTrack1 = makeMediaStreamTrack({ kind: 'audio' });
-            var audioTrack2 = makeMediaStreamTrack({ kind: 'audio' });
+            const audioTrack1 = makeMediaStreamTrack({ kind: 'audio' });
+            const audioTrack2 = makeMediaStreamTrack({ kind: 'audio' });
 
-            var mediaStream1 = makeMediaStream({
+            const mediaStream1 = makeMediaStream({
               audio: [audioTrack1]
             });
 
-            var mediaStream2 = makeMediaStream({
+            const mediaStream2 = makeMediaStream({
               audio: [audioTrack1, audioTrack2]
             });
 
-            var mediaStream3 = makeMediaStream({
+            const mediaStream3 = makeMediaStream({
               audio: [audioTrack1]
             });
 
@@ -483,10 +483,10 @@ describe('PeerConnectionManager', () => {
 
         context('when the DataTrackSenders did not change', () => {
           it('does not call offer on any PeerConnectionV2s created with #createAndOffer or #update', () => {
-            var test = makeTest({ isAudioContextSupported });
+            const test = makeTest({ isAudioContextSupported });
 
-            var dataTrackSender1 = new DataTrackSender(null, null, true);
-            var dataTrackSender2 = new DataTrackSender(null, null, true);
+            const dataTrackSender1 = new DataTrackSender(null, null, true);
+            const dataTrackSender2 = new DataTrackSender(null, null, true);
 
             test.peerConnectionManager.setMediaStreamTracksAndDataTrackSenders(
               [dataTrackSender1, dataTrackSender2]);
@@ -514,7 +514,7 @@ describe('PeerConnectionManager', () => {
   describe('#update', () => {
     context('when called with an array of PeerConnection states containing a new PeerConnection ID', () => {
       it('returns a Promise for the PeerConnectionManager', () => {
-        var test = makeTest();
+        const test = makeTest();
         return test.peerConnectionManager.update([
           { id: '123', fizz: 'buzz' }
         ]).then(peerConnectionManager => {
@@ -523,7 +523,7 @@ describe('PeerConnectionManager', () => {
       });
 
       it('constructs a new PeerConnectionV2 with the new PeerConnection ID using the most recent configuration passed to #setConfiguration', () => {
-        var test = makeTest();
+        const test = makeTest();
         return test.peerConnectionManager.update([
           { id: '123', fizz: 'buzz' }
         ]).then(() => {
@@ -537,8 +537,8 @@ describe('PeerConnectionManager', () => {
       [ true, false ].forEach(isAudioContextSupported => {
         context(`when AudioContext is ${isAudioContextSupported ? '' : 'not'} supported`, () => {
           it(`calls addMediaStream with the ._localMediaStream containing any previously-added MediaStreamTracks ${isAudioContextSupported ? ' and the dummy audio MediaStreamTrack' : ''} on the new PeerConnectionV2`, () => {
-            var test = makeTest({ isAudioContextSupported });
-            var mediaStream = makeMediaStream();
+            const test = makeTest({ isAudioContextSupported });
+            const mediaStream = makeMediaStream();
             test.peerConnectionManager.setMediaStreamTracksAndDataTrackSenders(mediaStream.getTracks());
             return test.peerConnectionManager.update([
               { id: '123', fizz: 'buzz' }
@@ -565,7 +565,7 @@ describe('PeerConnectionManager', () => {
       });
 
       it('passes the PeerConnection states to the new PeerConnectionV2\'s #update method', () => {
-        var test = makeTest();
+        const test = makeTest();
         return test.peerConnectionManager.update([
           { id: '123', fizz: 'buzz' }
         ]).then(() => {
@@ -578,9 +578,9 @@ describe('PeerConnectionManager', () => {
 
     context('when called with an array of PeerConnection states containing known PeerConnection IDs', () => {
       it('returns a Promise for the PeerConnectionManager', () => {
-        var test = makeTest();
+        const test = makeTest();
         return test.peerConnectionManager.createAndOffer().then(() => {
-          var peerConnectionState = {
+          const peerConnectionState = {
             id: test.peerConnectionV2s[0].id,
             fizz: 'buzz'
           };
@@ -591,9 +591,9 @@ describe('PeerConnectionManager', () => {
       });
 
       it('passes the PeerConnection states to the corresponding PeerConnectionV2\'s #update method', () => {
-        var test = makeTest();
+        const test = makeTest();
         return test.peerConnectionManager.createAndOffer().then(() => {
-          var peerConnectionState = {
+          const peerConnectionState = {
             id: test.peerConnectionV2s[0].id,
             fizz: 'buzz'
           };
@@ -611,15 +611,15 @@ describe('PeerConnectionManager', () => {
 
     context('when it is called more than once for the same id', () => {
       it('should result in the PeerConnection having only one listener for \'stateChanged\'', () => {
-        var test = makeTest();
+        const test = makeTest();
         return test.peerConnectionManager.createAndOffer().then(() => {
-          var peerConnectionState = {
+          const peerConnectionState = {
             id: test.peerConnectionV2s[0].id,
             fizz: 'buzz'
           };
           return test.peerConnectionManager.update([peerConnectionState]);
         }).then(() => {
-          var peerConnectionState = {
+          const peerConnectionState = {
             id: test.peerConnectionV2s[0].id,
             fizz: 'jazz'
           };
@@ -633,17 +633,17 @@ describe('PeerConnectionManager', () => {
 
   describe('"candidates" event', () => {
     it('is emitted whenever a PeerConnectionV2 created with #createAndOffer or #update emits it', () => {
-      var test = makeTest();
+      const test = makeTest();
       return test.peerConnectionManager.createAndOffer().then(() => {
         return test.peerConnectionManager.update([
           { id: '123' }
         ]);
       }).then(() => {
-        var promise1 = new Promise(resolve => test.peerConnectionManager.once('candidates', resolve));
+        const promise1 = new Promise(resolve => test.peerConnectionManager.once('candidates', resolve));
         test.peerConnectionV2s[0].emit('candidates', { foo: 'bar' });
         return promise1;
       }).then(result1 => {
-        var promise2 = new Promise(resolve => test.peerConnectionManager.once('candidates', resolve));
+        const promise2 = new Promise(resolve => test.peerConnectionManager.once('candidates', resolve));
         test.peerConnectionV2s[1].emit('candidates', { baz: 'qux' });
         return Promise.all([result1, promise2]);
       }).then(results => {
@@ -659,17 +659,17 @@ describe('PeerConnectionManager', () => {
 
   describe('"description" event', () => {
     it('is emitted whenever a PeerConnectionV2 created with #createAndOffer or #update emits it', () => {
-      var test = makeTest();
+      const test = makeTest();
       return test.peerConnectionManager.createAndOffer().then(() => {
         return test.peerConnectionManager.update([
           { id: '123' }
         ]);
       }).then(() => {
-        var promise1 = new Promise(resolve => test.peerConnectionManager.once('description', resolve));
+        const promise1 = new Promise(resolve => test.peerConnectionManager.once('description', resolve));
         test.peerConnectionV2s[0].emit('description', { foo: 'bar' });
         return promise1;
       }).then(result1 => {
-        var promise2 = new Promise(resolve => test.peerConnectionManager.once('description', resolve));
+        const promise2 = new Promise(resolve => test.peerConnectionManager.once('description', resolve));
         test.peerConnectionV2s[1].emit('description', { baz: 'qux' });
         return Promise.all([result1, promise2]);
       }).then(results => {
@@ -685,17 +685,17 @@ describe('PeerConnectionManager', () => {
 
   describe('"trackAdded" event', () => {
     it('is emitted whenever a PeerConnectionV2 created with #createAndOffer or #update emits it', () => {
-      var test = makeTest();
+      const test = makeTest();
       return test.peerConnectionManager.createAndOffer().then(() => {
         return test.peerConnectionManager.update([
           { id: '123' }
         ]);
       }).then(() => {
-        var promise1 = new Promise(resolve => test.peerConnectionManager.once('trackAdded', resolve));
+        const promise1 = new Promise(resolve => test.peerConnectionManager.once('trackAdded', resolve));
         test.peerConnectionV2s[0].emit('trackAdded', { foo: 'bar' });
         return promise1;
       }).then(result1 => {
-        var promise2 = new Promise(resolve => test.peerConnectionManager.once('trackAdded', resolve));
+        const promise2 = new Promise(resolve => test.peerConnectionManager.once('trackAdded', resolve));
         test.peerConnectionV2s[1].emit('trackAdded', { baz: 'qux' });
         return Promise.all([result1, promise2]);
       }).then(results => {
@@ -746,7 +746,7 @@ function makeAudioContextFactory(testOptions) {
 
 function makePeerConnectionV2Constructor(testOptions) {
   return function PeerConnectionV2(id, encodingParameters, options) {
-    var peerConnectionV2 = new EventEmitter();
+    const peerConnectionV2 = new EventEmitter();
 
     peerConnectionV2.configuration = {
       iceServers: testOptions.iceServers
@@ -800,18 +800,18 @@ function makeMediaStream(options) {
   options.video = options.video || 0;
 
   if (typeof options.audio === 'number') {
-    var audio = [];
-    for (var i = 0; i < options.audio; i++) {
-      var audioTrack = makeMediaStreamTrack({ kind: 'audio' });
+    const audio = [];
+    for (let i = 0; i < options.audio; i++) {
+      const audioTrack = makeMediaStreamTrack({ kind: 'audio' });
       audio.push(audioTrack);
     }
     options.audio = audio;
   }
 
   if (typeof options.video === 'number') {
-    var video = [];
-    for (var i = 0; i < options.video; i++) {
-      var videoTrack = makeMediaStreamTrack({ kind: 'video' });
+    const video = [];
+    for (let i = 0; i < options.video; i++) {
+      const videoTrack = makeMediaStreamTrack({ kind: 'video' });
       video.push(videoTrack);
     }
     options.video = video;
@@ -823,7 +823,7 @@ function makeMediaStream(options) {
   options.video = options.video.map(track => track instanceof MediaStreamTrack
     ? track : new MediaStreamTrack(track));
 
-  var mediaStream = new EventEmitter();
+  const mediaStream = new EventEmitter();
 
   mediaStream.addEventListener = mediaStream.addListener;
 

--- a/test/unit/spec/signaling/v2/peerconnectionmanager.js
+++ b/test/unit/spec/signaling/v2/peerconnectionmanager.js
@@ -18,7 +18,6 @@ describe('PeerConnectionManager', () => {
   describe('#close', () => {
     it('returns the PeerConnectionManager', () => {
       const test = makeTest();
-      const mediaStream = makeMediaStream();
       return test.peerConnectionManager.createAndOffer().then(() => {
         return test.peerConnectionManager.update([
           { id: '123' }
@@ -35,11 +34,10 @@ describe('PeerConnectionManager', () => {
       await test.iceServerSource.start();
       test.peerConnectionManager.close();
       assert(test.iceServerSource.stop.calledOnce);
-    })
+    });
 
     it('calls close on any PeerConnectionV2s created with #createAndOffer or #update', () => {
       const test = makeTest();
-      const mediaStream = makeMediaStream();
       return test.peerConnectionManager.createAndOffer().then(() => {
         return test.peerConnectionManager.update([
           { id: '123' }
@@ -212,7 +210,7 @@ describe('PeerConnectionManager', () => {
   });
 
   describe('#setMediaStreamTracksAndDataTrackSenders', () => {
-    [ true, false ].forEach(isAudioContextSupported => {
+    [true, false].forEach(isAudioContextSupported => {
       context(`when AudioContext is ${isAudioContextSupported ? '' : 'not'} supported`, () => {
         it('returns the PeerConnectionManager', () => {
           const test = makeTest({ isAudioContextSupported });
@@ -534,7 +532,7 @@ describe('PeerConnectionManager', () => {
         });
       });
 
-      [ true, false ].forEach(isAudioContextSupported => {
+      [true, false].forEach(isAudioContextSupported => {
         context(`when AudioContext is ${isAudioContextSupported ? '' : 'not'} supported`, () => {
           it(`calls addMediaStream with the ._localMediaStream containing any previously-added MediaStreamTracks ${isAudioContextSupported ? ' and the dummy audio MediaStreamTrack' : ''} on the new PeerConnectionV2`, () => {
             const test = makeTest({ isAudioContextSupported });
@@ -736,7 +734,7 @@ function makeAudioContextFactory(testOptions) {
   function AudioContext() {
     this.close = sinon.spy(() => {});
     this.createMediaStreamDestination = sinon.spy(() => {
-      const getAudioTracks = sinon.spy(() => [ new FakeMediaStreamTrack('audio') ]);
+      const getAudioTracks = sinon.spy(() => [new FakeMediaStreamTrack('audio')]);
       return { stream: { getAudioTracks } };
     });
   }
@@ -745,7 +743,7 @@ function makeAudioContextFactory(testOptions) {
 }
 
 function makePeerConnectionV2Constructor(testOptions) {
-  return function PeerConnectionV2(id, encodingParameters, options) {
+  return function PeerConnectionV2(id) {
     const peerConnectionV2 = new EventEmitter();
 
     peerConnectionV2.configuration = {

--- a/test/unit/spec/signaling/v2/peerconnectionmanager.js
+++ b/test/unit/spec/signaling/v2/peerconnectionmanager.js
@@ -1,16 +1,18 @@
 'use strict';
 
 const assert = require('assert');
-const EventEmitter = require('events').EventEmitter;
-const { FakeMediaStream, FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
-const inherits = require('util').inherits;
-const DataTrackSender = require('../../../../../lib/data/sender');
-const { makeEncodingParameters } = require('../../../../lib/util');
-const MockIceServerSource = require('../../../../lib/mockiceserversource');
-const { AudioContextFactory } = require('../../../../../lib/webaudio/audiocontext');
-const PeerConnectionManager = require('../../../../../lib/signaling/v2/peerconnectionmanager');
+const { EventEmitter } = require('events');
 const sinon = require('sinon');
-const util = require('../../../../../lib/util');
+const { inherits } = require('util');
+
+const DataTrackSender = require('../../../../../lib/data/sender');
+const PeerConnectionManager = require('../../../../../lib/signaling/v2/peerconnectionmanager');
+const { defer } = require('../../../../../lib/util');
+const { AudioContextFactory } = require('../../../../../lib/webaudio/audiocontext');
+
+const { FakeMediaStream, FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
+const MockIceServerSource = require('../../../../lib/mockiceserversource');
+const { makeEncodingParameters } = require('../../../../lib/util');
 
 describe('PeerConnectionManager', () => {
   describe('#close', () => {
@@ -79,7 +81,7 @@ describe('PeerConnectionManager', () => {
 
       it('after the PeerConnectionV2 has created an offer', () => {
         var peerConnectionV2 = new EventEmitter();
-        var deferred = util.defer();
+        var deferred = defer();
         peerConnectionV2.offer = () => deferred.promise;
         var test = makeTest({
           RTCPeerConnection: function() { return peerConnectionV2; }

--- a/test/unit/spec/signaling/v2/recording.js
+++ b/test/unit/spec/signaling/v2/recording.js
@@ -1,9 +1,11 @@
 'use strict';
 
 const assert = require('assert');
-const { combinationContext } = require('../../../../lib/util'); 
-const RecordingV2 = require('../../../../../lib/signaling/v2/recording');
 const sinon = require('sinon');
+
+const RecordingV2 = require('../../../../../lib/signaling/v2/recording');
+
+const { combinationContext } = require('../../../../lib/util'); 
 
 describe('RecordingV2', () => {
   // RecordingV2

--- a/test/unit/spec/signaling/v2/recording.js
+++ b/test/unit/spec/signaling/v2/recording.js
@@ -1,11 +1,10 @@
 'use strict';
 
 const assert = require('assert');
-const sinon = require('sinon');
 
 const RecordingV2 = require('../../../../../lib/signaling/v2/recording');
 
-const { combinationContext } = require('../../../../lib/util'); 
+const { combinationContext } = require('../../../../lib/util');
 
 describe('RecordingV2', () => {
   // RecordingV2
@@ -111,7 +110,7 @@ function testEnableOrDisable(method, argument, isEnabled) {
 
     it('emits an "updated" event with .isEnabled set to ' + expectedIsEnabled, () => {
       let actualIsEnabled;
-      recording.once('updated', () => actualIsEnabled = recording.isEnabled);
+      recording.once('updated', () => { actualIsEnabled = recording.isEnabled; });
       runMethod();
       assert.equal(actualIsEnabled, expectedIsEnabled);
     });
@@ -123,7 +122,7 @@ function testEnableOrDisable(method, argument, isEnabled) {
 
     it('does not emit an "updated" event', () => {
       let updated;
-      recording.once('updated', () => updated = true);
+      recording.once('updated', () => { updated = true; });
       runMethod();
       assert(!updated);
     });
@@ -165,14 +164,14 @@ function testUpdate(revision, enabled, isEnabled) {
     if (enabled === isEnabled) {
       it('does not emit an "updated" event', () => {
         let updated;
-        recording.once('updated', () => updated = true);
+        recording.once('updated', () => { updated = true; });
         recording.update(recordingState);
         assert(!updated);
       });
     } else {
       it('emits an "updated" event with .isEnabled set to ' + enabled, () => {
         let actualIsEnabled;
-        recording.once('updated', () => actualIsEnabled = recording.isEnabled);
+        recording.once('updated', () => { actualIsEnabled = recording.isEnabled; });
         recording.update(recordingState);
         assert.equal(actualIsEnabled, enabled);
       });
@@ -190,7 +189,7 @@ function testUpdate(revision, enabled, isEnabled) {
 
     it('does not emit an "updated" event', () => {
       let updated;
-      recording.once('updated', () => updated = true);
+      recording.once('updated', () => { updated = true; });
       recording.update(recordingState);
       assert(!updated);
     });

--- a/test/unit/spec/signaling/v2/recording.js
+++ b/test/unit/spec/signaling/v2/recording.js
@@ -75,12 +75,12 @@ describe('RecordingV2', () => {
 });
 
 function testEnableOrDisable(method, argument, isEnabled) {
-  var expectedIsEnabled = typeof argument === 'boolean'
+  const expectedIsEnabled = typeof argument === 'boolean'
     ? argument
     : method === 'enable';
 
-  var runMethod;
-  var recording;
+  let runMethod;
+  let recording;
 
   beforeEach(() => {
     recording = new RecordingV2();
@@ -110,7 +110,7 @@ function testEnableOrDisable(method, argument, isEnabled) {
     });
 
     it('emits an "updated" event with .isEnabled set to ' + expectedIsEnabled, () => {
-      var actualIsEnabled;
+      let actualIsEnabled;
       recording.once('updated', () => actualIsEnabled = recording.isEnabled);
       runMethod();
       assert.equal(actualIsEnabled, expectedIsEnabled);
@@ -122,7 +122,7 @@ function testEnableOrDisable(method, argument, isEnabled) {
     });
 
     it('does not emit an "updated" event', () => {
-      var updated = false;
+      let updated;
       recording.once('updated', () => updated = true);
       runMethod();
       assert(!updated);
@@ -131,11 +131,12 @@ function testEnableOrDisable(method, argument, isEnabled) {
 }
 
 function testUpdate(revision, enabled, isEnabled) {
-  var recording;
-  var recordingState = {
+  const recordingState = {
     enabled: enabled,
     revision: revision
   };
+
+  let recording;
 
   beforeEach(() => {
     recording = new RecordingV2();
@@ -163,14 +164,14 @@ function testUpdate(revision, enabled, isEnabled) {
 
     if (enabled === isEnabled) {
       it('does not emit an "updated" event', () => {
-        var updated = false;
+        let updated;
         recording.once('updated', () => updated = true);
         recording.update(recordingState);
         assert(!updated);
       });
     } else {
       it('emits an "updated" event with .isEnabled set to ' + enabled, () => {
-        var actualIsEnabled;
+        let actualIsEnabled;
         recording.once('updated', () => actualIsEnabled = recording.isEnabled);
         recording.update(recordingState);
         assert.equal(actualIsEnabled, enabled);
@@ -188,7 +189,7 @@ function testUpdate(revision, enabled, isEnabled) {
     }
 
     it('does not emit an "updated" event', () => {
-      var updated = false;
+      let updated;
       recording.once('updated', () => updated = true);
       recording.update(recordingState);
       assert(!updated);

--- a/test/unit/spec/signaling/v2/remoteparticipant.js
+++ b/test/unit/spec/signaling/v2/remoteparticipant.js
@@ -12,30 +12,30 @@ describe('RemoteParticipantV2', () => {
 
   describe('constructor', () => {
     it('sets .identity', () => {
-      var test = makeTest();
+      const test = makeTest();
       assert.equal(test.identity, test.participant.identity);
     });
 
     it('sets .revision', () => {
-      var test = makeTest();
+      const test = makeTest();
       assert.equal(test.revision, test.participant.revision);
     });
 
     it('sets .sid', () => {
-      var test = makeTest();
+      const test = makeTest();
       assert.equal(test.sid, test.participant.sid);
     });
 
     it('sets .state to "connected"', () => {
-      var test = makeTest();
+      const test = makeTest();
       assert.equal('connected', test.participant.state);
     });
 
     context('.tracks', () => {
       it('constructs a new RemoteTrackV2 from each trackState', () => {
-        var id1 = makeId();
-        var id2 = makeId();
-        var test = makeTest({
+        const id1 = makeId();
+        const id2 = makeId();
+        const test = makeTest({
           tracks: [
             { id: id1 },
             { id: id2 }
@@ -46,9 +46,9 @@ describe('RemoteParticipantV2', () => {
       });
 
       it('adds the newly-constructed RemoteTrackV2s to the RemoteParticipantV2\'s .tracks Map', () => {
-        var id1 = makeId();
-        var id2 = makeId();
-        var test = makeTest({
+        const id1 = makeId();
+        const id2 = makeId();
+        const test = makeTest({
           tracks: [
             { id: id1 },
             { id: id2 }
@@ -63,9 +63,9 @@ describe('RemoteParticipantV2', () => {
       });
 
       it('calls getMediaStreamTrackOrDataTrackTransceiver with the newly-constructed RemoteTrackV2s\' IDs', () => {
-        var id1 = makeId();
-        var id2 = makeId();
-        var test = makeTest({
+        const id1 = makeId();
+        const id2 = makeId();
+        const test = makeTest({
           tracks: [
             { id: id1 },
             { id: id2 }
@@ -76,9 +76,9 @@ describe('RemoteParticipantV2', () => {
       });
 
       it('calls setMediaStreamTrackOrDataTrackTransceiver on the newly-constructed RemoteTrackV2s with the results of calling getMediaStreamTrackOrDataTrackTransceiver', () => {
-        var id1 = makeId();
-        var id2 = makeId();
-        var test = makeTest({
+        const id1 = makeId();
+        const id2 = makeId();
+        const test = makeTest({
           tracks: [
             { id: id1 },
             { id: id2 }
@@ -86,7 +86,7 @@ describe('RemoteParticipantV2', () => {
         });
         // NOTE(mroberts): Really we should provide mediaStreamTrack1 and
         // mediaStreamTrack2, etc., but it is a pain to setup.
-        var mediaStreamTrack = {};
+        const mediaStreamTrack = {};
         test.getMediaStreamTrackOrDataTrackTransceiverDeferred.resolve(mediaStreamTrack);
         return test.getMediaStreamTrackOrDataTrackTransceiverDeferred.promise.then(() => {
           assert.equal(
@@ -103,16 +103,16 @@ describe('RemoteParticipantV2', () => {
   describe('#update, when called with a participantState at', () => {
     context('a newer revision', () => {
       it('returns the RemoteParticipantV2', () => {
-        var test = makeTest();
-        var participantState = test.state(test.revision + 1);
+        const test = makeTest();
+        const participantState = test.state(test.revision + 1);
         assert.equal(
           test.participant,
           test.participant.update(participantState));
       });
 
       it('updates the .revision', () => {
-        var test = makeTest();
-        var participantState = test.state(test.revision + 1);
+        const test = makeTest();
+        const participantState = test.state(test.revision + 1);
         test.participant.update(participantState);
         assert.equal(
           test.revision + 1,
@@ -121,17 +121,17 @@ describe('RemoteParticipantV2', () => {
 
       context('which includes a new trackState not matching an existing RemoteTrackV2', () => {
         it('constructs a new RemoteTrackV2 from the trackState', () => {
-          var test = makeTest();
-          var id = makeId();
-          var participantState = test.state(test.revision + 1).setTrack({ id: id });
+          const test = makeTest();
+          const id = makeId();
+          const participantState = test.state(test.revision + 1).setTrack({ id: id });
           test.participant.update(participantState);
           assert.equal(id, test.remoteTrackV2s[0].id);
         });
 
         it('adds the newly-constructed RemoteTrackV2 to the RemoteParticipantV2\'s .tracks Map', () => {
-          var test = makeTest();
-          var id = makeId();
-          var participantState = test.state(test.revision + 1).setTrack({ id: id });
+          const test = makeTest();
+          const id = makeId();
+          const participantState = test.state(test.revision + 1).setTrack({ id: id });
           test.participant.update(participantState);
           assert.equal(
             test.remoteTrackV2s[0],
@@ -139,9 +139,9 @@ describe('RemoteParticipantV2', () => {
         });
 
         it('emits the "trackAdded" event with the newly-constructed RemoteTrackV2', () => {
-          var test = makeTest();
-          var participantState = test.state(test.revision + 1).setTrack({ id: makeId() });
-          var track;
+          const test = makeTest();
+          const participantState = test.state(test.revision + 1).setTrack({ id: makeId() });
+          let track;
           test.participant.once('trackAdded', _track => track = _track);
           test.participant.update(participantState);
           assert.equal(
@@ -150,18 +150,18 @@ describe('RemoteParticipantV2', () => {
         });
 
         it('calls getMediaStreamTrackOrDataTrackTransceiver with the newly-constructed RemoteTrackV2\'s ID', () => {
-          var test = makeTest();
-          var id = makeId();
-          var participantState = test.state(test.revision + 1).setTrack({ id: id });
+          const test = makeTest();
+          const id = makeId();
+          const participantState = test.state(test.revision + 1).setTrack({ id: id });
           test.participant.update(participantState);
           assert.equal(id, test.getMediaStreamTrackOrDataTrackTransceiver.args[0][0]);
         });
 
         it('calls setMediaStreamTrackOrDataTrackTransceiver on the newly-constructed RemoteTrackV2 with the result of calling getMediaStreamTrackOrDataTrackTransceiver', () => {
-          var test = makeTest();
-          var participantState = test.state(test.revision + 1).setTrack({ id: makeId() });
+          const test = makeTest();
+          const participantState = test.state(test.revision + 1).setTrack({ id: makeId() });
           test.participant.update(participantState);
-          var mediaStreamTrack = {};
+          const mediaStreamTrack = {};
           test.getMediaStreamTrackOrDataTrackTransceiverDeferred.resolve(mediaStreamTrack);
           return test.getMediaStreamTrackOrDataTrackTransceiverDeferred.promise.then(() => {
             assert.equal(
@@ -171,9 +171,9 @@ describe('RemoteParticipantV2', () => {
         });
 
         it('calls update with the trackState on the newly-constructed RemoteTrackV2', () => {
-          var test = makeTest();
-          var id = makeId();
-          var participantState = test.state(test.revision + 1).setTrack({ id: id, fizz: 'buzz' });
+          const test = makeTest();
+          const id = makeId();
+          const participantState = test.state(test.revision + 1).setTrack({ id: id, fizz: 'buzz' });
           test.participant.update(participantState);
           assert.deepEqual(
             { id: id, fizz: 'buzz' },
@@ -183,9 +183,9 @@ describe('RemoteParticipantV2', () => {
 
       context('which includes a trackState matching an existing RemoteTrackV2', () => {
         it('calls update with the trackState on the existing RemoteTrackV2', () => {
-          var id = makeId();
-          var test = makeTest({ tracks: [ { id: id } ] });
-          var participantState = test.state(test.revision + 1).setTrack({ id: id, fizz: 'buzz' });
+          const id = makeId();
+          const test = makeTest({ tracks: [ { id: id } ] });
+          const participantState = test.state(test.revision + 1).setTrack({ id: id, fizz: 'buzz' });
           test.participant.update(participantState);
           assert.deepEqual(
             { id: id, fizz: 'buzz' },
@@ -195,18 +195,18 @@ describe('RemoteParticipantV2', () => {
 
       context('which no longer includes a trackState matching an existing RemoteTrackV2', () => {
         it('deletes the RemoteTrackV2 from the RemoteParticipantV2\'s .tracks Map', () => {
-          var id = makeId();
-          var test = makeTest({ tracks: [ { id: id } ] });
-          var participantState = test.state(test.revision + 1);
+          const id = makeId();
+          const test = makeTest({ tracks: [ { id: id } ] });
+          const participantState = test.state(test.revision + 1);
           test.participant.update(participantState);
           assert(!test.participant.tracks.has(id));
         });
 
         it('emits the "trackRemoved" event with the RemoteTrackV2', () => {
-          var id = makeId();
-          var test = makeTest({ tracks: [ { id: id } ] });
-          var participantState = test.state(test.revision + 1);
-          var track;
+          const id = makeId();
+          const test = makeTest({ tracks: [ { id: id } ] });
+          const participantState = test.state(test.revision + 1);
+          let track;
           test.participant.once('trackRemoved', _track => track = _track);
           test.participant.update(participantState);
           assert.equal(
@@ -218,8 +218,8 @@ describe('RemoteParticipantV2', () => {
       context('with .state set to "connected" when the RemoteParticipantV2\'s .state is', () => {
         context('"connected"', () => {
           it('the .state remains "connected"', () => {
-            var test = makeTest();
-            var participantState = test.state(test.revision + 1).setState('connected');
+            const test = makeTest();
+            const participantState = test.state(test.revision + 1).setState('connected');
             test.participant.update(participantState);
             assert.equal(
               'connected',
@@ -227,9 +227,9 @@ describe('RemoteParticipantV2', () => {
           });
 
           it('does not emit the "stateChanged" event', () => {
-            var test = makeTest();
-            var participantState = test.state(test.revision + 1).setState('connected');
-            var stateChanged = false;
+            const test = makeTest();
+            const participantState = test.state(test.revision + 1).setState('connected');
+            let stateChanged;
             test.participant.once('stateChanged', () => stateChanged = true);
             test.participant.update(participantState);
             assert(!stateChanged);
@@ -238,8 +238,8 @@ describe('RemoteParticipantV2', () => {
 
         context('"disconnected"', () => {
           it('the .state remains "disconnected"', () => {
-            var test = makeTest();
-            var participantState = test.state(test.revision + 1).setState('connected');
+            const test = makeTest();
+            const participantState = test.state(test.revision + 1).setState('connected');
             test.participant.disconnect();
             test.participant.update(participantState);
             assert.equal(
@@ -248,10 +248,10 @@ describe('RemoteParticipantV2', () => {
           });
 
           it('does not emit the "stateChanged" event', () => {
-            var test = makeTest();
-            var participantState = test.state(test.revision + 1).setState('connected');
+            const test = makeTest();
+            const participantState = test.state(test.revision + 1).setState('connected');
             test.participant.disconnect();
-            var stateChanged = false;
+            let stateChanged;
             test.participant.once('stateChanged', () => stateChanged = true);
             test.participant.update(participantState);
             assert(!stateChanged);
@@ -262,8 +262,8 @@ describe('RemoteParticipantV2', () => {
       context('with .state set to "disconnected" when the RemoteParticipantV2\'s .state is', () => {
         context('"connected"', () => {
           it('sets the .state to "disconnected"', () => {
-            var test = makeTest();
-            var participantState = test.state(test.revision + 1).setState('disconnected');
+            const test = makeTest();
+            const participantState = test.state(test.revision + 1).setState('disconnected');
             test.participant.update(participantState);
             assert.equal(
               'disconnected',
@@ -271,9 +271,9 @@ describe('RemoteParticipantV2', () => {
           });
 
           it('emits the "stateChanged" event with the new state "disconnected"', () => {
-            var test = makeTest();
-            var participantState = test.state(test.revision + 1).setState('disconnected');
-            var newState;
+            const test = makeTest();
+            const participantState = test.state(test.revision + 1).setState('disconnected');
+            let newState;
             test.participant.once('stateChanged', state => newState = state);
             test.participant.update(participantState);
             assert.equal(
@@ -284,8 +284,8 @@ describe('RemoteParticipantV2', () => {
 
         context('"disconnected"', () => {
           it('the .state remains "disconnected"', () => {
-            var test = makeTest();
-            var participantState = test.state(test.revision + 1).setState('disconnected');
+            const test = makeTest();
+            const participantState = test.state(test.revision + 1).setState('disconnected');
             test.participant.disconnect();
             test.participant.update(participantState);
             assert.equal(
@@ -294,10 +294,10 @@ describe('RemoteParticipantV2', () => {
           });
 
           it('does not emit the "stateChanged" event', () => {
-            var test = makeTest();
-            var participantState = test.state(test.revision + 1).setState('disconnected');
+            const test = makeTest();
+            const participantState = test.state(test.revision + 1).setState('disconnected');
             test.participant.disconnect();
-            var stateChanged = false;
+            let stateChanged;
             test.participant.once('stateChanged', () => stateChanged = true);
             test.participant.update(participantState);
             assert(!stateChanged);
@@ -307,8 +307,8 @@ describe('RemoteParticipantV2', () => {
 
       context('which changes the .identity', () => {
         it('the .identity remains unchanged', () => {
-          var test = makeTest();
-          var participantState = test.state(test.revision + 1).setIdentity(makeIdentity());
+          const test = makeTest();
+          const participantState = test.state(test.revision + 1).setIdentity(makeIdentity());
           test.participant.update(participantState);
           assert.equal(
             test.identity,
@@ -318,8 +318,8 @@ describe('RemoteParticipantV2', () => {
 
       context('which changes the .sid', () => {
         it('the .identity remains unchanged', () => {
-          var test = makeTest();
-          var participantState = test.state(test.revision + 1).setSid(makeSid());
+          const test = makeTest();
+          const participantState = test.state(test.revision + 1).setSid(makeSid());
           test.participant.update(participantState);
           assert.equal(
             test.sid,
@@ -330,16 +330,16 @@ describe('RemoteParticipantV2', () => {
 
     context('the same revision', () => {
       it('returns the RemoteParticipantV2', () => {
-        var test = makeTest();
-        var participantState = test.state(test.revision);
+        const test = makeTest();
+        const participantState = test.state(test.revision);
         assert.equal(
           test.participant,
           test.participant.update(participantState));
       });
 
       it('does not update the .revision', () => {
-        var test = makeTest();
-        var participantState = test.state(test.revision);
+        const test = makeTest();
+        const participantState = test.state(test.revision);
         test.participant.update(participantState);
         assert.equal(
           test.revision,
@@ -348,15 +348,15 @@ describe('RemoteParticipantV2', () => {
 
       context('which includes a new trackState not matching an existing RemoteTrackV2', () => {
         it('does not construct a new RemoteTrackV2 from the trackState', () => {
-          var test = makeTest();
-          var participantState = test.state(test.revision).setTrack({ id: makeId() });
+          const test = makeTest();
+          const participantState = test.state(test.revision).setTrack({ id: makeId() });
           test.participant.update(participantState);
           assert.equal(0, test.remoteTrackV2s.length);
         });
 
         it('does not call getMediaStreamTrackOrDataTrackTransceiver with a newly-constructed RemoteTrackV2\'s ID', () => {
-          var test = makeTest();
-          var participantState = test.state(test.revision).setTrack({ id: makeId() });
+          const test = makeTest();
+          const participantState = test.state(test.revision).setTrack({ id: makeId() });
           test.participant.update(participantState);
           assert(!test.getMediaStreamTrackOrDataTrackTransceiver.calledOnce);
         });
@@ -364,9 +364,9 @@ describe('RemoteParticipantV2', () => {
 
       context('which includes a trackState matching an existing RemoteTrackV2', () => {
         it('does not call update with the trackState on the existing RemoteTrackV2', () => {
-          var id = makeId();
-          var test = makeTest({ tracks: [ { id: id } ] });
-          var participantState = test.state(test.revision).setTrack({ id: id });
+          const id = makeId();
+          const test = makeTest({ tracks: [ { id: id } ] });
+          const participantState = test.state(test.revision).setTrack({ id: id });
           test.participant.update(participantState);
           assert(!test.remoteTrackV2s[0].update.calledTwice);
         });
@@ -374,9 +374,9 @@ describe('RemoteParticipantV2', () => {
 
       context('which no longer includes a trackState matching an existing RemoteTrackV2', () => {
         it('does not delete the RemoteTrackV2 from the RemoteParticipantV2\'s .tracks Map', () => {
-          var id = makeId();
-          var test = makeTest({ tracks: [ { id: id } ] });
-          var participantState = test.state(test.revision);
+          const id = makeId();
+          const test = makeTest({ tracks: [ { id: id } ] });
+          const participantState = test.state(test.revision);
           test.participant.update(participantState);
           assert.equal(
             test.remoteTrackV2s[0],
@@ -384,10 +384,10 @@ describe('RemoteParticipantV2', () => {
         });
 
         it('does not emit the "trackRemoved" event with the RemoteTrackV2', () => {
-          var id = makeId();
-          var test = makeTest({ tracks: [ { id: id } ] });
-          var participantState = test.state(test.revision);
-          var trackRemoved = false;
+          const id = makeId();
+          const test = makeTest({ tracks: [ { id: id } ] });
+          const participantState = test.state(test.revision);
+          let trackRemoved;
           test.participant.once('trackRemoved', () => trackRemoved = false);
           test.participant.update(participantState);
           assert(!trackRemoved);
@@ -397,8 +397,8 @@ describe('RemoteParticipantV2', () => {
       context('with .state set to "connected" when the RemoteParticipantV2\'s .state is', () => {
         context('"connected"', () => {
           it('the .state remains "connected"', () => {
-            var test = makeTest();
-            var participantState = test.state(test.revision).setState('connected');
+            const test = makeTest();
+            const participantState = test.state(test.revision).setState('connected');
             test.participant.update(participantState);
             assert.equal(
               'connected',
@@ -406,9 +406,9 @@ describe('RemoteParticipantV2', () => {
           });
 
           it('does not emit the "stateChanged" event', () => {
-            var test = makeTest();
-            var participantState = test.state(test.revision).setState('connected');
-            var stateChanged = false;
+            const test = makeTest();
+            const participantState = test.state(test.revision).setState('connected');
+            let stateChanged;
             test.participant.once('stateChanged', () => stateChanged = true);
             test.participant.update(participantState);
             assert(!stateChanged);
@@ -417,8 +417,8 @@ describe('RemoteParticipantV2', () => {
 
         context('"disconnected"', () => {
           it('the .state remains "disconnected"', () => {
-            var test = makeTest();
-            var participantState = test.state(test.revision).setState('connected');
+            const test = makeTest();
+            const participantState = test.state(test.revision).setState('connected');
             test.participant.disconnect();
             test.participant.update(participantState);
             assert.equal(
@@ -427,10 +427,10 @@ describe('RemoteParticipantV2', () => {
           });
 
           it('does not emit the "stateChanged" event', () => {
-            var test = makeTest();
-            var participantState = test.state(test.revision).setState('connected');
+            const test = makeTest();
+            const participantState = test.state(test.revision).setState('connected');
             test.participant.disconnect();
-            var stateChanged = false;
+            let stateChanged;
             test.participant.once('stateChanged', () => stateChanged = true);
             test.participant.update(participantState);
             assert(!stateChanged);
@@ -441,8 +441,8 @@ describe('RemoteParticipantV2', () => {
       context('with .state set to "disconnected" when the RemoteParticipantV2\'s .state is', () => {
         context('"connected"', () => {
           it('the .state remains "connected"', () => {
-            var test = makeTest();
-            var participantState = test.state(test.revision).setState('disconnected');
+            const test = makeTest();
+            const participantState = test.state(test.revision).setState('disconnected');
             test.participant.update(participantState);
             assert.equal(
               'connected',
@@ -450,9 +450,9 @@ describe('RemoteParticipantV2', () => {
           });
 
           it('does not emit the "stateChanged" event', () => {
-            var test = makeTest();
-            var participantState = test.state(test.revision).setState('disconnected');
-            var stateChanged = false;
+            const test = makeTest();
+            const participantState = test.state(test.revision).setState('disconnected');
+            let stateChanged;
             test.participant.once('stateChanged', () => stateChanged = true);
             test.participant.update(participantState);
             assert(!stateChanged);
@@ -461,8 +461,8 @@ describe('RemoteParticipantV2', () => {
 
         context('"disconnected"', () => {
           it('the .state remains "disconnected"', () => {
-            var test = makeTest();
-            var participantState = test.state(test.revision).setState('disconnected');
+            const test = makeTest();
+            const participantState = test.state(test.revision).setState('disconnected');
             test.participant.disconnect();
             test.participant.update(participantState);
             assert.equal(
@@ -471,10 +471,10 @@ describe('RemoteParticipantV2', () => {
           });
 
           it('does not emit the "stateChanged" event', () => {
-            var test = makeTest();
-            var participantState = test.state(test.revision).setState('disconnected');
+            const test = makeTest();
+            const participantState = test.state(test.revision).setState('disconnected');
             test.participant.disconnect();
-            var stateChanged = false;
+            let stateChanged;
             test.participant.once('stateChanged', () => stateChanged = true);
             test.participant.update(participantState);
             assert(!stateChanged);
@@ -484,8 +484,8 @@ describe('RemoteParticipantV2', () => {
 
       context('which changes the .identity', () => {
         it('the .identity remains unchanged', () => {
-          var test = makeTest();
-          var participantState = test.state(test.revision).setIdentity(makeIdentity());
+          const test = makeTest();
+          const participantState = test.state(test.revision).setIdentity(makeIdentity());
           test.participant.update(participantState);
           assert.equal(
             test.identity,
@@ -495,8 +495,8 @@ describe('RemoteParticipantV2', () => {
 
       context('which changes the .sid', () => {
         it('the .identity remains unchanged', () => {
-          var test = makeTest();
-          var participantState = test.state(test.revision).setSid(makeSid());
+          const test = makeTest();
+          const participantState = test.state(test.revision).setSid(makeSid());
           test.participant.update(participantState);
           assert.equal(
             test.sid,
@@ -507,8 +507,8 @@ describe('RemoteParticipantV2', () => {
 
     context('an older revision', () => {
       it('returns the RemoteParticipantV2', () => {
-        var test = makeTest();
-        var participantState = test.state(test.revision - 1);
+        const test = makeTest();
+        const participantState = test.state(test.revision - 1);
         test.participant.update(participantState);
         assert.equal(
           test.revision,
@@ -516,8 +516,8 @@ describe('RemoteParticipantV2', () => {
       });
 
       it('does not update the .revision', () => {
-        var test = makeTest();
-        var participantState = test.state(test.revision - 1);
+        const test = makeTest();
+        const participantState = test.state(test.revision - 1);
         test.participant.update(participantState);
         assert.equal(
           test.revision,
@@ -526,15 +526,15 @@ describe('RemoteParticipantV2', () => {
 
       context('which includes a new trackState not matching an existing RemoteTrackV2', () => {
         it('does not construct a new RemoteTrackV2 from the trackState', () => {
-          var test = makeTest();
-          var participantState = test.state(test.revision - 1).setTrack({ id: makeId() });
+          const test = makeTest();
+          const participantState = test.state(test.revision - 1).setTrack({ id: makeId() });
           test.participant.update(participantState);
           assert.equal(0, test.remoteTrackV2s.length);
         });
 
         it('does not call getMediaStreamTrackOrDataTrackTransceiver with a newly-constructed RemoteTrackV2\'s ID', () => {
-          var test = makeTest();
-          var participantState = test.state(test.revision - 1).setTrack({ id: makeId() });
+          const test = makeTest();
+          const participantState = test.state(test.revision - 1).setTrack({ id: makeId() });
           test.participant.update(participantState);
           assert(!test.getMediaStreamTrackOrDataTrackTransceiver.calledOnce);
         });
@@ -542,9 +542,9 @@ describe('RemoteParticipantV2', () => {
 
       context('which includes a trackState matching an existing RemoteTrackV2', () => {
         it('does not call update with the trackState on the existing RemoteTrackV2', () => {
-          var id = makeId();
-          var test = makeTest({ tracks: [ { id: id } ] });
-          var participantState = test.state(test.revision - 1).setTrack({ id: id });
+          const id = makeId();
+          const test = makeTest({ tracks: [ { id: id } ] });
+          const participantState = test.state(test.revision - 1).setTrack({ id: id });
           test.participant.update(participantState);
           assert(!test.remoteTrackV2s[0].update.calledTwice);
         });
@@ -552,9 +552,9 @@ describe('RemoteParticipantV2', () => {
 
       context('which no longer includes a trackState matching an existing RemoteTrackV2', () => {
         it('does not delete the RemoteTrackV2 from the RemoteParticipantV2\'s .tracks Map', () => {
-          var id = makeId();
-          var test = makeTest({ tracks: [ { id: id } ] });
-          var participantState = test.state(test.revision - 1);
+          const id = makeId();
+          const test = makeTest({ tracks: [ { id: id } ] });
+          const participantState = test.state(test.revision - 1);
           test.participant.update(participantState);
           assert.equal(
             test.remoteTrackV2s[0],
@@ -562,10 +562,10 @@ describe('RemoteParticipantV2', () => {
         });
 
         it('does not emit the "trackRemoved" event with the RemoteTrackV2', () => {
-          var id = makeId();
-          var test = makeTest({ tracks: [ { id: id } ] });
-          var participantState = test.state(test.revision - 1);
-          var trackRemoved = false;
+          const id = makeId();
+          const test = makeTest({ tracks: [ { id: id } ] });
+          const participantState = test.state(test.revision - 1);
+          let trackRemoved;
           test.participant.once('trackRemoved', () => trackRemoved = false);
           test.participant.update(participantState);
           assert(!trackRemoved);
@@ -575,8 +575,8 @@ describe('RemoteParticipantV2', () => {
       context('with .state set to "connected" when the RemoteParticipantV2\'s .state is', () => {
         context('"connected"', () => {
           it('the .state remains "connected"', () => {
-            var test = makeTest();
-            var participantState = test.state(test.revision - 1).setState('connected');
+            const test = makeTest();
+            const participantState = test.state(test.revision - 1).setState('connected');
             test.participant.update(participantState);
             assert.equal(
               'connected',
@@ -584,9 +584,9 @@ describe('RemoteParticipantV2', () => {
           });
 
           it('does not emit the "stateChanged" event', () => {
-            var test = makeTest();
-            var participantState = test.state(test.revision - 1).setState('connected');
-            var stateChanged = false;
+            const test = makeTest();
+            const participantState = test.state(test.revision - 1).setState('connected');
+            let stateChanged;
             test.participant.once('stateChanged', () => stateChanged = true);
             test.participant.update(participantState);
             assert(!stateChanged);
@@ -595,8 +595,8 @@ describe('RemoteParticipantV2', () => {
 
         context('"disconnected"', () => {
           it('the .state remains "disconnected"', () => {
-            var test = makeTest();
-            var participantState = test.state(test.revision - 1).setState('connected');
+            const test = makeTest();
+            const participantState = test.state(test.revision - 1).setState('connected');
             test.participant.disconnect();
             test.participant.update(participantState);
             assert.equal(
@@ -605,10 +605,10 @@ describe('RemoteParticipantV2', () => {
           });
 
           it('does not emit the "stateChanged" event', () => {
-            var test = makeTest();
-            var participantState = test.state(test.revision - 1).setState('connected');
+            const test = makeTest();
+            const participantState = test.state(test.revision - 1).setState('connected');
             test.participant.disconnect();
-            var stateChanged = false;
+            let stateChanged;
             test.participant.once('stateChanged', () => stateChanged = true);
             test.participant.update(participantState);
             assert(!stateChanged);
@@ -619,8 +619,8 @@ describe('RemoteParticipantV2', () => {
       context('with .state set to "disconnected" when the RemoteParticipantV2\'s .state is', () => {
         context('"connected"', () => {
           it('the .state remains "connected"', () => {
-            var test = makeTest();
-            var participantState = test.state(test.revision - 1).setState('disconnected');
+            const test = makeTest();
+            const participantState = test.state(test.revision - 1).setState('disconnected');
             test.participant.update(participantState);
             assert.equal(
               'connected',
@@ -628,9 +628,9 @@ describe('RemoteParticipantV2', () => {
           });
 
           it('does not emit the "stateChanged" event', () => {
-            var test = makeTest();
-            var participantState = test.state(test.revision - 1).setState('disconnected');
-            var stateChanged = false;
+            const test = makeTest();
+            const participantState = test.state(test.revision - 1).setState('disconnected');
+            let stateChanged;
             test.participant.once('stateChanged', () => stateChanged = true);
             test.participant.update(participantState);
             assert(!stateChanged);
@@ -639,8 +639,8 @@ describe('RemoteParticipantV2', () => {
 
         context('"disconnected"', () => {
           it('the .state remains "disconnected"', () => {
-            var test = makeTest();
-            var participantState = test.state(test.revision - 1).setState('disconnected');
+            const test = makeTest();
+            const participantState = test.state(test.revision - 1).setState('disconnected');
             test.participant.disconnect();
             test.participant.update(participantState);
             assert.equal(
@@ -649,10 +649,10 @@ describe('RemoteParticipantV2', () => {
           });
 
           it('does not emit the "stateChanged" event', () => {
-            var test = makeTest();
-            var participantState = test.state(test.revision - 1).setState('disconnected');
+            const test = makeTest();
+            const participantState = test.state(test.revision - 1).setState('disconnected');
             test.participant.disconnect();
-            var stateChanged = false;
+            let stateChanged;
             test.participant.once('stateChanged', () => stateChanged = true);
             test.participant.update(participantState);
             assert(!stateChanged);
@@ -662,8 +662,8 @@ describe('RemoteParticipantV2', () => {
 
       context('which changes the .identity', () => {
         it('the .identity remains unchanged', () => {
-          var test = makeTest();
-          var participantState = test.state(test.revision - 1).setIdentity(makeIdentity());
+          const test = makeTest();
+          const participantState = test.state(test.revision - 1).setIdentity(makeIdentity());
           test.participant.update(participantState);
           assert.equal(
             test.identity,
@@ -673,8 +673,8 @@ describe('RemoteParticipantV2', () => {
 
       context('which changes the .sid', () => {
         it('the .identity remains unchanged', () => {
-          var test = makeTest();
-          var participantState = test.state(test.revision - 1).setSid(makeSid());
+          const test = makeTest();
+          const participantState = test.state(test.revision - 1).setSid(makeSid());
           test.participant.update(participantState);
           assert.equal(
             test.sid,
@@ -689,19 +689,19 @@ describe('RemoteParticipantV2', () => {
 
   describe('#addTrack', () => {
     it('returns the RemoteParticipantV2', () => {
-      var RemoteTrackV2 = makeRemoteTrackV2Constructor();
-      var test = makeTest();
-      var track = new RemoteTrackV2({ id: makeId() });
+      const RemoteTrackV2 = makeRemoteTrackV2Constructor();
+      const test = makeTest();
+      const track = new RemoteTrackV2({ id: makeId() });
       assert.equal(
         test.participant,
         test.participant.addTrack(track));
     });
 
     it('adds the RemoteTrackV2 to the RemoteParticipantV2\'s .tracks Map', () => {
-      var RemoteTrackV2 = makeRemoteTrackV2Constructor();
-      var test = makeTest();
-      var id = makeId();
-      var track = new RemoteTrackV2({ id: id });
+      const RemoteTrackV2 = makeRemoteTrackV2Constructor();
+      const test = makeTest();
+      const id = makeId();
+      const track = new RemoteTrackV2({ id: id });
       test.participant.addTrack(track);
       assert.equal(
         track,
@@ -709,10 +709,10 @@ describe('RemoteParticipantV2', () => {
     });
 
     it('emits the "trackAdded" event with the RemoteTrackV2', () => {
-      var RemoteTrackV2 = makeRemoteTrackV2Constructor();
-      var test = makeTest();
-      var track = new RemoteTrackV2({ id: makeId() });
-      var trackAdded;
+      const RemoteTrackV2 = makeRemoteTrackV2Constructor();
+      const test = makeTest();
+      const track = new RemoteTrackV2({ id: makeId() });
+      let trackAdded;
       test.participant.once('trackAdded', track => trackAdded = track);
       test.participant.addTrack(track);
       assert.equal(
@@ -721,21 +721,21 @@ describe('RemoteParticipantV2', () => {
     });
 
     it('calls getMediaStreamTrackOrDataTrackTransceiver with the newly-constructed RemoteTrackV2\'s ID', () => {
-      var RemoteTrackV2 = makeRemoteTrackV2Constructor();
-      var test = makeTest();
-      var id = makeId();
-      var track = new RemoteTrackV2({ id: id });
+      const RemoteTrackV2 = makeRemoteTrackV2Constructor();
+      const test = makeTest();
+      const id = makeId();
+      const track = new RemoteTrackV2({ id: id });
       test.participant.addTrack(track);
       assert.equal(id, test.getMediaStreamTrackOrDataTrackTransceiver.args[0][0]);
     });
 
     it('calls setMediaStreamTrackOrDataTrackTransceiver on the newly-constructed RemoteTrackV2 with the result of calling getMediaStreamTrackOrDataTrackTransceiver', () => {
-      var RemoteTrackV2 = makeRemoteTrackV2Constructor();
-      var test = makeTest();
-      var id = makeId();
-      var track = new RemoteTrackV2({ id: id });
+      const RemoteTrackV2 = makeRemoteTrackV2Constructor();
+      const test = makeTest();
+      const id = makeId();
+      const track = new RemoteTrackV2({ id: id });
       test.participant.addTrack(track);
-      var mediaStreamTrack = {};
+      const mediaStreamTrack = {};
       test.getMediaStreamTrackOrDataTrackTransceiverDeferred.resolve(mediaStreamTrack);
       return test.getMediaStreamTrackOrDataTrackTransceiverDeferred.promise.then(() => {
         assert.equal(
@@ -748,14 +748,14 @@ describe('RemoteParticipantV2', () => {
   describe('#connect', () => {
     context('when the RemoteParticipantV2\'s .state is "connected"', () => {
       it('returns false', () => {
-        var test = makeTest();
+        const test = makeTest();
         assert.equal(
           false,
           test.participant.connect(makeSid(), makeIdentity()));
       });
 
       it('the .identity remains the same', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.participant.connect(makeSid(), makeIdentity());
         assert.equal(
           test.identity,
@@ -763,7 +763,7 @@ describe('RemoteParticipantV2', () => {
       });
 
       it('the .sid remains the same', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.participant.connect(makeSid(), makeIdentity());
         assert.equal(
           test.sid,
@@ -771,7 +771,7 @@ describe('RemoteParticipantV2', () => {
       });
 
       it('the .state remains "connected"', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.participant.connect(makeSid(), makeIdentity());
         assert.equal(
           'connected',
@@ -779,8 +779,8 @@ describe('RemoteParticipantV2', () => {
       });
 
       it('does not emit the "stateChanged" event', () => {
-        var test = makeTest();
-        var stateChanged;
+        const test = makeTest();
+        let stateChanged;
         test.participant.once('stateChanged', () => stateChanged = true);
         test.participant.connect(makeSid(), makeIdentity());
         assert(!stateChanged);
@@ -789,7 +789,7 @@ describe('RemoteParticipantV2', () => {
 
     context('when the RemoteParticipantV2\'s .state is "disconnected"', () => {
       it('returns false', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.participant.disconnect();
         assert.equal(
           false,
@@ -797,7 +797,7 @@ describe('RemoteParticipantV2', () => {
       });
 
       it('the .identity remains the same', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.participant.disconnect();
         test.participant.connect(makeSid(), makeIdentity());
         assert.equal(
@@ -806,7 +806,7 @@ describe('RemoteParticipantV2', () => {
       });
 
       it('the .sid remains the same', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.participant.disconnect();
         test.participant.connect(makeSid(), makeIdentity());
         assert.equal(
@@ -815,7 +815,7 @@ describe('RemoteParticipantV2', () => {
       });
 
       it('the .state remains "disconnected"', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.participant.disconnect();
         test.participant.connect(makeSid(), makeIdentity());
         assert.equal(
@@ -824,9 +824,9 @@ describe('RemoteParticipantV2', () => {
       });
 
       it('does not emit the "stateChanged" event', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.participant.disconnect();
-        var stateChanged;
+        let stateChanged;
         test.participant.once('stateChanged', () => stateChanged = true);
         test.participant.connect(makeSid(), makeIdentity());
         assert(!stateChanged);
@@ -837,14 +837,14 @@ describe('RemoteParticipantV2', () => {
   describe('#disconnect', () => {
     context('when the RemoteParticipantV2\'s .state is "connected"', () => {
       it('returns true', () => {
-        var test = makeTest();
+        const test = makeTest();
         assert.equal(
           true,
           test.participant.disconnect());
       });
 
       it('sets the .state to "disconnected"', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.participant.disconnect();
         assert.equal(
           'disconnected',
@@ -852,8 +852,8 @@ describe('RemoteParticipantV2', () => {
       });
 
       it('emits the "stateChanged" event with the new state "disconnected"', () => {
-        var test = makeTest();
-        var newState;
+        const test = makeTest();
+        let newState;
         test.participant.once('stateChanged', state => newState = state);
         test.participant.disconnect();
         assert.equal(
@@ -864,7 +864,7 @@ describe('RemoteParticipantV2', () => {
 
     context('when the RemoteParticipantV2\'s .state is "disconnected"', () => {
       it('returns false', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.participant.disconnect();
         assert.equal(
           false,
@@ -872,7 +872,7 @@ describe('RemoteParticipantV2', () => {
       });
 
       it('the .state remains "disconnected"', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.participant.disconnect();
         test.participant.disconnect();
         assert.equal(
@@ -881,9 +881,9 @@ describe('RemoteParticipantV2', () => {
       });
 
       it('does not emit the "stateChanged" event', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.participant.disconnect();
-        var stateChanged = false;
+        let stateChanged;
         test.participant.once('stateChanged', () => stateChanged = true);
         test.participant.disconnect();
         assert(!stateChanged);
@@ -894,21 +894,21 @@ describe('RemoteParticipantV2', () => {
   describe('#removeTrack', () => {
     context('when the RemoteTrackV2 to remove was previously added', () => {
       it('returns true', () => {
-        var test = makeTest({ tracks: [ { id: makeId() } ] });
+        const test = makeTest({ tracks: [ { id: makeId() } ] });
         assert.equal(
           true,
           test.participant.removeTrack(test.remoteTrackV2s[0]));
       });
 
       it('deletes the RemoteTrackV2 from the RemoteParticipantV2\'s .tracks Map', () => {
-        var test = makeTest({ tracks: [ { id: makeId() } ] });
+        const test = makeTest({ tracks: [ { id: makeId() } ] });
         test.participant.removeTrack(test.remoteTrackV2s[0]);
         assert(!test.participant.tracks.has(test.remoteTrackV2s[0].id));
       });
 
       it('emits the "trackRemoved" event with the RemoteTrackV2', () => {
-        var test = makeTest({ tracks: [ { id: makeId() } ] });
-        var trackRemoved;
+        const test = makeTest({ tracks: [ { id: makeId() } ] });
+        let trackRemoved;
         test.participant.once('trackRemoved', track => trackRemoved = track);
         test.participant.removeTrack(test.remoteTrackV2s[0]);
         assert.equal(
@@ -919,19 +919,19 @@ describe('RemoteParticipantV2', () => {
 
     context('when the RemoteTrackV2 to remove was not previously added', () => {
       it('returns false', () => {
-        var RemoteTrackV2 = makeRemoteTrackV2Constructor();
-        var track = new RemoteTrackV2({ id: makeId() });
-        var test = makeTest();
+        const RemoteTrackV2 = makeRemoteTrackV2Constructor();
+        const track = new RemoteTrackV2({ id: makeId() });
+        const test = makeTest();
         assert.equal(
           false,
           test.participant.removeTrack(track));
       });
 
       it('does not emit the "trackRemoved" event with the RemoteTrackV2', () => {
-        var RemoteTrackV2 = makeRemoteTrackV2Constructor();
-        var track = new RemoteTrackV2({ id: makeId() });
-        var test = makeTest();
-        var trackRemoved = false;
+        const RemoteTrackV2 = makeRemoteTrackV2Constructor();
+        const track = new RemoteTrackV2({ id: makeId() });
+        const test = makeTest();
+        let trackRemoved;
         test.participant.once('trackRemoved', () => trackRemoved = true);
         test.participant.removeTrack(track);
         assert(!trackRemoved);
@@ -949,8 +949,8 @@ function makeIdentity(length) {
 }
 
 function makeSid() {
-  var sid = 'PA';
-  for (var i = 0; i < 32; i++) {
+  let sid = 'PA';
+  for (let i = 0; i < 32; i++) {
     sid += 'abcdef0123456789'.split('')[Math.floor(Math.random() * 16)];
   }
   return sid;

--- a/test/unit/spec/signaling/v2/remoteparticipant.js
+++ b/test/unit/spec/signaling/v2/remoteparticipant.js
@@ -1,9 +1,10 @@
 'use strict';
 
-var assert = require('assert');
-var RemoteParticipantV2 = require('../../../../../lib/signaling/v2/remoteparticipant');
-var sinon = require('sinon');
-var util = require('../../../../../lib/util');
+const assert = require('assert');
+const sinon = require('sinon');
+
+const RemoteParticipantV2 = require('../../../../../lib/signaling/v2/remoteparticipant');
+const { defer } = require('../../../../../lib/util');
 
 describe('RemoteParticipantV2', () => {
   // RemoteParticipantV2
@@ -969,7 +970,7 @@ function makeTest(options) {
   options.remoteTrackV2s = options.remoteTrackV2s || [];
 
   options.getMediaStreamTrackOrDataTrackTransceiverDeferred = options.getMediaStreamTrackOrDataTrackTransceiverDeferred
-    || util.defer();
+    || defer();
   options.getMediaStreamTrackOrDataTrackTransceiver = options.getMediaStreamTrackOrDataTrackTransceiver
     || sinon.spy(() => options.getMediaStreamTrackOrDataTrackTransceiverDeferred.promise);
   options.RemoteTrackV2 = options.RemoteTrackV2 || makeRemoteTrackV2Constructor(options);

--- a/test/unit/spec/signaling/v2/remoteparticipant.js
+++ b/test/unit/spec/signaling/v2/remoteparticipant.js
@@ -142,7 +142,7 @@ describe('RemoteParticipantV2', () => {
           const test = makeTest();
           const participantState = test.state(test.revision + 1).setTrack({ id: makeId() });
           let track;
-          test.participant.once('trackAdded', _track => track = _track);
+          test.participant.once('trackAdded', _track => { track = _track; });
           test.participant.update(participantState);
           assert.equal(
             test.remoteTrackV2s[0],
@@ -184,7 +184,7 @@ describe('RemoteParticipantV2', () => {
       context('which includes a trackState matching an existing RemoteTrackV2', () => {
         it('calls update with the trackState on the existing RemoteTrackV2', () => {
           const id = makeId();
-          const test = makeTest({ tracks: [ { id: id } ] });
+          const test = makeTest({ tracks: [{ id: id }] });
           const participantState = test.state(test.revision + 1).setTrack({ id: id, fizz: 'buzz' });
           test.participant.update(participantState);
           assert.deepEqual(
@@ -196,7 +196,7 @@ describe('RemoteParticipantV2', () => {
       context('which no longer includes a trackState matching an existing RemoteTrackV2', () => {
         it('deletes the RemoteTrackV2 from the RemoteParticipantV2\'s .tracks Map', () => {
           const id = makeId();
-          const test = makeTest({ tracks: [ { id: id } ] });
+          const test = makeTest({ tracks: [{ id: id }] });
           const participantState = test.state(test.revision + 1);
           test.participant.update(participantState);
           assert(!test.participant.tracks.has(id));
@@ -204,10 +204,10 @@ describe('RemoteParticipantV2', () => {
 
         it('emits the "trackRemoved" event with the RemoteTrackV2', () => {
           const id = makeId();
-          const test = makeTest({ tracks: [ { id: id } ] });
+          const test = makeTest({ tracks: [{ id: id }] });
           const participantState = test.state(test.revision + 1);
           let track;
-          test.participant.once('trackRemoved', _track => track = _track);
+          test.participant.once('trackRemoved', _track => { track = _track; });
           test.participant.update(participantState);
           assert.equal(
             test.remoteTrackV2s[0],
@@ -230,7 +230,7 @@ describe('RemoteParticipantV2', () => {
             const test = makeTest();
             const participantState = test.state(test.revision + 1).setState('connected');
             let stateChanged;
-            test.participant.once('stateChanged', () => stateChanged = true);
+            test.participant.once('stateChanged', () => { stateChanged = true; });
             test.participant.update(participantState);
             assert(!stateChanged);
           });
@@ -252,7 +252,7 @@ describe('RemoteParticipantV2', () => {
             const participantState = test.state(test.revision + 1).setState('connected');
             test.participant.disconnect();
             let stateChanged;
-            test.participant.once('stateChanged', () => stateChanged = true);
+            test.participant.once('stateChanged', () => { stateChanged = true; });
             test.participant.update(participantState);
             assert(!stateChanged);
           });
@@ -274,7 +274,7 @@ describe('RemoteParticipantV2', () => {
             const test = makeTest();
             const participantState = test.state(test.revision + 1).setState('disconnected');
             let newState;
-            test.participant.once('stateChanged', state => newState = state);
+            test.participant.once('stateChanged', state => { newState = state; });
             test.participant.update(participantState);
             assert.equal(
               'disconnected',
@@ -298,7 +298,7 @@ describe('RemoteParticipantV2', () => {
             const participantState = test.state(test.revision + 1).setState('disconnected');
             test.participant.disconnect();
             let stateChanged;
-            test.participant.once('stateChanged', () => stateChanged = true);
+            test.participant.once('stateChanged', () => { stateChanged = true; });
             test.participant.update(participantState);
             assert(!stateChanged);
           });
@@ -365,7 +365,7 @@ describe('RemoteParticipantV2', () => {
       context('which includes a trackState matching an existing RemoteTrackV2', () => {
         it('does not call update with the trackState on the existing RemoteTrackV2', () => {
           const id = makeId();
-          const test = makeTest({ tracks: [ { id: id } ] });
+          const test = makeTest({ tracks: [{ id: id }] });
           const participantState = test.state(test.revision).setTrack({ id: id });
           test.participant.update(participantState);
           assert(!test.remoteTrackV2s[0].update.calledTwice);
@@ -375,7 +375,7 @@ describe('RemoteParticipantV2', () => {
       context('which no longer includes a trackState matching an existing RemoteTrackV2', () => {
         it('does not delete the RemoteTrackV2 from the RemoteParticipantV2\'s .tracks Map', () => {
           const id = makeId();
-          const test = makeTest({ tracks: [ { id: id } ] });
+          const test = makeTest({ tracks: [{ id: id }] });
           const participantState = test.state(test.revision);
           test.participant.update(participantState);
           assert.equal(
@@ -385,10 +385,10 @@ describe('RemoteParticipantV2', () => {
 
         it('does not emit the "trackRemoved" event with the RemoteTrackV2', () => {
           const id = makeId();
-          const test = makeTest({ tracks: [ { id: id } ] });
+          const test = makeTest({ tracks: [{ id: id }] });
           const participantState = test.state(test.revision);
           let trackRemoved;
-          test.participant.once('trackRemoved', () => trackRemoved = false);
+          test.participant.once('trackRemoved', () => { trackRemoved = false; });
           test.participant.update(participantState);
           assert(!trackRemoved);
         });
@@ -409,7 +409,7 @@ describe('RemoteParticipantV2', () => {
             const test = makeTest();
             const participantState = test.state(test.revision).setState('connected');
             let stateChanged;
-            test.participant.once('stateChanged', () => stateChanged = true);
+            test.participant.once('stateChanged', () => { stateChanged = true; });
             test.participant.update(participantState);
             assert(!stateChanged);
           });
@@ -431,7 +431,7 @@ describe('RemoteParticipantV2', () => {
             const participantState = test.state(test.revision).setState('connected');
             test.participant.disconnect();
             let stateChanged;
-            test.participant.once('stateChanged', () => stateChanged = true);
+            test.participant.once('stateChanged', () => { stateChanged = true; });
             test.participant.update(participantState);
             assert(!stateChanged);
           });
@@ -453,7 +453,7 @@ describe('RemoteParticipantV2', () => {
             const test = makeTest();
             const participantState = test.state(test.revision).setState('disconnected');
             let stateChanged;
-            test.participant.once('stateChanged', () => stateChanged = true);
+            test.participant.once('stateChanged', () => { stateChanged = true; });
             test.participant.update(participantState);
             assert(!stateChanged);
           });
@@ -475,7 +475,7 @@ describe('RemoteParticipantV2', () => {
             const participantState = test.state(test.revision).setState('disconnected');
             test.participant.disconnect();
             let stateChanged;
-            test.participant.once('stateChanged', () => stateChanged = true);
+            test.participant.once('stateChanged', () => { stateChanged = true; });
             test.participant.update(participantState);
             assert(!stateChanged);
           });
@@ -543,7 +543,7 @@ describe('RemoteParticipantV2', () => {
       context('which includes a trackState matching an existing RemoteTrackV2', () => {
         it('does not call update with the trackState on the existing RemoteTrackV2', () => {
           const id = makeId();
-          const test = makeTest({ tracks: [ { id: id } ] });
+          const test = makeTest({ tracks: [{ id: id }] });
           const participantState = test.state(test.revision - 1).setTrack({ id: id });
           test.participant.update(participantState);
           assert(!test.remoteTrackV2s[0].update.calledTwice);
@@ -553,7 +553,7 @@ describe('RemoteParticipantV2', () => {
       context('which no longer includes a trackState matching an existing RemoteTrackV2', () => {
         it('does not delete the RemoteTrackV2 from the RemoteParticipantV2\'s .tracks Map', () => {
           const id = makeId();
-          const test = makeTest({ tracks: [ { id: id } ] });
+          const test = makeTest({ tracks: [{ id: id }] });
           const participantState = test.state(test.revision - 1);
           test.participant.update(participantState);
           assert.equal(
@@ -563,10 +563,10 @@ describe('RemoteParticipantV2', () => {
 
         it('does not emit the "trackRemoved" event with the RemoteTrackV2', () => {
           const id = makeId();
-          const test = makeTest({ tracks: [ { id: id } ] });
+          const test = makeTest({ tracks: [{ id: id }] });
           const participantState = test.state(test.revision - 1);
           let trackRemoved;
-          test.participant.once('trackRemoved', () => trackRemoved = false);
+          test.participant.once('trackRemoved', () => { trackRemoved = false; });
           test.participant.update(participantState);
           assert(!trackRemoved);
         });
@@ -587,7 +587,7 @@ describe('RemoteParticipantV2', () => {
             const test = makeTest();
             const participantState = test.state(test.revision - 1).setState('connected');
             let stateChanged;
-            test.participant.once('stateChanged', () => stateChanged = true);
+            test.participant.once('stateChanged', () => { stateChanged = true; });
             test.participant.update(participantState);
             assert(!stateChanged);
           });
@@ -609,7 +609,7 @@ describe('RemoteParticipantV2', () => {
             const participantState = test.state(test.revision - 1).setState('connected');
             test.participant.disconnect();
             let stateChanged;
-            test.participant.once('stateChanged', () => stateChanged = true);
+            test.participant.once('stateChanged', () => { stateChanged = true; });
             test.participant.update(participantState);
             assert(!stateChanged);
           });
@@ -631,7 +631,7 @@ describe('RemoteParticipantV2', () => {
             const test = makeTest();
             const participantState = test.state(test.revision - 1).setState('disconnected');
             let stateChanged;
-            test.participant.once('stateChanged', () => stateChanged = true);
+            test.participant.once('stateChanged', () => { stateChanged = true; });
             test.participant.update(participantState);
             assert(!stateChanged);
           });
@@ -653,7 +653,7 @@ describe('RemoteParticipantV2', () => {
             const participantState = test.state(test.revision - 1).setState('disconnected');
             test.participant.disconnect();
             let stateChanged;
-            test.participant.once('stateChanged', () => stateChanged = true);
+            test.participant.once('stateChanged', () => { stateChanged = true; });
             test.participant.update(participantState);
             assert(!stateChanged);
           });
@@ -713,7 +713,7 @@ describe('RemoteParticipantV2', () => {
       const test = makeTest();
       const track = new RemoteTrackV2({ id: makeId() });
       let trackAdded;
-      test.participant.once('trackAdded', track => trackAdded = track);
+      test.participant.once('trackAdded', track => { trackAdded = track; });
       test.participant.addTrack(track);
       assert.equal(
         track,
@@ -781,7 +781,7 @@ describe('RemoteParticipantV2', () => {
       it('does not emit the "stateChanged" event', () => {
         const test = makeTest();
         let stateChanged;
-        test.participant.once('stateChanged', () => stateChanged = true);
+        test.participant.once('stateChanged', () => { stateChanged = true; });
         test.participant.connect(makeSid(), makeIdentity());
         assert(!stateChanged);
       });
@@ -827,7 +827,7 @@ describe('RemoteParticipantV2', () => {
         const test = makeTest();
         test.participant.disconnect();
         let stateChanged;
-        test.participant.once('stateChanged', () => stateChanged = true);
+        test.participant.once('stateChanged', () => { stateChanged = true; });
         test.participant.connect(makeSid(), makeIdentity());
         assert(!stateChanged);
       });
@@ -854,7 +854,7 @@ describe('RemoteParticipantV2', () => {
       it('emits the "stateChanged" event with the new state "disconnected"', () => {
         const test = makeTest();
         let newState;
-        test.participant.once('stateChanged', state => newState = state);
+        test.participant.once('stateChanged', state => { newState = state; });
         test.participant.disconnect();
         assert.equal(
           'disconnected',
@@ -884,7 +884,7 @@ describe('RemoteParticipantV2', () => {
         const test = makeTest();
         test.participant.disconnect();
         let stateChanged;
-        test.participant.once('stateChanged', () => stateChanged = true);
+        test.participant.once('stateChanged', () => { stateChanged = true; });
         test.participant.disconnect();
         assert(!stateChanged);
       });
@@ -894,22 +894,22 @@ describe('RemoteParticipantV2', () => {
   describe('#removeTrack', () => {
     context('when the RemoteTrackV2 to remove was previously added', () => {
       it('returns true', () => {
-        const test = makeTest({ tracks: [ { id: makeId() } ] });
+        const test = makeTest({ tracks: [{ id: makeId() }] });
         assert.equal(
           true,
           test.participant.removeTrack(test.remoteTrackV2s[0]));
       });
 
       it('deletes the RemoteTrackV2 from the RemoteParticipantV2\'s .tracks Map', () => {
-        const test = makeTest({ tracks: [ { id: makeId() } ] });
+        const test = makeTest({ tracks: [{ id: makeId() }] });
         test.participant.removeTrack(test.remoteTrackV2s[0]);
         assert(!test.participant.tracks.has(test.remoteTrackV2s[0].id));
       });
 
       it('emits the "trackRemoved" event with the RemoteTrackV2', () => {
-        const test = makeTest({ tracks: [ { id: makeId() } ] });
+        const test = makeTest({ tracks: [{ id: makeId() }] });
         let trackRemoved;
-        test.participant.once('trackRemoved', track => trackRemoved = track);
+        test.participant.once('trackRemoved', track => { trackRemoved = track; });
         test.participant.removeTrack(test.remoteTrackV2s[0]);
         assert.equal(
           test.remoteTrackV2s[0],
@@ -932,7 +932,7 @@ describe('RemoteParticipantV2', () => {
         const track = new RemoteTrackV2({ id: makeId() });
         const test = makeTest();
         let trackRemoved;
-        test.participant.once('trackRemoved', () => trackRemoved = true);
+        test.participant.once('trackRemoved', () => { trackRemoved = true; });
         test.participant.removeTrack(track);
         assert(!trackRemoved);
       });
@@ -944,7 +944,7 @@ function makeId() {
   return Math.floor(Math.random() * 1000 + 0.5);
 }
 
-function makeIdentity(length) {
+function makeIdentity() {
   return Math.random().toString(36).slice(2);
 }
 

--- a/test/unit/spec/signaling/v2/remotetrack.js
+++ b/test/unit/spec/signaling/v2/remotetrack.js
@@ -11,7 +11,7 @@ describe('RemoteTrackV2', () => {
 
   describe('constructor', () => {
     it('sets .id', () => {
-      var id = makeId();
+      const id = makeId();
       assert.equal(id, (new RemoteTrackV2({
         enabled: makeEnabled(),
         id: id,
@@ -22,7 +22,7 @@ describe('RemoteTrackV2', () => {
     });
 
     it('sets .name', () => {
-      var name = makeUUID();
+      const name = makeUUID();
       assert.equal(name, (new RemoteTrackV2({
         enabled: makeEnabled(),
         id: makeId(),
@@ -33,7 +33,7 @@ describe('RemoteTrackV2', () => {
     });
 
     it('sets .sid', () => {
-      var sid = makeSid();
+      const sid = makeSid();
       assert.equal(sid, (new RemoteTrackV2({
         enabled: makeEnabled(),
         id: makeId(),
@@ -96,43 +96,43 @@ describe('RemoteTrackV2', () => {
     context('called with a trackState setting .enabled to false when the RemoteTrackV2 is', () => {
       context('enabled', () => {
         it('returns the RemoteTrackV2', () => {
-          var trackState = {
+          const trackState = {
             id: makeId(),
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
             sid: makeSid()
           };
-          var track = new RemoteTrackV2(trackState);
+          const track = new RemoteTrackV2(trackState);
           trackState.enabled = false;
           assert.equal(track, track.update(trackState));
         });
 
         it('sets .isEnabled to false', () => {
-          var trackState = {
+          const trackState = {
             id: makeId(),
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
             sid: makeSid()
           };
-          var track = new RemoteTrackV2(trackState);
+          const track = new RemoteTrackV2(trackState);
           trackState.enabled = false;
           track.update(trackState);
           assert(!track.isEnabled);
         });
 
         it('emits an "updated" event with .isEnabled set to false', () => {
-          var trackState = {
+          const trackState = {
             id: makeId(),
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
             sid: makeSid()
           };
-          var track = new RemoteTrackV2(trackState);
+          const track = new RemoteTrackV2(trackState);
           trackState.enabled = false;
-          var isEnabled;
+          let isEnabled;
           track.once('updated', () => isEnabled = track.isEnabled);
           track.update(trackState);
           assert.equal(false, isEnabled);
@@ -141,43 +141,43 @@ describe('RemoteTrackV2', () => {
 
       context('disabled', () => {
         it('returns the RemoteTrackV2', () => {
-          var trackState = {
+          const trackState = {
             id: makeId(),
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
             sid: makeSid()
           };
-          var track = new RemoteTrackV2(trackState);
+          const track = new RemoteTrackV2(trackState);
           trackState.enabled = false;
           assert.equal(track, track.update(trackState));
         });
 
         it('.isEnabled remains false', () => {
-          var trackState = {
+          const trackState = {
             id: makeId(),
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
             sid: makeSid()
           };
-          var track = new RemoteTrackV2(trackState);
+          const track = new RemoteTrackV2(trackState);
           trackState.enabled = false;
           track.update(trackState);
           assert(!track.isEnabled);
         });
 
         it('"updated" does not emit', () => {
-          var trackState = {
+          const trackState = {
             id: makeId(),
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
             sid: makeSid()
           };
-          var track = new RemoteTrackV2(trackState);
+          const track = new RemoteTrackV2(trackState);
           trackState.enabled = false;
-          var updated = false;
+          let updated;
           track.once('updated', () => updated = true);
           track.update(trackState);
           assert(!updated);
@@ -188,43 +188,43 @@ describe('RemoteTrackV2', () => {
     context('called with a trackState setting .enabled to true when the RemoteTrackV2 is', () => {
       context('enabled', () => {
         it('returns the RemoteTrackV2', () => {
-          var trackState = {
+          const trackState = {
             id: makeId(),
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
             sid: makeSid()
           };
-          var track = new RemoteTrackV2(trackState);
+          const track = new RemoteTrackV2(trackState);
           trackState.enabled = true;
           assert.equal(track, track.update(trackState));
         });
 
         it('.isEnabled remains true', () => {
-          var trackState = {
+          const trackState = {
             id: makeId(),
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
             sid: makeSid()
           };
-          var track = new RemoteTrackV2(trackState);
+          const track = new RemoteTrackV2(trackState);
           trackState.enabled = true;
           track.update(trackState);
           assert(track.isEnabled);
         });
 
         it('"updated" does not emit', () => {
-          var trackState = {
+          const trackState = {
             id: makeId(),
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
             sid: makeSid()
           };
-          var track = new RemoteTrackV2(trackState);
+          const track = new RemoteTrackV2(trackState);
           trackState.enabled = true;
-          var updated = false;
+          let updated;
           track.once('updated', () => updated = true);
           track.update(trackState);
           assert(!updated);
@@ -233,43 +233,43 @@ describe('RemoteTrackV2', () => {
 
       context('disabled', () => {
         it('returns the RemoteTrackV2', () => {
-          var trackState = {
+          const trackState = {
             id: makeId(),
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
             sid: makeSid()
           };
-          var track = new RemoteTrackV2(trackState);
+          const track = new RemoteTrackV2(trackState);
           trackState.enabled = true;
           assert.equal(track, track.update(trackState));
         });
 
         it('sets .isEnabled to true', () => {
-          var trackState = {
+          const trackState = {
             id: makeId(),
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
             sid: makeSid()
           };
-          var track = new RemoteTrackV2(trackState);
+          const track = new RemoteTrackV2(trackState);
           trackState.enabled = true;
           track.update(trackState);
           assert(track.isEnabled);
         });
 
         it('emits an "updated" event with .isEnabled set to true', () => {
-          var trackState = {
+          const trackState = {
             id: makeId(),
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
             sid: makeSid()
           };
-          var track = new RemoteTrackV2(trackState);
+          const track = new RemoteTrackV2(trackState);
           trackState.enabled = true;
-          var isEnabled;
+          let isEnabled;
           track.once('updated', () => isEnabled = track.isEnabled);
           track.update(trackState);
           assert(isEnabled);
@@ -284,7 +284,7 @@ describe('RemoteTrackV2', () => {
   describe('#disable', () => {
     context('called when the RemoteTrackV2 is enabled', () => {
       it('returns the RemoteTrackV2', () => {
-        var track = new RemoteTrackV2({
+        const track = new RemoteTrackV2({
           id: makeId(),
           enabled: true,
           kind: makeKind(),
@@ -295,7 +295,7 @@ describe('RemoteTrackV2', () => {
       });
 
       it('sets .isEnabled to false', () => {
-        var track = new RemoteTrackV2({
+        const track = new RemoteTrackV2({
           id: makeId(),
           enabled: true,
           kind: makeKind(),
@@ -307,14 +307,14 @@ describe('RemoteTrackV2', () => {
       });
 
       it('emits an "updated" event with .isEnabled set to false', () => {
-        var track = new RemoteTrackV2({
+        const track = new RemoteTrackV2({
           id: makeId(),
           enabled: true,
           kind: makeKind(),
           name: makeUUID(),
           sid: makeSid()
         });
-        var isEnabled;
+        let isEnabled;
         track.once('updated', () => isEnabled = track.isEnabled);
         track.disable();
         assert.equal(false, isEnabled);
@@ -323,7 +323,7 @@ describe('RemoteTrackV2', () => {
 
     context('called when the RemoteTrackV2 is disabled', () => {
       it('returns the RemoteTrackV2', () => {
-        var track = new RemoteTrackV2({
+        const track = new RemoteTrackV2({
           id: makeId(),
           enabled: false,
           kind: makeKind(),
@@ -334,7 +334,7 @@ describe('RemoteTrackV2', () => {
       });
 
       it('.isEnabled remains false', () => {
-        var track = new RemoteTrackV2({
+        const track = new RemoteTrackV2({
           id: makeId(),
           enabled: false,
           kind: makeKind(),
@@ -346,14 +346,14 @@ describe('RemoteTrackV2', () => {
       });
 
       it('"updated" does not emit', () => {
-        var track = new RemoteTrackV2({
+        const track = new RemoteTrackV2({
           id: makeId(),
           enabled: false,
           kind: makeKind(),
           name: makeUUID(),
           sid: makeSid()
         });
-        var updated = false;
+        let updated;
         track.once('updated', () => updated = true);
         track.disable();
         assert(!updated);
@@ -365,7 +365,7 @@ describe('RemoteTrackV2', () => {
     context('called with false when the RemoteTrackV2 is', () => {
       context('enabled', () => {
         it('returns the RemoteTrackV2', () => {
-          var track = new RemoteTrackV2({
+          const track = new RemoteTrackV2({
             id: makeId(),
             enabled: true,
             kind: makeKind(),
@@ -376,7 +376,7 @@ describe('RemoteTrackV2', () => {
         });
 
         it('sets .isEnabled to false', () => {
-          var track = new RemoteTrackV2({
+          const track = new RemoteTrackV2({
             id: makeId(),
             enabled: true,
             kind: makeKind(),
@@ -388,14 +388,14 @@ describe('RemoteTrackV2', () => {
         });
 
         it('emits an "updated" event with .isEnabled set to false', () => {
-          var track = new RemoteTrackV2({
+          const track = new RemoteTrackV2({
             id: makeId(),
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
             sid: makeSid()
           });
-          var isEnabled;
+          let isEnabled;
           track.once('updated', () => isEnabled = track.isEnabled);
           track.enable(false);
           assert.equal(false, isEnabled);
@@ -404,7 +404,7 @@ describe('RemoteTrackV2', () => {
 
       context('disabled', () => {
         it('returns the RemoteTrackV2', () => {
-          var track = new RemoteTrackV2({
+          const track = new RemoteTrackV2({
             id: makeId(),
             enabled: false,
             kind: makeKind(),
@@ -415,7 +415,7 @@ describe('RemoteTrackV2', () => {
         });
 
         it('.isEnabled remains false', () => {
-          var track = new RemoteTrackV2({
+          const track = new RemoteTrackV2({
             id: makeId(),
             enabled: false,
             kind: makeKind(),
@@ -427,14 +427,14 @@ describe('RemoteTrackV2', () => {
         });
 
         it('"updated" does not emit', () => {
-          var track = new RemoteTrackV2({
+          const track = new RemoteTrackV2({
             id: makeId(),
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
             sid: makeSid()
           });
-          var updated = false;
+          let updated;
           track.once('updated', () => updated = true);
           track.enable(false);
           assert(!updated);
@@ -445,7 +445,7 @@ describe('RemoteTrackV2', () => {
     context('called with true when the RemoteTrackV2 is', () => {
       context('enabled', () => {
         it('returns the RemoteTrackV2', () => {
-          var track = new RemoteTrackV2({
+          const track = new RemoteTrackV2({
             id: makeId(),
             enabled: true,
             kind: makeKind(),
@@ -456,7 +456,7 @@ describe('RemoteTrackV2', () => {
         });
 
         it('.isEnabled remains true', () => {
-          var track = new RemoteTrackV2({
+          const track = new RemoteTrackV2({
             id: makeId(),
             enabled: true,
             kind: makeKind(),
@@ -468,14 +468,14 @@ describe('RemoteTrackV2', () => {
         });
 
         it('"updated" does not emit', () => {
-          var track = new RemoteTrackV2({
+          const track = new RemoteTrackV2({
             id: makeId(),
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
             sid: makeSid()
           });
-          var updated = false;
+          let updated;
           track.once('updated', () => updated = true);
           track.enable(true);
           assert(!updated);
@@ -484,7 +484,7 @@ describe('RemoteTrackV2', () => {
 
       context('disabled', () => {
         it('returns the RemoteTrackV2', () => {
-          var track = new RemoteTrackV2({
+          const track = new RemoteTrackV2({
             id: makeId(),
             enabled: false,
             kind: makeKind(),
@@ -495,7 +495,7 @@ describe('RemoteTrackV2', () => {
         });
 
         it('sets .isEnabled to true', () => {
-          var track = new RemoteTrackV2({
+          const track = new RemoteTrackV2({
             id: makeId(),
             enabled: false,
             kind: makeKind(),
@@ -507,14 +507,14 @@ describe('RemoteTrackV2', () => {
         });
 
         it('emits an "updated" event with .isEnabled set to true', () => {
-          var track = new RemoteTrackV2({
+          const track = new RemoteTrackV2({
             id: makeId(),
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
             sid: makeSid()
           });
-          var isEnabled;
+          let isEnabled;
           track.once('updated', () => isEnabled = track.isEnabled);
           track.enable(true);
           assert(isEnabled);
@@ -525,7 +525,7 @@ describe('RemoteTrackV2', () => {
     context('called without an argument when the RemoteTrackV2 is', () => {
       context('enabled', () => {
         it('returns the RemoteTrackV2', () => {
-          var track = new RemoteTrackV2({
+          const track = new RemoteTrackV2({
             id: makeId(),
             enabled: true,
             kind: makeKind(),
@@ -536,7 +536,7 @@ describe('RemoteTrackV2', () => {
         });
 
         it('.isEnabled remains true', () => {
-          var track = new RemoteTrackV2({
+          const track = new RemoteTrackV2({
             id: makeId(),
             enabled: true,
             kind: makeKind(),
@@ -548,14 +548,14 @@ describe('RemoteTrackV2', () => {
         });
 
         it('"updated" does not emit', () => {
-          var track = new RemoteTrackV2({
+          const track = new RemoteTrackV2({
             id: makeId(),
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
             sid: makeSid()
           });
-          var updated = false;
+          let updated;
           track.once('updated', () => updated = true);
           track.enable();
           assert(!updated);
@@ -564,7 +564,7 @@ describe('RemoteTrackV2', () => {
 
       context('disabled', () => {
         it('returns the RemoteTrackV2', () => {
-          var track = new RemoteTrackV2({
+          const track = new RemoteTrackV2({
             id: makeId(),
             enabled: false,
             kind: makeKind(),
@@ -575,7 +575,7 @@ describe('RemoteTrackV2', () => {
         });
 
         it('sets .isEnabled to true', () => {
-          var track = new RemoteTrackV2({
+          const track = new RemoteTrackV2({
             id: makeId(),
             enabled: false,
             kind: makeKind(),
@@ -587,14 +587,14 @@ describe('RemoteTrackV2', () => {
         });
 
         it('emits an "updated" event with .isEnabled set to true', () => {
-          var track = new RemoteTrackV2({
+          const track = new RemoteTrackV2({
             id: makeId(),
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
             sid: makeSid()
           });
-          var isEnabled;
+          let isEnabled;
           track.once('updated', () => isEnabled = track.isEnabled);
           track.enable();
           assert(isEnabled);
@@ -606,14 +606,14 @@ describe('RemoteTrackV2', () => {
   describe('#getMediaStreamTrackOrDataTrackTransceiver', () => {
     context('called after setMediaStreamTrackOrDataTrackTransceiver', () => {
       it('returns a Promise that resolves to the MediaStreamTrack passed to setMediaStreamTrackOrDataTrackTransceiver', () => {
-        var track = new RemoteTrackV2({
+        const track = new RemoteTrackV2({
           id: makeId(),
           enabled: makeEnabled(),
           kind: makeKind(),
           name: makeUUID(),
           sid: makeSid()
         });
-        var mediaStreamTrack = {};
+        const mediaStreamTrack = {};
         track.setMediaStreamTrackOrDataTrackTransceiver(mediaStreamTrack);
         return track.getMediaStreamTrackOrDataTrackTransceiver().then(track => {
           assert.equal(mediaStreamTrack, track);
@@ -623,15 +623,15 @@ describe('RemoteTrackV2', () => {
 
     context('called before setMediaStreamTrackOrDataTrackTransceiver', () => {
       it('returns a Promise that resolves to the MediaStreamTrack eventually passed to setMediaStreamTrackOrDataTrackTransceiver', () => {
-        var track = new RemoteTrackV2({
+        const track = new RemoteTrackV2({
           id: makeId(),
           enabled: makeEnabled(),
           kind: makeKind(),
           name: makeUUID(),
           sid: makeSid()
         });
-        var mediaStreamTrack = {};
-        var promise = track.getMediaStreamTrackOrDataTrackTransceiver().then(track => {
+        const mediaStreamTrack = {};
+        const promise = track.getMediaStreamTrackOrDataTrackTransceiver().then(track => {
           assert.equal(mediaStreamTrack, track);
         });
         track.setMediaStreamTrackOrDataTrackTransceiver(mediaStreamTrack);
@@ -642,14 +642,14 @@ describe('RemoteTrackV2', () => {
 
   describe('#setMediaStreamTrackOrDataTrackTransceiver', () => {
     it('returns the RemoteTrackV2', () => {
-      var track = new RemoteTrackV2({
+      const track = new RemoteTrackV2({
         id: makeId(),
         enabled: makeEnabled(),
         kind: makeKind(),
         name: makeUUID(),
         sid: makeSid()
       });
-      var mediaStreamTrack = {};
+      const mediaStreamTrack = {};
       assert.equal(track, track.setMediaStreamTrackOrDataTrackTransceiver(mediaStreamTrack));
     });
   });

--- a/test/unit/spec/signaling/v2/remotetrack.js
+++ b/test/unit/spec/signaling/v2/remotetrack.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var assert = require('assert');
-var RemoteTrackV2 = require('../../../../../lib/signaling/v2/remotetrack');
-var util = require('../../../../../lib/util');
+const assert = require('assert');
+
+const RemoteTrackV2 = require('../../../../../lib/signaling/v2/remotetrack');
+const { makeUUID } = require('../../../../../lib/util');
 
 describe('RemoteTrackV2', () => {
   // RemoteTrackV2
@@ -15,13 +16,13 @@ describe('RemoteTrackV2', () => {
         enabled: makeEnabled(),
         id: id,
         kind: makeKind(),
-        name: util.makeUUID(),
+        name: makeUUID(),
         sid: makeSid()
       })).id);
     });
 
     it('sets .name', () => {
-      var name = util.makeUUID();
+      var name = makeUUID();
       assert.equal(name, (new RemoteTrackV2({
         enabled: makeEnabled(),
         id: makeId(),
@@ -37,7 +38,7 @@ describe('RemoteTrackV2', () => {
         enabled: makeEnabled(),
         id: makeId(),
         kind: makeKind(),
-        name: util.makeUUID(),
+        name: makeUUID(),
         sid: sid
       })).sid);
     });
@@ -48,7 +49,7 @@ describe('RemoteTrackV2', () => {
           enabled: true,
           id: makeId(),
           kind: makeKind(),
-          name: util.makeUUID(),
+          name: makeUUID(),
           sid: makeSid()
         })).isEnabled);
       });
@@ -60,7 +61,7 @@ describe('RemoteTrackV2', () => {
           enabled: false,
           id: makeId(),
           kind: makeKind(),
-          name: util.makeUUID(),
+          name: makeUUID(),
           sid: makeSid()
         })).isEnabled);
       });
@@ -72,7 +73,7 @@ describe('RemoteTrackV2', () => {
           enabled: makeEnabled(),
           id: makeId(),
           kind: 'audio',
-          name: util.makeUUID(),
+          name: makeUUID(),
           sid: makeSid()
         })).kind);
       });
@@ -84,7 +85,7 @@ describe('RemoteTrackV2', () => {
           enabled: makeEnabled(),
           id: makeId(),
           kind: 'video',
-          name: util.makeUUID(),
+          name: makeUUID(),
           sid: makeSid()
         })).kind);
       });
@@ -99,7 +100,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: true,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           };
           var track = new RemoteTrackV2(trackState);
@@ -112,7 +113,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: true,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           };
           var track = new RemoteTrackV2(trackState);
@@ -126,7 +127,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: true,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           };
           var track = new RemoteTrackV2(trackState);
@@ -144,7 +145,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: false,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           };
           var track = new RemoteTrackV2(trackState);
@@ -157,7 +158,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: false,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           };
           var track = new RemoteTrackV2(trackState);
@@ -171,7 +172,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: false,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           };
           var track = new RemoteTrackV2(trackState);
@@ -191,7 +192,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: true,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           };
           var track = new RemoteTrackV2(trackState);
@@ -204,7 +205,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: true,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           };
           var track = new RemoteTrackV2(trackState);
@@ -218,7 +219,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: true,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           };
           var track = new RemoteTrackV2(trackState);
@@ -236,7 +237,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: false,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           };
           var track = new RemoteTrackV2(trackState);
@@ -249,7 +250,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: false,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           };
           var track = new RemoteTrackV2(trackState);
@@ -263,7 +264,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: false,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           };
           var track = new RemoteTrackV2(trackState);
@@ -287,7 +288,7 @@ describe('RemoteTrackV2', () => {
           id: makeId(),
           enabled: true,
           kind: makeKind(),
-          name: util.makeUUID(),
+          name: makeUUID(),
           sid: makeSid()
         });
         assert.equal(track, track.disable());
@@ -298,7 +299,7 @@ describe('RemoteTrackV2', () => {
           id: makeId(),
           enabled: true,
           kind: makeKind(),
-          name: util.makeUUID(),
+          name: makeUUID(),
           sid: makeSid()
         });
         track.disable();
@@ -310,7 +311,7 @@ describe('RemoteTrackV2', () => {
           id: makeId(),
           enabled: true,
           kind: makeKind(),
-          name: util.makeUUID(),
+          name: makeUUID(),
           sid: makeSid()
         });
         var isEnabled;
@@ -326,7 +327,7 @@ describe('RemoteTrackV2', () => {
           id: makeId(),
           enabled: false,
           kind: makeKind(),
-          name: util.makeUUID(),
+          name: makeUUID(),
           sid: makeSid()
         });
         assert.equal(track, track.disable());
@@ -337,7 +338,7 @@ describe('RemoteTrackV2', () => {
           id: makeId(),
           enabled: false,
           kind: makeKind(),
-          name: util.makeUUID(),
+          name: makeUUID(),
           sid: makeSid()
         });
         track.disable();
@@ -349,7 +350,7 @@ describe('RemoteTrackV2', () => {
           id: makeId(),
           enabled: false,
           kind: makeKind(),
-          name: util.makeUUID(),
+          name: makeUUID(),
           sid: makeSid()
         });
         var updated = false;
@@ -368,7 +369,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: true,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           });
           assert.equal(track, track.enable(false));
@@ -379,7 +380,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: true,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           });
           track.enable(false);
@@ -391,7 +392,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: true,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           });
           var isEnabled;
@@ -407,7 +408,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: false,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           });
           assert.equal(track, track.enable(false));
@@ -418,7 +419,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: false,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           });
           track.enable(false);
@@ -430,7 +431,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: false,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           });
           var updated = false;
@@ -448,7 +449,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: true,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           });
           assert.equal(track, track.enable(true));
@@ -459,7 +460,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: true,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           });
           track.enable(true);
@@ -471,7 +472,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: true,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           });
           var updated = false;
@@ -487,7 +488,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: false,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           });
           assert.equal(track, track.enable(true));
@@ -498,7 +499,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: false,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           });
           track.enable(true);
@@ -510,7 +511,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: false,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           });
           var isEnabled;
@@ -528,7 +529,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: true,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           });
           assert.equal(track, track.enable());
@@ -539,7 +540,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: true,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           });
           track.enable();
@@ -551,7 +552,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: true,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           });
           var updated = false;
@@ -567,7 +568,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: false,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           });
           assert.equal(track, track.enable());
@@ -578,7 +579,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: false,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           });
           track.enable();
@@ -590,7 +591,7 @@ describe('RemoteTrackV2', () => {
             id: makeId(),
             enabled: false,
             kind: makeKind(),
-            name: util.makeUUID(),
+            name: makeUUID(),
             sid: makeSid()
           });
           var isEnabled;
@@ -609,7 +610,7 @@ describe('RemoteTrackV2', () => {
           id: makeId(),
           enabled: makeEnabled(),
           kind: makeKind(),
-          name: util.makeUUID(),
+          name: makeUUID(),
           sid: makeSid()
         });
         var mediaStreamTrack = {};
@@ -626,7 +627,7 @@ describe('RemoteTrackV2', () => {
           id: makeId(),
           enabled: makeEnabled(),
           kind: makeKind(),
-          name: util.makeUUID(),
+          name: makeUUID(),
           sid: makeSid()
         });
         var mediaStreamTrack = {};
@@ -645,7 +646,7 @@ describe('RemoteTrackV2', () => {
         id: makeId(),
         enabled: makeEnabled(),
         kind: makeKind(),
-        name: util.makeUUID(),
+        name: makeUUID(),
         sid: makeSid()
       });
       var mediaStreamTrack = {};
@@ -659,7 +660,7 @@ function makeEnabled() {
 }
 
 function makeId() {
-  return util.makeUUID();
+  return makeUUID();
 }
 
 function makeKind() {
@@ -667,5 +668,5 @@ function makeKind() {
 }
 
 function makeSid() {
-  return util.makeUUID();
+  return makeUUID();
 }

--- a/test/unit/spec/signaling/v2/remotetrack.js
+++ b/test/unit/spec/signaling/v2/remotetrack.js
@@ -133,7 +133,7 @@ describe('RemoteTrackV2', () => {
           const track = new RemoteTrackV2(trackState);
           trackState.enabled = false;
           let isEnabled;
-          track.once('updated', () => isEnabled = track.isEnabled);
+          track.once('updated', () => { isEnabled = track.isEnabled; });
           track.update(trackState);
           assert.equal(false, isEnabled);
         });
@@ -178,7 +178,7 @@ describe('RemoteTrackV2', () => {
           const track = new RemoteTrackV2(trackState);
           trackState.enabled = false;
           let updated;
-          track.once('updated', () => updated = true);
+          track.once('updated', () => { updated = true; });
           track.update(trackState);
           assert(!updated);
         });
@@ -225,7 +225,7 @@ describe('RemoteTrackV2', () => {
           const track = new RemoteTrackV2(trackState);
           trackState.enabled = true;
           let updated;
-          track.once('updated', () => updated = true);
+          track.once('updated', () => { updated = true; });
           track.update(trackState);
           assert(!updated);
         });
@@ -270,7 +270,7 @@ describe('RemoteTrackV2', () => {
           const track = new RemoteTrackV2(trackState);
           trackState.enabled = true;
           let isEnabled;
-          track.once('updated', () => isEnabled = track.isEnabled);
+          track.once('updated', () => { isEnabled = track.isEnabled; });
           track.update(trackState);
           assert(isEnabled);
         });
@@ -315,7 +315,7 @@ describe('RemoteTrackV2', () => {
           sid: makeSid()
         });
         let isEnabled;
-        track.once('updated', () => isEnabled = track.isEnabled);
+        track.once('updated', () => { isEnabled = track.isEnabled; });
         track.disable();
         assert.equal(false, isEnabled);
       });
@@ -354,7 +354,7 @@ describe('RemoteTrackV2', () => {
           sid: makeSid()
         });
         let updated;
-        track.once('updated', () => updated = true);
+        track.once('updated', () => { updated = true; });
         track.disable();
         assert(!updated);
       });
@@ -396,7 +396,7 @@ describe('RemoteTrackV2', () => {
             sid: makeSid()
           });
           let isEnabled;
-          track.once('updated', () => isEnabled = track.isEnabled);
+          track.once('updated', () => { isEnabled = track.isEnabled; });
           track.enable(false);
           assert.equal(false, isEnabled);
         });
@@ -435,7 +435,7 @@ describe('RemoteTrackV2', () => {
             sid: makeSid()
           });
           let updated;
-          track.once('updated', () => updated = true);
+          track.once('updated', () => { updated = true; });
           track.enable(false);
           assert(!updated);
         });
@@ -476,7 +476,7 @@ describe('RemoteTrackV2', () => {
             sid: makeSid()
           });
           let updated;
-          track.once('updated', () => updated = true);
+          track.once('updated', () => { updated = true; });
           track.enable(true);
           assert(!updated);
         });
@@ -515,7 +515,7 @@ describe('RemoteTrackV2', () => {
             sid: makeSid()
           });
           let isEnabled;
-          track.once('updated', () => isEnabled = track.isEnabled);
+          track.once('updated', () => { isEnabled = track.isEnabled; });
           track.enable(true);
           assert(isEnabled);
         });
@@ -556,7 +556,7 @@ describe('RemoteTrackV2', () => {
             sid: makeSid()
           });
           let updated;
-          track.once('updated', () => updated = true);
+          track.once('updated', () => { updated = true; });
           track.enable();
           assert(!updated);
         });
@@ -595,7 +595,7 @@ describe('RemoteTrackV2', () => {
             sid: makeSid()
           });
           let isEnabled;
-          track.once('updated', () => isEnabled = track.isEnabled);
+          track.once('updated', () => { isEnabled = track.isEnabled; });
           track.enable();
           assert(isEnabled);
         });

--- a/test/unit/spec/signaling/v2/room.js
+++ b/test/unit/spec/signaling/v2/room.js
@@ -13,28 +13,28 @@ describe('RoomV2', () => {
 
   describe('constructor', () => {
     it('sets .localParticipant', () => {
-      var test = makeTest();
+      const test = makeTest();
       assert.equal(
         test.localParticipant,
         test.room.localParticipant);
     });
 
     it('sets .name', () => {
-      var test = makeTest();
+      const test = makeTest();
       assert.equal(
         test.name,
         test.room.name);
     });
 
     it('sets .sid', () => {
-      var test = makeTest();
+      const test = makeTest();
       assert.equal(
         test.sid,
         test.room.sid);
     });
 
     it('sets the .state to "connected"', () => {
-      var test = makeTest();
+      const test = makeTest();
       assert.equal(
         'connected',
         test.room.state);
@@ -60,9 +60,9 @@ describe('RoomV2', () => {
     });
 
     it('should periodically call .publishEvent on the underlying Transport', async () => {
-      var test = makeTest({ statsPublishIntervalMs: 50 });
-      var wait = ms => new Promise(resolve => setTimeout(resolve, ms));
-      var expectedArgs = [
+      const test = makeTest({ statsPublishIntervalMs: 50 });
+      const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
+      const expectedArgs = [
         [
           'quality',
           'stats-report',
@@ -96,9 +96,9 @@ describe('RoomV2', () => {
 
     context('.participants', () => {
       it('constructs a new ParticipantV2 for each Participant state', () => {
-        var sid1 = makeParticipantSid();
-        var sid2 = makeParticipantSid();
-        var test = makeTest({
+        const sid1 = makeParticipantSid();
+        const sid2 = makeParticipantSid();
+        const test = makeTest({
           participants: [
             { sid: sid1 },
             { sid: sid2 }
@@ -109,9 +109,9 @@ describe('RoomV2', () => {
       });
 
       it('adds the newly-constructed ParticipantV2s to the RoomV2\'s .participants Map', () => {
-        var sid1 = makeParticipantSid();
-        var sid2 = makeParticipantSid();
-        var test = makeTest({
+        const sid1 = makeParticipantSid();
+        const sid2 = makeParticipantSid();
+        const test = makeTest({
           participants: [
             { sid: sid1 },
             { sid: sid2 }
@@ -126,9 +126,9 @@ describe('RoomV2', () => {
       });
 
       it('calls .update with the Participants states on the newly-constructed RemoteParticipantV2s', () => {
-        var sid1 = makeParticipantSid();
-        var sid2 = makeParticipantSid();
-        var test = makeTest({
+        const sid1 = makeParticipantSid();
+        const sid2 = makeParticipantSid();
+        const test = makeTest({
           participants: [
             { sid: sid1, foo: 'bar' },
             { sid: sid2, baz: 'qux' }
@@ -145,7 +145,7 @@ describe('RoomV2', () => {
 
     context('.peer_connections', () => {
       it('calls .update with the .peer_connections on the PeerConnectionManager', () => {
-        var test = makeTest({
+        const test = makeTest({
           peer_connections: { fizz: 'buzz' }
         });
         assert.deepEqual(
@@ -156,28 +156,28 @@ describe('RoomV2', () => {
 
     context('PeerConnectionManager', () => {
       it('dequeues any enqueued "candidates" events', () => {
-        var test = makeTest();
+        const test = makeTest();
         assert(test.peerConnectionManager.dequeue.calledWith('candidates'));
       });
 
       it('dequeues any enqueued "description" events', () => {
-        var test = makeTest();
+        const test = makeTest();
         assert(test.peerConnectionManager.dequeue.calledWith('description'));
       });
 
       it('dequeues any enqueued "trackAdded" events', () => {
-        var test = makeTest();
+        const test = makeTest();
         assert(test.peerConnectionManager.dequeue.calledWith('trackAdded'));
       });
 
       context('before the getMediaStreamTrackOrDataTrackTransceiver function passed to RemoteParticipantV2\'s is called with the MediaStreamTrack\'s ID', () => {
         it('calling getMediaStreamTrackOrDataTrackTransceiver resolves to the MediaStreamTrack and MediaStream', () => {
-          var id = makeId();
-          var mediaStreamTrack = { id: id };
-          var peerConnectionManager = makePeerConnectionManager();
+          const id = makeId();
+          const mediaStreamTrack = { id: id };
+          const peerConnectionManager = makePeerConnectionManager();
           peerConnectionManager.getRemoteMediaStreamTracksAndDataTrackReceivers = () => [mediaStreamTrack];
 
-          var test = makeTest({
+          const test = makeTest({
             participants: [
               { sid: makeSid() }
             ],
@@ -198,7 +198,7 @@ describe('RoomV2', () => {
   describe('#connectParticipant, called when the ParticipantV2 was', () => {
     context('previously connected', () => {
       it('returns false', () => {
-        var test = makeTest({
+        const test = makeTest({
           participants: [
             { sid: makeSid() }
           ]
@@ -209,7 +209,7 @@ describe('RoomV2', () => {
       });
 
       it('the ParticipantV2 remains in the RoomV2\'s .participants Map', () => {
-        var test = makeTest({
+        const test = makeTest({
           participants: [
             { sid: makeSid() }
           ]
@@ -221,12 +221,12 @@ describe('RoomV2', () => {
       });
 
       it('does not emit the "participantConnected" event', () => {
-        var test = makeTest({
+        const test = makeTest({
           participants: [
             { sid: makeSid() }
           ]
         });
-        var participantConnected = false;
+        const participantConnected = false;
         test.room.once('participantConnected', () => participantConnected = true);
         test.room.connectParticipant(test.participantV2s[0]);
         assert(!participantConnected);
@@ -235,18 +235,18 @@ describe('RoomV2', () => {
 
     context('not previously connected', () => {
       it('returns true', () => {
-        var RemoteParticipantV2 = makeRemoteParticipantV2Constructor();
-        var participant = new RemoteParticipantV2({ sid: makeSid() });
-        var test = makeTest();
+        const RemoteParticipantV2 = makeRemoteParticipantV2Constructor();
+        const participant = new RemoteParticipantV2({ sid: makeSid() });
+        const test = makeTest();
         assert.equal(
           true,
           test.room.connectParticipant(participant));
       });
 
       it('adds the ParticipantV2 to the RoomV2\'s .participants Map', () => {
-        var RemoteParticipantV2 = makeRemoteParticipantV2Constructor();
-        var participant = new RemoteParticipantV2({ sid: makeSid() });
-        var test = makeTest();
+        const RemoteParticipantV2 = makeRemoteParticipantV2Constructor();
+        const participant = new RemoteParticipantV2({ sid: makeSid() });
+        const test = makeTest();
         test.room.connectParticipant(participant);
         assert.equal(
           participant,
@@ -254,10 +254,10 @@ describe('RoomV2', () => {
       });
 
       it('emits the "participantConnected" event with the ParticipantV2', () => {
-        var RemoteParticipantV2 = makeRemoteParticipantV2Constructor();
-        var participant = new RemoteParticipantV2({ sid: makeSid() });
-        var test = makeTest();
-        var participantConnected;
+        const RemoteParticipantV2 = makeRemoteParticipantV2Constructor();
+        const participant = new RemoteParticipantV2({ sid: makeSid() });
+        const test = makeTest();
+        let participantConnected;
         test.room.once('participantConnected', participant => participantConnected = participant);
         test.room.connectParticipant(participant);
         assert.equal(
@@ -270,14 +270,14 @@ describe('RoomV2', () => {
   describe('#disconnect, called when the RoomV2 .state is', () => {
     context('"connected"', () => {
       it('returns true', () => {
-        var test = makeTest();
+        const test = makeTest();
         assert.equal(
           true,
           test.room.disconnect());
       });
 
       it('sets the .state to "disconnected"', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.room.disconnect();
         assert.equal(
           'disconnected',
@@ -285,8 +285,8 @@ describe('RoomV2', () => {
       });
 
       it('emits the "stateChanged" event with the new state "disconnected"', () => {
-        var test = makeTest();
-        var newState;
+        const test = makeTest();
+        let newState;
         test.room.once('stateChanged', state => newState = state);
         test.room.disconnect();
         assert.equal(
@@ -295,19 +295,19 @@ describe('RoomV2', () => {
       });
 
       it('calls .close on the PeerConnectionManager', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.room.disconnect();
         assert(test.peerConnectionManager.close.calledOnce);
       });
 
       it('calls .disconnect on the Transport', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.room.disconnect();
         assert(test.transport.disconnect.calledOnce);
       });
 
       it('does not call .disconnect on any connected ParticipantV2\'s', () => {
-        var test = makeTest({
+        const test = makeTest({
           participants: [
             { sid: makeSid() },
             { sid: makeSid() }
@@ -320,7 +320,7 @@ describe('RoomV2', () => {
       });
 
       it('does not remove any ParticipantV2\'s from the RoomV2\'s .participants Map', () => {
-        var test = makeTest({
+        const test = makeTest({
           participants: [
             { sid: makeSid() },
             { sid: makeSid() }
@@ -335,22 +335,22 @@ describe('RoomV2', () => {
       });
 
       it('does not emit any "participantDisconnected" events', () => {
-        var test = makeTest({
+        const test = makeTest({
           participants: [
             { sid: makeSid() },
             { sid: makeSid() }
           ]
         });
-        var participantDisconnected = false;
+        let participantDisconnected;
         test.room.once('participantDisconnected', () => participantDisconnected = true);
         test.room.disconnect();
         assert(!participantDisconnected);
       });
 
       it('should stop the periodic calls to .publishEvent on the underlying Transport', async () => {
-        var publishEventCallCount;
-        var test = makeTest({ statsPublishIntervalMs: 50 });
-        var wait = ms => new Promise(resolve => setTimeout(resolve, ms));
+        let publishEventCallCount;
+        const test = makeTest({ statsPublishIntervalMs: 50 });
+        const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
 
         await wait(175);
         publishEventCallCount = test.transport.publishEvent.callCount;
@@ -363,7 +363,7 @@ describe('RoomV2', () => {
 
     context('"disconnected"', () => {
       it('returns false', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.room.disconnect();
         assert.equal(
           false,
@@ -371,7 +371,7 @@ describe('RoomV2', () => {
       });
 
       it('the .state remains "disconnected"', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.room.disconnect();
         test.room.disconnect();
         assert.equal(
@@ -380,23 +380,23 @@ describe('RoomV2', () => {
       });
 
       it('does not emit the "stateChanged" event', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.room.disconnect();
-        var stateChanged = false;
+        let stateChanged;
         test.room.once('stateChanged', () => stateChanged = true);
         test.room.disconnect();
         assert(!stateChanged);
       });
 
       it('does not call .disconnect on the Transport', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.room.disconnect();
         test.room.disconnect();
         assert(!test.transport.disconnect.calledTwice);
       });
 
       it('does not call .disconnect on any connected ParticipantV2\'s', () => {
-        var test = makeTest({
+        const test = makeTest({
           participants: [
             { sid: makeSid() },
             { sid: makeSid() }
@@ -410,7 +410,7 @@ describe('RoomV2', () => {
       });
 
       it('does not remove any ParticipantV2\'s from the RoomV2\'s .participants Map', () => {
-        var test = makeTest({
+        const test = makeTest({
           participants: [
             { sid: makeSid() },
             { sid: makeSid() }
@@ -426,14 +426,14 @@ describe('RoomV2', () => {
       });
 
       it('does not emit any "participantDisconnected" events', () => {
-        var test = makeTest({
+        const test = makeTest({
           participants: [
             { sid: makeSid() },
             { sid: makeSid() }
           ]
         });
         test.room.disconnect();
-        var participantDisconnected = false;
+        let participantDisconnected;
         test.room.once('participantDisconnected', () => participantDisconnected = true);
         test.room.disconnect();
         assert(!participantDisconnected);
@@ -444,7 +444,7 @@ describe('RoomV2', () => {
   describe('"participantDisconnected" event', () => {
     context('when a connected ParticipantV2 emits a "stateChanged" event with a new state "disconnected"', () => {
       it('removes the ParticipantV2 from the RoomV2\'s .participants Map', () => {
-        var test = makeTest({
+        const test = makeTest({
           participants: [
             { sid: makeSid() }
           ]
@@ -454,12 +454,12 @@ describe('RoomV2', () => {
       });
 
       it('emits the "participantDisconnected" event with the ParticipantV2', () => {
-        var test = makeTest({
+        const test = makeTest({
           participants: [
             { sid: makeSid() }
           ]
         });
-        var participantDisconnected;
+        let participantDisconnected;
         test.room.once('participantDisconnected', participant => participantDisconnected = participant);
         test.participantV2s[0].emit('stateChanged', 'disconnected');
         assert.equal(
@@ -512,8 +512,8 @@ describe('RoomV2', () => {
 
     context('"trackAdded" event', () => {
       it('calls .setMediaStreamTracksAndDataTrackSenders with the LocalParticipantSignaling\'s LocalTrackSignalings\' MediaStreamTracks on the PeerConnectionManager', async () => {
-        var track = makeTrack();
-        var test = makeTest({
+        const track = makeTrack();
+        const test = makeTest({
           tracks: [track]
         });
         test.localParticipant.emit('trackAdded', track);
@@ -523,8 +523,8 @@ describe('RoomV2', () => {
       });
 
       it('calls .update on the LocalParticipantSignaling', async () => {
-        var track = makeTrack();
-        var test = makeTest({
+        const track = makeTrack();
+        const test = makeTest({
           tracks: [track]
         });
         test.localParticipant.emit('trackAdded', track);
@@ -533,8 +533,8 @@ describe('RoomV2', () => {
       });
 
       it('calls .publish on the Transport with the LocalparticipantSignaling state', async () => {
-        var track = makeTrack();
-        var test = makeTest({
+        const track = makeTrack();
+        const test = makeTest({
           tracks: [track]
         });
         test.localParticipant.emit('trackAdded', track);
@@ -551,8 +551,8 @@ describe('RoomV2', () => {
 
     context('"trackRemoved" event', () => {
       it('calls .setMediaStreamTracksAndDataTrackSenders with the LocalParticipantSignaling\'s LocalTrackSignalings\' MediaStreams on the PeerConnectionManager', async () => {
-        var track = makeTrack();
-        var test = makeTest({
+        const track = makeTrack();
+        const test = makeTest({
           tracks: [track]
         });
         test.localParticipant.emit('trackRemoved', track);
@@ -563,8 +563,8 @@ describe('RoomV2', () => {
       });
 
       it('calls .update on the LocalParticipantSignaling', async () => {
-        var track = makeTrack();
-        var test = makeTest({
+        const track = makeTrack();
+        const test = makeTest({
           tracks: [track]
         });
         test.localParticipant.emit('trackRemoved', track);
@@ -573,8 +573,8 @@ describe('RoomV2', () => {
       });
 
       it('calls .publish on the Transport with the LocalParticipantSignaling state', async () => {
-        var track = makeTrack();
-        var test = makeTest({
+        const track = makeTrack();
+        const test = makeTest({
           tracks: [track]
         });
         test.localParticipant.emit('trackRemoved', track);
@@ -592,8 +592,8 @@ describe('RoomV2', () => {
     context('when an added TrackV2 emits an "updated" event in a new state', () => {
       context('with .isEnabled set to false', () => {
         it('calls .publish on the Transport with the LocalParticipantSignaling state', () => {
-          var track = makeTrack();
-          var test = makeTest({
+          const track = makeTrack();
+          const test = makeTest({
             tracks: [track]
           });
           track.disable();
@@ -609,8 +609,8 @@ describe('RoomV2', () => {
 
       context('with .isEnabled set to true', () => {
         it('calls .publish on the Transport with the LocalParticipantSignaling state', () => {
-          var track = makeTrack();
-          var test = makeTest({
+          const track = makeTrack();
+          const test = makeTest({
             tracks: [track]
           });
           track.enable();
@@ -628,8 +628,8 @@ describe('RoomV2', () => {
     context('when a removed TrackV2 emits an "updated" event in a new state', () => {
       context('with .isEnabled set to false"', () => {
         it('does not call .publish on the Transport', () => {
-          var track = makeTrack();
-          var test = makeTest({
+          const track = makeTrack();
+          const test = makeTest({
             tracks: [track]
           });
           test.localParticipant.emit('trackRemoved', track);
@@ -640,8 +640,8 @@ describe('RoomV2', () => {
 
       context('with .isEnabled set to true', () => {
         it('does not call .publish on the Transport', () => {
-          var track = makeTrack();
-          var test = makeTest({
+          const track = makeTrack();
+          const test = makeTest({
             tracks: [track]
           });
           test.localParticipant.emit('trackRemoved', track);
@@ -655,7 +655,7 @@ describe('RoomV2', () => {
   describe('PeerConnectionManager', () => {
     context('when the PeerConnectionManager emits a "description" event', () => {
       it('calls .publish on the Transport with the PeerConnectionManager\'s new description', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.peerConnectionManager.emit('description', { fizz: 'buzz' });
         assert.deepEqual(
           {
@@ -672,7 +672,7 @@ describe('RoomV2', () => {
 
     context('when the PeerConnectionManager emits a "candidates" event', () => {
       it('calls .publish on the Transport with the PeerConnectionManager\'s new candidates', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.peerConnectionManager.emit('candidates', { fizz: 'buzz' });
         assert.deepEqual(
           {
@@ -691,13 +691,13 @@ describe('RoomV2', () => {
       context('never been used before', () => {
         context('before the getMediaStreamTrackOrDataTrackTransceiver function passed to RemoteParticipantV2\'s is called with the MediaStreamTrack\'s ID', () => {
           it('calling getMediaStreamTrackOrDataTrackTransceiver resolves to the MediaStreamTrack', () => {
-            var test = makeTest({
+            const test = makeTest({
               participants: [
                 { sid: makeSid() }
               ]
             });
-            var id = makeId();
-            var mediaStreamTrack = { id: id };
+            const id = makeId();
+            const mediaStreamTrack = { id: id };
             test.peerConnectionManager.emit('trackAdded', mediaStreamTrack);
             return test.participantV2s[0].getMediaStreamTrackOrDataTrackTransceiver(id).then(track => {
               assert.equal(mediaStreamTrack, track);
@@ -707,14 +707,14 @@ describe('RoomV2', () => {
 
         context('after the getMediaStreamTrackOrDataTrackTransceiver function passed to RemoteParticipantV2\'s is called with the MediaStreamTrack\'s ID', () => {
           it('calling getMediaStreamTrackOrDataTrackTransceiver resolves to the MediaStreamTrack', () => {
-            var test = makeTest({
+            const test = makeTest({
               participants: [
                 { sid: makeSid() }
               ]
             });
-            var id = makeId();
-            var mediaStreamTrack = { id: id };
-            var promise = test.participantV2s[0].getMediaStreamTrackOrDataTrackTransceiver(id);
+            const id = makeId();
+            const mediaStreamTrack = { id: id };
+            const promise = test.participantV2s[0].getMediaStreamTrackOrDataTrackTransceiver(id);
             test.peerConnectionManager.emit('trackAdded', mediaStreamTrack);
             return promise.then(track => {
               assert.equal(mediaStreamTrack, track);
@@ -726,15 +726,15 @@ describe('RoomV2', () => {
       context('been used before', () => {
         context('before the getMediaStreamTrackOrDataTrackTransceiver function passed to RemoteParticipantV2\'s is called with the MediaStreamTrack\'s ID', () => {
           it('calling getMediaStreamTrackOrDataTrackTransceiver resolves to the MediaStreamTrack', () => {
-            var test = makeTest({
+            const test = makeTest({
               participants: [
                 { sid: makeSid() }
               ]
             });
 
-            var id = makeId();
-            var mediaStreamTrack1 = { id: id };
-            var mediaStreamTrack2 = { id: id };
+            const id = makeId();
+            const mediaStreamTrack1 = { id: id };
+            const mediaStreamTrack2 = { id: id };
 
             // First usage
             test.peerConnectionManager.emit('trackAdded', mediaStreamTrack1);
@@ -751,18 +751,18 @@ describe('RoomV2', () => {
 
         context('after the getMediaStreamTrackOrDataTrackTransceiver function passed to RemoteParticipantV2\'s is called with the MediaStreamTrack\'s ID', () => {
           it('calling getMediaStreamTrackOrDataTrackTransceiver resolves to the MediaStreamTrack', () => {
-            var test = makeTest({
+            const test = makeTest({
               participants: [
                 { sid: makeSid() }
               ]
             });
 
-            var id = makeId();
-            var mediaStreamTrack1 = { id: id };
-            var mediaStreamTrack2 = { id: id };
+            const id = makeId();
+            const mediaStreamTrack1 = { id: id };
+            const mediaStreamTrack2 = { id: id };
 
             // First usage
-            var promise = test.participantV2s[0].getMediaStreamTrackOrDataTrackTransceiver(id);
+            let promise = test.participantV2s[0].getMediaStreamTrackOrDataTrackTransceiver(id);
             test.peerConnectionManager.emit('trackAdded', mediaStreamTrack1);
             return promise.then(pair => {
 
@@ -782,7 +782,7 @@ describe('RoomV2', () => {
   describe('when the Transport emits an "message" event containing Room state', () => {
     context('when the .name changes', () => {
       it('the .name remains the same', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.transport.emit('message', {
           name: makeName(),
           participants: [],
@@ -796,7 +796,7 @@ describe('RoomV2', () => {
 
     context('when the .sid changes', () => {
       it('the .sid remains the same', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.transport.emit('message', {
           participants: [],
           peer_connections: [],
@@ -810,10 +810,10 @@ describe('RoomV2', () => {
 
     context('.participant', () => {
       it('should update the newly published LocalTrackV2s with their corresponding SIDs', () => {
-        var id = makeId();
-        var sid = makeSid();
-        var test = makeTest();
-        var track = makeTrack({ id });
+        const id = makeId();
+        const sid = makeSid();
+        const test = makeTest();
+        const track = makeTrack({ id });
 
         test.room.localParticipant.tracks.push(track);
         test.transport.emit('message', {
@@ -838,8 +838,8 @@ describe('RoomV2', () => {
       context('when .participants includes a new Participant state', () => {
         context('and the Participant state\'s .state is "connected"', () => {
           it('constructs a new ParticipantV2 with the Participant state', () => {
-            var test = makeTest();
-            var sid = makeParticipantSid();
+            const test = makeTest();
+            const sid = makeParticipantSid();
             test.transport.emit('message', {
               participants: [
                 { sid: sid }
@@ -852,8 +852,8 @@ describe('RoomV2', () => {
           });
 
           it('adds the newly-constructed ParticipantV2 to the RoomV2\'s .participants Map', () => {
-            var test = makeTest();
-            var sid = makeParticipantSid();
+            const test = makeTest();
+            const sid = makeParticipantSid();
             test.transport.emit('message', {
               participants: [
                 { sid: sid }
@@ -866,9 +866,9 @@ describe('RoomV2', () => {
           });
 
           it('emits the "participantConnected" event with the newly-constructed ParticipantV2', () => {
-            var test = makeTest();
-            var sid = makeParticipantSid();
-            var participantConnected;
+            const test = makeTest();
+            const sid = makeParticipantSid();
+            let participantConnected;
             test.room.once('participantConnected', participant => participantConnected = participant);
             test.transport.emit('message', {
               participants: [
@@ -882,8 +882,8 @@ describe('RoomV2', () => {
           });
 
           it('calls .update with the Participant state on the newly-constructed ParticipantV2', () => {
-            var test = makeTest();
-            var sid = makeParticipantSid();
+            const test = makeTest();
+            const sid = makeParticipantSid();
             test.transport.emit('message', {
               participants: [
                 { sid: sid, fizz: 'buzz' }
@@ -898,8 +898,8 @@ describe('RoomV2', () => {
 
         context('and the Participant state\'s .state is "disconnected"', () => {
           it('constructs a new ParticipantV2 with the Participant state', () => {
-            var test = makeTest();
-            var sid = makeParticipantSid();
+            const test = makeTest();
+            const sid = makeParticipantSid();
             test.transport.emit('message', {
               participants: [
                 { sid: sid, state: 'disconnected' }
@@ -912,8 +912,8 @@ describe('RoomV2', () => {
           });
 
           it('does not add the newly-constructed ParticipantV2 to the RoomV2\'s .participants Map', () => {
-            var test = makeTest();
-            var sid = makeParticipantSid();
+            const test = makeTest();
+            const sid = makeParticipantSid();
             test.transport.emit('message', {
               participants: [
                 { sid: sid, state: 'disconnected' }
@@ -924,9 +924,9 @@ describe('RoomV2', () => {
           });
 
           it('does not emit a "participantConnected" event', () => {
-            var test = makeTest();
-            var sid = makeParticipantSid();
-            var participantConnected;
+            const test = makeTest();
+            const sid = makeParticipantSid();
+            let participantConnected;
             test.room.once('participantConnected', () => participantConnected = true);
             test.transport.emit('message', {
               participants: [
@@ -941,8 +941,8 @@ describe('RoomV2', () => {
 
       context('when .participants includes a Participant state for a connected ParticipantV2', () => {
         it('calls .update with the Participant state on the ParticipantV2', () => {
-          var sid = makeParticipantSid();
-          var test = makeTest({
+          const sid = makeParticipantSid();
+          const test = makeTest({
             participants: [
               { sid: sid }
             ]
@@ -961,8 +961,8 @@ describe('RoomV2', () => {
 
       context('when .participants includes a Participant state for a disconnected ParticipantV2', () => {
         it('does not construct a new ParticipantV2 with the Participant state', () => {
-          var sid = makeParticipantSid();
-          var test = makeTest({
+          const sid = makeParticipantSid();
+          const test = makeTest({
             participants: [
               { sid: sid }
             ]
@@ -980,8 +980,8 @@ describe('RoomV2', () => {
         });
 
         it('does not call .update with the Participant state on the disconnected ParticipantV2', () => {
-          var sid = makeParticipantSid();
-          var test = makeTest({
+          const sid = makeParticipantSid();
+          const test = makeTest({
             participants: [
               { sid: sid }
             ]
@@ -999,8 +999,8 @@ describe('RoomV2', () => {
 
       context('when .participants omits a Participant state for a connected ParticipantV2', () => {
         it('does not call .disconnect on the ParticipantV2', () => {
-          var sid = makeParticipantSid();
-          var test = makeTest({
+          const sid = makeParticipantSid();
+          const test = makeTest({
             participants: [
               { sid: sid }
             ]
@@ -1013,8 +1013,8 @@ describe('RoomV2', () => {
         });
 
         it('the ParticipantV2 remains in the RoomV2\'s .participants Map', () => {
-          var sid = makeParticipantSid();
-          var test = makeTest({
+          const sid = makeParticipantSid();
+          const test = makeTest({
             participants: [
               { sid: sid }
             ]
@@ -1029,13 +1029,13 @@ describe('RoomV2', () => {
         });
 
         it('does not emit a "participantDisconnected" event', () => {
-          var sid = makeParticipantSid();
-          var test = makeTest({
+          const sid = makeParticipantSid();
+          const test = makeTest({
             participants: [
               { sid: sid }
             ]
           });
-          var participantDisconnected = false;
+          let participantDisconnected;
           test.room.once('participantDisconnected', () => participantDisconnected = true);
           test.transport.emit('message', {
             participants: [],
@@ -1048,7 +1048,7 @@ describe('RoomV2', () => {
 
     context('.peer_connections', () => {
       it('calls .update with the .peer_connections on the PeerConnectionManager', () => {
-        var test = makeTest();
+        const test = makeTest();
         test.transport.emit('message', {
           participants: [],
           peer_connections: { fizz: 'buzz' }
@@ -1074,16 +1074,16 @@ function makeName() {
 }
 
 function makeSid() {
-  var sid = 'RM';
-  for (var i = 0; i < 32; i++) {
+  let sid = 'RM';
+  for (let i = 0; i < 32; i++) {
     sid += 'abcdef0123456789'.split('')[Math.floor(Math.random() * 16)];
   }
   return sid;
 }
 
 function makeParticipantSid() {
-  var sid = 'PA';
-  for (var i = 0; i < 32; i++) {
+  let sid = 'PA';
+  for (let i = 0; i < 32; i++) {
     sid += 'abcdef0123456789'.split('')[Math.floor(Math.random() * 16)];
   }
   return sid;
@@ -1143,7 +1143,7 @@ function makeRoomV2(options) {
 }
 
 function makeTransport(options) {
-  var transport = new EventEmitter();
+  const transport = new EventEmitter();
   transport.disconnect = sinon.spy(() => {});
   transport.publish = sinon.spy(() => {});
   transport.publishEvent = sinon.spy(() => {});
@@ -1152,7 +1152,7 @@ function makeTransport(options) {
 };
 
 function makePeerConnectionManager(options) {
-  var peerConnectionManager = new EventEmitter();
+  const peerConnectionManager = new EventEmitter();
   peerConnectionManager.close = sinon.spy(() => {});
   peerConnectionManager.dequeue = sinon.spy(() => {});
   peerConnectionManager.setMediaStreamTracksAndDataTrackSenders = sinon.spy(() => {});
@@ -1214,7 +1214,7 @@ RoomStateBuilder.prototype.setParticipants = function setParticipants(participan
 };
 
 function makeLocalParticipant(options) {
-  var localParticipant = new EventEmitter();
+  const localParticipant = new EventEmitter();
   localParticipant.sid = makeSid();
   localParticipant.identity = makeIdentity();
   localParticipant.revision = 0;
@@ -1237,7 +1237,7 @@ function makeLocalParticipant(options) {
 }
 
 function makeTrack(options) {
-  var track = new EventEmitter();
+  const track = new EventEmitter();
   options = options || {};
   track.id = options.id || makeId();
   track.sid = null;

--- a/test/unit/spec/signaling/v2/room.js
+++ b/test/unit/spec/signaling/v2/room.js
@@ -1,10 +1,11 @@
 'use strict';
 
-var assert = require('assert');
-var EventEmitter = require('events').EventEmitter;
-var inherits = require('util').inherits;
-var RoomV2 = require('../../../../../lib/signaling/v2/room');
-var sinon = require('sinon');
+const assert = require('assert');
+const { EventEmitter }  = require('events');
+const { inherits } = require('util');
+const sinon = require('sinon');
+
+const RoomV2 = require('../../../../../lib/signaling/v2/room');
 
 describe('RoomV2', () => {
   // RoomV2

--- a/test/unit/spec/signaling/v2/room.js
+++ b/test/unit/spec/signaling/v2/room.js
@@ -61,32 +61,34 @@ describe('RoomV2', () => {
 
     it('should periodically call .publishEvent on the underlying Transport', async () => {
       const test = makeTest({ statsPublishIntervalMs: 50 });
-      const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
+      function wait(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+      }
       const expectedArgs = [
         [
           'quality',
           'stats-report',
           {
-            audioTrackStats: [ { bar: 'baz' } ],
-            localAudioTrackStats: [ { zee: 'foo' } ],
-            localVideoTrackStats: [ { foo: 'bar' } ],
+            audioTrackStats: [{ bar: 'baz' }],
+            localAudioTrackStats: [{ zee: 'foo' }],
+            localVideoTrackStats: [{ foo: 'bar' }],
             participantSid: test.localParticipant.sid,
             peerConnectionId: 'foo',
             roomSid: test.sid,
-            videoTrackStats: [ { baz: 'zee' } ]
+            videoTrackStats: [{ baz: 'zee' }]
           }
         ],
         [
           'quality',
           'stats-report',
           {
-            audioTrackStats: [ { xyz: 'uvw' } ],
-            localAudioTrackStats: [ { abc: 'def' } ],
-            localVideoTrackStats: [ { ghi: 'jkl' } ],
+            audioTrackStats: [{ xyz: 'uvw' }],
+            localAudioTrackStats: [{ abc: 'def' }],
+            localVideoTrackStats: [{ ghi: 'jkl' }],
             participantSid: test.localParticipant.sid,
             peerConnectionId: 'bar',
             roomSid: test.sid,
-            videoTrackStats: [ { pqr: 'mno' } ]
+            videoTrackStats: [{ pqr: 'mno' }]
           }
         ]
       ];
@@ -146,6 +148,7 @@ describe('RoomV2', () => {
     context('.peer_connections', () => {
       it('calls .update with the .peer_connections on the PeerConnectionManager', () => {
         const test = makeTest({
+          // eslint-disable-next-line camelcase
           peer_connections: { fizz: 'buzz' }
         });
         assert.deepEqual(
@@ -226,8 +229,8 @@ describe('RoomV2', () => {
             { sid: makeSid() }
           ]
         });
-        const participantConnected = false;
-        test.room.once('participantConnected', () => participantConnected = true);
+        let participantConnected = false;
+        test.room.once('participantConnected', () => { participantConnected = true; });
         test.room.connectParticipant(test.participantV2s[0]);
         assert(!participantConnected);
       });
@@ -258,7 +261,7 @@ describe('RoomV2', () => {
         const participant = new RemoteParticipantV2({ sid: makeSid() });
         const test = makeTest();
         let participantConnected;
-        test.room.once('participantConnected', participant => participantConnected = participant);
+        test.room.once('participantConnected', participant => { participantConnected = participant; });
         test.room.connectParticipant(participant);
         assert.equal(
           participant,
@@ -287,7 +290,7 @@ describe('RoomV2', () => {
       it('emits the "stateChanged" event with the new state "disconnected"', () => {
         const test = makeTest();
         let newState;
-        test.room.once('stateChanged', state => newState = state);
+        test.room.once('stateChanged', state => { newState = state; });
         test.room.disconnect();
         assert.equal(
           'disconnected',
@@ -342,7 +345,7 @@ describe('RoomV2', () => {
           ]
         });
         let participantDisconnected;
-        test.room.once('participantDisconnected', () => participantDisconnected = true);
+        test.room.once('participantDisconnected', () => { participantDisconnected = true; });
         test.room.disconnect();
         assert(!participantDisconnected);
       });
@@ -350,7 +353,9 @@ describe('RoomV2', () => {
       it('should stop the periodic calls to .publishEvent on the underlying Transport', async () => {
         let publishEventCallCount;
         const test = makeTest({ statsPublishIntervalMs: 50 });
-        const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
+        function wait(ms) {
+          return new Promise(resolve => setTimeout(resolve, ms));
+        }
 
         await wait(175);
         publishEventCallCount = test.transport.publishEvent.callCount;
@@ -383,7 +388,7 @@ describe('RoomV2', () => {
         const test = makeTest();
         test.room.disconnect();
         let stateChanged;
-        test.room.once('stateChanged', () => stateChanged = true);
+        test.room.once('stateChanged', () => { stateChanged = true; });
         test.room.disconnect();
         assert(!stateChanged);
       });
@@ -434,7 +439,7 @@ describe('RoomV2', () => {
         });
         test.room.disconnect();
         let participantDisconnected;
-        test.room.once('participantDisconnected', () => participantDisconnected = true);
+        test.room.once('participantDisconnected', () => { participantDisconnected = true; });
         test.room.disconnect();
         assert(!participantDisconnected);
       });
@@ -460,7 +465,7 @@ describe('RoomV2', () => {
           ]
         });
         let participantDisconnected;
-        test.room.once('participantDisconnected', participant => participantDisconnected = participant);
+        test.room.once('participantDisconnected', participant => { participantDisconnected = participant; });
         test.participantV2s[0].emit('stateChanged', 'disconnected');
         assert.equal(
           test.participantV2s[0],
@@ -473,7 +478,7 @@ describe('RoomV2', () => {
     context('multiple Track events in the same tick', () => {
       context('two "trackAdded" events', () => {
         it('should call .setMediaStreamTracksAndDataTrackSenders once on the underlying PeerConnectionManager with the corresponding MediaStreamTracks', async () => {
-          const tracks = [ makeTrack(), makeTrack() ];
+          const tracks = [makeTrack(), makeTrack()];
           const test = makeTest({ tracks });
           tracks.forEach(track => test.localParticipant.emit('trackAdded', track));
           await new Promise(resolve => setTimeout(resolve));
@@ -486,26 +491,26 @@ describe('RoomV2', () => {
 
     context('"trackAdded" event followed by "trackRemoved" event', () => {
       it('should call .setMediaStreamTracksAndDataTrackSenders once on the underlying PeerConnectionManager with the corresponding MediaStreamTracks', async () => {
-        const [ track, addedTrack, removedTrack ] = [ makeTrack(), makeTrack(), makeTrack() ];
-        const test = makeTest({ tracks: [ track, addedTrack ] });
+        const [track, addedTrack, removedTrack] = [makeTrack(), makeTrack(), makeTrack()];
+        const test = makeTest({ tracks: [track, addedTrack] });
         test.localParticipant.emit('trackAdded', addedTrack);
         test.localParticipant.emit('trackRemoved', removedTrack);
         await new Promise(resolve => setTimeout(resolve));
         sinon.assert.callCount(test.peerConnectionManager.setMediaStreamTracksAndDataTrackSenders, 1);
-        assert.deepEqual([ track.mediaStreamTrackOrDataTrackTransceiver, addedTrack.mediaStreamTrackOrDataTrackTransceiver ],
+        assert.deepEqual([track.mediaStreamTrackOrDataTrackTransceiver, addedTrack.mediaStreamTrackOrDataTrackTransceiver],
           test.peerConnectionManager.setMediaStreamTracksAndDataTrackSenders.args[0][0]);
       });
     });
 
     context('two "trackRemoved" events', () => {
       it('should call .setMediaStreamTracksAndDataTrackSenders once on the underlying PeerConnectionManager with the corresponding MediaStreamTracks', async () => {
-        const [ track, removedTrack1, removedTrack2 ] = [ makeTrack(), makeTrack(), makeTrack() ];
-        const test = makeTest({ tracks: [ track ] });
+        const [track, removedTrack1, removedTrack2] = [makeTrack(), makeTrack(), makeTrack()];
+        const test = makeTest({ tracks: [track] });
         test.localParticipant.emit('trackRemoved', removedTrack1);
         test.localParticipant.emit('trackRemoved', removedTrack2);
         await new Promise(resolve => setTimeout(resolve));
         sinon.assert.callCount(test.peerConnectionManager.setMediaStreamTracksAndDataTrackSenders, 1);
-        assert.deepEqual([ track.mediaStreamTrackOrDataTrackTransceiver ],
+        assert.deepEqual([track.mediaStreamTrackOrDataTrackTransceiver],
           test.peerConnectionManager.setMediaStreamTracksAndDataTrackSenders.args[0][0]);
       });
     });
@@ -662,6 +667,7 @@ describe('RoomV2', () => {
             participant: {
               revision: 0
             },
+            // eslint-disable-next-line camelcase
             peer_connections: [
               { fizz: 'buzz' }
             ]
@@ -679,6 +685,7 @@ describe('RoomV2', () => {
             participant: {
               revision: 0
             },
+            // eslint-disable-next-line camelcase
             peer_connections: [
               { fizz: 'buzz' }
             ]
@@ -764,7 +771,7 @@ describe('RoomV2', () => {
             // First usage
             let promise = test.participantV2s[0].getMediaStreamTrackOrDataTrackTransceiver(id);
             test.peerConnectionManager.emit('trackAdded', mediaStreamTrack1);
-            return promise.then(pair => {
+            return promise.then(() => {
 
               // Second usage
               promise = test.participantV2s[0].getMediaStreamTrackOrDataTrackTransceiver(id);
@@ -786,6 +793,7 @@ describe('RoomV2', () => {
         test.transport.emit('message', {
           name: makeName(),
           participants: [],
+          // eslint-disable-next-line camelcase
           peer_connections: []
         });
         assert.equal(
@@ -799,6 +807,7 @@ describe('RoomV2', () => {
         const test = makeTest();
         test.transport.emit('message', {
           participants: [],
+          // eslint-disable-next-line camelcase
           peer_connections: [],
           sid: makeSid()
         });
@@ -844,6 +853,7 @@ describe('RoomV2', () => {
               participants: [
                 { sid: sid }
               ],
+              // eslint-disable-next-line camelcase
               peer_connections: []
             });
             assert.equal(
@@ -858,6 +868,7 @@ describe('RoomV2', () => {
               participants: [
                 { sid: sid }
               ],
+              // eslint-disable-next-line camelcase
               peer_connections: []
             });
             assert.equal(
@@ -869,11 +880,12 @@ describe('RoomV2', () => {
             const test = makeTest();
             const sid = makeParticipantSid();
             let participantConnected;
-            test.room.once('participantConnected', participant => participantConnected = participant);
+            test.room.once('participantConnected', participant => { participantConnected = participant; });
             test.transport.emit('message', {
               participants: [
                 { sid: sid }
               ],
+              // eslint-disable-next-line camelcase
               peer_connections: []
             });
             assert.equal(
@@ -888,6 +900,7 @@ describe('RoomV2', () => {
               participants: [
                 { sid: sid, fizz: 'buzz' }
               ],
+              // eslint-disable-next-line camelcase
               peer_connections: []
             });
             assert.deepEqual(
@@ -904,6 +917,7 @@ describe('RoomV2', () => {
               participants: [
                 { sid: sid, state: 'disconnected' }
               ],
+              // eslint-disable-next-line camelcase
               peer_connections: []
             });
             assert.equal(
@@ -918,6 +932,7 @@ describe('RoomV2', () => {
               participants: [
                 { sid: sid, state: 'disconnected' }
               ],
+              // eslint-disable-next-line camelcase
               peer_connections: []
             });
             assert(!test.room.participants.has(sid));
@@ -927,11 +942,12 @@ describe('RoomV2', () => {
             const test = makeTest();
             const sid = makeParticipantSid();
             let participantConnected;
-            test.room.once('participantConnected', () => participantConnected = true);
+            test.room.once('participantConnected', () => { participantConnected = true; });
             test.transport.emit('message', {
               participants: [
                 { sid: sid, state: 'disconnected' }
               ],
+              // eslint-disable-next-line camelcase
               peer_connections: []
             });
             assert(!participantConnected);
@@ -951,6 +967,7 @@ describe('RoomV2', () => {
             participants: [
               { sid: sid, fizz: 'buzz' }
             ],
+            // eslint-disable-next-line camelcase
             peer_connections: []
           });
           assert.deepEqual(
@@ -972,6 +989,7 @@ describe('RoomV2', () => {
             participants: [
               { sid: sid, fizz: 'buzz' }
             ],
+            // eslint-disable-next-line camelcase
             peer_connections: []
           });
           assert.equal(
@@ -991,6 +1009,7 @@ describe('RoomV2', () => {
             participants: [
               { sid: sid, fizz: 'buzz' }
             ],
+            // eslint-disable-next-line camelcase
             peer_connections: []
           });
           assert(!test.participantV2s[0].update.calledTwice);
@@ -1007,6 +1026,7 @@ describe('RoomV2', () => {
           });
           test.transport.emit('message', {
             participants: [],
+            // eslint-disable-next-line camelcase
             peer_connections: []
           });
           assert(!test.participantV2s[0].disconnect.calledOnce);
@@ -1021,6 +1041,7 @@ describe('RoomV2', () => {
           });
           test.transport.emit('message', {
             participants: [],
+            // eslint-disable-next-line camelcase
             peer_connections: []
           });
           assert.equal(
@@ -1036,9 +1057,10 @@ describe('RoomV2', () => {
             ]
           });
           let participantDisconnected;
-          test.room.once('participantDisconnected', () => participantDisconnected = true);
+          test.room.once('participantDisconnected', () => { participantDisconnected = true; });
           test.transport.emit('message', {
             participants: [],
+            // eslint-disable-next-line camelcase
             peer_connections: []
           });
           assert(!participantDisconnected);
@@ -1051,6 +1073,7 @@ describe('RoomV2', () => {
         const test = makeTest();
         test.transport.emit('message', {
           participants: [],
+          // eslint-disable-next-line camelcase
           peer_connections: { fizz: 'buzz' }
         });
         assert.deepEqual(
@@ -1089,10 +1112,6 @@ function makeParticipantSid() {
   return sid;
 }
 
-function makeRevision() {
-  return Math.floor(Math.random() * 101);
-}
-
 function makeTest(options) {
   options = options || {};
 
@@ -1107,7 +1126,7 @@ function makeTest(options) {
   options.peerConnectionManager = options.peerConnectionManager || makePeerConnectionManager(options);
   options.transport = options.transport || makeTransport(options);
 
-  options.room = options.room || makeRoomV2(options);
+  const room = options.room = options.room || makeRoomV2(options);
 
   options.state = function state() {
     return new RoomStateBuilder(room);
@@ -1142,16 +1161,16 @@ function makeRoomV2(options) {
   return new RoomV2(options.localParticipant, options, options.transport, options.peerConnectionManager, options);
 }
 
-function makeTransport(options) {
+function makeTransport() {
   const transport = new EventEmitter();
   transport.disconnect = sinon.spy(() => {});
   transport.publish = sinon.spy(() => {});
   transport.publishEvent = sinon.spy(() => {});
   transport.sync = sinon.spy(() => {});
   return transport;
-};
+}
 
-function makePeerConnectionManager(options) {
+function makePeerConnectionManager() {
   const peerConnectionManager = new EventEmitter();
   peerConnectionManager.close = sinon.spy(() => {});
   peerConnectionManager.dequeue = sinon.spy(() => {});
@@ -1159,17 +1178,17 @@ function makePeerConnectionManager(options) {
   peerConnectionManager.getRemoteMediaStreamTracksAndDataTrackReceivers = sinon.spy(() => []);
 
   peerConnectionManager.getStats = () => Promise.resolve([{
-    localAudioTrackStats: [ { zee: 'foo' } ],
-    localVideoTrackStats: [ { foo: 'bar' } ],
+    localAudioTrackStats: [{ zee: 'foo' }],
+    localVideoTrackStats: [{ foo: 'bar' }],
     peerConnectionId: 'foo',
-    remoteAudioTrackStats: [ { bar: 'baz' } ],
-    remoteVideoTrackStats: [ { baz: 'zee' } ]
+    remoteAudioTrackStats: [{ bar: 'baz' }],
+    remoteVideoTrackStats: [{ baz: 'zee' }]
   }, {
-    localAudioTrackStats: [ { abc: 'def' } ],
-    localVideoTrackStats: [ { ghi: 'jkl' } ],
+    localAudioTrackStats: [{ abc: 'def' }],
+    localVideoTrackStats: [{ ghi: 'jkl' }],
     peerConnectionId: 'bar',
-    remoteAudioTrackStats: [ { xyz: 'uvw' } ],
-    remoteVideoTrackStats: [ { pqr: 'mno' } ]
+    remoteAudioTrackStats: [{ xyz: 'uvw' }],
+    remoteVideoTrackStats: [{ pqr: 'mno' }]
   }]);
 
   peerConnectionManager.update = sinon.spy(() => {});
@@ -1180,6 +1199,7 @@ function RoomStateBuilder(room) {
   this.name = room.name;
   this.sid = room.sid;
   this.participants = [];
+  // eslint-disable-next-line camelcase
   this.peer_connections = [];
 }
 

--- a/test/unit/spec/signaling/v2/transport.js
+++ b/test/unit/spec/signaling/v2/transport.js
@@ -17,7 +17,7 @@ const TwilioError = require('../../../../../lib/util/twilioerror');
 
 describe('Transport', () => {
   describe('constructor', () => {
-    var test;
+    let test;
 
     beforeEach(() => {
       test = makeTest();
@@ -67,7 +67,7 @@ describe('Transport', () => {
 
         context('the createMessage function, called when the Transport\'s .state is', () => {
           context('"connected", returns an RSP message that', () => {
-            var message;
+            let message;
 
             beforeEach(() => {
               test.connect();
@@ -92,7 +92,7 @@ describe('Transport', () => {
           });
 
           context('"connecting", returns an RSP message that', () => {
-            var message;
+            let message;
 
             beforeEach(() => {
               message = test.mediaHandler.createMessage();
@@ -116,7 +116,7 @@ describe('Transport', () => {
           });
 
           context('"disconnected", returns an RSP message that', () => {
-            var message;
+            let message;
 
             beforeEach(() => {
               test.transport.disconnect();
@@ -132,7 +132,7 @@ describe('Transport', () => {
           });
 
           context('"syncing", returns an RSP message that', () => {
-            var message;
+            let message;
 
             beforeEach(() => {
               test.connect();
@@ -162,8 +162,8 @@ describe('Transport', () => {
   });
 
   describe('#disconnect, called when the Transport\'s .state is', () => {
-    var test;
-    var ret;
+    let test;
+    let ret;
 
     context('"connected"', () => {
       beforeEach(() => {
@@ -331,12 +331,12 @@ describe('Transport', () => {
   });
 
   describe('#publish, called when the Transport\'s .state is', () => {
-    var test;
-    var ret;
+    let test;
+    let ret;
 
     // NOTE(mroberts): These are used to test .publish in the "connecting" and
     // "syncing" states below.
-    var extraPublishes = [
+    const extraPublishes = [
       {
         participant: {
           revision: 1,
@@ -394,7 +394,7 @@ describe('Transport', () => {
       },
     ];
 
-    var expectedPublish = {
+    const expectedPublish = {
       participant: {
         revision: 2,
         tracks: [
@@ -476,8 +476,9 @@ describe('Transport', () => {
       });
 
       context('when fails with a 5xx error', () => {
-        var test;
-        var sendRequestCallTimes = [];
+        const sendRequestCallTimes = [];
+
+        let test;
 
         beforeEach(() => {
           return new Promise(resolve => {
@@ -654,8 +655,8 @@ describe('Transport', () => {
   });
 
   describe('#publishEvent', () => {
-    var test;
-    var ret;
+    let test;
+    let ret;
 
     before(() => {
       test = makeTest();
@@ -673,8 +674,8 @@ describe('Transport', () => {
   });
 
   describe('#sync, called when the Transport\'s .state is', () => {
-    var test;
-    var ret;
+    let test;
+    let ret;
 
     context('"connected"', () => {
       beforeEach(() => {
@@ -767,7 +768,7 @@ describe('Transport', () => {
   });
 
   describe('the underlying SIP.js Session emits', () => {
-    var test;
+    let test;
 
     beforeEach(() => {
       test = makeTest();
@@ -775,7 +776,7 @@ describe('Transport', () => {
 
     context('an "accepted" event, and the Transport\'s .state is', () => {
       context('"connected", and the request contains an RSP message with type', () => {
-        var eventEmitted;
+        let eventEmitted;
 
         beforeEach(() => {
           test.connect();
@@ -843,12 +844,13 @@ describe('Transport', () => {
 
       context('"connecting", and the request contains an RSP message with type', () => {
         context('"connected"', () => {
-          var message = {
+          const message = {
             type: 'connected',
             foo: 'bar'
           };
-          var connectedEvent;
-          var messageEvent;
+
+          let connectedEvent;
+          let messageEvent;
 
           beforeEach(() => {
             connectedEvent = null;
@@ -874,8 +876,8 @@ describe('Transport', () => {
         });
 
         context('"disconnected"', () => {
-          var connectedEvent;
-          var messageEvent;
+          let connectedEvent;
+          let messageEvent;
 
           beforeEach(() => {
             connectedEvent = false;
@@ -901,8 +903,8 @@ describe('Transport', () => {
         });
 
         context('"error"', () => {
-          var connectedEvent;
-          var messageEvent;
+          let connectedEvent;
+          let messageEvent;
 
           beforeEach(() => {
             connectedEvent = false;
@@ -928,7 +930,7 @@ describe('Transport', () => {
         });
 
         context('"error" with code and message in the response body', () => {
-          var disconnect;
+          let disconnect;
 
           beforeEach(() => {
             disconnect = test.transport.disconnect;
@@ -937,7 +939,7 @@ describe('Transport', () => {
           });
 
           it('calls #disconnect() with a TwilioError', () => {
-            var error = test.transport.disconnect.args[0][0];
+            const error = test.transport.disconnect.args[0][0];
             assert(error instanceof TwilioError);
             assert.equal(error.code, 12345);
             assert.equal(error.message, 'foo bar');
@@ -949,7 +951,7 @@ describe('Transport', () => {
         });
 
         context('"error" with code and message in the response header', () => {
-          var disconnect;
+          let disconnect;
 
           beforeEach(() => {
             disconnect = test.transport.disconnect;
@@ -958,7 +960,7 @@ describe('Transport', () => {
           });
 
           it('calls #disconnect() with a TwilioError', () => {
-            var error = test.transport.disconnect.args[0][0];
+            const error = test.transport.disconnect.args[0][0];
             assert(error instanceof TwilioError);
             assert.equal(error.code, 67890);
             assert.equal(error.message, 'bar baz');
@@ -970,7 +972,7 @@ describe('Transport', () => {
         });
 
         context('"error" with no code or message in either the body or the header', () => {
-          var disconnect;
+          let disconnect;
 
           beforeEach(() => {
             disconnect = test.transport.disconnect;
@@ -979,7 +981,7 @@ describe('Transport', () => {
           });
 
           it('calls #disconnect() with an unknown TwilioError', () => {
-            var error = test.transport.disconnect.args[0][0];
+            const error = test.transport.disconnect.args[0][0];
             assert(error instanceof TwilioError);
             assert.equal(error.code, 0);
             assert.equal(error.message, 'Unknown error');
@@ -991,11 +993,12 @@ describe('Transport', () => {
         });
 
         context('"synced"', () => {
-          var message = {
+          const message = {
             type: 'synced'
           };
-          var connectedEvent;
-          var messageEvent;
+
+          let connectedEvent;
+          let messageEvent;
 
           beforeEach(() => {
             connectedEvent = false;
@@ -1041,11 +1044,12 @@ describe('Transport', () => {
         });
 
         context('"update"', () => {
-          var message = {
+          const message = {
             type: 'update'
           };
-          var connectedEvent;
-          var messageEvent;
+
+          let connectedEvent;
+          let messageEvent;
 
           beforeEach(() => {
             connectedEvent = false;
@@ -1092,8 +1096,8 @@ describe('Transport', () => {
       });
 
       context('"disconnected", and the request contains an RSP message with type', () => {
-        var connectedEvent;
-        var messageEvent;
+        let connectedEvent;
+        let messageEvent;
 
         beforeEach(() => {
           test.receiveRequest({ type: 'disconnected' });
@@ -1196,7 +1200,7 @@ describe('Transport', () => {
       });
 
       context('"syncing", and the request contains an RSP message with type', () => {
-        var eventEmitted;
+        let eventEmitted;
 
         beforeEach(() => {
           test.connect();
@@ -1265,7 +1269,7 @@ describe('Transport', () => {
     });
 
     context('a "failed" event, and the Transport\'s .state is', () => {
-      var evtPayloads = [
+      const evtPayloads = [
         [ ],
         [ { body: '{ "type": "error", "code": 12345 "message": "foo bar" }' } ],
         [ { body: '{ "type": "error", "code": 12345, "message": "foo bar" }' } ],
@@ -1273,8 +1277,9 @@ describe('Transport', () => {
         [ null, 'Request Timeout' ],
         [ null, 'Connection Error' ]
       ];
-      var evtPayloadsIdx = 0;
-      var eventEmitted;
+
+      let evtPayloadsIdx = 0;
+      let eventEmitted;
 
       function setupTest() {
         test.transitions = [];
@@ -1297,7 +1302,7 @@ describe('Transport', () => {
       });
 
       context('"connecting"', () => {
-        var disconnect;
+        let disconnect;
         beforeEach(() => {
           disconnect = test.transport.disconnect;
           if (evtPayloadsIdx > 0) {
@@ -1313,38 +1318,38 @@ describe('Transport', () => {
         });
 
         it('should call #disconnect() with SignalingIncomingMessageInvalidError when event payload has an error body with invalid JSON', () => {
-          var error = test.transport.disconnect.args[0][0];
-          var expectedError = new SignalingIncomingMessageInvalidError();
+          const error = test.transport.disconnect.args[0][0];
+          const expectedError = new SignalingIncomingMessageInvalidError();
           assert(error instanceof SignalingIncomingMessageInvalidError);
           assert.equal(error.code, expectedError.code);
           assert.equal(error.message, expectedError.message);
         });
 
         it('should call #disconnect() with TwilioError when event payload has an error body', () => {
-          var error = test.transport.disconnect.args[0][0];
+          const error = test.transport.disconnect.args[0][0];
           assert(error instanceof TwilioError);
           assert.equal(error.code, 12345);
           assert.equal(error.message, 'foo bar');
         });
 
         it('should call #disconnect() with TwilioError when event payload has an error header', () => {
-          var error = test.transport.disconnect.args[0][0];
+          const error = test.transport.disconnect.args[0][0];
           assert(error instanceof TwilioError);
           assert.equal(error.code, 67890);
           assert.equal(error.message, 'bar baz');
         });
 
         it('should call #disconnect() with TwilioError when cause is "Request Timeout"', () => {
-          var error = test.transport.disconnect.args[0][0];
-          var expectedError = new SignalingConnectionTimeoutError();
+          const error = test.transport.disconnect.args[0][0];
+          const expectedError = new SignalingConnectionTimeoutError();
           assert(error instanceof SignalingConnectionTimeoutError);
           assert.equal(error.code, expectedError.code);
           assert.equal(error.message, expectedError.message);
         });
 
         it('should call #disconnect() with TwilioError when cause is "Connection Error"', () => {
-          var error = test.transport.disconnect.args[0][0];
-          var expectedError = new SignalingConnectionError();
+          const error = test.transport.disconnect.args[0][0];
+          const expectedError = new SignalingConnectionError();
           assert(error instanceof SignalingConnectionError);
           assert.equal(error.code, expectedError.code);
           assert.equal(error.message, expectedError.message);
@@ -1391,10 +1396,11 @@ describe('Transport', () => {
         });
 
         context('"connected"', () => {
-          var message = {
+          const message = {
             type: 'connected'
           };
-          var emittedEvent;
+
+          let emittedEvent;
 
           beforeEach(() => {
             emittedEvent = null;
@@ -1408,7 +1414,7 @@ describe('Transport', () => {
         });
 
         context('"disconnected"', () => {
-          var message = {
+          const message = {
             type: 'disconnected'
           };
 
@@ -1425,7 +1431,7 @@ describe('Transport', () => {
         });
 
         context('"error"', () => {
-          var message = {
+          const message = {
             type: 'error'
           };
 
@@ -1442,7 +1448,7 @@ describe('Transport', () => {
         });
 
         context('"error" with code and message in the response body', () => {
-          var disconnect;
+          let disconnect;
 
           beforeEach(() => {
             disconnect = test.transport.disconnect;
@@ -1451,7 +1457,7 @@ describe('Transport', () => {
           });
 
           it('calls #disconnect() with a TwilioError', () => {
-            var error = test.transport.disconnect.args[0][0];
+            const error = test.transport.disconnect.args[0][0];
             assert(error instanceof TwilioError);
             assert.equal(error.code, 12345);
             assert.equal(error.message, 'foo bar');
@@ -1463,7 +1469,7 @@ describe('Transport', () => {
         });
 
         context('"error" with code and message in the response header', () => {
-          var disconnect;
+          let disconnect;
 
           beforeEach(() => {
             disconnect = test.transport.disconnect;
@@ -1472,7 +1478,7 @@ describe('Transport', () => {
           });
 
           it('calls #disconnect() with a TwilioError', () => {
-            var error = test.transport.disconnect.args[0][0];
+            const error = test.transport.disconnect.args[0][0];
             assert(error instanceof TwilioError);
             assert.equal(error.code, 67890);
             assert.equal(error.message, 'bar baz');
@@ -1484,7 +1490,7 @@ describe('Transport', () => {
         });
 
         context('"error" with no code or message in either the body or the header', () => {
-          var disconnect;
+          let disconnect;
 
           beforeEach(() => {
             disconnect = test.transport.disconnect;
@@ -1493,7 +1499,7 @@ describe('Transport', () => {
           });
 
           it('calls #disconnect() with a unknown TwilioError', () => {
-            var error = test.transport.disconnect.args[0][0];
+            const error = test.transport.disconnect.args[0][0];
             assert(error instanceof TwilioError);
             assert.equal(error.code, 0);
             assert.equal(error.message, 'Unknown error');
@@ -1505,10 +1511,11 @@ describe('Transport', () => {
         });
 
         context('"synced"', () => {
-          var message = {
+          const message = {
             type: 'synced'
           };
-          var emittedEvent;
+
+          let emittedEvent;
 
           beforeEach(() => {
             emittedEvent = null;
@@ -1522,10 +1529,11 @@ describe('Transport', () => {
         });
 
         context('"update"', () => {
-          var message = {
+          const message = {
             type: 'update'
           };
-          var emittedEvent;
+
+          let emittedEvent;
 
           beforeEach(() => {
             emittedEvent = null;
@@ -1541,11 +1549,12 @@ describe('Transport', () => {
 
       context('"connecting", and the request contains an RSP message with type', () => {
         context('"connected"', () => {
-          var message = {
+          const message = {
             type: 'connected'
           };
-          var connectedEvent;
-          var messageEvent;
+
+          let connectedEvent;
+          let messageEvent;
 
           beforeEach(() => {
             connectedEvent = null;
@@ -1595,7 +1604,7 @@ describe('Transport', () => {
         });
 
         context('"error" with code and message in the response body', () => {
-          var disconnect;
+          let disconnect;
 
           beforeEach(() => {
             disconnect = test.transport.disconnect;
@@ -1604,7 +1613,7 @@ describe('Transport', () => {
           });
 
           it('calls #disconnect() with a TwilioError', () => {
-            var error = test.transport.disconnect.args[0][0];
+            const error = test.transport.disconnect.args[0][0];
             assert(error instanceof TwilioError);
             assert.equal(error.code, 12345);
             assert.equal(error.message, 'foo bar');
@@ -1616,7 +1625,7 @@ describe('Transport', () => {
         });
 
         context('"error" with code and message in the response header', () => {
-          var disconnect;
+          let disconnect;
 
           beforeEach(() => {
             disconnect = test.transport.disconnect;
@@ -1625,7 +1634,7 @@ describe('Transport', () => {
           });
 
           it('calls #disconnect() with a TwilioError', () => {
-            var error = test.transport.disconnect.args[0][0];
+            const error = test.transport.disconnect.args[0][0];
             assert(error instanceof TwilioError);
             assert.equal(error.code, 67890);
             assert.equal(error.message, 'bar baz');
@@ -1637,7 +1646,7 @@ describe('Transport', () => {
         });
 
         context('"error" with no code or message in either the body or the header', () => {
-          var disconnect;
+          let disconnect;
 
           beforeEach(() => {
             disconnect = test.transport.disconnect;
@@ -1646,7 +1655,7 @@ describe('Transport', () => {
           });
 
           it('calls #disconnect() with a unknown TwilioError', () => {
-            var error = test.transport.disconnect.args[0][0];
+            const error = test.transport.disconnect.args[0][0];
             assert(error instanceof TwilioError);
             assert.equal(error.code, 0);
             assert.equal(error.message, 'Unknown error');
@@ -1658,11 +1667,12 @@ describe('Transport', () => {
         });
 
         context('"synced"', () => {
-          var message = {
+          const message = {
             type: 'synced'
           };
-          var connectedEvent;
-          var messageEvent;
+
+          let connectedEvent;
+          let messageEvent;
 
           beforeEach(() => {
             connectedEvent = false;
@@ -1702,11 +1712,12 @@ describe('Transport', () => {
         });
 
         context('"update"', () => {
-          var message = {
+          const message = {
             type: 'update'
           };
-          var connectedEvent;
-          var messageEvent;
+
+          let connectedEvent;
+          let messageEvent;
 
           beforeEach(() => {
             connectedEvent = false;
@@ -1747,7 +1758,7 @@ describe('Transport', () => {
       });
 
       context('"disconnected", and the request contains an RSP message with type', () => {
-        var eventEmitted;
+        let eventEmitted;
 
         beforeEach(() => {
           test.transport.disconnect();
@@ -1821,11 +1832,12 @@ describe('Transport', () => {
         });
 
         context('"connected"', () => {
-          var message = {
+          const message = {
             type: 'connected'
           };
-          var connectedEvent;
-          var messageEvents;
+
+          let connectedEvent;
+          let messageEvents;
 
           beforeEach(() => {
             connectedEvent = false;
@@ -1891,7 +1903,7 @@ describe('Transport', () => {
         });
 
         context('"error" with code and message in the response body', () => {
-          var disconnect;
+          let disconnect;
 
           beforeEach(() => {
             disconnect = test.transport.disconnect;
@@ -1900,7 +1912,7 @@ describe('Transport', () => {
           });
 
           it('calls #disconnect() with a TwilioError', () => {
-            var error = test.transport.disconnect.args[0][0];
+            const error = test.transport.disconnect.args[0][0];
             assert(error instanceof TwilioError);
             assert.equal(error.code, 12345);
             assert.equal(error.message, 'foo bar');
@@ -1912,7 +1924,7 @@ describe('Transport', () => {
         });
 
         context('"error" with code and message in the response header', () => {
-          var disconnect;
+          let disconnect;
 
           beforeEach(() => {
             disconnect = test.transport.disconnect;
@@ -1921,7 +1933,7 @@ describe('Transport', () => {
           });
 
           it('calls #disconnect() with a TwilioError', () => {
-            var error = test.transport.disconnect.args[0][0];
+            const error = test.transport.disconnect.args[0][0];
             assert(error instanceof TwilioError);
             assert.equal(error.code, 67890);
             assert.equal(error.message, 'bar baz');
@@ -1933,7 +1945,7 @@ describe('Transport', () => {
         });
 
         context('"error" with no code or message in either the body or the header', () => {
-          var disconnect;
+          let disconnect;
 
           beforeEach(() => {
             disconnect = test.transport.disconnect;
@@ -1942,7 +1954,7 @@ describe('Transport', () => {
           });
 
           it('calls #disconnect() with a unknown TwilioError', () => {
-            var error = test.transport.disconnect.args[0][0];
+            const error = test.transport.disconnect.args[0][0];
             assert(error instanceof TwilioError);
             assert.equal(error.code, 0);
             assert.equal(error.message, 'Unknown error');
@@ -1954,11 +1966,12 @@ describe('Transport', () => {
         });
 
         context('"synced"', () => {
-          var message = {
+          const message = {
             type: 'synced'
           };
-          var connectedEvent;
-          var messageEvent;
+
+          let connectedEvent;
+          let messageEvent;
 
           beforeEach(() => {
             connectedEvent = false;
@@ -1980,11 +1993,12 @@ describe('Transport', () => {
         });
 
         context('"update"', () => {
-          var message = {
+          const message = {
             type: 'update'
           };
-          var connectedEvent;
-          var messageEvents;
+
+          let connectedEvent;
+          let messageEvents;
 
           beforeEach(() => {
             connectedEvent = false;
@@ -2026,7 +2040,7 @@ describe('Transport', () => {
     });
 
     context('a "bye" event, and the Transport\'s .state is', () => {
-      var evtPayloads = [
+      const evtPayloads = [
         [ ],
         [ { body: '{ "type": "error", "code": 12345 "message": "foo bar" }' } ],
         [ { body: '{ "type": "error", "code": 12345, "message": "foo bar" }' } ],
@@ -2034,10 +2048,11 @@ describe('Transport', () => {
         [ null, 'Request Timeout' ],
         [ null, 'Connection Error' ]
       ];
-      var evtPayloadsIdx = 0;
+
+      let evtPayloadsIdx = 0;
 
       context('"connected"', () => {
-        var disconnect;
+        let disconnect;
 
         beforeEach(() => {
           disconnect = test.transport.disconnect;
@@ -2057,38 +2072,38 @@ describe('Transport', () => {
         });
 
         it('should call #disconnect() with SignalingIncomingMessageInvalidError when event payload has an error body with invalid JSON', () => {
-          var error = test.transport.disconnect.args[0][0];
-          var expectedError = new SignalingIncomingMessageInvalidError();
+          const error = test.transport.disconnect.args[0][0];
+          const expectedError = new SignalingIncomingMessageInvalidError();
           assert(error instanceof SignalingIncomingMessageInvalidError);
           assert.equal(error.code, expectedError.code);
           assert.equal(error.message, expectedError.message);
         });
 
         it('should call #disconnect() with TwilioError when event payload has an error body', () => {
-          var error = test.transport.disconnect.args[0][0];
+          const error = test.transport.disconnect.args[0][0];
           assert(error instanceof TwilioError);
           assert.equal(error.code, 12345);
           assert.equal(error.message, 'foo bar');
         });
 
         it('should call #disconnect() with TwilioError when event payload has an error header', () => {
-          var error = test.transport.disconnect.args[0][0];
+          const error = test.transport.disconnect.args[0][0];
           assert(error instanceof TwilioError);
           assert.equal(error.code, 67890);
           assert.equal(error.message, 'bar baz');
         });
 
         it('should call #disconnect() with TwilioError when cause is "Request Timeout"', () => {
-          var error = test.transport.disconnect.args[0][0];
-          var expectedError = new SignalingConnectionTimeoutError();
+          const error = test.transport.disconnect.args[0][0];
+          const expectedError = new SignalingConnectionTimeoutError();
           assert(error instanceof SignalingConnectionTimeoutError);
           assert.equal(error.code, expectedError.code);
           assert.equal(error.message, expectedError.message);
         });
 
         it('should call #disconnect() with TwilioError when cause is "Connection Error"', () => {
-          var error = test.transport.disconnect.args[0][0];
-          var expectedError = new SignalingConnectionError();
+          const error = test.transport.disconnect.args[0][0];
+          const expectedError = new SignalingConnectionError();
           assert(error instanceof SignalingConnectionError);
           assert.equal(error.code, expectedError.code);
           assert.equal(error.message, expectedError.message);
@@ -2103,7 +2118,7 @@ describe('Transport', () => {
       });
 
       context('"connecting"', () => {
-        var disconnect;
+        let disconnect;
 
         beforeEach(() => {
           disconnect = test.transport.disconnect;
@@ -2120,38 +2135,38 @@ describe('Transport', () => {
         });
 
         it('should call #disconnect() with SignalingIncomingMessageInvalidError when event payload has an error body with invalid JSON', () => {
-          var error = test.transport.disconnect.args[0][0];
-          var expectedError = new SignalingIncomingMessageInvalidError();
+          const error = test.transport.disconnect.args[0][0];
+          const expectedError = new SignalingIncomingMessageInvalidError();
           assert(error instanceof SignalingIncomingMessageInvalidError);
           assert.equal(error.code, expectedError.code);
           assert.equal(error.message, expectedError.message);
         });
 
         it('should call #disconnect() with TwilioError when event payload has an error body', () => {
-          var error = test.transport.disconnect.args[0][0];
+          const error = test.transport.disconnect.args[0][0];
           assert(error instanceof TwilioError);
           assert.equal(error.code, 12345);
           assert.equal(error.message, 'foo bar');
         });
 
         it('should call #disconnect() with TwilioError when event payload has an error header', () => {
-          var error = test.transport.disconnect.args[0][0];
+          const error = test.transport.disconnect.args[0][0];
           assert(error instanceof TwilioError);
           assert.equal(error.code, 67890);
           assert.equal(error.message, 'bar baz');
         });
 
         it('should call #disconnect() with TwilioError when cause is "Request Timeout"', () => {
-          var error = test.transport.disconnect.args[0][0];
-          var expectedError = new SignalingConnectionTimeoutError();
+          const error = test.transport.disconnect.args[0][0];
+          const expectedError = new SignalingConnectionTimeoutError();
           assert(error instanceof SignalingConnectionTimeoutError);
           assert.equal(error.code, expectedError.code);
           assert.equal(error.message, expectedError.message);
         });
 
         it('should call #disconnect() with TwilioError when cause is "Connection Error"', () => {
-          var error = test.transport.disconnect.args[0][0];
-          var expectedError = new SignalingConnectionError();
+          const error = test.transport.disconnect.args[0][0];
+          const expectedError = new SignalingConnectionError();
           assert(error instanceof SignalingConnectionError);
           assert.equal(error.code, expectedError.code);
           assert.equal(error.message, expectedError.message);
@@ -2182,7 +2197,7 @@ describe('Transport', () => {
       });
 
       context('"syncing"', () => {
-        var disconnect;
+        let disconnect;
 
         beforeEach(() => {
           disconnect = test.transport.disconnect;
@@ -2202,38 +2217,38 @@ describe('Transport', () => {
         });
 
         it('should call #disconnect() with SignalingIncomingMessageInvalidError when event payload has an error body with invalid JSON', () => {
-          var error = test.transport.disconnect.args[0][0];
-          var expectedError = new SignalingIncomingMessageInvalidError();
+          const error = test.transport.disconnect.args[0][0];
+          const expectedError = new SignalingIncomingMessageInvalidError();
           assert(error instanceof SignalingIncomingMessageInvalidError);
           assert.equal(error.code, expectedError.code);
           assert.equal(error.message, expectedError.message);
         });
 
         it('should call #disconnect() with TwilioError when event payload has an error body', () => {
-          var error = test.transport.disconnect.args[0][0];
+          const error = test.transport.disconnect.args[0][0];
           assert(error instanceof TwilioError);
           assert.equal(error.code, 12345);
           assert.equal(error.message, 'foo bar');
         });
 
         it('should call #disconnect() with TwilioError when event payload has an error header', () => {
-          var error = test.transport.disconnect.args[0][0];
+          const error = test.transport.disconnect.args[0][0];
           assert(error instanceof TwilioError);
           assert.equal(error.code, 67890);
           assert.equal(error.message, 'bar baz');
         });
 
         it('should call #disconnect() with TwilioError when cause is "Request Timeout"', () => {
-          var error = test.transport.disconnect.args[0][0];
-          var expectedError = new SignalingConnectionTimeoutError();
+          const error = test.transport.disconnect.args[0][0];
+          const expectedError = new SignalingConnectionTimeoutError();
           assert(error instanceof SignalingConnectionTimeoutError);
           assert.equal(error.code, expectedError.code);
           assert.equal(error.message, expectedError.message);
         });
 
         it('should call #disconnect() with TwilioError when cause is "Connection Error"', () => {
-          var error = test.transport.disconnect.args[0][0];
-          var expectedError = new SignalingConnectionError();
+          const error = test.transport.disconnect.args[0][0];
+          const expectedError = new SignalingConnectionError();
           assert(error instanceof SignalingConnectionError);
           assert.equal(error.code, expectedError.code);
           assert.equal(error.message, expectedError.message);
@@ -2304,7 +2319,7 @@ function makeAccessToken() {
 }
 
 function makeLocalParticipant(options) {
-  var localParticipant = {};
+  const localParticipant = {};
   localParticipant.getState = sinon.spy(() => options.localParticipantState);
   return localParticipant;
 }
@@ -2315,7 +2330,7 @@ function makePeerConnectionManager(options) {
 
 function makeSession(options) {
   options.sendRequest = options.sendRequest || (() => {});
-  var session = new EventEmitter();
+  const session = new EventEmitter();
   session.terminate = sinon.spy(() => {});
   session.sendReinvite = sinon.spy(() => {});
   session.sendRequest = sinon.spy(options.sendRequest);
@@ -2323,7 +2338,7 @@ function makeSession(options) {
 }
 
 function makeUA(options) {
-  var ua = {};
+  const ua = {};
   ua.invite = sinon.spy(() => options.session);
   ua.once = sinon.spy(() => {});
   ua.stop = sinon.spy(() => {});

--- a/test/unit/spec/signaling/v2/transport.js
+++ b/test/unit/spec/signaling/v2/transport.js
@@ -342,6 +342,7 @@ describe('Transport', () => {
           revision: 1,
           tracks: []
         },
+        // eslint-disable-next-line camelcase
         peer_connections: [
           {
             id: 'a',
@@ -366,6 +367,7 @@ describe('Transport', () => {
             { fizz: 'buzz' }
           ]
         },
+        // eslint-disable-next-line camelcase
         peer_connections: [
           {
             id: 'a',
@@ -401,6 +403,7 @@ describe('Transport', () => {
           { fizz: 'buzz' }
         ]
       },
+      // eslint-disable-next-line camelcase
       peer_connections: [
         {
           id: 'a',
@@ -485,13 +488,14 @@ describe('Transport', () => {
             test = makeTest({
               sendRequest(type, request) {
                 sendRequestCallTimes.push(Date.now());
+                // eslint-disable-next-line camelcase
                 request.receiveResponse({ status_code: 500 });
                 if (sendRequestCallTimes.length === PUBLISH_MAX_ATTEMPTS) {
                   resolve();
                 }
               }
             });
-            sendRequestCallTimes = [];
+            sendRequestCallTimes.splice(0);
             test.connect();
             test.transport.publish({ foo: 'bar' });
           });
@@ -781,8 +785,8 @@ describe('Transport', () => {
         beforeEach(() => {
           test.connect();
           eventEmitted = false;
-          test.transport.once('connected', () => eventEmitted = true);
-          test.transport.once('message', () => eventEmitted = true);
+          test.transport.once('connected', () => { eventEmitted = true; });
+          test.transport.once('message', () => { eventEmitted = true; });
           test.transitions = [];
         });
 
@@ -855,8 +859,8 @@ describe('Transport', () => {
           beforeEach(() => {
             connectedEvent = null;
             messageEvent = false;
-            test.transport.once('connected', message => connectedEvent = message);
-            test.transport.once('message', () => messageEvent = true);
+            test.transport.once('connected', message => { connectedEvent = message; });
+            test.transport.once('message', () => { messageEvent = true; });
             test.accepted(message);
           });
 
@@ -882,8 +886,8 @@ describe('Transport', () => {
           beforeEach(() => {
             connectedEvent = false;
             messageEvent = false;
-            test.transport.once('connected', () => connectedEvent = true);
-            test.transport.once('message', () => messageEvent = true);
+            test.transport.once('connected', () => { connectedEvent = true; });
+            test.transport.once('message', () => { messageEvent = true; });
             test.accepted({ type: 'disconnected' });
           });
 
@@ -909,8 +913,8 @@ describe('Transport', () => {
           beforeEach(() => {
             connectedEvent = false;
             messageEvent = false;
-            test.transport.once('connected', () => connectedEvent = true);
-            test.transport.once('message', () => messageEvent = true);
+            test.transport.once('connected', () => { connectedEvent = true; });
+            test.transport.once('message', () => { messageEvent = true; });
             test.accepted({ type: 'error' });
           });
 
@@ -1003,8 +1007,8 @@ describe('Transport', () => {
           beforeEach(() => {
             connectedEvent = false;
             messageEvent = null;
-            test.transport.once('connected', () => connectedEvent = true);
-            test.transport.once('message', message => messageEvent = message);
+            test.transport.once('connected', () => { connectedEvent = true; });
+            test.transport.once('message', message => { messageEvent = message; });
             test.accepted(message);
           });
 
@@ -1054,8 +1058,8 @@ describe('Transport', () => {
           beforeEach(() => {
             connectedEvent = false;
             messageEvent = null;
-            test.transport.once('connected', () => connectedEvent = true);
-            test.transport.once('message', message => messageEvent = message);
+            test.transport.once('connected', () => { connectedEvent = true; });
+            test.transport.once('message', message => { messageEvent = message; });
             test.accepted(message);
           });
 
@@ -1104,8 +1108,8 @@ describe('Transport', () => {
           test.transitions = [];
           connectedEvent = false;
           messageEvent = false;
-          test.transport.once('connected', () => connectedEvent = true);
-          test.transport.once('message', () => messageEvent = true);
+          test.transport.once('connected', () => { connectedEvent = true; });
+          test.transport.once('message', () => { messageEvent = true; });
         });
 
         context('"connected"', () => {
@@ -1207,8 +1211,8 @@ describe('Transport', () => {
           test.transport.sync();
           test.transitions = [];
           eventEmitted = false;
-          test.transport.once('connected', () => eventEmitted = true);
-          test.transport.once('message', () => eventEmitted = true);
+          test.transport.once('connected', () => { eventEmitted = true; });
+          test.transport.once('message', () => { eventEmitted = true; });
         });
 
         context('"connected"', () => {
@@ -1270,12 +1274,12 @@ describe('Transport', () => {
 
     context('a "failed" event, and the Transport\'s .state is', () => {
       const evtPayloads = [
-        [ ],
-        [ { body: '{ "type": "error", "code": 12345 "message": "foo bar" }' } ],
-        [ { body: '{ "type": "error", "code": 12345, "message": "foo bar" }' } ],
-        [ { headers: { 'X-Twilio-Error': [ { raw: '67890 bar baz' } ] } } ],
-        [ null, 'Request Timeout' ],
-        [ null, 'Connection Error' ]
+        [],
+        [{ body: '{ "type": "error", "code": 12345 "message": "foo bar" }' }],
+        [{ body: '{ "type": "error", "code": 12345, "message": "foo bar" }' }],
+        [{ headers: { 'X-Twilio-Error': [{ raw: '67890 bar baz' }] } }],
+        [null, 'Request Timeout'],
+        [null, 'Connection Error']
       ];
 
       let evtPayloadsIdx = 0;
@@ -1284,8 +1288,8 @@ describe('Transport', () => {
       function setupTest() {
         test.transitions = [];
         eventEmitted = false;
-        test.transport.once('connected', () => eventEmitted = true);
-        test.transport.once('message', () => eventEmitted = true);
+        test.transport.once('connected', () => { eventEmitted = true; });
+        test.transport.once('message', () => { eventEmitted = true; });
         test.session.emit.apply(test.session, ['failed'].concat(evtPayloads[evtPayloadsIdx]));
       }
 
@@ -1356,7 +1360,7 @@ describe('Transport', () => {
         });
 
         afterEach(() => {
-          if(evtPayloadsIdx > 0) {
+          if (evtPayloadsIdx > 0) {
             test.transport.disconnect = disconnect;
           }
           evtPayloadsIdx = (evtPayloadsIdx + 1) % evtPayloads.length;
@@ -1404,7 +1408,7 @@ describe('Transport', () => {
 
           beforeEach(() => {
             emittedEvent = null;
-            test.transport.once('message', message => emittedEvent = message);
+            test.transport.once('message', message => { emittedEvent = message; });
             test.receiveRequest(message);
           });
 
@@ -1519,7 +1523,7 @@ describe('Transport', () => {
 
           beforeEach(() => {
             emittedEvent = null;
-            test.transport.once('message', message => emittedEvent = message);
+            test.transport.once('message', message => { emittedEvent = message; });
             test.receiveRequest(message);
           });
 
@@ -1537,7 +1541,7 @@ describe('Transport', () => {
 
           beforeEach(() => {
             emittedEvent = null;
-            test.transport.once('message', message => emittedEvent = message);
+            test.transport.once('message', message => { emittedEvent = message; });
             test.receiveRequest(message);
           });
 
@@ -1559,8 +1563,8 @@ describe('Transport', () => {
           beforeEach(() => {
             connectedEvent = null;
             messageEvent = false;
-            test.transport.once('connected', message => connectedEvent = message);
-            test.transport.once('message', () => messageEvent = true);
+            test.transport.once('connected', message => { connectedEvent = message; });
+            test.transport.once('message', () => { messageEvent = true; });
             test.receiveRequest(message);
           });
 
@@ -1677,8 +1681,8 @@ describe('Transport', () => {
           beforeEach(() => {
             connectedEvent = false;
             messageEvent = false;
-            test.transport.once('connected', () => connectedEvent = true);
-            test.transport.once('message', message => messageEvent = message);
+            test.transport.once('connected', () => { connectedEvent = true; });
+            test.transport.once('message', message => { messageEvent = message; });
             test.receiveRequest(message);
           });
 
@@ -1722,8 +1726,8 @@ describe('Transport', () => {
           beforeEach(() => {
             connectedEvent = false;
             messageEvent = false;
-            test.transport.once('connected', () => connectedEvent = true);
-            test.transport.once('message', message => messageEvent = message);
+            test.transport.once('connected', () => { connectedEvent = true; });
+            test.transport.once('message', message => { messageEvent = message; });
             test.receiveRequest(message);
           });
 
@@ -1764,8 +1768,8 @@ describe('Transport', () => {
           test.transport.disconnect();
           test.transitions = [];
           eventEmitted = false;
-          test.transport.once('connected', () => eventEmitted = true);
-          test.transport.once('message', () => eventEmitted = true);
+          test.transport.once('connected', () => { eventEmitted = true; });
+          test.transport.once('message', () => { eventEmitted = true; });
         });
 
         context('"connected"', () => {
@@ -1842,7 +1846,7 @@ describe('Transport', () => {
           beforeEach(() => {
             connectedEvent = false;
             messageEvents = [];
-            test.transport.once('connected', () => connectedEvent = true);
+            test.transport.once('connected', () => { connectedEvent = true; });
             test.transport.on('message', message => messageEvents.push(message));
             test.receiveRequest(message);
           });
@@ -1970,14 +1974,11 @@ describe('Transport', () => {
             type: 'synced'
           };
 
-          let connectedEvent;
           let messageEvent;
 
           beforeEach(() => {
-            connectedEvent = false;
             messageEvent = false;
-            test.transport.once('connected', () => connectedEvent = true);
-            test.transport.once('message', message => messageEvent = message);
+            test.transport.once('message', message => { messageEvent = message; });
             test.receiveRequest(message);
           });
 
@@ -2003,7 +2004,7 @@ describe('Transport', () => {
           beforeEach(() => {
             connectedEvent = false;
             messageEvents = [];
-            test.transport.once('connected', () => connectedEvent = true);
+            test.transport.once('connected', () => { connectedEvent = true; });
             test.transport.on('message', message => messageEvents.push(message));
             test.receiveRequest(message);
           });
@@ -2041,12 +2042,12 @@ describe('Transport', () => {
 
     context('a "bye" event, and the Transport\'s .state is', () => {
       const evtPayloads = [
-        [ ],
-        [ { body: '{ "type": "error", "code": 12345 "message": "foo bar" }' } ],
-        [ { body: '{ "type": "error", "code": 12345, "message": "foo bar" }' } ],
-        [ { headers: { 'X-Twilio-Error': [ { raw: '67890 bar baz' } ] } } ],
-        [ null, 'Request Timeout' ],
-        [ null, 'Connection Error' ]
+        [],
+        [{ body: '{ "type": "error", "code": 12345 "message": "foo bar" }' }],
+        [{ body: '{ "type": "error", "code": 12345, "message": "foo bar" }' }],
+        [{ headers: { 'X-Twilio-Error': [{ raw: '67890 bar baz' }] } }],
+        [null, 'Request Timeout'],
+        [null, 'Connection Error']
       ];
 
       let evtPayloadsIdx = 0;
@@ -2173,7 +2174,7 @@ describe('Transport', () => {
         });
 
         afterEach(() => {
-          if(evtPayloadsIdx > 0) {
+          if (evtPayloadsIdx > 0) {
             test.transport.disconnect = disconnect;
           }
           evtPayloadsIdx = (evtPayloadsIdx + 1) % evtPayloads.length;
@@ -2255,7 +2256,7 @@ describe('Transport', () => {
         });
 
         afterEach(() => {
-          if(evtPayloadsIdx > 0) {
+          if (evtPayloadsIdx > 0) {
             test.transport.disconnect = disconnect;
           }
           evtPayloadsIdx = (evtPayloadsIdx + 1) % evtPayloads.length;
@@ -2295,7 +2296,7 @@ function makeTest(options) {
   });
   options.receiveRequest = (message, type, headers) => {
     headers = Object.keys(headers || {}).reduce((headers_, name) => {
-      headers_[name] = [ { raw: headers[name] } ];
+      headers_[name] = [{ raw: headers[name] }];
       return headers_;
     }, {});
     options.session.emit(type || 'info', {
@@ -2324,7 +2325,7 @@ function makeLocalParticipant(options) {
   return localParticipant;
 }
 
-function makePeerConnectionManager(options) {
+function makePeerConnectionManager() {
   return {};
 }
 

--- a/test/unit/spec/signaling/v2/transport.js
+++ b/test/unit/spec/signaling/v2/transport.js
@@ -1,15 +1,19 @@
 'use strict';
 
-var assert = require('assert');
-var constants = require('../../../../../lib/util/constants');
-var EventEmitter = require('events').EventEmitter;
-var sinon = require('sinon');
-var Transport = require('../../../../../lib/signaling/v2/transport');
-var TwilioError = require('../../../../../lib/util/twilioerror');
-var TwilioErrors = require('../../../../../lib/util/twilio-video-errors');
-var SignalingIncomingMessageInvalidError = TwilioErrors.SignalingIncomingMessageInvalidError;
-var SignalingConnectionTimeoutError = TwilioErrors.SignalingConnectionTimeoutError;
-var SignalingConnectionError = TwilioErrors.SignalingConnectionError;
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const sinon = require('sinon');
+
+const Transport = require('../../../../../lib/signaling/v2/transport');
+const { PUBLISH_MAX_ATTEMPTS } = require('../../../../../lib/util/constants');
+
+const {
+  SignalingConnectionError,
+  SignalingConnectionTimeoutError,
+  SignalingIncomingMessageInvalidError
+} = require('../../../../../lib/util/twilio-video-errors');
+
+const TwilioError = require('../../../../../lib/util/twilioerror');
 
 describe('Transport', () => {
   describe('constructor', () => {
@@ -481,7 +485,7 @@ describe('Transport', () => {
               sendRequest(type, request) {
                 sendRequestCallTimes.push(Date.now());
                 request.receiveResponse({ status_code: 500 });
-                if (sendRequestCallTimes.length === constants.PUBLISH_MAX_ATTEMPTS) {
+                if (sendRequestCallTimes.length === PUBLISH_MAX_ATTEMPTS) {
                   resolve();
                 }
               }

--- a/test/unit/spec/statemachine.js
+++ b/test/unit/spec/statemachine.js
@@ -19,7 +19,7 @@ describe('StateMachine', function() {
   describe('#bracket', function() {
     context('when the Promise returned by the transition function rejects', function(done) {
       it('releases the lock and rejects with the error', function(done) {
-        var sm = new StateMachine('foo', { foo: [] });
+        const sm = new StateMachine('foo', { foo: [] });
         sm.bracket('lock', function(key) {
           sm.takeLockSync(key);  // reenter
           throw new Error(':-)');
@@ -34,7 +34,7 @@ describe('StateMachine', function() {
 
     context('when the Promise returned by the transition function resolves', function() {
       it('releases the lock and resolves', function(done) {
-        var sm = new StateMachine('foo', { foo: [] });
+        const sm = new StateMachine('foo', { foo: [] });
         sm.bracket('lock', function(key) {
           sm.takeLockSync(key);  // reenter
         }).then(function() {
@@ -47,21 +47,21 @@ describe('StateMachine', function() {
   describe('#hasLock', function() {
     context('when locked', function() {
       it('returns true if called with the key returned by #takeLock', function(done) {
-        var sm = new StateMachine('foo', { foo: [] });
+        const sm = new StateMachine('foo', { foo: [] });
         sm.takeLock().then(function(key) {
           assert(sm.hasLock(key));
         }).then(done, done);
       });
 
       it('returns true if called with the key returned by #takeLockSync', function() {
-        var sm = new StateMachine('foo', { foo: [] });
-        var key = sm.takeLockSync('key');
+        const sm = new StateMachine('foo', { foo: [] });
+        const key = sm.takeLockSync('key');
         assert(sm.hasLock(key));
       });
 
       it('returns false if called with another key', function() {
-        var sm = new StateMachine('foo', { foo: [] });
-        var key = takeAndReleaseLockSync(sm, 'lock1');
+        const sm = new StateMachine('foo', { foo: [] });
+        const key = takeAndReleaseLockSync(sm, 'lock1');
         sm.takeLockSync('lock2');
         assert.equal(false, sm.hasLock(key));
       });
@@ -69,8 +69,8 @@ describe('StateMachine', function() {
 
     context('when unlocked', function() {
       it('returns false', function() {
-        var sm = new StateMachine('foo', { foo: [] });
-        var key = takeAndReleaseLockSync(sm, 'lock');
+        const sm = new StateMachine('foo', { foo: [] });
+        const key = takeAndReleaseLockSync(sm, 'lock');
         assert.equal(false, sm.hasLock(key));
       });
     });
@@ -79,7 +79,7 @@ describe('StateMachine', function() {
   describe('#preempt', function() {
     context('when the transition is invalid', function() {
       it('throws an Error', function() {
-        var sm = new StateMachine('foo', { foo: [] });
+        const sm = new StateMachine('foo', { foo: [] });
         assert.throws(sm.preempt.bind(sm, 'bar'));
       });
     });
@@ -88,10 +88,11 @@ describe('StateMachine', function() {
       context('the StateMachine is locked', function() {
         context('and a new lock is not requested', function() {
           it('sets .state and releases the current lock', function(done) {
-            var sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
-            var key = sm.takeLockSync('lock');
-            var i = 0;
-            var deferred = defer();
+            const sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
+            const key = sm.takeLockSync('lock');
+            const deferred = defer();
+
+            let i = 0;
 
             // The "stateChanged" event should fire before anyone waiting to
             // take the lock. Taking the lock from within the "stateChanged"
@@ -125,10 +126,11 @@ describe('StateMachine', function() {
 
         context('and a new lock is requested', function() {
           it('sets .state, releases the current lock, and takes a new lock', function(done) {
-            var sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
-            var key1 = sm.takeLockSync('lock1');
-            var i = 0;
-            var deferred = defer();
+            const sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
+            const key1 = sm.takeLockSync('lock1');
+            const deferred = defer();
+
+            let i = 0;
 
             // The "stateChanged" event should fire before anyone waiting to
             // take the lock. Taking the lock from within the "stateChanged"
@@ -153,7 +155,7 @@ describe('StateMachine', function() {
               assert.equal(3, order[2]);
             }).then(done, done);
 
-            var key2 = sm.preempt('bar', 'lock2');
+            const key2 = sm.preempt('bar', 'lock2');
             assert.equal('bar', sm.state);
             assert(sm.hasLock(key2));
             i++;  // 1
@@ -165,7 +167,7 @@ describe('StateMachine', function() {
       context('the StateMachine is unlocked', function() {
         context('and a new lock is not requested', function() {
           it('sets .state', function(done) {
-            var sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
+            const sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
             sm.once('stateChanged', function(bar, baz) {
               try {
                 assert.equal('bar', sm.state);
@@ -183,7 +185,7 @@ describe('StateMachine', function() {
 
         context('and a new lock is requested', function() {
           it('sets .state and takes a new lock', function(done) {
-            var sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
+            const sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
             sm.once('stateChanged', function(bar, baz) {
               try {
                 assert.equal('bar', sm.state);
@@ -194,7 +196,7 @@ describe('StateMachine', function() {
               }
               done();
             });
-            var key = sm.preempt('bar', 'lock', ['baz']);
+            const key = sm.preempt('bar', 'lock', ['baz']);
             assert.equal('bar', sm.state);
             assert(sm.hasLock(key));
           });
@@ -206,15 +208,15 @@ describe('StateMachine', function() {
   describe('#releaseLock', function() {
     context('when locked', function() {
       it('throws an Error if the wrong key is provided', function() {
-        var sm = new StateMachine('foo', { foo: [] });
-        var key = takeAndReleaseLockSync(sm, 'lock1');
+        const sm = new StateMachine('foo', { foo: [] });
+        const key = takeAndReleaseLockSync(sm, 'lock1');
         sm.takeLockSync('lock2');
         assert.throws(sm.releaseLock.bind(sm, key));
       });
 
       it('sets .isLocked to false if the key is provided', function() {
-        var sm = new StateMachine('foo', { foo: [] });
-        var key = takeAndReleaseLockSync(sm, 'lock');
+        const sm = new StateMachine('foo', { foo: [] });
+        const key = takeAndReleaseLockSync(sm, 'lock');
         assert.equal(false, sm.hasLock(key));
         assert.equal(false, sm.isLocked);
       });
@@ -222,8 +224,8 @@ describe('StateMachine', function() {
 
     context('when unlocked', function() {
       it('throws an Error', function() {
-        var sm = new StateMachine('foo', { foo: [] });
-        var key = takeAndReleaseLockSync(sm, 'lock');
+        const sm = new StateMachine('foo', { foo: [] });
+        const key = takeAndReleaseLockSync(sm, 'lock');
         assert.throws(sm.releaseLock.bind(sm, key));
       });
     });
@@ -233,9 +235,9 @@ describe('StateMachine', function() {
     context('when locked', function() {
       context('and called with a string', function() {
         it('returns a Promise that resolves to a key once the current lock is released', function(done) {
-          var sm = new StateMachine('foo', { foo: [] });
-          var key1 = sm.takeLockSync('lock1');
-          var key2 = null;
+          const sm = new StateMachine('foo', { foo: [] });
+          const key1 = sm.takeLockSync('lock1');
+          let key2;
           sm.takeLock().then(function(key) {
             key2 = key;
             assert(sm.hasLock(key2));
@@ -248,8 +250,8 @@ describe('StateMachine', function() {
 
       context('and called with the key for the lock', function() {
         it('reenters the lock and returns a Promise that resolves to the same key', function(done) {
-          var sm = new StateMachine('foo', { foo: [] });
-          var key = sm.takeLockSync('lock');
+          const sm = new StateMachine('foo', { foo: [] });
+          const key = sm.takeLockSync('lock');
           sm.takeLock(key).then(function(_key) {
             assert.equal(key, _key);
           }).then(done, done);
@@ -258,8 +260,8 @@ describe('StateMachine', function() {
 
       context('and called with the key for a different lock', function() {
         it('returns a Promise that rejects with an Error', function(done) {
-          var sm = new StateMachine('foo', { foo: [] });
-          var key = takeAndReleaseLockSync(sm, 'lock1');
+          const sm = new StateMachine('foo', { foo: [] });
+          const key = takeAndReleaseLockSync(sm, 'lock1');
           sm.takeLockSync('lock2');
           sm.takeLock(key).then(function(key) {
             throw new Error('Unexpected resolution');
@@ -273,7 +275,7 @@ describe('StateMachine', function() {
     context('when unlocked', function() {
       context('and called with a string', function() {
         it('returns a Promise that resolves to a key', function(done) {
-          var sm = new StateMachine('foo', { foo: [] });
+          const sm = new StateMachine('foo', { foo: [] });
           sm.takeLock().then(function(key) {
             assert(sm.hasLock(key));
             assert(sm.isLocked);
@@ -283,8 +285,8 @@ describe('StateMachine', function() {
 
       context('and called with a key', function() {
         it('returns a Promise that rejects with an Error', function(done) {
-          var sm = new StateMachine('foo', { foo: [] });
-          var key = takeAndReleaseLockSync(sm, 'lock');
+          const sm = new StateMachine('foo', { foo: [] });
+          const key = takeAndReleaseLockSync(sm, 'lock');
           sm.takeLock(key).then(function(key) {
             throw new Error('Unexpected resolution');
           }, function(error) {
@@ -299,7 +301,7 @@ describe('StateMachine', function() {
     context('when locked', function() {
       context('and called with a string', function() {
         it('throws an Error', function() {
-          var sm = new StateMachine('foo', { foo: [] });
+          const sm = new StateMachine('foo', { foo: [] });
           sm.takeLockSync('lock1');
           assert.throws(sm.takeLockSync.bind(sm, 'lock2'));
         });
@@ -307,16 +309,16 @@ describe('StateMachine', function() {
 
       context('and called with the key for the lock', function() {
         it('reenters the lock', function() {
-          var sm = new StateMachine('foo', { foo: [] });
-          var key = sm.takeLockSync('lock');
+          const sm = new StateMachine('foo', { foo: [] });
+          const key = sm.takeLockSync('lock');
           assert.equal(key, sm.takeLockSync(key));
         });
       });
 
       context('and called with the key for a different lock', function() {
         it('throws an Error', function() {
-          var sm = new StateMachine('foo', { foo: [] });
-          var key = takeAndReleaseLockSync(sm, 'lock1');
+          const sm = new StateMachine('foo', { foo: [] });
+          const key = takeAndReleaseLockSync(sm, 'lock1');
           sm.takeLockSync('lock2');
           assert.throws(sm.takeLockSync.bind(sm, key));
         });
@@ -326,8 +328,8 @@ describe('StateMachine', function() {
     context('when unlocked', function() {
       context('and called with a string', function() {
         it('returns a key', function() {
-          var sm = new StateMachine('foo', { foo: [] });
-          var key = sm.takeLockSync('lock');
+          const sm = new StateMachine('foo', { foo: [] });
+          const key = sm.takeLockSync('lock');
           assert(sm.hasLock(key));
           assert(sm.isLocked);
         });
@@ -335,8 +337,8 @@ describe('StateMachine', function() {
 
       context('and called with a key', function() {
         it('throws an Error', function() {
-          var sm = new StateMachine('foo', { foo: [] });
-          var key = takeAndReleaseLockSync(sm, 'lock');
+          const sm = new StateMachine('foo', { foo: [] });
+          const key = takeAndReleaseLockSync(sm, 'lock');
           assert.throws(sm.takeLockSync.bind(sm, key));
         });
       });
@@ -346,27 +348,27 @@ describe('StateMachine', function() {
   describe('#transition', function() {
     context('when locked', function() {
       it('throws an Error if the key is not provided', function() {
-        var sm = new StateMachine('foo', { foo: [] });
+        const sm = new StateMachine('foo', { foo: [] });
         sm.takeLockSync('lock');
         assert.throws(sm.transition.bind(sm, 'bar'));
       });
 
       it('throws an Error if the wrong key is provided', function() {
-        var sm = new StateMachine('foo', { foo: [] });
-        var key = takeAndReleaseLockSync(sm, 'lock1');
+        const sm = new StateMachine('foo', { foo: [] });
+        const key = takeAndReleaseLockSync(sm, 'lock1');
         sm.takeLockSync('lock2');
         assert.throws(sm.transition.bind(sm, 'bar', key));
       });
 
       it('throws an Error if the key is provided but the transition is invalid', function() {
-        var sm = new StateMachine('foo', { foo: [] });
-        var key = sm.takeLockSync('lock');
+        const sm = new StateMachine('foo', { foo: [] });
+        const key = sm.takeLockSync('lock');
         assert.throws(sm.transition.bind(sm, 'bar', key));
       });
 
       it('sets .state to the new state if the key is provided and the transition is valid', function() {
-        var sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
-        var key = sm.takeLockSync('lock');
+        const sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
+        const key = sm.takeLockSync('lock');
         sm.transition('bar', key);
         assert.equal('bar', sm.state);
       });
@@ -374,8 +376,8 @@ describe('StateMachine', function() {
       describe('when the key is provided and the transition is valid', function() {
         describe('and no payload is provided', function() {
           it('emits the "stateChanged" event', function(done) {
-            var sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
-            var key = sm.takeLockSync('lock');
+            const sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
+            const key = sm.takeLockSync('lock');
             sm.once('stateChanged', function() {
               try {
                 assert.equal('bar', sm.state);
@@ -391,8 +393,8 @@ describe('StateMachine', function() {
 
         describe('and a payload is provided', function() {
           it('emits the "stateChanged" event with the extra payload', function(done) {
-            var sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
-            var key = sm.takeLockSync('lock');
+            const sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
+            const key = sm.takeLockSync('lock');
             sm.once('stateChanged', function(bar, baz, qux) {
               try {
                 assert.equal('bar', bar);
@@ -412,26 +414,26 @@ describe('StateMachine', function() {
 
     context('when unlocked', function() {
       it('throws an Error if a key is provided', function() {
-        var sm = new StateMachine('foo', { foo: [] });
-        var key = takeAndReleaseLockSync(sm, 'lock');
+        const sm = new StateMachine('foo', { foo: [] });
+        const key = takeAndReleaseLockSync(sm, 'lock');
         assert.throws(sm.transition.bind(sm, 'bar', key));
       });
 
       it('throws an Error if the transition is invalid', function() {
-        var sm = new StateMachine('foo', { foo: [] });
+        const sm = new StateMachine('foo', { foo: [] });
         assert.throws(sm.transition.bind(sm, 'bar'));
       });
 
       describe('when the transition is valid', function() {
         describe('and no payload is provided', function() {
           it('sets .state to the new state', function() {
-            var sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
+            const sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
             sm.transition('bar');
             assert.equal('bar', sm.state);
           });
 
           it('emits the "stateChanged" event', function(done) {
-            var sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
+            const sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
             sm.once('stateChanged', function() {
               try {
                 assert.equal('bar', sm.state);
@@ -447,13 +449,13 @@ describe('StateMachine', function() {
 
         describe('and a payload is provided', function() {
           it('sets .state to the new state', function() {
-            var sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
+            const sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
             sm.transition('bar', null, ['baz', 'qux']);
             assert.equal('bar', sm.state);
           });
 
           it('emits the "stateChanged" event with the extra payload', function(done) {
-            var sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
+            const sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
             sm.once('stateChanged', function(bar, baz, qux) {
               try {
                 assert.equal('bar', bar);
@@ -475,13 +477,13 @@ describe('StateMachine', function() {
   describe('#when', function() {
     describe('when the state matches the current state', () => {
       it('returns a Promise that resolves to the StateMachine', () => {
-        var sm = new StateMachine('foo', { foo: [] });
+        const sm = new StateMachine('foo', { foo: [] });
         return sm.when('foo').then(_sm => assert.equal(sm, _sm));
       });
 
       it('should delete the Promise from the ._whenDeferreds Set', () => {
-        var sm = new StateMachine('foo', { foo: [] });
-        var whenDeferredsSize = sm._whenDeferreds.size;
+        const sm = new StateMachine('foo', { foo: [] });
+        const whenDeferredsSize = sm._whenDeferreds.size;
         return sm.when('foo').then(_sm => assert.equal(sm._whenDeferreds.size, whenDeferredsSize));
       });
     });
@@ -489,15 +491,15 @@ describe('StateMachine', function() {
     describe('when the state does not match the current state, and', () => {
       describe('the state is not reachable from the current state', () => {
         it('returns a Promise that rejects with an Error', () => {
-          var sm = new StateMachine('foo', { foo: [], bar: [] });
+          const sm = new StateMachine('foo', { foo: [], bar: [] });
           return sm.when('bar').then(
             () => { throw new Error('Unexpected resolution'); },
             error => assert(error instanceof Error));
         });
 
         it('should delete the Promise from the ._whenDeferreds Set', () => {
-          var sm = new StateMachine('foo', { foo: [], bar: [] });
-          var whenDeferredsSize = sm._whenDeferreds.size;
+          const sm = new StateMachine('foo', { foo: [], bar: [] });
+          const whenDeferredsSize = sm._whenDeferreds.size;
           return sm.when('bar').then(
             () => { throw new Error('Unexpected resolution'); },
             error => assert.equal(sm._whenDeferreds.size, whenDeferredsSize));
@@ -507,16 +509,16 @@ describe('StateMachine', function() {
       describe('the state is reachable from the current state, and it transitions to', () => {
         describe('the state', () => {
           it('returns a Promise that resolves to the StateMachine', () => {
-            var sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
-            var promise = sm.when('bar').then(_sm => assert.equal(sm, _sm));
+            const sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
+            const promise = sm.when('bar').then(_sm => assert.equal(sm, _sm));
             sm.transition('bar');
             return promise;
           });
 
           it('should delete the Promise from the ._whenDeferreds Set', () => {
-            var sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
-            var whenDeferredsSize = sm._whenDeferreds.size;
-            var promise = sm.when('bar').then(_sm => assert.equal(sm._whenDeferreds.size, whenDeferredsSize));
+            const sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
+            const whenDeferredsSize = sm._whenDeferreds.size;
+            const promise = sm.when('bar').then(_sm => assert.equal(sm._whenDeferreds.size, whenDeferredsSize));
             sm.transition('bar');
             return promise;
           });
@@ -524,8 +526,8 @@ describe('StateMachine', function() {
 
         describe('a new state from which the state is no longer reachable', () => {
           it('returns a Promise that rejects with an Error', () => {
-            var sm = new StateMachine('foo', { foo: ['bar', 'baz'], bar: [], baz: [] });
-            var promise = sm.when('baz').then(
+            const sm = new StateMachine('foo', { foo: ['bar', 'baz'], bar: [], baz: [] });
+            const promise = sm.when('baz').then(
               () => { throw new Error('Unexpected resolution'); },
               error => assert(error instanceof Error));
             sm.transition('bar');
@@ -533,9 +535,9 @@ describe('StateMachine', function() {
           });
 
           it('should delete the Promise from the ._whenDeferreds Set', () => {
-            var sm = new StateMachine('foo', { foo: ['bar', 'baz'], bar: [], baz: [] });
-            var whenDeferredsSize = sm._whenDeferreds.size;
-            var promise = sm.when('baz').then(
+            const sm = new StateMachine('foo', { foo: ['bar', 'baz'], bar: [], baz: [] });
+            const whenDeferredsSize = sm._whenDeferreds.size;
+            const promise = sm.when('baz').then(
               () => { throw new Error('Unexpected resolution'); },
               error => assert.equal(sm._whenDeferreds.size, whenDeferredsSize));
             sm.transition('bar');
@@ -548,7 +550,7 @@ describe('StateMachine', function() {
 });
 
 function takeAndReleaseLockSync(sm, name) {
-  var key = sm.takeLockSync(name);
+  const key = sm.takeLockSync(name);
   sm.releaseLock(key);
   return key;
 }

--- a/test/unit/spec/statemachine.js
+++ b/test/unit/spec/statemachine.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var assert = require('assert');
-var StateMachine = require('../../../lib/statemachine');
-var util = require('../../../lib/util');
+const assert = require('assert');
+
+const StateMachine = require('../../../lib/statemachine');
+const { defer } = require('../../../lib/util');
 
 describe('StateMachine', function() {
   describe('constructor', function() {
@@ -90,7 +91,7 @@ describe('StateMachine', function() {
             var sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
             var key = sm.takeLockSync('lock');
             var i = 0;
-            var deferred = util.defer();
+            var deferred = defer();
 
             // The "stateChanged" event should fire before anyone waiting to
             // take the lock. Taking the lock from within the "stateChanged"
@@ -127,7 +128,7 @@ describe('StateMachine', function() {
             var sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
             var key1 = sm.takeLockSync('lock1');
             var i = 0;
-            var deferred = util.defer();
+            var deferred = defer();
 
             // The "stateChanged" event should fire before anyone waiting to
             // take the lock. Taking the lock from within the "stateChanged"

--- a/test/unit/spec/statemachine.js
+++ b/test/unit/spec/statemachine.js
@@ -90,8 +90,9 @@ describe('StateMachine', () => {
         context('and a new lock is not requested', () => {
           it('sets .state and releases the current lock', async () => {
             const sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
-            const key = sm.takeLockSync('lock');
             const deferred = defer();
+
+            sm.takeLockSync('lock');
 
             let i = 0;
 
@@ -129,8 +130,9 @@ describe('StateMachine', () => {
         context('and a new lock is requested', () => {
           it('sets .state, releases the current lock, and takes a new lock', async () => {
             const sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
-            const key1 = sm.takeLockSync('lock1');
             const deferred = defer();
+
+            sm.takeLockSync('lock1');
 
             let i = 0;
 
@@ -151,7 +153,7 @@ describe('StateMachine', () => {
                 return i++;
               }),
               deferred.promise
-            ])
+            ]);
 
             const key2 = sm.preempt('bar', 'lock2');
             assert.equal('bar', sm.state);
@@ -178,7 +180,7 @@ describe('StateMachine', () => {
             sm.preempt('bar', null, ['baz']);
             assert.equal('bar', sm.state);
 
-            const [bar, baz] = await promise;
+            const [, baz] = await promise;
             assert.equal('bar', sm.state);
             assert.equal('baz', baz);
           });
@@ -195,7 +197,7 @@ describe('StateMachine', () => {
             assert.equal('bar', sm.state);
             assert(sm.hasLock(key));
 
-            const [bar, baz] = await promise;
+            const [, baz] = await promise;
             assert.equal('bar', sm.state);
             assert.equal('baz', baz);
           });
@@ -474,7 +476,7 @@ describe('StateMachine', () => {
       it('should delete the Promise from the ._whenDeferreds Set', () => {
         const sm = new StateMachine('foo', { foo: [] });
         const whenDeferredsSize = sm._whenDeferreds.size;
-        return sm.when('foo').then(_sm => assert.equal(sm._whenDeferreds.size, whenDeferredsSize));
+        return sm.when('foo').then(() => assert.equal(sm._whenDeferreds.size, whenDeferredsSize));
       });
     });
 
@@ -492,7 +494,7 @@ describe('StateMachine', () => {
           const whenDeferredsSize = sm._whenDeferreds.size;
           return sm.when('bar').then(
             () => { throw new Error('Unexpected resolution'); },
-            error => assert.equal(sm._whenDeferreds.size, whenDeferredsSize));
+            () => assert.equal(sm._whenDeferreds.size, whenDeferredsSize));
         });
       });
 
@@ -508,7 +510,7 @@ describe('StateMachine', () => {
           it('should delete the Promise from the ._whenDeferreds Set', () => {
             const sm = new StateMachine('foo', { foo: ['bar'], bar: [] });
             const whenDeferredsSize = sm._whenDeferreds.size;
-            const promise = sm.when('bar').then(_sm => assert.equal(sm._whenDeferreds.size, whenDeferredsSize));
+            const promise = sm.when('bar').then(() => assert.equal(sm._whenDeferreds.size, whenDeferredsSize));
             sm.transition('bar');
             return promise;
           });
@@ -529,7 +531,7 @@ describe('StateMachine', () => {
             const whenDeferredsSize = sm._whenDeferreds.size;
             const promise = sm.when('baz').then(
               () => { throw new Error('Unexpected resolution'); },
-              error => assert.equal(sm._whenDeferreds.size, whenDeferredsSize));
+              () => assert.equal(sm._whenDeferreds.size, whenDeferredsSize));
             sm.transition('bar');
             return promise;
           });

--- a/test/unit/spec/stats/localaudiotrackstats.js
+++ b/test/unit/spec/stats/localaudiotrackstats.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var assert = require('assert');
-var LocalAudioTrackStats = require('../../../../lib/stats/localaudiotrackstats');
+const assert = require('assert');
+
+const LocalAudioTrackStats = require('../../../../lib/stats/localaudiotrackstats');
 
 describe('LocalAudioTrackStats', () => {
   describe('constructor', () => {

--- a/test/unit/spec/stats/localaudiotrackstats.js
+++ b/test/unit/spec/stats/localaudiotrackstats.js
@@ -6,7 +6,7 @@ const LocalAudioTrackStats = require('../../../../lib/stats/localaudiotrackstats
 
 describe('LocalAudioTrackStats', () => {
   describe('constructor', () => {
-    var stats = {
+    const stats = {
       trackId: 'abcd',
       timestamp: 12345,
       ssrc: 'foo',
@@ -15,13 +15,13 @@ describe('LocalAudioTrackStats', () => {
     };
 
     it('should set the audioLevel and jitter properties', () => {
-      var trackStats = new LocalAudioTrackStats(stats.trackId, stats);
+      const trackStats = new LocalAudioTrackStats(stats.trackId, stats);
       assert.equal(trackStats.audioLevel, stats.audioInputLevel);
       assert.equal(trackStats.jitter, stats.jitter);
     });
 
     [['audioLevel', 'audioInputLevel'], 'jitter'].forEach(statName => {
-      var propName = typeof statName === 'string'
+      const propName = typeof statName === 'string'
         ? statName : statName[0];
 
       statName = typeof statName === 'string'
@@ -29,10 +29,10 @@ describe('LocalAudioTrackStats', () => {
 
       context(`when ${statName} is absent from the StandardizedTrackStatsReport`, () => {
         it(`should set the ${propName} property to null`, () => {
-          var statValue = stats[statName];
+          const statValue = stats[statName];
           delete stats[statName];
 
-          var trackStats = new LocalAudioTrackStats(stats.trackId, stats);
+          const trackStats = new LocalAudioTrackStats(stats.trackId, stats);
           assert.equal(trackStats[propName], null);
 
           stats[statName] = statValue;

--- a/test/unit/spec/stats/localtrackstats.js
+++ b/test/unit/spec/stats/localtrackstats.js
@@ -6,7 +6,7 @@ const LocalTrackStats = require('../../../../lib/stats/localtrackstats');
 
 describe('LocalTrackStats', () => {
   describe('constructor', () => {
-    var stats = {
+    const stats = {
       trackId: 'abcd',
       timestamp: 12345,
       ssrc: 'foo',
@@ -16,7 +16,7 @@ describe('LocalTrackStats', () => {
     };
 
     it('should set bytesSent, packetsSent and roundTripTime properties', () => {
-      var trackStats = new LocalTrackStats(stats.trackId, stats);
+      const trackStats = new LocalTrackStats(stats.trackId, stats);
       assert.equal(trackStats.bytesSent, stats.bytesSent);
       assert.equal(trackStats.packetsSent, stats.packetsSent);
       assert.equal(trackStats.roundTripTime, stats.roundTripTime);
@@ -25,10 +25,10 @@ describe('LocalTrackStats', () => {
     ['bytesSent', 'packetsSent', 'roundTripTime'].forEach(statName => {
       context(`when ${statName} is absent from the StandardizedTrackStatsReport`, () => {
         it(`should set the ${statName} property to null`, () => {
-          var statValue = stats[statName];
+          const statValue = stats[statName];
           delete stats[statName];
 
-          var trackStats = new LocalTrackStats(stats.trackId, stats);
+          const trackStats = new LocalTrackStats(stats.trackId, stats);
           assert.equal(trackStats[statName], null);
 
           stats[statName] = statValue;

--- a/test/unit/spec/stats/localtrackstats.js
+++ b/test/unit/spec/stats/localtrackstats.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var assert = require('assert');
-var LocalTrackStats = require('../../../../lib/stats/localtrackstats');
+const assert = require('assert');
+
+const LocalTrackStats = require('../../../../lib/stats/localtrackstats');
 
 describe('LocalTrackStats', () => {
   describe('constructor', () => {

--- a/test/unit/spec/stats/localvideotrackstats.js
+++ b/test/unit/spec/stats/localvideotrackstats.js
@@ -49,7 +49,7 @@ describe('LocalVideoTrackStats', () => {
           const trackStats = new LocalVideoTrackStats(stats.trackId, stats);
           assert.equal(trackStats[prop], null);
 
-          statNames.forEach(name => stats[name] = statsValues[name]);
+          statNames.forEach(name => { stats[name] = statsValues[name]; });
         });
       });
     });

--- a/test/unit/spec/stats/localvideotrackstats.js
+++ b/test/unit/spec/stats/localvideotrackstats.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var assert = require('assert');
-var LocalVideoTrackStats = require('../../../../lib/stats/localvideotrackstats');
+const assert = require('assert');
+
+const LocalVideoTrackStats = require('../../../../lib/stats/localvideotrackstats');
 
 describe('LocalVideoTrackStats', () => {
   describe('constructor', () => {

--- a/test/unit/spec/stats/localvideotrackstats.js
+++ b/test/unit/spec/stats/localvideotrackstats.js
@@ -6,7 +6,7 @@ const LocalVideoTrackStats = require('../../../../lib/stats/localvideotrackstats
 
 describe('LocalVideoTrackStats', () => {
   describe('constructor', () => {
-    var stats = {
+    const stats = {
       trackId: 'abcd',
       timestamp: 12345,
       ssrc: 'foo',
@@ -19,7 +19,7 @@ describe('LocalVideoTrackStats', () => {
     };
 
     it('should set the captureDimensions, dimensions, captureFrameRate and frameRate properties', () => {
-      var trackStats = new LocalVideoTrackStats(stats.trackId, stats);
+      const trackStats = new LocalVideoTrackStats(stats.trackId, stats);
       assert.deepEqual(trackStats.captureDimensions, {
         width: stats.frameWidthInput,
         height: stats.frameHeightInput
@@ -37,19 +37,16 @@ describe('LocalVideoTrackStats', () => {
       [['frameWidthSent', 'frameHeightSent'], 'dimensions'],
       [['frameRateInput'], 'captureFrameRate'],
       [['frameRateSent'], 'frameRate']
-    ].forEach(nulledStats => {
-      var statNames = nulledStats[0];
-      var prop = nulledStats[1];
-
+    ].forEach(([statNames, prop]) => {
       context(`when the StandardizedTrackStatsReport does not have ${statNames.join(', ')}`, () => {
         it(`should set the ${prop} property to null`, () => {
-          var statsValues = statNames.reduce((values, name) => {
+          const statsValues = statNames.reduce((values, name) => {
             values[name] = stats[name];
             delete stats[name];
             return values;
           }, {});
 
-          var trackStats = new LocalVideoTrackStats(stats.trackId, stats);
+          const trackStats = new LocalVideoTrackStats(stats.trackId, stats);
           assert.equal(trackStats[prop], null);
 
           statNames.forEach(name => stats[name] = statsValues[name]);

--- a/test/unit/spec/stats/remoteaudiotrackstats.js
+++ b/test/unit/spec/stats/remoteaudiotrackstats.js
@@ -6,7 +6,7 @@ const RemoteAudioTrackStats = require('../../../../lib/stats/remoteaudiotracksta
 
 describe('RemoteAudioTrackStats', () => {
   describe('constructor', () => {
-    var stats = {
+    const stats = {
       trackId: 'abcd',
       timestamp: 12345,
       ssrc: 'foo',
@@ -15,13 +15,13 @@ describe('RemoteAudioTrackStats', () => {
     };
 
     it('should set the audioLevel and jitter properties', () => {
-      var trackStats = new RemoteAudioTrackStats(stats.trackId, stats);
+      const trackStats = new RemoteAudioTrackStats(stats.trackId, stats);
       assert.equal(trackStats.audioLevel, stats.audioOutputLevel);
       assert.equal(trackStats.jitter, stats.jitter);
     });
 
     [['audioLevel','audioOutputLevel'], 'jitter'].forEach(statName => {
-      var propName = typeof statName === 'string'
+      const propName = typeof statName === 'string'
         ? statName : statName[0];
 
       statName = typeof statName === 'string'
@@ -29,10 +29,10 @@ describe('RemoteAudioTrackStats', () => {
 
       context(`when ${statName} is absent from the StandardizedTrackStatsReport`, () => {
         it(`should set the ${propName} property to null`, () => {
-          var statValue = stats[statName];
+          const statValue = stats[statName];
           delete stats[statName];
 
-          var trackStats = new RemoteAudioTrackStats(stats.trackId, stats);
+          const trackStats = new RemoteAudioTrackStats(stats.trackId, stats);
           assert.equal(trackStats[propName], null);
 
           stats[statName] = statValue;

--- a/test/unit/spec/stats/remoteaudiotrackstats.js
+++ b/test/unit/spec/stats/remoteaudiotrackstats.js
@@ -20,7 +20,7 @@ describe('RemoteAudioTrackStats', () => {
       assert.equal(trackStats.jitter, stats.jitter);
     });
 
-    [['audioLevel','audioOutputLevel'], 'jitter'].forEach(statName => {
+    [['audioLevel', 'audioOutputLevel'], 'jitter'].forEach(statName => {
       const propName = typeof statName === 'string'
         ? statName : statName[0];
 

--- a/test/unit/spec/stats/remoteaudiotrackstats.js
+++ b/test/unit/spec/stats/remoteaudiotrackstats.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var assert = require('assert');
-var RemoteAudioTrackStats = require('../../../../lib/stats/remoteaudiotrackstats');
+const assert = require('assert');
+
+const RemoteAudioTrackStats = require('../../../../lib/stats/remoteaudiotrackstats');
 
 describe('RemoteAudioTrackStats', () => {
   describe('constructor', () => {

--- a/test/unit/spec/stats/remotetrackstats.js
+++ b/test/unit/spec/stats/remotetrackstats.js
@@ -6,7 +6,7 @@ const RemoteTrackStats = require('../../../../lib/stats/remotetrackstats');
 
 describe('RemoteTrackStats', () => {
   describe('constructor', () => {
-    var stats = {
+    const stats = {
       trackId: 'abcd',
       timestamp: 12345,
       ssrc: 'foo',
@@ -15,7 +15,7 @@ describe('RemoteTrackStats', () => {
     };
 
     it('should set bytesReceived and packetsReceived properties', () => {
-      var trackStats = new RemoteTrackStats(stats.trackId, stats);
+      const trackStats = new RemoteTrackStats(stats.trackId, stats);
       assert.equal(trackStats.bytesReceived, stats.bytesReceived);
       assert.equal(trackStats.packetsReceived, stats.packetsReceived);
     });
@@ -23,10 +23,10 @@ describe('RemoteTrackStats', () => {
     ['bytesReceived', 'packetsReceived'].forEach(statName => {
       context(`when ${statName} is absent from the StandardizedTrackStatsReport`, () => {
         it(`should set the ${statName} property to null`, () => {
-          var statValue = stats[statName];
+          const statValue = stats[statName];
           delete stats[statName];
 
-          var trackStats = new RemoteTrackStats(stats.trackId, stats);
+          const trackStats = new RemoteTrackStats(stats.trackId, stats);
           assert.equal(trackStats[statName], null);
 
           stats[statName] = statValue;

--- a/test/unit/spec/stats/remotetrackstats.js
+++ b/test/unit/spec/stats/remotetrackstats.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var assert = require('assert');
-var RemoteTrackStats = require('../../../../lib/stats/remotetrackstats');
+const assert = require('assert');
+
+const RemoteTrackStats = require('../../../../lib/stats/remotetrackstats');
 
 describe('RemoteTrackStats', () => {
   describe('constructor', () => {

--- a/test/unit/spec/stats/remotevideotrackstats.js
+++ b/test/unit/spec/stats/remotevideotrackstats.js
@@ -6,7 +6,7 @@ const RemoteVideoTrackStats = require('../../../../lib/stats/remotevideotracksta
 
 describe('RemoteVideoTrackStats', () => {
   describe('constructor', () => {
-    var stats = {
+    const stats = {
       trackId: 'abcd',
       timestamp: 12345,
       ssrc: 'foo',
@@ -16,7 +16,7 @@ describe('RemoteVideoTrackStats', () => {
     };
 
     it('should set the dimensions and frameRate properties', () => {
-      var trackStats = new RemoteVideoTrackStats(stats.trackId, stats);
+      const trackStats = new RemoteVideoTrackStats(stats.trackId, stats);
       assert.deepEqual(trackStats.dimensions, {
         width: stats.frameWidthReceived,
         height: stats.frameHeightReceived
@@ -27,19 +27,16 @@ describe('RemoteVideoTrackStats', () => {
     [
       [['frameWidthReceived', 'frameHeightReceived'], 'dimensions'],
       [['frameRateReceived'], 'frameRate']
-    ].forEach(nulledStats => {
-      var statNames = nulledStats[0];
-      var prop = nulledStats[1];
-
+    ].forEach(([statNames, prop]) => {
       context(`when the StandardizedTrackStatsReport does not have ${statNames.join(', ')}`, () => {
         it(`should set the ${prop} property to null`, () => {
-          var statsValues = statNames.reduce((values, name) => {
+          const statsValues = statNames.reduce((values, name) => {
             values[name] = stats[name];
             delete stats[name];
             return values;
           }, {});
 
-          var trackStats = new RemoteVideoTrackStats(stats.trackId, stats);
+          const trackStats = new RemoteVideoTrackStats(stats.trackId, stats);
           assert.equal(trackStats[prop], null);
 
           statNames.forEach(name => stats[name] = statsValues[name]);

--- a/test/unit/spec/stats/remotevideotrackstats.js
+++ b/test/unit/spec/stats/remotevideotrackstats.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var assert = require('assert');
-var RemoteVideoTrackStats = require('../../../../lib/stats/remotevideotrackstats');
+const assert = require('assert');
+
+const RemoteVideoTrackStats = require('../../../../lib/stats/remotevideotrackstats');
 
 describe('RemoteVideoTrackStats', () => {
   describe('constructor', () => {

--- a/test/unit/spec/stats/remotevideotrackstats.js
+++ b/test/unit/spec/stats/remotevideotrackstats.js
@@ -39,7 +39,7 @@ describe('RemoteVideoTrackStats', () => {
           const trackStats = new RemoteVideoTrackStats(stats.trackId, stats);
           assert.equal(trackStats[prop], null);
 
-          statNames.forEach(name => stats[name] = statsValues[name]);
+          statNames.forEach(name => { stats[name] = statsValues[name]; });
         });
       });
     });

--- a/test/unit/spec/stats/trackstats.js
+++ b/test/unit/spec/stats/trackstats.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var assert = require('assert');
-var TrackStats = require('../../../../lib/stats/trackstats');
+const assert = require('assert');
+
+const TrackStats = require('../../../../lib/stats/trackstats');
 
 describe('TrackStats', () => {
   describe('constructor', () => {

--- a/test/unit/spec/stats/trackstats.js
+++ b/test/unit/spec/stats/trackstats.js
@@ -6,7 +6,7 @@ const TrackStats = require('../../../../lib/stats/trackstats');
 
 describe('TrackStats', () => {
   describe('constructor', () => {
-    var stats = {
+    const stats = {
       trackId: 'abcd',
       ssrc: 'foo',
       timestamp: 12345,
@@ -23,7 +23,7 @@ describe('TrackStats', () => {
     });
 
     it('should set trackId, ssrc, timestamp, packetsLost, and codec properties', () => {
-      var trackStats = new TrackStats(stats.trackId, stats);
+      const trackStats = new TrackStats(stats.trackId, stats);
       assert.equal(trackStats.trackId, stats.trackId);
       assert.equal(trackStats.ssrc, stats.ssrc);
       assert.equal(trackStats.timestamp, stats.timestamp);
@@ -32,7 +32,7 @@ describe('TrackStats', () => {
     });
 
     ['packetsLost', ['codec', 'codecName']].forEach(statName => {
-      var propName = typeof statName === 'string'
+      const propName = typeof statName === 'string'
         ? statName : statName[0];
 
       statName = typeof statName === 'string'
@@ -40,10 +40,10 @@ describe('TrackStats', () => {
 
       context(`when ${statName} is absent from the StandardizedTrackStatsReport`, () => {
         it(`should set the ${propName} property to null`, () => {
-          var statValue = stats[statName];
+          const statValue = stats[statName];
           delete stats[statName];
 
-          var trackStats = new TrackStats(stats.trackId, stats);
+          const trackStats = new TrackStats(stats.trackId, stats);
           assert.equal(trackStats[propName], null);
 
           stats[statName] = statValue;

--- a/test/unit/spec/util/cancelablepromise.js
+++ b/test/unit/spec/util/cancelablepromise.js
@@ -171,7 +171,7 @@ describe('CancelablePromise', () => {
             cancelablePromise.catch(() => {});
           });
         }
-      }); 
+      });
     });
   });
 
@@ -333,7 +333,7 @@ describe('CancelablePromise', () => {
             cancelablePromise.catch(() => {});
           });
         }
-      }); 
+      });
     });
   });
 });

--- a/test/unit/spec/util/cancelablepromise.js
+++ b/test/unit/spec/util/cancelablepromise.js
@@ -1,8 +1,10 @@
 'use strict';
 
 const assert = require('assert');
-const { a } = require('../../../lib/util');
+
 const CancelablePromise = require('../../../../lib/util/cancelablepromise');
+
+const { a } = require('../../../lib/util');
 
 describe('CancelablePromise', () => {
   describe('constructor', () => {

--- a/test/unit/spec/util/index.js
+++ b/test/unit/spec/util/index.js
@@ -1,18 +1,17 @@
 'use strict';
 
-var assert = require('assert');
-var constants = require('../../../../lib/util/constants');
-var EventEmitter = require('events').EventEmitter;
-var sinon = require('sinon');
-var util = require('../../../../lib/util');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const sinon = require('sinon');
 
+const { makeUUID, promiseFromEvents } = require('../../../../lib/util');
 
 describe('util', function() {
   describe('makeUUID', function() {
     it('should generate a unique UUID', function() {
-      var uuid1 = util.makeUUID();
-      var uuid2 = util.makeUUID();
-      var uuid3 = util.makeUUID();
+      var uuid1 = makeUUID();
+      var uuid2 = makeUUID();
+      var uuid3 = makeUUID();
 
       assert.notEqual(uuid1, uuid2);
       assert.notEqual(uuid2, uuid3);
@@ -28,7 +27,7 @@ describe('util', function() {
     beforeEach(function() {
       emitter = new EventEmitter();
       spy = sinon.spy();
-      promise = util.promiseFromEvents(spy, emitter, 'foo', 'bar');
+      promise = promiseFromEvents(spy, emitter, 'foo', 'bar');
     });
 
     it('should call the function passed', function() {
@@ -46,7 +45,7 @@ describe('util', function() {
     });
 
     it('should not require a failure event', function(done) {
-      promise = util.promiseFromEvents(spy, emitter, 'foo');
+      promise = promiseFromEvents(spy, emitter, 'foo');
       promise.then(done);
       emitter.emit('foo');
     });

--- a/test/unit/spec/util/index.js
+++ b/test/unit/spec/util/index.js
@@ -9,9 +9,9 @@ const { makeUUID, promiseFromEvents } = require('../../../../lib/util');
 describe('util', function() {
   describe('makeUUID', function() {
     it('should generate a unique UUID', function() {
-      var uuid1 = makeUUID();
-      var uuid2 = makeUUID();
-      var uuid3 = makeUUID();
+      const uuid1 = makeUUID();
+      const uuid2 = makeUUID();
+      const uuid3 = makeUUID();
 
       assert.notEqual(uuid1, uuid2);
       assert.notEqual(uuid2, uuid3);
@@ -20,9 +20,9 @@ describe('util', function() {
   });
 
   describe('promiseFromEvents', function() {
-    var emitter;
-    var promise;
-    var spy;
+    let emitter;
+    let promise;
+    let spy;
 
     beforeEach(function() {
       emitter = new EventEmitter();

--- a/test/unit/spec/util/index.js
+++ b/test/unit/spec/util/index.js
@@ -6,9 +6,9 @@ const sinon = require('sinon');
 
 const { makeUUID, promiseFromEvents } = require('../../../../lib/util');
 
-describe('util', function() {
-  describe('makeUUID', function() {
-    it('should generate a unique UUID', function() {
+describe('util', () => {
+  describe('makeUUID', () => {
+    it('should generate a unique UUID', () => {
       const uuid1 = makeUUID();
       const uuid2 = makeUUID();
       const uuid3 = makeUUID();
@@ -19,35 +19,41 @@ describe('util', function() {
     });
   });
 
-  describe('promiseFromEvents', function() {
+  describe('promiseFromEvents', () => {
     let emitter;
     let promise;
     let spy;
 
-    beforeEach(function() {
+    beforeEach(() => {
       emitter = new EventEmitter();
       spy = sinon.spy();
       promise = promiseFromEvents(spy, emitter, 'foo', 'bar');
     });
 
-    it('should call the function passed', function() {
+    it('should call the function passed', () => {
       assert(spy.calledOnce);
     });
 
-    it('should resolve when the success event is fired', function(done) {
-      promise.then(done);
+    it('should resolve when the success event is fired', () => {
       emitter.emit('foo');
+      return promise;
     });
 
-    it('should reject when the failure event is fired', function(done) {
-      promise.catch(done);
+    it('should reject when the failure event is fired', async () => {
       emitter.emit('bar');
+      try {
+        await promise;
+      } catch (error) {
+        // Expected rejection
+        return;
+      }
+      throw new Error('Unexpected resolution');
     });
 
-    it('should not require a failure event', function(done) {
+    it('should not require a failure event', () => {
       promise = promiseFromEvents(spy, emitter, 'foo');
-      promise.then(done);
       emitter.emit('foo');
+      return promise;
     });
   });
 });

--- a/test/unit/spec/util/insightspublisher.js
+++ b/test/unit/spec/util/insightspublisher.js
@@ -1,11 +1,12 @@
 'use strict';
 
-const EventTarget = require('../../../../lib/eventtarget');
-const InsightsPublisher = require('../../../../lib/util/insightspublisher');
 const assert = require('assert');
-const inherits = require('util').inherits;
+const { inherits } = require('util');
 const sinon = require('sinon');
-const util = require('../../../../lib/util');
+
+const EventTarget = require('../../../../lib/eventtarget');
+const { defer } = require('../../../../lib/util');
+const InsightsPublisher = require('../../../../lib/util/insightspublisher');
 
 describe('InsightsPublisher', () => {
   describe('constructor', () => {
@@ -279,7 +280,7 @@ describe('InsightsPublisher', () => {
         var disconnectedError = null;
         var reconnectingEmitted = false;
         var reconnectAttemptsLeft;
-        const reconnectDeferreds = [ util.defer(), util.defer() ];
+        const reconnectDeferreds = [ defer(), defer() ];
         var reconnectedDeferredsIdx = 0;
         const timestamps = [];
 

--- a/test/unit/spec/util/insightspublisher.js
+++ b/test/unit/spec/util/insightspublisher.js
@@ -21,6 +21,7 @@ describe('InsightsPublisher', () => {
 
     context('when called without the "new" keyword', () => {
       it('should return an instance of InsightsPublisher', () => {
+        // eslint-disable-next-line new-cap
         const publisher = InsightsPublisher('token', 'foo', 'bar', 'baz', 'zee', {
           WebSocket: FakeWebSocket
         });
@@ -38,7 +39,7 @@ describe('InsightsPublisher', () => {
       });
     });
 
-    [ 'CLOSING', 'CLOSED' ].forEach(readyState => {
+    ['CLOSING', 'CLOSED'].forEach(readyState => {
       context(`when the underlying WebSocket is ${readyState}`, () => {
         it('should return false', () => {
           publisher._ws.readyState = FakeWebSocket[readyState];
@@ -47,7 +48,7 @@ describe('InsightsPublisher', () => {
       });
     });
 
-    [ 'CONNECTING', 'OPEN' ].forEach(readyState => {
+    ['CONNECTING', 'OPEN'].forEach(readyState => {
       context(`when the underlying WebSocket is ${readyState}`, () => {
         beforeEach(() => {
           publisher._ws.readyState = FakeWebSocket[readyState];
@@ -90,7 +91,7 @@ describe('InsightsPublisher', () => {
     });
 
     context('when the ._session of the InsightsPublisher is null', () => {
-      [ 'CONNECTING', 'OPEN' ].forEach(readyState => {
+      ['CONNECTING', 'OPEN'].forEach(readyState => {
         const contextDesc = `when the underlying WebSocket is ${readyState}`;
         context(contextDesc, () => {
           let payload;
@@ -183,7 +184,7 @@ describe('InsightsPublisher', () => {
             wsUrl = url;
           })
         };
-        const publisher = new InsightsPublisher('token', 'foo', 'bar', 'baz', 'zee', options);
+        new InsightsPublisher('token', 'foo', 'bar', 'baz', 'zee', options);
         assert.equal(wsUrl, 'somegateway');
       });
     });
@@ -196,7 +197,7 @@ describe('InsightsPublisher', () => {
             wsUrl = url;
           })
         };
-        const publisher = new InsightsPublisher('token', 'foo', 'bar', 'baz', 'zee', options);
+        new InsightsPublisher('token', 'foo', 'bar', 'baz', 'zee', options);
         assert.equal(wsUrl, 'wss://sdkgw.baz-zee.twilio.com/v1/VideoEvents');
       });
     });
@@ -233,7 +234,7 @@ describe('InsightsPublisher', () => {
           WebSocket: FakeWebSocket
         });
 
-        publisher.once('connected', () => connectedEmitted = true);
+        publisher.once('connected', () => { connectedEmitted = true; });
         publisher._eventQueue.push({ foo: 1 });
         publisher._eventQueue.push({ bar: 'baz' });
         publisher._reconnectAttemptsLeft = 1;
@@ -275,8 +276,8 @@ describe('InsightsPublisher', () => {
     });
 
     context('when the underlying WebSocket emits a "message" event with an "error" message', () => {
-      [ '> 0', '=== 0' ].forEach((scenario, i) => {
-        const reconnectDeferreds = [ defer(), defer() ];
+      ['> 0', '=== 0'].forEach((scenario, i) => {
+        const reconnectDeferreds = [defer(), defer()];
         const timestamps = [];
 
         let publisher;
@@ -297,8 +298,8 @@ describe('InsightsPublisher', () => {
               })
             });
 
-            publisher.once('disconnected', error => disconnectedError = error);
-            publisher.once('reconnecting', () => reconnectingEmitted = true);
+            publisher.once('disconnected', error => { disconnectedError = error; });
+            publisher.once('reconnecting', () => { reconnectingEmitted = true; });
             publisher._reconnectAttemptsLeft = i === 1 ? 0 : 10;
             reconnectAttemptsLeft = publisher._reconnectAttemptsLeft;
             publisher._ws.readyState = FakeWebSocket.OPEN;
@@ -357,12 +358,12 @@ function FakeWebSocket(arg) {
 
 inherits(FakeWebSocket, EventTarget);
 
-[ 'CONNECTING', 'OPEN', 'CLOSING', 'CLOSED' ].forEach((readyState, i) => {
+['CONNECTING', 'OPEN', 'CLOSING', 'CLOSED'].forEach((readyState, i) => {
   FakeWebSocket[readyState] = i;
 });
 
 function customizedWebSocket(ctor, init) {
   const customized = ctor.bind(null, init);
-  Object.keys(ctor).forEach(key => customized[key] = ctor[key]);
+  Object.keys(ctor).forEach(key => { customized[key] = ctor[key]; });
   return customized;
 }

--- a/test/unit/spec/util/insightspublisher.js
+++ b/test/unit/spec/util/insightspublisher.js
@@ -168,7 +168,7 @@ describe('InsightsPublisher', () => {
   describe('connect/reconnect', () => {
     it('should throw when the WebSocket constructor throws', () => {
       assert.throws(() => new InsightsPublisher('token', 'foo', 'bar', 'baz', 'zee', {
-        WebSocket: customizedWebSocket(FakeWebSocket, function() {
+        WebSocket: customizedWebSocket(FakeWebSocket, () => {
           throw new Error('test');
         })
       }));
@@ -179,7 +179,7 @@ describe('InsightsPublisher', () => {
         let wsUrl;
         const options = {
           gateway: 'somegateway',
-          WebSocket: customizedWebSocket(FakeWebSocket, function(url) {
+          WebSocket: customizedWebSocket(FakeWebSocket, url => {
             wsUrl = url;
           })
         };
@@ -192,7 +192,7 @@ describe('InsightsPublisher', () => {
       it('should call the WebSocket constructor with the gateway created from environment and realm', () => {
         let wsUrl;
         const options = {
-          WebSocket: customizedWebSocket(FakeWebSocket, function(url) {
+          WebSocket: customizedWebSocket(FakeWebSocket, url => {
             wsUrl = url;
           })
         };
@@ -291,7 +291,7 @@ describe('InsightsPublisher', () => {
               maxReconnectAttempts: 10,
               reconnectIntervalMs: 100,
               userAgent: 'baz',
-              WebSocket: customizedWebSocket(FakeWebSocket, function() {
+              WebSocket: customizedWebSocket(FakeWebSocket, () => {
                 reconnectDeferreds[reconnectedDeferredsIdx++].resolve();
                 timestamps.push(Date.now());
               })

--- a/test/unit/spec/util/insightspublisher.js
+++ b/test/unit/spec/util/insightspublisher.js
@@ -30,7 +30,7 @@ describe('InsightsPublisher', () => {
   });
 
   describe('#disconnect', () => {
-    var publisher;
+    let publisher;
 
     beforeEach(() => {
       publisher = new InsightsPublisher('token', 'foo', 'bar', 'baz', 'zee', {
@@ -74,7 +74,7 @@ describe('InsightsPublisher', () => {
   });
 
   describe('#publish', () => {
-    var publisher;
+    let publisher;
 
     beforeEach(() => {
       publisher = new InsightsPublisher('token', 'foo', 'bar', 'baz', 'zee', {
@@ -93,8 +93,8 @@ describe('InsightsPublisher', () => {
       [ 'CONNECTING', 'OPEN' ].forEach(readyState => {
         const contextDesc = `when the underlying WebSocket is ${readyState}`;
         context(contextDesc, () => {
-          var payload;
-          var ret;
+          let payload;
+          let ret;
 
           beforeEach(() => {
             payload = { baz: 1 };
@@ -129,8 +129,8 @@ describe('InsightsPublisher', () => {
     });
 
     context('when the ._session of the InsightsPublisher is not null', () => {
-      var payload;
-      var ret;
+      let payload;
+      let ret;
 
       beforeEach(() => {
         payload = { baz: 1 };
@@ -176,7 +176,7 @@ describe('InsightsPublisher', () => {
 
     context('when the WebSocket gateway is specified in the options', () => {
       it('should call the WebSocket constructor with the provided gateway', () => {
-        var wsUrl;
+        let wsUrl;
         const options = {
           gateway: 'somegateway',
           WebSocket: customizedWebSocket(FakeWebSocket, function(url) {
@@ -190,7 +190,7 @@ describe('InsightsPublisher', () => {
 
     context('when the WebSocket gateway is not specified in the options', () => {
       it('should call the WebSocket constructor with the gateway created from environment and realm', () => {
-        var wsUrl;
+        let wsUrl;
         const options = {
           WebSocket: customizedWebSocket(FakeWebSocket, function(url) {
             wsUrl = url;
@@ -224,8 +224,8 @@ describe('InsightsPublisher', () => {
     });
 
     context('when the underlying WebSocket emits a "message" event with a "connected" RSP message', () => {
-      var publisher;
-      var connectedEmitted = false;
+      let publisher;
+      let connectedEmitted;
 
       before(() => {
         publisher = new InsightsPublisher('token', 'foo', 'bar', 'baz', 'zee', {
@@ -276,13 +276,14 @@ describe('InsightsPublisher', () => {
 
     context('when the underlying WebSocket emits a "message" event with an "error" message', () => {
       [ '> 0', '=== 0' ].forEach((scenario, i) => {
-        var publisher;
-        var disconnectedError = null;
-        var reconnectingEmitted = false;
-        var reconnectAttemptsLeft;
         const reconnectDeferreds = [ defer(), defer() ];
-        var reconnectedDeferredsIdx = 0;
         const timestamps = [];
+
+        let publisher;
+        let disconnectedError;
+        let reconnectingEmitted;
+        let reconnectAttemptsLeft;
+        let reconnectedDeferredsIdx = 0;
 
         context(`when the ._reconnectAttemptsLeft ${scenario}`, () => {
           before(() => {

--- a/test/unit/spec/util/log.js
+++ b/test/unit/spec/util/log.js
@@ -6,7 +6,13 @@ const sinon = require('sinon');
 const { DEFAULT_LOG_LEVEL } = require('../../../../lib/util/constants');
 const Log = require('../../../../lib/util/log');
 
-const component = (name) => ({ toString: () => name });
+function component(name) {
+  return {
+    toString() {
+      return name;
+    }
+  };
+}
 
 describe('Log', () => {
   const log = Log.prototype.log;
@@ -38,6 +44,7 @@ describe('Log', () => {
 
     it('should return an instance of Log', () => {
       const log1 = new Log('foo', component('log1'));
+      // eslint-disable-next-line new-cap
       const log2 = Log('bar', component('log2'));
 
       assert(log1 instanceof Log);
@@ -67,7 +74,7 @@ describe('Log', () => {
         foo: 'debug',
         bar: 'error'
       });
-      const level = log.logLevel;
+      void log.logLevel;
       assert(Log.getLevelByName.calledWith('debug'));
     });
 
@@ -96,7 +103,7 @@ describe('Log', () => {
 
     it('should return the corresponding constant if the input is a valid log level', () => {
       const level = Log.getLevelByName('off');
-      assert.equal(level, Log['OFF']);
+      assert.equal(level, Log.OFF);
     });
   });
 
@@ -138,6 +145,7 @@ describe('Log', () => {
 
   describe('#log(logLevel, message)', () => {
     it('should throw an error if the logLevel passed is invalid', () => {
+      // eslint-disable-next-line new-cap
       const log = Log('foo', component('bar'));
       assert.throws(log.log.bind(log, 999), error => {
         return error instanceof RangeError && /logLevel must be one of/.test(error.message);
@@ -145,12 +153,14 @@ describe('Log', () => {
     });
 
     it('should call the log function if the logLevel is within the Logs verbosity', () => {
+      // eslint-disable-next-line new-cap
       const log = Log('foo', component('bar'), { foo: 'warn' });
       log.log(Log.ERROR, 'foo');
       assert(Log._levels[Log.ERROR].logFn.called);
     });
 
     it('should not call the log function if the logLevel is outside of the Logs verbosity', () => {
+      // eslint-disable-next-line new-cap
       const log = Log('foo', component('bar'), { foo: 'off' });
       log.log(Log.WARN, 'foo');
       assert(!Log._levels[Log.WARN].logFn.called);
@@ -159,6 +169,7 @@ describe('Log', () => {
 
   describe('#debug(messages)', () => {
     it('should call #log(Log.DEBUG, message)', () => {
+      // eslint-disable-next-line new-cap
       const log = Log('foo', component('bar'), { foo: 'debug' });
       log.debug('baz');
       sinon.assert.calledWith(log.log, Log.DEBUG, ['baz']);
@@ -168,6 +179,7 @@ describe('Log', () => {
   describe('#deprecated(deprecationWarning)', () => {
     context('the first time the deprecationWarning is passed', () => {
       it('should call #log(Log.WARN, message)', () => {
+        // eslint-disable-next-line new-cap
         const log = Log('foo', component('bar'), { foo: 'warn' });
         log.deprecated('baz');
         sinon.assert.calledWith(log.log, Log.WARN, ['baz']);
@@ -176,6 +188,7 @@ describe('Log', () => {
 
     context('subsequent times the deprecationWarning is passed', () => {
       it('should call #log(Log.WARN, message)', () => {
+        // eslint-disable-next-line new-cap
         const log = Log('foo', component('bar'), { foo: 'warn' });
         log.deprecated('baz');
         log.deprecated('baz');
@@ -186,6 +199,7 @@ describe('Log', () => {
 
   describe('#info(messages)', () => {
     it('should call #log(Log.INFO, message)', () => {
+      // eslint-disable-next-line new-cap
       const log = Log('foo', component('bar'), { foo: 'info' });
       log.info('baz');
       sinon.assert.calledWith(log.log, Log.INFO, ['baz']);
@@ -194,6 +208,7 @@ describe('Log', () => {
 
   describe('#warn(messages)', () => {
     it('should call #log(Log.WARN, message)', () => {
+      // eslint-disable-next-line new-cap
       const log = Log('foo', component('bar'), { foo: 'warn' });
       log.warn('baz');
       sinon.assert.calledWith(log.log, Log.WARN, ['baz']);
@@ -203,6 +218,7 @@ describe('Log', () => {
   describe('#warnOnce(deprecationWarning)', () => {
     context('the first time the warning is passed', () => {
       it('should call #log(Log.WARN, message)', () => {
+        // eslint-disable-next-line new-cap
         const log = Log('foo', component('bar'), { foo: 'warn' });
         log.warnOnce('baz');
         sinon.assert.calledWith(log.log, Log.WARN, ['baz']);
@@ -211,6 +227,7 @@ describe('Log', () => {
 
     context('subsequent times the warning is passed', () => {
       it('should call #log(Log.WARN, message)', () => {
+        // eslint-disable-next-line new-cap
         const log = Log('foo', component('bar'), { foo: 'warn' });
         log.warnOnce('baz');
         log.warnOnce('baz');
@@ -221,6 +238,7 @@ describe('Log', () => {
 
   describe('#error(messages)', () => {
     it('should call #log(Log.ERROR, message)', () => {
+      // eslint-disable-next-line new-cap
       const log = Log('foo', component('bar'), { foo: 'error' });
       log.error('baz');
       sinon.assert.calledWith(log.log, Log.ERROR, ['baz']);
@@ -229,6 +247,7 @@ describe('Log', () => {
 
   describe('#throw(error, message)', () => {
     it('should throw an error and call #log(Log.ERROR, message)', () => {
+      // eslint-disable-next-line new-cap
       const log = Log('foo', component('bar'), { foo: 'error' });
       const error = new Error('baz');
       assert.throws(log.throw.bind(log, error));
@@ -236,13 +255,16 @@ describe('Log', () => {
     });
 
     it('should call the errors clone method if it exists', () => {
+      // eslint-disable-next-line new-cap
       const log = Log('foo', component('bar'), { foo: 'error' });
       const error = new Error('baz');
       error.clone = sinon.spy();
 
       try {
         log.throw(error, 'foobar');
-      } catch(e) { }
+      } catch (error) {
+        // Do nothing
+      }
 
       assert(error.clone.calledOnce);
     });

--- a/test/unit/spec/util/log.js
+++ b/test/unit/spec/util/log.js
@@ -1,11 +1,12 @@
 'use strict';
 
-var assert = require('assert');
-var sinon = require('sinon');
-var constants = require('../../../../lib/util/constants');
-var component = (name) => ({ toString: () => name });
+const assert = require('assert');
+const sinon = require('sinon');
 
-var Log = require('../../../../lib/util/log');
+const { DEFAULT_LOG_LEVEL } = require('../../../../lib/util/constants');
+const Log = require('../../../../lib/util/log');
+
+const component = (name) => ({ toString: () => name });
 
 describe('Log', function() {
   var log = Log.prototype.log;
@@ -72,12 +73,12 @@ describe('Log', function() {
 
     it('should set the default Log level if module specific level is not specified', () => {
       var log = new Log('foo', component('bar'), { baz: 'error' });
-      assert.equal(log.logLevel, Log.getLevelByName(constants.DEFAULT_LOG_LEVEL));
+      assert.equal(log.logLevel, Log.getLevelByName(DEFAULT_LOG_LEVEL));
     });
 
     it('should set the default Log level if logLevels object is not specified', () => {
       var log = new Log('foo', component('bar'));
-      assert.equal(log.logLevel, Log.getLevelByName(constants.DEFAULT_LOG_LEVEL));
+      assert.equal(log.logLevel, Log.getLevelByName(DEFAULT_LOG_LEVEL));
     });
   });
 

--- a/test/unit/spec/util/log.js
+++ b/test/unit/spec/util/log.js
@@ -8,13 +8,13 @@ const Log = require('../../../../lib/util/log');
 
 const component = (name) => ({ toString: () => name });
 
-describe('Log', function() {
+describe('Log', () => {
   const log = Log.prototype.log;
-  beforeEach(function() {
+  beforeEach(() => {
     Log.prototype.log = sinon.spy(log);
   });
 
-  before(function() {
+  before(() => {
     Log._levels.splice(0, Log._levels.length,
       { name: 'DEBUG', logFn: sinon.spy() },
       { name: 'INFO',  logFn: sinon.spy() },
@@ -24,19 +24,19 @@ describe('Log', function() {
     );
   });
 
-  describe('new Log(component, logLevels)', function() {
+  describe('new Log(component, logLevels)', () => {
     let getLevelByName;
 
-    before(function() {
+    before(() => {
       getLevelByName = Log.getLevelByName;
       Log.getLevelByName = sinon.spy();
     });
 
-    after(function() {
+    after(() => {
       Log.getLevelByName = getLevelByName;
     });
 
-    it('should return an instance of Log', function() {
+    it('should return an instance of Log', () => {
       const log1 = new Log('foo', component('log1'));
       const log2 = Log('bar', component('log2'));
 
@@ -62,7 +62,7 @@ describe('Log', function() {
       assert.equal(log.name, comp.toString());
     });
 
-    it('should call getLevelByName with the passed logLevel', function() {
+    it('should call getLevelByName with the passed logLevel', () => {
       const log = new Log('foo', component('bar'), {
         foo: 'debug',
         bar: 'error'
@@ -82,19 +82,19 @@ describe('Log', function() {
     });
   });
 
-  describe('#getLevelByName(name)', function() {
-    it('should return the input if the input is a number', function() {
+  describe('#getLevelByName(name)', () => {
+    it('should return the input if the input is a number', () => {
       const level = Log.getLevelByName(3);
       assert.equal(level, 3);
     });
 
-    it('should throw an error if the input string is not valid', function() {
+    it('should throw an error if the input string is not valid', () => {
       assert.throws(Log.getLevelByName.bind(null, 'foo'), error => {
         return error instanceof RangeError && /level must be one of/.test(error.message);
       });
     });
 
-    it('should return the corresponding constant if the input is a valid log level', function() {
+    it('should return the corresponding constant if the input is a valid log level', () => {
       const level = Log.getLevelByName('off');
       assert.equal(level, Log['OFF']);
     });
@@ -136,46 +136,46 @@ describe('Log', function() {
     });
   });
 
-  describe('#log(logLevel, message)', function() {
-    it('should throw an error if the logLevel passed is invalid', function() {
+  describe('#log(logLevel, message)', () => {
+    it('should throw an error if the logLevel passed is invalid', () => {
       const log = Log('foo', component('bar'));
       assert.throws(log.log.bind(log, 999), error => {
         return error instanceof RangeError && /logLevel must be one of/.test(error.message);
       });
     });
 
-    it('should call the log function if the logLevel is within the Logs verbosity', function() {
+    it('should call the log function if the logLevel is within the Logs verbosity', () => {
       const log = Log('foo', component('bar'), { foo: 'warn' });
       log.log(Log.ERROR, 'foo');
       assert(Log._levels[Log.ERROR].logFn.called);
     });
 
-    it('should not call the log function if the logLevel is outside of the Logs verbosity', function() {
+    it('should not call the log function if the logLevel is outside of the Logs verbosity', () => {
       const log = Log('foo', component('bar'), { foo: 'off' });
       log.log(Log.WARN, 'foo');
       assert(!Log._levels[Log.WARN].logFn.called);
     });
   });
 
-  describe('#debug(messages)', function() {
-    it('should call #log(Log.DEBUG, message)', function() {
+  describe('#debug(messages)', () => {
+    it('should call #log(Log.DEBUG, message)', () => {
       const log = Log('foo', component('bar'), { foo: 'debug' });
       log.debug('baz');
       sinon.assert.calledWith(log.log, Log.DEBUG, ['baz']);
     });
   });
 
-  describe('#deprecated(deprecationWarning)', function() {
-    context('the first time the deprecationWarning is passed', function() {
-      it('should call #log(Log.WARN, message)', function() {
+  describe('#deprecated(deprecationWarning)', () => {
+    context('the first time the deprecationWarning is passed', () => {
+      it('should call #log(Log.WARN, message)', () => {
         const log = Log('foo', component('bar'), { foo: 'warn' });
         log.deprecated('baz');
         sinon.assert.calledWith(log.log, Log.WARN, ['baz']);
       });
     });
 
-    context('subsequent times the deprecationWarning is passed', function() {
-      it('should call #log(Log.WARN, message)', function() {
+    context('subsequent times the deprecationWarning is passed', () => {
+      it('should call #log(Log.WARN, message)', () => {
         const log = Log('foo', component('bar'), { foo: 'warn' });
         log.deprecated('baz');
         log.deprecated('baz');
@@ -184,33 +184,33 @@ describe('Log', function() {
     });
   });
 
-  describe('#info(messages)', function() {
-    it('should call #log(Log.INFO, message)', function() {
+  describe('#info(messages)', () => {
+    it('should call #log(Log.INFO, message)', () => {
       const log = Log('foo', component('bar'), { foo: 'info' });
       log.info('baz');
       sinon.assert.calledWith(log.log, Log.INFO, ['baz']);
     });
   });
 
-  describe('#warn(messages)', function() {
-    it('should call #log(Log.WARN, message)', function() {
+  describe('#warn(messages)', () => {
+    it('should call #log(Log.WARN, message)', () => {
       const log = Log('foo', component('bar'), { foo: 'warn' });
       log.warn('baz');
       sinon.assert.calledWith(log.log, Log.WARN, ['baz']);
     });
   });
 
-  describe('#warnOnce(deprecationWarning)', function() {
-    context('the first time the warning is passed', function() {
-      it('should call #log(Log.WARN, message)', function() {
+  describe('#warnOnce(deprecationWarning)', () => {
+    context('the first time the warning is passed', () => {
+      it('should call #log(Log.WARN, message)', () => {
         const log = Log('foo', component('bar'), { foo: 'warn' });
         log.warnOnce('baz');
         sinon.assert.calledWith(log.log, Log.WARN, ['baz']);
       });
     });
 
-    context('subsequent times the warning is passed', function() {
-      it('should call #log(Log.WARN, message)', function() {
+    context('subsequent times the warning is passed', () => {
+      it('should call #log(Log.WARN, message)', () => {
         const log = Log('foo', component('bar'), { foo: 'warn' });
         log.warnOnce('baz');
         log.warnOnce('baz');
@@ -219,23 +219,23 @@ describe('Log', function() {
     });
   });
 
-  describe('#error(messages)', function() {
-    it('should call #log(Log.ERROR, message)', function() {
+  describe('#error(messages)', () => {
+    it('should call #log(Log.ERROR, message)', () => {
       const log = Log('foo', component('bar'), { foo: 'error' });
       log.error('baz');
       sinon.assert.calledWith(log.log, Log.ERROR, ['baz']);
     });
   });
 
-  describe('#throw(error, message)', function() {
-    it('should throw an error and call #log(Log.ERROR, message)', function() {
+  describe('#throw(error, message)', () => {
+    it('should throw an error and call #log(Log.ERROR, message)', () => {
       const log = Log('foo', component('bar'), { foo: 'error' });
       const error = new Error('baz');
       assert.throws(log.throw.bind(log, error));
       sinon.assert.calledWith(log.log, Log.ERROR, error);
     });
 
-    it('should call the errors clone method if it exists', function() {
+    it('should call the errors clone method if it exists', () => {
       const log = Log('foo', component('bar'), { foo: 'error' });
       const error = new Error('baz');
       error.clone = sinon.spy();

--- a/test/unit/spec/util/log.js
+++ b/test/unit/spec/util/log.js
@@ -9,7 +9,7 @@ const Log = require('../../../../lib/util/log');
 const component = (name) => ({ toString: () => name });
 
 describe('Log', function() {
-  var log = Log.prototype.log;
+  const log = Log.prototype.log;
   beforeEach(function() {
     Log.prototype.log = sinon.spy(log);
   });
@@ -25,7 +25,7 @@ describe('Log', function() {
   });
 
   describe('new Log(component, logLevels)', function() {
-    var getLevelByName;
+    let getLevelByName;
 
     before(function() {
       getLevelByName = Log.getLevelByName;
@@ -37,8 +37,8 @@ describe('Log', function() {
     });
 
     it('should return an instance of Log', function() {
-      var log1 = new Log('foo', component('log1'));
-      var log2 = Log('bar', component('log2'));
+      const log1 = new Log('foo', component('log1'));
+      const log2 = Log('bar', component('log2'));
 
       assert(log1 instanceof Log);
       assert(log2 instanceof Log);
@@ -57,34 +57,34 @@ describe('Log', function() {
     });
 
     it('should set the name to component.toString()', () => {
-      var comp = component('bar');
-      var log = new Log('foo', comp);
+      const comp = component('bar');
+      const log = new Log('foo', comp);
       assert.equal(log.name, comp.toString());
     });
 
     it('should call getLevelByName with the passed logLevel', function() {
-      var log = new Log('foo', component('bar'), {
+      const log = new Log('foo', component('bar'), {
         foo: 'debug',
         bar: 'error'
       });
-      var level = log.logLevel;
+      const level = log.logLevel;
       assert(Log.getLevelByName.calledWith('debug'));
     });
 
     it('should set the default Log level if module specific level is not specified', () => {
-      var log = new Log('foo', component('bar'), { baz: 'error' });
+      const log = new Log('foo', component('bar'), { baz: 'error' });
       assert.equal(log.logLevel, Log.getLevelByName(DEFAULT_LOG_LEVEL));
     });
 
     it('should set the default Log level if logLevels object is not specified', () => {
-      var log = new Log('foo', component('bar'));
+      const log = new Log('foo', component('bar'));
       assert.equal(log.logLevel, Log.getLevelByName(DEFAULT_LOG_LEVEL));
     });
   });
 
   describe('#getLevelByName(name)', function() {
     it('should return the input if the input is a number', function() {
-      var level = Log.getLevelByName(3);
+      const level = Log.getLevelByName(3);
       assert.equal(level, 3);
     });
 
@@ -95,64 +95,63 @@ describe('Log', function() {
     });
 
     it('should return the corresponding constant if the input is a valid log level', function() {
-      var level = Log.getLevelByName('off');
+      const level = Log.getLevelByName('off');
       assert.equal(level, Log['OFF']);
     });
   });
 
   describe('#createLog(moduleName, component)', () => {
     it('should create a Log whose logLevels reference is the same as that of its parent', () => {
-      var logLevels = { foo: 'debug', bar: 'error' };
-      var parent = new Log('foo', component('parent'), logLevels);
-      var child = parent.createLog('bar', component('child'));
+      const logLevels = { foo: 'debug', bar: 'error' };
+      const parent = new Log('foo', component('parent'), logLevels);
+      const child = parent.createLog('bar', component('child'));
       assert.equal(child._logLevels, parent._logLevels);
     });
   });
 
   describe('#setLevels(levels)', () => {
     it('should set _logLevels to the new values', () => {
-      var log = new Log('foo', component('bar'), { foo: 'debug' });
+      const log = new Log('foo', component('bar'), { foo: 'debug' });
       log.setLevels({ foo: 'warn' });
       assert.deepEqual(log._logLevels, { foo: 'warn' });
       assert.equal(log.logLevel, Log.getLevelByName('warn'));
     });
 
     it('should update the log levels of the child Logs', () => {
-      var logLevels = { foo: 'debug', bar: 'error' };
-      var newLogLevels = { foo: 'debug', bar: 'warn' };
-      var parent = new Log('foo', component('parent'), logLevels);
-      var child = parent.createLog('bar', component('child'));
+      const logLevels = { foo: 'debug', bar: 'error' };
+      const newLogLevels = { foo: 'debug', bar: 'warn' };
+      const parent = new Log('foo', component('parent'), logLevels);
+      const child = parent.createLog('bar', component('child'));
       parent.setLevels(newLogLevels);
       assert.deepEqual(child._logLevels, newLogLevels);
       assert.equal(child.logLevel, Log.getLevelByName('warn'));
     });
 
     it('should not update #logLevel when some other module\'s level is updated in logLevels', () => {
-      var logLevels = { foo: 'error', bar: 'debug' };
-      var log = new Log('foo', component('bar'), logLevels);
-      var oldLevel = log.logLevel;
-      logLevels = Object.assign(logLevels, { bar: 'off' });
-      log.setLevels(logLevels);
+      const logLevels = { foo: 'error', bar: 'debug' };
+      const log = new Log('foo', component('bar'), logLevels);
+      const oldLevel = log.logLevel;
+      log.setLevels(Object.assign({}, logLevels, { bar: 'off' }));
       assert.equal(log.logLevel, oldLevel);
     });
   });
 
   describe('#log(logLevel, message)', function() {
     it('should throw an error if the logLevel passed is invalid', function() {
-      var log = Log('foo', component('bar'));
+      const log = Log('foo', component('bar'));
       assert.throws(log.log.bind(log, 999), error => {
         return error instanceof RangeError && /logLevel must be one of/.test(error.message);
       });
     });
 
     it('should call the log function if the logLevel is within the Logs verbosity', function() {
-      var log = Log('foo', component('bar'), { foo: 'warn' });
+      const log = Log('foo', component('bar'), { foo: 'warn' });
       log.log(Log.ERROR, 'foo');
       assert(Log._levels[Log.ERROR].logFn.called);
     });
 
     it('should not call the log function if the logLevel is outside of the Logs verbosity', function() {
-      var log = Log('foo', component('bar'), { foo: 'off' });
+      const log = Log('foo', component('bar'), { foo: 'off' });
       log.log(Log.WARN, 'foo');
       assert(!Log._levels[Log.WARN].logFn.called);
     });
@@ -160,7 +159,7 @@ describe('Log', function() {
 
   describe('#debug(messages)', function() {
     it('should call #log(Log.DEBUG, message)', function() {
-      var log = Log('foo', component('bar'), { foo: 'debug' });
+      const log = Log('foo', component('bar'), { foo: 'debug' });
       log.debug('baz');
       sinon.assert.calledWith(log.log, Log.DEBUG, ['baz']);
     });
@@ -169,7 +168,7 @@ describe('Log', function() {
   describe('#deprecated(deprecationWarning)', function() {
     context('the first time the deprecationWarning is passed', function() {
       it('should call #log(Log.WARN, message)', function() {
-        var log = Log('foo', component('bar'), { foo: 'warn' });
+        const log = Log('foo', component('bar'), { foo: 'warn' });
         log.deprecated('baz');
         sinon.assert.calledWith(log.log, Log.WARN, ['baz']);
       });
@@ -177,7 +176,7 @@ describe('Log', function() {
 
     context('subsequent times the deprecationWarning is passed', function() {
       it('should call #log(Log.WARN, message)', function() {
-        var log = Log('foo', component('bar'), { foo: 'warn' });
+        const log = Log('foo', component('bar'), { foo: 'warn' });
         log.deprecated('baz');
         log.deprecated('baz');
         sinon.assert.calledOnce(log.log);
@@ -187,7 +186,7 @@ describe('Log', function() {
 
   describe('#info(messages)', function() {
     it('should call #log(Log.INFO, message)', function() {
-      var log = Log('foo', component('bar'), { foo: 'info' });
+      const log = Log('foo', component('bar'), { foo: 'info' });
       log.info('baz');
       sinon.assert.calledWith(log.log, Log.INFO, ['baz']);
     });
@@ -195,7 +194,7 @@ describe('Log', function() {
 
   describe('#warn(messages)', function() {
     it('should call #log(Log.WARN, message)', function() {
-      var log = Log('foo', component('bar'), { foo: 'warn' });
+      const log = Log('foo', component('bar'), { foo: 'warn' });
       log.warn('baz');
       sinon.assert.calledWith(log.log, Log.WARN, ['baz']);
     });
@@ -204,7 +203,7 @@ describe('Log', function() {
   describe('#warnOnce(deprecationWarning)', function() {
     context('the first time the warning is passed', function() {
       it('should call #log(Log.WARN, message)', function() {
-        var log = Log('foo', component('bar'), { foo: 'warn' });
+        const log = Log('foo', component('bar'), { foo: 'warn' });
         log.warnOnce('baz');
         sinon.assert.calledWith(log.log, Log.WARN, ['baz']);
       });
@@ -212,7 +211,7 @@ describe('Log', function() {
 
     context('subsequent times the warning is passed', function() {
       it('should call #log(Log.WARN, message)', function() {
-        var log = Log('foo', component('bar'), { foo: 'warn' });
+        const log = Log('foo', component('bar'), { foo: 'warn' });
         log.warnOnce('baz');
         log.warnOnce('baz');
         sinon.assert.calledOnce(log.log);
@@ -222,7 +221,7 @@ describe('Log', function() {
 
   describe('#error(messages)', function() {
     it('should call #log(Log.ERROR, message)', function() {
-      var log = Log('foo', component('bar'), { foo: 'error' });
+      const log = Log('foo', component('bar'), { foo: 'error' });
       log.error('baz');
       sinon.assert.calledWith(log.log, Log.ERROR, ['baz']);
     });
@@ -230,15 +229,15 @@ describe('Log', function() {
 
   describe('#throw(error, message)', function() {
     it('should throw an error and call #log(Log.ERROR, message)', function() {
-      var log = Log('foo', component('bar'), { foo: 'error' });
-      var error = new Error('baz');
+      const log = Log('foo', component('bar'), { foo: 'error' });
+      const error = new Error('baz');
       assert.throws(log.throw.bind(log, error));
       sinon.assert.calledWith(log.log, Log.ERROR, error);
     });
 
     it('should call the errors clone method if it exists', function() {
-      var log = Log('foo', component('bar'), { foo: 'error' });
-      var error = new Error('baz');
+      const log = Log('foo', component('bar'), { foo: 'error' });
+      const error = new Error('baz');
       error.clone = sinon.spy();
 
       try {

--- a/test/unit/spec/util/sdp.js
+++ b/test/unit/spec/util/sdp.js
@@ -1,9 +1,11 @@
 'use strict';
 
 const assert = require('assert');
-const { combinationContext } = require('../../../lib/util');
-const { makeSdpWithTracks } = require('../../../lib/mocksdp');
+
 const { setBitrateParameters, setCodecPreferences } = require('../../../../lib/util/sdp');
+
+const { makeSdpWithTracks } = require('../../../lib/mocksdp');
+const { combinationContext } = require('../../../lib/util');
 
 describe('setBitrateParameters', () => {
   context('when there is no existing b= line in the SDP', () => {

--- a/test/unit/spec/util/sdp.js
+++ b/test/unit/spec/util/sdp.js
@@ -82,13 +82,15 @@ describe('setBitrateParameters', () => {
       });
 
       ['audio', 'video'].forEach(kind => {
-        const getMaxBitrate = (maxAudioBitrate, maxVideoBitrate) => kind === 'audio'
-          ? modifier === 'TIAS'
-            ? maxAudioBitrate
-            : maxAudioBitrate && Math.round((maxAudioBitrate + 16000) / 950)
-          : modifier === 'TIAS'
-            ? maxVideoBitrate
-            : maxVideoBitrate &&  Math.round((maxVideoBitrate + 16000) / 950);
+        function getMaxBitrate(maxAudioBitrate, maxVideoBitrate) {
+          return kind === 'audio'
+            ? modifier === 'TIAS'
+              ? maxAudioBitrate
+              : maxAudioBitrate && Math.round((maxAudioBitrate + 16000) / 950)
+            : modifier === 'TIAS'
+              ? maxVideoBitrate
+              : maxVideoBitrate &&  Math.round((maxVideoBitrate + 16000) / 950);
+        }
 
         const currentMaxBitrate = getMaxBitrate(currentMaxAudioBitrate, currentMaxVideoBitrate);
         const maxBitrate = getMaxBitrate(maxAudioBitrate, maxVideoBitrate);
@@ -113,11 +115,11 @@ describe('setCodecPreferences', () => {
     ],
     [
       ['', 'PCMA,G722'],
-      x => `when preferredAudioCodecs is ${x ? 'not ': ''}empty`
+      x => `when preferredAudioCodecs is ${x ? 'not ' : ''}empty`
     ],
     [
       ['', 'H264,VP9'],
-      x => `when preferredVideoCodecs is ${x ? 'not ': ''}empty`
+      x => `when preferredVideoCodecs is ${x ? 'not ' : ''}empty`
     ]
   ], ([sdpType, preferredAudioCodecs, preferredVideoCodecs]) => {
     preferredAudioCodecs = preferredAudioCodecs ? preferredAudioCodecs.split(',') : [];

--- a/test/unit/spec/util/sdp.js
+++ b/test/unit/spec/util/sdp.js
@@ -23,7 +23,7 @@ describe('setBitrateParameters', () => {
         x => `when maxVideoBitrate is ${x ? 'not ' : ''}null`
       ]
     ], ([modifier, maxAudioBitrate, maxVideoBitrate]) => {
-      var sdp;
+      let sdp;
 
       beforeEach(() => {
         sdp = makeSdpWithTracks(modifier === 'TIAS' ? 'unified' : 'planb', {
@@ -70,7 +70,8 @@ describe('setBitrateParameters', () => {
     ], ([modifier, maxAudioBitrate, maxVideoBitrate]) => {
       const currentMaxAudioBitrate = 6000;
       const currentMaxVideoBitrate = 9000;
-      var sdp;
+
+      let sdp;
 
       beforeEach(() => {
         sdp = makeSdpWithTracks(modifier === 'TIAS' ? 'unified' : 'planb', {

--- a/test/unit/spec/util/twilioerror.js
+++ b/test/unit/spec/util/twilioerror.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 
 const TwilioError = require('../../../../lib/util/twilioerror');
 
-describe('TwilioError', function() {
+describe('TwilioError', () => {
   describe('constructor', () => {
     let error;
 

--- a/test/unit/spec/util/twilioerror.js
+++ b/test/unit/spec/util/twilioerror.js
@@ -6,7 +6,7 @@ const TwilioError = require('../../../../lib/util/twilioerror');
 
 describe('TwilioError', function() {
   describe('constructor', () => {
-    var error;
+    let error;
 
     before(() => {
       error = new TwilioError(1234);
@@ -31,7 +31,7 @@ describe('TwilioError', function() {
 
     context('when message is provided', () => {
       it('should set the message property', () => {
-        var errorWithMsg = new TwilioError(1234, 'some error message');
+        const errorWithMsg = new TwilioError(1234, 'some error message');
         assert.equal(errorWithMsg.message, 'some error message');
       });
     });

--- a/test/unit/spec/util/twilioerror.js
+++ b/test/unit/spec/util/twilioerror.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var assert = require('assert');
-var TwilioError = require('../../../../lib/util/twilioerror');
+const assert = require('assert');
+
+const TwilioError = require('../../../../lib/util/twilioerror');
 
 describe('TwilioError', function() {
   describe('constructor', () => {

--- a/test/unit/spec/webaudio/audiocontext.js
+++ b/test/unit/spec/webaudio/audiocontext.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const assert = require('assert');
-const AudioContextFactory = require('../../../../lib/webaudio/audiocontext').AudioContextFactory;
 const sinon = require('sinon');
+
+const { AudioContextFactory } = require('../../../../lib/webaudio/audiocontext');
 
 describe('AudioContextFactory', () => {
   let audioContext;


### PR DESCRIPTION
There are some changes to `lib/` in #202 that aren't quite ready. This PR includes only the test improvements. EDIT: Notes on some of these changes:

1. Updates ESLint
2. Lints `test/`
3. Removes `_sidDeferred`/`getSid` from `lib/signaling/track.js` as they were unused
4. Gates some of our `dummyEl` and related code in `lib/media/tracks` on presence of `document`
5. Adds logging support to PeerConnectionV2—we can see, for example, if applying a local or remote description fails (esp. useful in Travis CI logs)
6. Removes an unused property on RoomV2
7. Adds `getStats` integration tests