### PR TITLE
JSDK-1599: Track subscription errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,32 @@ New Features
 
   We recommend you only enable this setting in Group Rooms.
 
+- By default, when you connect to a Group Room, you subscribe to all
+  RemoteParticipants' Tracks. However, sometimes your device may lack the codec
+  required to decode a particular Track. For example, an H.264-only Safari
+  Participant would be unable to decode a VP8 VideoTrack. In these cases, we now
+  raise a new event, "trackSubscriptionFailed", on the RemoteParticipant who
+  published the Track you could not subscribe to. For example, the following
+  code
+
+  ```js
+  room.participants.forEach(handleParticipant);
+  room.on('participantConnected', handleParticipant);
+
+  function handleParticipant(participant) {
+    participant.on('trackSubscriptionFailed', (error, trackPublication) =>
+      console.warn('Failed to subscribe to RemoteTrack %s with name "%s": %s',
+        trackPublication.trackSid, trackPublication.trackName, error.message)));
+  }
+  ```
+
+  will log something like
+
+  > Failed to subscribe to RemoteTrack MTxxx with name "123": No codec supported
+
+  to the console. twilio-video.js will also log these warnings by default.
+  Please refer to the API docs for more information.
+
 Bug Fixes
 ---------
 

--- a/lib/media/track/remotetrackpublication.js
+++ b/lib/media/track/remotetrackpublication.js
@@ -1,0 +1,68 @@
+'use strict';
+
+var buildLogLevels = require('../../util').buildLogLevels;
+var Log = require('../../util/log');
+var DEFAULT_LOG_LEVEL = require('../../util/constants').DEFAULT_LOG_LEVEL;
+var nInstances = 0;
+
+/**
+ * Construct a {@link RemoteTrackPublication}.
+ * @class
+ * @classdesc A {@link RemoteTrackPublication} represents a {@link RemoteTrack}
+ *   that has been published to a {@link Room}.
+ * @param {Track.Kind} kind - the {@link RemoteTrack}'s kind
+ * @param {Track.SID} trackSid - the {@link RemoteTrack}'s SID
+ * @param {string} trackName - the {@link RemoteTrack}'s name
+ * @param {RemoteTrackPublicationOptions} options - {@link RemoteTrackPublication}
+ *   options
+ * @property {Track.Kind} kind - kind of the published {@link RemoteTrack}
+ * @property {?RemoteTrack} track - unless you have subscribed to the
+ *   {@link RemoteTrack}, this property is null
+ * @property {string} trackName - the {@link RemoteTrack}'s name
+ * @property {Track.SID} trackSid - the {@link RemoteTrack}'s SID
+ */
+function RemoteTrackPublication(kind, trackSid, trackName, options) {
+  options = Object.assign({
+    logLevel: DEFAULT_LOG_LEVEL
+  }, options);
+
+  var logLevels = buildLogLevels(options.logLevel);
+
+  Object.defineProperties(this, {
+    _instanceId: {
+      value: nInstances++
+    },
+    _log: {
+      value: options.log || new Log('default', this, logLevels)
+    },
+    kind: {
+      enumerable: true,
+      value: kind
+    },
+    track: {
+      enumerable: true,
+      value: null
+    },
+    trackName: {
+      enumerable: true,
+      value: trackName
+    },
+    trackSid: {
+      enumerable: true,
+      value: trackSid
+    }
+  });
+}
+
+RemoteTrackPublication.prototype.toString = function toString() {
+  return '[RemoteTrackPublication #' + this._instanceId + ': ' + this.trackSid + ']';
+};
+
+/**
+/**
+ * {@link RemoteTrackPublication} options
+ * @typedef {object} RemoteTrackPublicationOptions
+ * @property {LogLevel|LogLevels} logLevel - Log level for 'media' modules
+ */
+
+module.exports = RemoteTrackPublication;

--- a/lib/participant.js
+++ b/lib/participant.js
@@ -2,6 +2,7 @@
 
 var RemoteAudioTrack = require('./media/track/remoteaudiotrack');
 var RemoteDataTrack = require('./media/track/remotedatatrack');
+var RemoteTrackPublication = require('./media/track/remotetrackpublication');
 var RemoteVideoTrack = require('./media/track/remotevideotrack');
 var EventEmitter = require('events').EventEmitter;
 var inherits = require('util').inherits;
@@ -170,7 +171,24 @@ Participant.prototype._handleTrackSignalingEvents = function _handleTrackSignali
   var signaling = this._signaling;
 
   function trackSignalingAdded(signaling) {
+    function handleTrackSubscriptionFailed() {
+      if (!signaling.error) {
+        return;
+      }
+      signaling.removeListener('updated', handleTrackSubscriptionFailed);
+      var remoteTrackPublication = new RemoteTrackPublication(
+        signaling.kind,
+        signaling.sid,
+        signaling.name,
+        { log: log });
+      self.emit('trackSubscriptionFailed', signaling.error, remoteTrackPublication);
+    }
+
+    signaling.on('updated', handleTrackSubscriptionFailed);
+
     signaling.getTrackTransceiver().then(function(trackReceiver) {
+      signaling.removeListener('updated', handleTrackSubscriptionFailed);
+
       var RemoteTrack = {
         audio: RemoteAudioTrack,
         video: RemoteVideoTrack,

--- a/lib/participant.js
+++ b/lib/participant.js
@@ -181,6 +181,9 @@ Participant.prototype._handleTrackSignalingEvents = function _handleTrackSignali
         signaling.sid,
         signaling.name,
         { log: log });
+      self._log.warn('Failed to subscribe to Remote' +
+        util.capitalize(signaling.kind) + 'Track ' + signaling.sid + ' with ' +
+        'name "' + signaling.name + '": ' + signaling.error.message);
       self.emit('trackSubscriptionFailed', signaling.error, remoteTrackPublication);
     }
 

--- a/lib/remoteparticipant.js
+++ b/lib/remoteparticipant.js
@@ -27,6 +27,7 @@ var Participant = require('./participant');
  * @fires RemoteParticipant#trackRemoved
  * @fires RemoteParticipant#trackStarted
  * @fires RemoteParticipant#trackSubscribed
+ * @fires RemoteParticipant#trackSubscriptionFailed
  * @fires RemoteParticipant#trackUnsubscribed
  */
 function RemoteParticipant(signaling, options) {
@@ -129,6 +130,13 @@ RemoteParticipant.prototype._removeTrack = function _removeTrack(remoteTrack) {
  * A {@link RemoteParticipant}'s {@link RemoteTrack} was subscribed to.
  * @param {RemoteTrack} track - The {@link RemoteTrack} that was subscribed to
  * @event RemoteParticipant#trackSubscribed
+ */
+
+/**
+ * A {@link RemoteParticipant}'s {@link RemoteTrack} could not be subscribed to.
+ * @param {TwilioError} error - The reason the {@link RemoteTrack} could not be
+ *   subscribed to
+ * @event RemoteParticipant#trackSubscriptionFailed
  */
 
 /**

--- a/lib/room.js
+++ b/lib/room.js
@@ -304,6 +304,7 @@ function connectParticipant(room, participantSignaling) {
     'trackRemoved',
     'trackStarted',
     'trackSubscribed',
+    'trackSubscriptionFailed',
     'trackUnsubscribed'
   ].map(function(event) {
     function reemit() {

--- a/lib/signaling/remotetrack.js
+++ b/lib/signaling/remotetrack.js
@@ -14,10 +14,21 @@ var TrackSignaling = require('./track');
  * @param {Track.Kind} kind
  * @param {boolean} isEnabled
  * @property {boolean} isSubscribed
+ * @property {?Error} error - non-null if subscription failed
  */
 function RemoteTrackSignaling(sid, name, id, kind, isEnabled) {
   TrackSignaling.call(this, name, id, kind, isEnabled);
   Object.defineProperties(this, {
+    _error: {
+      value: null,
+      writable: true
+    },
+    error: {
+      enumerable: true,
+      get: function() {
+        return this._error;
+      }
+    },
     isSubscribed: {
       enumerable: true,
       get: function() {
@@ -29,5 +40,17 @@ function RemoteTrackSignaling(sid, name, id, kind, isEnabled) {
 }
 
 inherits(RemoteTrackSignaling, TrackSignaling);
+
+/**
+ * @param {Error} error
+ * @returns {this}
+ */
+RemoteTrackSignaling.prototype.subscribeFailed = function subscribeFailed(error) {
+  if (!this._error) {
+    this._error = error;
+    this.emit('updated');
+  }
+  return this;
+};
 
 module.exports = RemoteTrackSignaling;

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -384,12 +384,11 @@ function periodicallyPublishStats(roomV2, localParticipant, transport, intervalM
 }
 
 function handleSubscriptionFailures(room) {
-  var remoteTracks = Array.from(room.participants.values()).reduce(function(remoteTracks, participant) {
-    participant.tracks.forEach(function(track) {
-      remoteTracks.set(track.sid, track);
+  var remoteTracks = new Map(util.flatMap(room.participants, function(participant) {
+    return Array.from(participant.tracks.values()).map(function(track) {
+      return [track.sid, track];
     });
-    return remoteTracks;
-  }, new Map());
+  }));
 
   room._subscriptionFailures.forEach(function(error, trackSid) {
     var remoteTrack = remoteTracks.get(trackSid);

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -5,6 +5,7 @@ var RecordingV2 = require('./recording');
 var RoomSignaling = require('../room');
 var RemoteParticipantV2 = require('./remoteparticipant');
 var util = require('../../util');
+var createTwilioError = require('../../util/twilio-video-errors').createTwilioError;
 
 var STATS_PUBLISH_INTERVAL_MS = 1000;
 
@@ -38,6 +39,13 @@ function RoomV2(localParticipant, initialState, transport, peerConnectionManager
       value: options.RemoteParticipantV2
     },
     _subscribed: {
+      value: new Map()
+    },
+    _subscribedRevision: {
+      value: 0,
+      writable: true
+    },
+    _subscriptionFailures: {
       value: new Map()
     },
     _transport: {
@@ -152,11 +160,17 @@ RoomV2.prototype._publishPeerConnectionState = function _publishPeerConnectionSt
 RoomV2.prototype._update = function _update(roomState) {
   var participantsToKeep = new Set();
 
-  roomState.subscribed.forEach(function(trackState) {
-    if (trackState.id) {
-      this._subscribed.set(trackState.id, trackState.sid);
-    }
-  }, this);
+  if (roomState.subscribed && roomState.subscribed.revision > this._subscribedRevision) {
+    this._subscribedRevision = roomState.subscribed.revision;
+    roomState.subscribed.tracks.forEach(function(trackState) {
+      if (trackState.id) {
+        this._subscriptionFailures.delete(trackState.sid);
+        this._subscribed.set(trackState.id, trackState.sid);
+      } else if (trackState.error && !this._subscriptionFailures.has(trackState.sid)) {
+        this._subscriptionFailures.set(trackState.sid, trackState.error);
+      }
+    }, this);
+  }
 
   // TODO(mroberts): Remove me once the Server is fixed.
   (roomState.participants || []).forEach(function(participantState) {
@@ -168,6 +182,8 @@ RoomV2.prototype._update = function _update(roomState) {
     participant.update(participantState);
     participantsToKeep.add(participant);
   }, this);
+
+  handleSubscriptionFailures(this);
 
   // TODO(mroberts): Remove me once the Server is fixed.
   /* eslint camelcase:0 */
@@ -367,4 +383,20 @@ function periodicallyPublishStats(roomV2, localParticipant, transport, intervalM
   });
 }
 
+function handleSubscriptionFailures(room) {
+  var remoteTracks = Array.from(room.participants.values()).reduce(function(remoteTracks, participant) {
+    participant.tracks.forEach(function(track) {
+      remoteTracks.set(track.sid, track);
+    });
+    return remoteTracks;
+  }, new Map());
+
+  room._subscriptionFailures.forEach(function(error, trackSid) {
+    var remoteTrack = remoteTracks.get(trackSid);
+    if (remoteTrack) {
+      room._subscriptionFailures.delete(trackSid);
+      remoteTrack.subscribeFailed(createTwilioError(error.code, error.message));
+    }
+  });
+}
 module.exports = RoomV2;

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -152,19 +152,14 @@ RoomV2.prototype._publishPeerConnectionState = function _publishPeerConnectionSt
 RoomV2.prototype._update = function _update(roomState) {
   var participantsToKeep = new Set();
 
+  roomState.subscribed.forEach(function(trackState) {
+    if (trackState.id) {
+      this._subscribed.set(trackState.id, trackState.sid);
+    }
+  }, this);
+
   // TODO(mroberts): Remove me once the Server is fixed.
   (roomState.participants || []).forEach(function(participantState) {
-    // TODO(mroberts): Really, we should use the new subscribed payload for
-    // identifying which RemoteTracks are currently subscribed to; however,
-    // there is a bug, VMS-852, which, until it is fixed, means we learn about
-    // unannounced MediaStreamTracks. Since we're going to use the subscribed
-    // Map to filter/update the results of getStats, we can't read the
-    // subscribed payload until this bug is fixed. In the meantime, we can use
-    // each Participant's announced RemoteTracks.
-    participantState.tracks.forEach(function(trackState) {
-      this._subscribed.set(trackState.id, trackState.sid);
-    }, this);
-
     if (participantState.sid === this.localParticipant.sid ||
         this._disconnectedParticipantSids.has(participantState.sid)) {
       return;

--- a/test/unit/spec/room.js
+++ b/test/unit/spec/room.js
@@ -122,6 +122,14 @@ describe('Room', () => {
       assert.equal(spy.callCount, 1);
     });
 
+    it('should re-emit RemoteParticipants trackSubscriptionFailed event for matching RemoteParticipant only', () => {
+      const spy = sinon.spy();
+      room.on('trackSubscriptionFailed', spy);
+
+      participants.bar.emit('trackSubscriptionFailed');
+      assert.equal(spy.callCount, 1);
+    });
+
     it('should re-emit RemoteParticipants trackUnsubscribed event for matching RemoteParticipant only', () => {
       const spy = sinon.spy();
       room.on('trackUnsubscribed', spy);
@@ -142,6 +150,7 @@ describe('Room', () => {
       room.on('trackRemoved', spy);
       room.on('trackStarted', spy);
       room.on('trackSubscribed', spy);
+      room.on('trackSubscriptionFailed', spy);
       room.on('trackUnsubscribed', spy);
 
       participants.foo.emit('trackAdded');
@@ -152,6 +161,7 @@ describe('Room', () => {
       participants.foo.emit('trackRemoved');
       participants.foo.emit('trackStarted');
       participants.foo.emit('trackSubscribed');
+      participants.foo.emit('trackSubscriptionFailed');
       participants.foo.emit('trackUnsubscribed');
       assert.equal(spy.callCount, 0);
     });

--- a/test/unit/spec/signaling/v2/room.js
+++ b/test/unit/spec/signaling/v2/room.js
@@ -1173,6 +1173,9 @@ describe('RoomV2', () => {
           test.peerConnectionManager.update.args[0][0]);
       });
     });
+
+    context('.subscribed', () => {
+    });
   });
 });
 


### PR DESCRIPTION
_Not ready to merge._

The point of this PR is to allow raising "trackSubscriptionFailed" events in the event that, for example,

1. A VP8-only Participant connects to a Group Room that supports VP8 and H.264.
2. An H.264-only Participant connects to the same Group Room and publishes a VideoTrack.

Once Step 2 occurs, we want the VP8-only Participant to learn that there was a VideoTrack they ought to have subscribed to, but couldn't, because they didn't support the required codec.