### PR TITLE
Prepare for 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
-1.8.1 (in progress)
+1.9.0 (in progress)
 ===================
+
+New Features
+------------
+
+- By default, twilio-video.js waits up to 3000 milliseconds to fetch ICE servers
+  before connecting to a Room; and, if fetching ICE servers takes longer than
+  3000 milliseconds or otherwise fails, twilio-video.js will fallback to using
+  hard-coded STUN servers. Now you can configure this timeout with a new
+  property in ConnectOptions, `iceServersTimeout`. You can also disable the
+  fallback behavior by setting another new property in ConnectOptions,
+  `abortOnIceServersTimeout`, to `true`. Doing so will cause the Promise
+  returned by `connect` to reject with TwilioError 53500, "Unable to acquire
+  configuration", if fetching ICE servers times out or otherwise fails.
 
 Bug Fixes
 ---------

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "twilio-video",
-  "version": "1.8.1-dev",
+  "version": "1.9.0-dev",
   "description": "Twilio Video JavaScript library",
   "license": "BSD",
   "authors": [

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -121,7 +121,7 @@ function connect(token, options) {
   }
 
   options = Object.assign({
-    abortIfIceServersTimeout: false,
+    abortOnIceServersTimeout: false,
     createLocalTracks,
     environment: constants.DEFAULT_ENVIRONMENT,
     iceServersTimeout: constants.ICE_SERVERS_TIMEOUT_MS,
@@ -209,7 +209,7 @@ function connect(token, options) {
   });
 
   const ntsIceServerSourceOptions = Object.assign({}, options, {
-    abortIfTimeout: options.abortIfIceServersTimeout,
+    abortOnTimeout: options.abortOnIceServersTimeout,
     timeout: options.iceServersTimeout
   });
 
@@ -258,7 +258,7 @@ function connect(token, options) {
  * You may pass these options to {@link connect} in order to override the
  * default behavior.
  * @typedef {object} ConnectOptions
- * @property {boolean} [abortIfIceServersTimeout=false] - If fetching ICE
+ * @property {boolean} [abortOnIceServersTimeout=false] - If fetching ICE
  *   servers times out (for example, due to a restrictive network or slow HTTP
  *   proxy), then, by default, twilio-video.js will fallback to using hard-coded
  *   STUN servers and continue connecting to the Room. Setting this property to

--- a/lib/iceserversource/nts.js
+++ b/lib/iceserversource/nts.js
@@ -39,7 +39,7 @@ class NTSIceServerSource extends EventEmitter {
     super();
 
     options = Object.assign({
-      abortIfTimeout: false,
+      abortOnTimeout: false,
       defaultTTL: constants.ICE_SERVERS_DEFAULT_TTL,
       environment: constants.DEFAULT_ENVIRONMENT,
       getConfiguration: ECS.getConfiguration,
@@ -57,8 +57,8 @@ class NTSIceServerSource extends EventEmitter {
       : new Log('default', this, util.buildLogLevels('off'));
 
     Object.defineProperties(this, {
-      _abortIfTimeout: {
-        value: options.abortIfTimeout
+      _abortOnTimeout: {
+        value: options.abortOnTimeout
       },
       // This Promise represents the current invocation of `poll`. `start` sets it
       // and `stop` clears it out.
@@ -211,7 +211,7 @@ function poll(client) {
     if (!client.isStarted) {
       throw alreadyStopped;
     } else if (configWithTimeout.isTimedOut) {
-      if (client._abortIfTimeout) {
+      if (client._abortOnTimeout) {
         client._log.warn('Getting ICE servers took too long');
         throw new ConfigurationAcquireFailedError();
       }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "twilio-video",
   "title": "Twilio Video",
   "description": "Twilio Video JavaScript library",
-  "version": "1.8.1-dev",
+  "version": "1.9.0-dev",
   "homepage": "https://twilio.com",
   "author": "Mark Andrus Roberts <mroberts@twilio.com>",
   "contributors": [


### PR DESCRIPTION
@manjeshbhargav it was suggested we rename `abortIfIceServersTimeout` to `abortOnIceServersTimeout`. Also, since this is a new feature, we'll need to bump the minor version.