### PR TITLE
JSDK-1627 Set DataTrackReceiver's RTCDataChannel .binaryType to "arraybuffer"

### DIFF
--- a/lib/data/receiver.js
+++ b/lib/data/receiver.js
@@ -22,6 +22,12 @@ function DataTrackReceiver(dataChannel) {
     dataChannel.maxPacketLifeTime,
     dataChannel.maxRetransmits,
     dataChannel.ordered);
+
+  // NOTE(mmalavalli): In Firefox, the default value for "binaryType" is "blob".
+  // So, we set it to "arraybuffer" to ensure that it is consistent with Chrome
+  // and Safari.
+  dataChannel.binaryType = 'arraybuffer';
+
   var self = this;
   dataChannel.addEventListener('message', function(event) {
     self.emit('message', event.data);


### PR DESCRIPTION
@markandrus In Firefox, The `DataTrackReceiver`'s `RTCDataChannel` has it's `.binaryType` set to "blob", where as in Chrome/Safari it is set to "arraybuffer". So we explicitly set it.