### PR TITLE
Fix negotiation loop in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Bug Fixes
   RTCDataChannel's `binaryType` to "arraybuffer" in order to ensure consistent
   behavior across browsers. (JSDK-1627)
 - We always stringify `name`s passed via LocalTrackOptions now. (JSDK-1565)
+- Fixed some code that could lead to a renegotiation loop in Firefox.
 
 1.6.0 (October 24, 2017)
 ========================

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -288,7 +288,9 @@ PeerConnectionV2.prototype._answer = function _answer(offer) {
   }).then(function() {
     return self._checkIceBox(offer);
   }).then(function() {
-    return self._maybeReoffer(offer);
+    return self._peerConnection.localDescription
+      ? self._maybeReoffer(self._peerConnection.localDescription)
+      : Promise.resolve();
   }).catch(function(error) {
     throw error instanceof MediaClientRemoteDescFailedError
       ? error
@@ -410,10 +412,10 @@ PeerConnectionV2.prototype._handleTrackEvent = function _handleTrackEvent(event)
 
 /**
  * Conditionally re-offer.
- * @param {RTCSessionDescriptionInit} offer
+ * @param {RTCSessionDescriptionInit} localDescription
  * @returns {Promise<void>}
  */
-PeerConnectionV2.prototype._maybeReoffer = function _maybeReoffer(offer) {
+PeerConnectionV2.prototype._maybeReoffer = function _maybeReoffer(localDescription) {
   var shouldReoffer = this._shouldOffer;
 
   // NOTE(mmalavalli): In Firefox, if the remote RTCPeerConnection sends
@@ -434,7 +436,7 @@ PeerConnectionV2.prototype._maybeReoffer = function _maybeReoffer(offer) {
       return sender.track;
     });
     shouldReoffer = ['audio', 'video'].reduce(function(shouldOffer, kind) {
-      var mediaSections = getMediaSections(offer.sdp, kind, '(sendrecv|recvonly)');
+      var mediaSections = getMediaSections(localDescription.sdp, kind, '(sendrecv|sendonly)');
       var sendersOfKind = senders.filter(isSenderOfKind.bind(null, kind));
       return shouldOffer || (mediaSections.length < sendersOfKind.length);
     }, shouldReoffer);
@@ -443,7 +445,7 @@ PeerConnectionV2.prototype._maybeReoffer = function _maybeReoffer(offer) {
   // NOTE(mroberts): We also need to re-offer if we have a DataTrack to share
   // but no m= application section.
   var hasDataTrack = this._dataChannels.size > 0;
-  var hasApplicationMediaSection = getMediaSections(offer.sdp, 'application').length > 0;
+  var hasApplicationMediaSection = getMediaSections(localDescription.sdp, 'application').length > 0;
   var needsApplicationMediaSection = hasDataTrack && !hasApplicationMediaSection;
   shouldReoffer = shouldReoffer || needsApplicationMediaSection;
 
@@ -630,15 +632,9 @@ PeerConnectionV2.prototype._updateDescription = function _updateDescription(desc
     return self._queuedDescription && self._updateDescription(self._queuedDescription);
   }).then(function() {
     self._queuedDescription = null;
-    var offer = self._peerConnection.localDescription && self._peerConnection.localDescription.type === 'offer'
-      ? self._peerConnection.localDescription
-      : self._peerConnection.remoteDescription && self._peerConnection.remoteDescription.type === 'offer'
-        ? self._peerConnection.remoteDescription
-        : null;
-    if (offer) {
-      return self._maybeReoffer(offer);
-    }
-    return Promise.resolve();
+    return self._peerConnection.localDescription
+      ? self._maybeReoffer(self._peerConnection.localDescription)
+      : Promise.resolve();
   });
 };
 

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -1266,17 +1266,14 @@ describe('PeerConnectionV2', () => {
         beforeEach(async () => {
           test = makeTest({
             offers: 1,
-            answers: 1
+            answers: [makeAnswer({ application: !lacks })]
           });
           descriptions = [];
 
           const dataTrackSender = makeDataTrackSender();
           test.pcv2.addDataTrackSender(dataTrackSender);
 
-          const offer = makeOffer();
-          if (!lacks) {
-            offer.sdp += 'm=application foo bar baz\r\na=sendrecv\r\n';
-          }
+          const offer = makeOffer({ application: !lacks });
           desc = test.state().setDescription(offer, 1);
 
           test.pcv2.on('description', description => descriptions.push(description));
@@ -1800,6 +1797,9 @@ function makeDescription(type, options) {
       type === 'pranswer') {
     const session = 'session' in options ? options.session : Number.parseInt(Math.random() * 1000);
     description.sdp = 'o=- ' + session + '\r\n';
+    if (options.application) {
+      description.sdp += 'm=application foo bar baz\r\na=sendrecv\r\n';
+    }
     if (options.ufrag) {
       description.sdp += 'a=ice-ufrag:' + options.ufrag + '\r\n';
     }


### PR DESCRIPTION
PeerConnectionV2 had a bug that I noticed when testing Firefox Stable/Beta to Firefox Stable/Beta. The bug is this: in order to decide whether to renegotiate, we always check if the current offer (local _or_ remote) contains at least as many media sections with directions "sendrecv" or "recvonly" as RTCRtpSenders we have (taking into account kind).

However, this doesn't work in the local case with Firefox Stable/Beta. Consider if we have two local audio tracks, we've been offered one remote audio track in a previous round of negotiation, and now we call `createOffer`:

* We have two RTCRtpSenders (one for each of our two local audio tracks)
* We have two m=sections, one with "a=sendrecv" and one with "a=sendonly"

But our check is for "sendrecv" or "recvonly", and so our logic would say to re-negotiate. This can lead to a loop! Here is a fix: instead of checking the current offer (local _or_ remote), we should check the current local description (offer _or_ answer) and "sendrecv" or _"sendonly"_ (instead of "recvonly").

Firefox Nightly (with RTCRtpTransceiver support) isn't triggering this, since the spec says the second media section should have "a=sendrecv", rather than "a=sendonly". This loop may have been slowing down (or failing) our tests—hopefully this fixes it.