### PR TITLE
Update ws package to 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   "dependencies": {
     "@twilio/sip.js": "^0.7.6",
     "@twilio/webrtc": "^1.1.0",
-    "ws": "^2.3.1",
+    "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },
   "browser": {


### PR DESCRIPTION
3.3.1 also contains a fix for a DOS attack for ws servers that most packages will be updating to. Keeping twilio-video.js on 2.x forces consumers to duplicate packages