### PR TITLE
JSDK-1796: Add iceServersTimeout and abortIfIceServersTimeout to ConnectOptions

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -121,8 +121,10 @@ function connect(token, options) {
   }
 
   options = Object.assign({
+    allowIceServersToTimeout: true,
     createLocalTracks,
     environment: constants.DEFAULT_ENVIRONMENT,
+    iceServersTimeout: constants.ICE_SERVERS_TIMEOUT_MS,
     insights: true,
     LocalAudioTrack,
     LocalDataTrack,
@@ -206,11 +208,16 @@ function connect(token, options) {
     maxVideoBitrate: options.maxVideoBitrate
   });
 
+  const ntsIceServerSourceOptions = Object.assign({}, options, {
+    allowTimeout: options.allowIceServersToTimeout,
+    timeout: options.iceServersTimeout
+  });
+
   const iceServerSource = Array.isArray(options.iceServers)
     ? new ConstantIceServerSource(options.iceServers)
     : typeof options.iceServers === 'object'
       ? options.iceServers
-      : new NTSIceServerSource(token, options);
+      : new NTSIceServerSource(token, ntsIceServerSourceOptions);
 
   const preferredCodecs = {
     audio: options.preferredAudioCodecs,
@@ -251,11 +258,23 @@ function connect(token, options) {
  * You may pass these options to {@link connect} in order to override the
  * default behavior.
  * @typedef {object} ConnectOptions
+ * @property {boolean} [allowIceServersToTimeout=true] - Allow fetching ICE
+ *   servers to timeout; if enabled, failure to acquire STUN and TURN servers
+ *   (for example, due to a restrictive or slow HTTP proxy) will not fail a call
+ *   to {@link connect}, since, in a Group Room, STUN and TURN servers may not
+ *   be necessary; if disabled, {@link connect} may fail with a
+ *   {@link ConfigurationAcquireFailedError}
  * @property {boolean|CreateLocalTrackOptions} [audio=true] - Whether or not to
  *   get local audio with <code>getUserMedia</code> when <code>tracks</code>
  *   are not provided.
  * @property {Array<RTCIceServer>} iceServers - Override the STUN and TURN
  *   servers used when connecting to {@link Room}s
+ * @property {number} [iceServersTimeout=3000] - Override the amount of time, in
+ *   milliseconds, that the SDK will wait when acquiring STUN and TURN servers
+ *   before connecting to a {@link Room}; if the timeout elapses,
+ *   <code>allowIceServersToTimeout</code> is enabled, and STUN and TURN servers
+ *   have not been acquired, then the SDK will use default STUN servers
+ * @property {boolean} [false=
  * @property {RTCIceTransportPolicy} [iceTransportPolicy="all"] - Override the
  *   ICE transport policy to be one of "relay" or "all"
  * @property {boolean} [insights=true] - Whether publishing events

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -121,7 +121,7 @@ function connect(token, options) {
   }
 
   options = Object.assign({
-    allowIceServersToTimeout: true,
+    abortIfIceServersTimeout: false,
     createLocalTracks,
     environment: constants.DEFAULT_ENVIRONMENT,
     iceServersTimeout: constants.ICE_SERVERS_TIMEOUT_MS,
@@ -209,7 +209,7 @@ function connect(token, options) {
   });
 
   const ntsIceServerSourceOptions = Object.assign({}, options, {
-    allowTimeout: options.allowIceServersToTimeout,
+    abortIfTimeout: options.abortIfIceServersTimeout,
     timeout: options.iceServersTimeout
   });
 
@@ -258,12 +258,12 @@ function connect(token, options) {
  * You may pass these options to {@link connect} in order to override the
  * default behavior.
  * @typedef {object} ConnectOptions
- * @property {boolean} [allowIceServersToTimeout=true] - Allow fetching ICE
- *   servers to timeout; if enabled, failure to acquire STUN and TURN servers
- *   (for example, due to a restrictive or slow HTTP proxy) will not fail a call
- *   to {@link connect}, since, in a Group Room, STUN and TURN servers may not
- *   be necessary; if disabled, {@link connect} may fail with a
- *   {@link ConfigurationAcquireFailedError}
+ * @property {boolean} [abortIfIceServersTimeout=false] - If fetching ICE
+ *   servers times out (for example, due to a restrictive network or slow HTTP
+ *   proxy), then, by default, twilio-video.js will fallback to using hard-coded
+ *   STUN servers and continue connecting to the Room. Setting this property to
+ *   <code>true</code> will cause twilio-video.js to abort instead, and
+ *   {@link connect} will reject with a {@link ConfigurationAcquireFailedError}.
  * @property {boolean|CreateLocalTrackOptions} [audio=true] - Whether or not to
  *   get local audio with <code>getUserMedia</code> when <code>tracks</code>
  *   are not provided.
@@ -271,9 +271,6 @@ function connect(token, options) {
  *   servers used when connecting to {@link Room}s
  * @property {number} [iceServersTimeout=3000] - Override the amount of time, in
  *   milliseconds, that the SDK will wait when acquiring STUN and TURN servers
- *   before connecting to a {@link Room}; if the timeout elapses,
- *   <code>allowIceServersToTimeout</code> is enabled, and STUN and TURN servers
- *   have not been acquired, then the SDK will use default STUN servers
  * @property {boolean} [false=
  * @property {RTCIceTransportPolicy} [iceTransportPolicy="all"] - Override the
  *   ICE transport policy to be one of "relay" or "all"

--- a/lib/iceserversource/nts.js
+++ b/lib/iceserversource/nts.js
@@ -6,6 +6,7 @@ const EventEmitter = require('events').EventEmitter;
 const Log = require('../util/log');
 const TimeoutPromise = require('../util/timeoutpromise');
 const util = require('../util');
+const { ConfigurationAcquireFailedError } = require('../util/twilio-video-errors');
 const version = require('../../package.json').version;
 
 let instances = 0;
@@ -38,6 +39,7 @@ class NTSIceServerSource extends EventEmitter {
     super();
 
     options = Object.assign({
+      allowTimeout: true,
       defaultTTL: constants.ICE_SERVERS_DEFAULT_TTL,
       environment: constants.DEFAULT_ENVIRONMENT,
       getConfiguration: ECS.getConfiguration,
@@ -55,6 +57,9 @@ class NTSIceServerSource extends EventEmitter {
       : new Log('default', this, util.buildLogLevels('off'));
 
     Object.defineProperties(this, {
+      _allowTimeout: {
+        value: options.allowTimeout
+      },
       // This Promise represents the current invocation of `poll`. `start` sets it
       // and `stop` clears it out.
       _currentPoll: {
@@ -206,6 +211,10 @@ function poll(client) {
     if (!client.isStarted) {
       throw alreadyStopped;
     } else if (configWithTimeout.isTimedOut) {
+      if (!client._allowTimeout) {
+        client._log.warn('Getting ICE servers took too long');
+        throw new ConfigurationAcquireFailedError();
+      }
       client._log.warn('Getting ICE servers took too long (using defaults)');
     } else {
       // NOTE(mroberts): Stop if we get an Access Token error (2xxxx)

--- a/lib/iceserversource/nts.js
+++ b/lib/iceserversource/nts.js
@@ -39,7 +39,7 @@ class NTSIceServerSource extends EventEmitter {
     super();
 
     options = Object.assign({
-      allowTimeout: true,
+      abortIfTimeout: false,
       defaultTTL: constants.ICE_SERVERS_DEFAULT_TTL,
       environment: constants.DEFAULT_ENVIRONMENT,
       getConfiguration: ECS.getConfiguration,
@@ -57,8 +57,8 @@ class NTSIceServerSource extends EventEmitter {
       : new Log('default', this, util.buildLogLevels('off'));
 
     Object.defineProperties(this, {
-      _allowTimeout: {
-        value: options.allowTimeout
+      _abortIfTimeout: {
+        value: options.abortIfTimeout
       },
       // This Promise represents the current invocation of `poll`. `start` sets it
       // and `stop` clears it out.
@@ -211,7 +211,7 @@ function poll(client) {
     if (!client.isStarted) {
       throw alreadyStopped;
     } else if (configWithTimeout.isTimedOut) {
-      if (!client._allowTimeout) {
+      if (client._abortIfTimeout) {
         client._log.warn('Getting ICE servers took too long');
         throw new ConfigurationAcquireFailedError();
       }


### PR DESCRIPTION
The current default in twilio-video.js is to wait 3 s for ICE servers (STUN and TURN). If this takes longer than 3 s, twilio-video.js proceeds with hard-coded STUN servers. On some networks, 3 s is too short a timeout. So now it can be extended, e.g.

```js
connect(token, {
  iceServersTimeout: 10 * 1000 // ms
});
```

will wait 10 s. Additionally, on some networks, connecting to a Room isn't going to work at all without TURN servers. So there is a new option, `abortIfIceServersTimeout`, that allows failing the `connect` call, e.g.

```js
try {
  await connect(token, {
    abortIfIceServersTimeout: true,
    iceServersTimeout: 10 * 1000 // ms
  })
} catch (error) {
  switch (error.code) {
    case 53500: // ConfigurationAcquireFailedError
      console.error('It took too long to get ICE servers! Check any HTTP proxies and make sure you have whitelisted the necessary endpoints for using twilio-video.js');
    default:
      throw error;
  }
}
```

We should also consider raising the default `iceServersTimeout` from 3000 to 5000 or 10000.