### PR TITLE
JSDK-1626 Should always pass SDP dict to ._setLocalDescription()

### DIFF
--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -314,8 +314,7 @@ PeerConnectionV2.prototype._handleDataChannelEvent = function _handleDataChannel
 PeerConnectionV2.prototype._handleGlare = function _handleGlare(offer) {
   var self = this;
   return Promise.resolve().then(function() {
-    var rollback = new self._RTCSessionDescription({ type: 'rollback' });
-    return self._setLocalDescription(rollback);
+    return self._setLocalDescription({ type: 'rollback' });
   }).then(function() {
     return self._answer(offer);
   }).then(function() {
@@ -423,22 +422,22 @@ PeerConnectionV2.prototype._offer = function _offer() {
       offer.sdp,
       self._preferredAudioCodecs,
       self._preferredVideoCodecs);
-    var updatedOffer = new RTCSessionDescription({
-      type: 'offer',
-      sdp: updatedSdp
-    });
+
     self._shouldOffer = false;
     if (!self._negotiationRole) {
       self._negotiationRole = 'offerer';
       self._needsInitialAnswer = true;
     }
-    return self._setLocalDescription(updatedOffer);
+    return self._setLocalDescription({
+      type: 'offer',
+      sdp: updatedSdp
+    });
   });
 };
 
 /**
  * Set a local description on the {@link PeerConnectionV2}.
- * @param {RTCSessionDescriptionInit} description
+ * @param {RTCSessionDescription|RTCSessionDescriptionInit} description
  * @returns {Promise<void>}
  */
 PeerConnectionV2.prototype._setLocalDescription = function _setLocalDescription(description) {
@@ -450,9 +449,15 @@ PeerConnectionV2.prototype._setLocalDescription = function _setLocalDescription(
 
   return Promise.resolve().then(function() {
     if (description.sdp) {
-      description.sdp = isChrome && vp8SimulcastRequested
-        ? self._setSimulcast(description.sdp, self._trackIdsToAttributes)
-        : description.sdp;
+      // NOTE(mmalavalli): We do not directly modify "description.sdp" here as
+      // "description" might be an RTCSessionDescription, in which case its
+      // properties are immutable.
+      description = {
+        type: description.type,
+        sdp: isChrome && vp8SimulcastRequested
+          ? self._setSimulcast(description.sdp, self._trackIdsToAttributes)
+          : description.sdp
+      };
     }
     description = new self._RTCSessionDescription(description);
     if (description.type === 'answer') {

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -66,7 +66,7 @@ describe('LocalParticipant', function() {
         }
       ],
       [
-        'when three LocalTracks (audio, video, and date) are published together',
+        'when three LocalTracks (audio, video, and data) are published together',
         async () => {
           trackPublications = await Promise.all(tracks.map(track => {
             return room.localParticipant.publishTrack(track);


### PR DESCRIPTION
@markandrus 

In some places we were passing `RTCSessionDescription` to `._setLocalDescription`, where we were trying to apply the sdp transform for simulcast. So this PR now passes only the `RTCSessionDescriptionInitDict`.