### PR TITLE
JSDK-1579 Removing options items which are explicitly "undefined".

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -113,6 +113,13 @@ var didPrintSafariWarning = false;
  * });
  */
 function connect(token, options) {
+  if (typeof options === 'undefined') {
+    options = {};
+  }
+  if (typeof options !== 'object' || Array.isArray(options)) {
+    return CancelablePromise.reject(new E.INVALID_TYPE('options', 'object'));
+  }
+
   options = Object.assign({
     createLocalTracks: createLocalTracks,
     environment: constants.DEFAULT_ENVIRONMENT,
@@ -130,7 +137,7 @@ function connect(token, options) {
     preferredVideoCodecs: [],
     realm: constants.DEFAULT_REALM,
     signaling: SignalingV2
-  }, options);
+  }, util.filterObject(options));
 
   /* eslint new-cap:0 */
   options = Object.assign({

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -73,6 +73,22 @@ function difference(list1, list2) {
 }
 
 /**
+ * Filter out the keys in an object with a given value.
+ * @param {object} object - Object to be filtered
+ * @param {*} [filterValue] - Value to be filtered out; If not specified, then
+ *   filters out all keys which have an explicit value of "undefined"
+ * @returns {object} - Filtered object
+ */
+function filterObject(object, filterValue) {
+  return Object.keys(object).reduce(function(filtered, key) {
+    if (object[key] !== filterValue) {
+      filtered[key] = object[key];
+    }
+    return filtered;
+  }, {});
+}
+
+/**
  * Map a list to an array of arrays, and return the flattened result.
  * @param {Array<*>|Set<*>|Map<*>} list
  * @param {function(*): Array<*>} [mapFn]
@@ -393,6 +409,7 @@ exports.asLocalTrack = asLocalTrack;
 exports.asLocalTrackPublication = asLocalTrackPublication;
 exports.capitalize = capitalize;
 exports.difference = difference;
+exports.filterObject = filterObject;
 exports.flatMap = flatMap;
 exports.guessBrowser = guessBrowser;
 exports.makeClientSIPURI = makeClientSIPURI;


### PR DESCRIPTION
@markandrus ,

We now remove any keys in `ConnectOptions` that are explicitly set to `undefined`. That way,
in this specific bug, `wsServer` is properly constructed.