### PR TITLE
Move LocalParticipantV2 revision management out of RoomV2

### DIFF
--- a/lib/signaling/v2/localparticipant.js
+++ b/lib/signaling/v2/localparticipant.js
@@ -6,6 +6,7 @@ const LocalTrackPublicationV2 = require('./localtrackpublication');
 /**
  * @extends ParticipantSignaling
  * @property {number} revision
+ * @emits LocalParticipantV2#updated
  */
 class LocalParticipantV2 extends ParticipantSignaling {
   /**
@@ -22,6 +23,9 @@ class LocalParticipantV2 extends ParticipantSignaling {
     Object.defineProperties(this, {
       _encodingParameters: {
         value: encodingParameters
+      },
+      _removeListeners: {
+        value: new Map()
       },
       _LocalTrackPublicationV2: {
         value: options.LocalTrackPublicationV2
@@ -83,8 +87,43 @@ class LocalParticipantV2 extends ParticipantSignaling {
    * @returns {this}
    */
   addTrack(trackSender, name) {
-    const localTrackPublicationV2 = new this._LocalTrackPublicationV2(trackSender, name);
-    return super.addTrack.call(this, localTrackPublicationV2);
+    const publication = new this._LocalTrackPublicationV2(trackSender, name);
+    super.addTrack.call(this, publication);
+
+    let { sid } = publication;
+
+    const updated = () => {
+      // NOTE(mmalavalli): The LocalParticipantV2's state is only published if
+      // the "updated" event is emitted due to LocalTrackPublicationV2's
+      // .isEnabled being toggled. We do not publish if it is fired due to the
+      // LocalTrackPublicationV2's .sid being set.
+      if (sid === publication.sid) {
+        this.didUpdate();
+        return;
+      }
+      sid = publication.sid;
+    };
+
+    publication.on('updated', updated);
+
+    this._removeListener(publication);
+    this._removeListeners.set(publication, () => publication.removeListener('updated', updated));
+
+    this.didUpdate();
+
+    return this;
+  }
+
+  /**
+   * @private
+   * @param {LocalTrackPublicationV2} publication
+   * @returns {void}
+   */
+  _removeListener(publication) {
+    const removeListener = this._removeListeners.get(publication);
+    if (removeListener) {
+      removeListener();
+    }
   }
 
   /**
@@ -100,11 +139,12 @@ class LocalParticipantV2 extends ParticipantSignaling {
 
   /**
    * Increment the revision for the {@link LocalParticipantV2}.
-   * @returns {this}
+   * @private
+   * @returns {void}
    */
-  incrementRevision() {
+  didUpdate() {
     this._revision++;
-    return this;
+    this.emit('updated');
   }
 
   /**
@@ -114,11 +154,16 @@ class LocalParticipantV2 extends ParticipantSignaling {
    * @returns {boolean}
    */
   removeTrack(trackSender) {
-    const localTrackPublicationV2 = this.tracks.get(trackSender.id);
-    if (!localTrackPublicationV2) {
+    const publication = this.tracks.get(trackSender.id);
+    if (!publication) {
       return false;
     }
-    return super.removeTrack.call(this, localTrackPublicationV2);
+    const didDelete = super.removeTrack.call(this, publication);
+    if (didDelete) {
+      this._removeListener(publication);
+      this.didUpdate();
+    }
+    return didDelete;
   }
 }
 
@@ -156,6 +201,10 @@ class LocalParticipantV2 extends ParticipantSignaling {
  * @interface TrackError
  * @property {number} code
  * @property {string} message
+ */
+
+/**
+ * @event LocalParticipantV2#updated
  */
 
 module.exports = LocalParticipantV2;

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -165,7 +165,6 @@ class RoomV2 extends RoomSignaling {
    * @private
    */
   _publishNewLocalParticipantState() {
-    this.localParticipant.incrementRevision();
     this._transport.publish(this._getState());
   }
 
@@ -274,66 +273,24 @@ class RoomV2 extends RoomSignaling {
  */
 
 function handleLocalParticipantEvents(roomV2, localParticipant) {
-  const removeListeners = new Map();
-  const peerConnectionManager = roomV2._peerConnectionManager;
-
-  const updateLocalParticipantStateAndRenegotiate = util.oncePerTick(() => {
-    roomV2._publishNewLocalParticipantState();
-    renegotiate();
+  const renegotiate = util.oncePerTick(() => {
+    const trackSenders = util.flatMap(localParticipant.tracks, trackV2 => trackV2.trackTransceiver);
+    roomV2._peerConnectionManager.setTrackSenders(trackSenders);
   });
 
-  function renegotiate() {
-    const trackSenders = util.flatMap(localParticipant.tracks, trackV2 => trackV2.trackTransceiver);
-    peerConnectionManager.setTrackSenders(trackSenders);
-  }
+  const localParticipantUpdated = util.oncePerTick(() => {
+    roomV2._publishNewLocalParticipantState();
+  });
 
-  function addListener(track) {
-    let trackSid = track.sid;
-
-    function updated() {
-      // NOTE(mmalavalli): The LocalParticipantV2's state is only published if
-      // the "updated" event is emitted due to LocalTrackPublicationV2's
-      // .isEnabled being toggled. We do not publish if it is fired due to the
-      // LocalTrackPublicationV2's .sid being set.
-      if (trackSid === track.sid) {
-        roomV2._publishNewLocalParticipantState();
-      } else {
-        trackSid = track.sid;
-      }
-    }
-
-    track.on('updated', updated);
-
-    removeListener(track);
-    removeListeners.set(track, track.removeListener.bind(track, 'updated', updated));
-  }
-
-  function removeListener(track) {
-    const removeListener = removeListeners.get(track);
-    if (removeListener) {
-      removeListener();
-    }
-  }
-
-  function trackAdded(track) {
-    addListener(track);
-    updateLocalParticipantStateAndRenegotiate();
-  }
-
-  function trackRemoved(track) {
-    removeListener(track);
-    updateLocalParticipantStateAndRenegotiate();
-  }
-
-  localParticipant.on('trackAdded', trackAdded);
-  localParticipant.on('trackRemoved', trackRemoved);
-
-  localParticipant.tracks.forEach(addListener);
+  localParticipant.on('trackAdded', renegotiate);
+  localParticipant.on('trackRemoved', renegotiate);
+  localParticipant.on('updated', localParticipantUpdated);
 
   roomV2.on('stateChanged', function stateChanged(state) {
     if (state === 'disconnected') {
-      localParticipant.removeListener('trackAdded', trackAdded);
-      localParticipant.removeListener('trackRemoved', trackRemoved);
+      localParticipant.removeListener('trackAdded', renegotiate);
+      localParticipant.removeListener('trackRemoved', renegotiate);
+      localParticipant.removeListener('updated', localParticipantUpdated);
       roomV2.removeListener('stateChanged', stateChanged);
       localParticipant.disconnect();
     }

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -37,6 +37,7 @@ require('./spec/media/track/transceiver');
 require('./spec/signaling/v2');
 require('./spec/signaling/v2/cancelableroomsignalingpromise');
 require('./spec/signaling/v2/icebox');
+require('./spec/signaling/v2/localparticipant');
 require('./spec/signaling/v2/recording');
 require('./spec/signaling/v2/remoteparticipant');
 require('./spec/signaling/v2/room');

--- a/test/unit/spec/signaling/v2/localparticipant.js
+++ b/test/unit/spec/signaling/v2/localparticipant.js
@@ -1,0 +1,153 @@
+'use strict';
+
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const sinon = require('sinon');
+
+const DataTrackSender = require('../../../../../lib/data/sender');
+const EncodingParameters = require('../../../../../lib/encodingparameters');
+const LocalParticipantV2 = require('../../../../../lib/signaling/v2/localparticipant');
+
+class MockLocalTrackPublicationV2 extends EventEmitter {
+  constructor(trackSender, name) {
+    super();
+    this.trackSender = trackSender;
+    this.id = trackSender.id;
+    this.name = name;
+    this.sid = null;
+  }
+}
+
+describe('LocalParticipantV2', () => {
+  let LocalTrackPublicationV2Constructor;
+  let localParticipant;
+  let trackSender;
+  let name;
+  let publication;
+
+  beforeEach(() => {
+    LocalTrackPublicationV2Constructor = sinon.spy(function() {
+      publication = new MockLocalTrackPublicationV2(...arguments);
+      return publication;
+    });
+
+    localParticipant = new LocalParticipantV2(new EncodingParameters(), {
+      LocalTrackPublicationV2: LocalTrackPublicationV2Constructor
+    });
+
+    trackSender = new DataTrackSender();
+
+    name = `track-${Math.random() * 1000}`;
+  });
+
+  describe('constructor', () => {
+    it('returns an instanceof LocalParticipantV2', () => {
+      assert(localParticipant instanceof LocalParticipantV2);
+    });
+  });
+
+  describe('#addTrack', () => {
+    describe('called with a TrackSender and a name', () => {
+      it('returns the LocalParticipantV2 instance', () => {
+        assert.equal(localParticipant.addTrack(trackSender, name), localParticipant);
+      });
+
+      it('constructs a LocalTrackPublicationV2 with the TrackSender and name', () => {
+        localParticipant.addTrack(trackSender, name);
+        sinon.assert.calledWith(LocalTrackPublicationV2Constructor, trackSender, name);
+      });
+
+      it('adds the LocalTrackPublicationV2 to the LocalParticipantV2\'s .tracks Map', () => {
+        localParticipant.addTrack(trackSender, name);
+        assert.equal(localParticipant.tracks.get(trackSender.id), publication);
+      });
+
+      it('emits "trackAdded", followed by "updated"', () => {
+        const events = [];
+        ['trackAdded', 'updated'].forEach(event =>
+          localParticipant.once(event, () => events.push(event)));
+        localParticipant.addTrack(trackSender, name);
+        assert.deepEqual(events, ['trackAdded', 'updated']);
+      });
+
+      describe('starts listening to the resulting LocalTrackPublicationV2\'s "updated" event and,', () => {
+        beforeEach(() => {
+          localParticipant.addTrack(trackSender, name);
+        });
+
+        describe('when the LocalTrackPublicationV2\'s SID is set,', () => {
+          // FIXME(mroberts): This might be the source of our problems.
+          it('does not emit "updated"', () => {
+            let didEmitUpdated = false;
+            localParticipant.once('updated', () => { didEmitUpdated = true; });
+            publication.sid = 'MT123';
+            publication.emit('updated');
+            assert(!didEmitUpdated);
+          });
+        });
+
+        describe('when the LocalTrackPublicationV2 is enabled or disabled,', () => {
+          it('emits "updated"', () => {
+            publication.sid = 'MT123';
+            publication.emit('updated');
+
+            let didEmitUpdated = false;
+            localParticipant.once('updated', () => { didEmitUpdated = true; });
+            publication.emit('updated');
+            assert(didEmitUpdated);
+          });
+        });
+      });
+    });
+  });
+
+  describe('#removeTrack, called with a DataTrackSedner or MediaTrackSender that is', () => {
+    describe('currently added', () => {
+      beforeEach(() => {
+        localParticipant.addTrack(trackSender, name);
+        publication.sid = 'MT123';
+        publication.emit('updated');
+      });
+
+      it('returns true', () => {
+        assert(localParticipant.removeTrack(trackSender));
+      });
+
+      it('removes the LocalTrackPublicationV2 from the LocalParticipantV2\'s .tracks Map', () => {
+        localParticipant.removeTrack(trackSender);
+        assert(!localParticipant.tracks.has(trackSender.id));
+      });
+
+      it('emits "trackRemoved", followed by "updated"', () => {
+        const events = [];
+        ['trackRemoved', 'updated'].forEach(event =>
+          localParticipant.once(event, () => events.push(event)));
+        localParticipant.removeTrack(trackSender);
+        assert.deepEqual(events, ['trackRemoved', 'updated']);
+      });
+
+      it('stops listening to the LocalTrackPublicationV2\'s "updated" event', () => {
+        localParticipant.removeTrack(trackSender);
+
+        let didEmitUpdated = false;
+        localParticipant.once('updated', () => { didEmitUpdated = true; });
+        publication.emit('updated');
+        assert(!didEmitUpdated);
+      });
+    });
+
+    describe('not currently added', () => {
+      it('returns false', () => {
+        assert(!localParticipant.removeTrack(trackSender));
+      });
+
+      it('does not emit "trackRemoved" or "updated"', () => {
+        const events = [];
+        ['trackRemoved', 'updated'].forEach(event =>
+          localParticipant.once(event, () => events.push(event)));
+        localParticipant.removeTrack(trackSender);
+        assert.deepEqual(events, []);
+      });
+    });
+  });
+});

--- a/test/unit/spec/signaling/v2/room.js
+++ b/test/unit/spec/signaling/v2/room.js
@@ -619,22 +619,14 @@ describe('RoomV2', () => {
           test.peerConnectionManager.setTrackSenders.args[0][0]);
       });
 
-      it('calls .update on the LocalParticipantSignaling', async () => {
-        const track = makeTrack();
-        const test = makeTest({
-          localTracks: [track]
-        });
-        test.localParticipant.emit('trackAdded', track);
-        await new Promise(resolve => setTimeout(resolve));
-        assert(test.localParticipant.incrementRevision.calledOnce);
-      });
-
       it('calls .publish on the Transport with the LocalparticipantSignaling state', async () => {
         const track = makeTrack();
         const test = makeTest({
           localTracks: [track]
         });
         test.localParticipant.emit('trackAdded', track);
+        test.localParticipant.revision++;
+        test.localParticipant.emit('updated');
         await new Promise(resolve => setTimeout(resolve));
         assert.deepEqual(
           {
@@ -659,22 +651,14 @@ describe('RoomV2', () => {
           test.peerConnectionManager.setTrackSenders.args[0][0]);
       });
 
-      it('calls .update on the LocalParticipantSignaling', async () => {
-        const track = makeTrack();
-        const test = makeTest({
-          localTracks: [track]
-        });
-        test.localParticipant.emit('trackRemoved', track);
-        await new Promise(resolve => setTimeout(resolve));
-        assert(test.localParticipant.incrementRevision.calledOnce);
-      });
-
       it('calls .publish on the Transport with the LocalParticipantSignaling state', async () => {
         const track = makeTrack();
         const test = makeTest({
           localTracks: [track]
         });
         test.localParticipant.emit('trackRemoved', track);
+        test.localParticipant.revision++;
+        test.localParticipant.emit('updated', track);
         await new Promise(resolve => setTimeout(resolve));
         assert.deepEqual(
           {
@@ -683,42 +667,6 @@ describe('RoomV2', () => {
             }
           },
           test.transport.publish.args[0][0]);
-      });
-    });
-
-    context('when an added TrackV2 emits an "updated" event in a new state', () => {
-      context('with .isEnabled set to false', () => {
-        it('calls .publish on the Transport with the LocalParticipantSignaling state', () => {
-          const track = makeTrack();
-          const test = makeTest({
-            localTracks: [track]
-          });
-          track.disable();
-          assert.deepEqual(
-            {
-              participant: {
-                revision: 1
-              }
-            },
-            test.transport.publish.args[0][0]);
-        });
-      });
-
-      context('with .isEnabled set to true', () => {
-        it('calls .publish on the Transport with the LocalParticipantSignaling state', () => {
-          const track = makeTrack();
-          const test = makeTest({
-            localTracks: [track]
-          });
-          track.enable();
-          assert.deepEqual(
-            {
-              participant: {
-                revision: 1
-              }
-            },
-            test.transport.publish.args[0][0]);
-        });
       });
     });
 


### PR DESCRIPTION
@manjeshbhargav previously, RoomV2 was managing LocalParticipantV2's `revision`, which we identified as being weird. Now, LocalParticipantV2 manages it in response to

* Tracks being added,
* Tracks being removed, and
* Added Tracks changing (except for SID assignment).

Basically, I just moved the logic from lib/signaling/v2/room.js into lib/signaling/v2/localparticipant.js.

I still need to find a way to test the `revision` re-use bug when enabling/disabling a Track early when connecting to a Room.