### PR TITLE
Allow PCMU/PCMA rtpmap entries to be missing

### DIFF
--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -4,6 +4,11 @@ var difference = require('../').difference;
 var flatMap = require('../').flatMap;
 var setSimulcastInMediaSection = require('./simulcast');
 
+var ptToFixedBitrateAudioCodecName = {
+  0: 'PCMU',
+  8: 'PCMA'
+};
+
 /**
  * A payload type
  * @typedef {number} PT
@@ -61,7 +66,11 @@ function createPtToCodecName(mediaSection) {
   return getPayloadTypesInMediaSection(mediaSection).reduce(function(ptToCodecName, pt) {
     var rtpmapPattern = new RegExp('a=rtpmap:' + pt + ' ([^/]+)');
     var matches = mediaSection.match(rtpmapPattern);
-    var codecName = matches ? matches[1].toLowerCase() : '';
+    var codecName = matches
+      ? matches[1].toLowerCase()
+      : ptToFixedBitrateAudioCodecName[pt]
+        ? ptToFixedBitrateAudioCodecName[pt].toLowerCase()
+        : '';
     return ptToCodecName.set(pt, codecName);
   }, new Map());
 }
@@ -260,6 +269,7 @@ function setSimulcast(sdp, trackIdsToAttributes) {
  * @typedef {number} PayloadType
  */
 
+exports.createCodecMapForMediaSection = createCodecMapForMediaSection;
 exports.createPtToCodecName = createPtToCodecName;
 exports.getMediaSections = getMediaSections;
 exports.setBitrateParameters = setBitrateParameters;


### PR DESCRIPTION
Porting this forward from https://github.com/twilio/twilio-video.js/pull/225