### PR TITLE
JSDK-1810: Add support for ICE restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ Bug Fixes
   timely manner. Now, WebSocket timeouts can be identified in around 30 seconds.
   If a WebSocket timeout occurs, for example, due to a WebSocket disconnect,
   Room will emit a "disconnected" event with SignalingConnectionTimeoutError.
+- If an ICE failure occurs, for example due to disconnecting a VPN, but the
+  but the signaling connection remains online, twilio-video.js will attempt an
+  ICE restart to repair the media connection. (JSDK-1810)
 
 1.8.0 (February 9, 2018)
 ========================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ Bug Fixes
   If a WebSocket timeout occurs, for example, due to a WebSocket disconnect,
   Room will emit a "disconnected" event with SignalingConnectionTimeoutError.
 - If an ICE failure occurs, for example due to disconnecting a VPN, but the
-  but the signaling connection remains online, twilio-video.js will attempt an
-  ICE restart to repair the media connection. (JSDK-1810)
+  signaling connection remains online, twilio-video.js will attempt an ICE
+  restart to repair the media connection. (JSDK-1810)
 
 1.8.0 (February 9, 2018)
 ========================

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -19,6 +19,9 @@ const DataTrackReceiver = require('../../data/receiver');
 const MediaTrackReceiver = require('../../media/track/receiver');
 const StateMachine = require('../../statemachine');
 const StatsReport = require('../../stats/statsreport');
+const { buildLogLevels } = require('../../util');
+const { DEFAULT_LOG_LEVEL } = require('../../util/constants');
+const Log = require('../../util/log');
 const IdentityTrackMatcher = require('../../util/sdp/trackmatcher/identity');
 const OrderedTrackMatcher = require('../../util/sdp/trackmatcher/ordered');
 const MIDTrackMatcher = require('../../util/sdp/trackmatcher/mid');
@@ -80,6 +83,7 @@ class PeerConnectionV2 extends StateMachine {
 
     options = Object.assign({
       iceServers: [],
+      logLevel: DEFAULT_LOG_LEVEL,
       offerOptions: {},
       setBitrateParameters,
       setCodecPreferences,
@@ -91,6 +95,7 @@ class PeerConnectionV2 extends StateMachine {
     }, options);
 
     const configuration = getConfiguration(options);
+    const logLevels = buildLogLevels(options.logLevel);
     const RTCPeerConnection = options.RTCPeerConnection;
     const peerConnection = new RTCPeerConnection(configuration);
 
@@ -142,7 +147,7 @@ class PeerConnectionV2 extends StateMachine {
       _log: {
         value: options.log
           ? options.log.createLog('signaling', this)
-          : null
+          : new Log('webrtc', this, logLevels),
       },
       _rtpSenders: {
         value: new Map()
@@ -342,13 +347,9 @@ class PeerConnectionV2 extends StateMachine {
    * @returns {Promise<void>}
    */
   _handleGlare(offer) {
-    if (this._log) {
-      this._log.debug('Glare detected; rolling back');
-    }
+    this._log.debug('Glare detected; rolling back');
     if (this._isRestartingIce) {
-      if (this._log) {
-        this._log.debug('An ICE restart was in progress; we\'ll need to restart ICE again after rolling back');
-      }
+      this._log.debug('An ICE restart was in progress; we\'ll need to restart ICE again after rolling back');
       this._isRestartingIce = false;
       this._shouldRestartIce = true;
     }
@@ -387,24 +388,18 @@ class PeerConnectionV2 extends StateMachine {
   _handleIceConnectionStateChange() {
     const { iceConnectionState } = this._peerConnection;
 
-    if (this._log) {
-      this._log.debug(`ICE connection state is "${iceConnectionState}"`);
-    }
+    this._log.debug(`ICE connection state is "${iceConnectionState}"`);
 
     // Case 1: Transition to "failed".
     if (this._lastIceConnectionState !== 'failed' && iceConnectionState === 'failed' && !this._shouldRestartIce && !this._isRestartingIce) {
-      if (this._log) {
-        this._log.warn('ICE failed; attempting to restart ICE');
-      }
+      this._log.warn('ICE failed; attempting to restart ICE');
       this._shouldRestartIce = true;
       this.offer();
     }
 
     // Case 2: Transition from "failed".
     else if (this._lastIceConnectionState === 'failed' && (iceConnectionState === 'connected' || iceConnectionState === 'completed')) {
-      if (this._log) {
-        this._log.info('ICE reconnected');
-      }
+      this._log.info('ICE reconnected');
     }
 
     this._lastIceConnectionState = iceConnectionState;
@@ -557,11 +552,9 @@ class PeerConnectionV2 extends StateMachine {
       }
       return this._peerConnection.setLocalDescription(description);
     }).catch(error => {
-      if (this._log) {
-        this._log.warn(`Calling setLocalDescription with an RTCSessionDescription of type "${description.type}" failed with the error "${error.message}".`);
-        if (description.sdp) {
-          this._log.warn(`The SDP was ${description.sdp}`);
-        }
+      this._log.warn(`Calling setLocalDescription with an RTCSessionDescription of type "${description.type}" failed with the error "${error.message}".`);
+      if (description.sdp) {
+        this._log.warn(`The SDP was ${description.sdp}`);
       }
       throw new MediaClientLocalDescFailedError();
     }).then(() => {
@@ -598,16 +591,12 @@ class PeerConnectionV2 extends StateMachine {
     description = new this._RTCSessionDescription(description);
     return this._peerConnection.setRemoteDescription(description).catch(error => {
       if (description.type === 'answer' && this._isRestartingIce) {
-        if (this._log) {
-          this._log.debug('An ICE restart was in-progress and is now completed');
-        }
+        this._log.debug('An ICE restart was in-progress and is now completed');
         this._isRestartingIce = false;
       }
-      if (this._log) {
-        this._log.warn(`Calling setRemoteDescription with an RTCSessionDescription of type "${description.type}" failed with the error "${error.message}".`);
-        if (description.sdp) {
-          this._log.warn(`The SDP was ${description.sdp}`);
-        }
+      this._log.warn(`Calling setRemoteDescription with an RTCSessionDescription of type "${description.type}" failed with the error "${error.message}".`);
+      if (description.sdp) {
+        this._log.warn(`The SDP was ${description.sdp}`);
       }
       throw error;
     });

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -108,6 +108,14 @@ class PeerConnectionV2 extends StateMachine {
       _encodingParameters: {
         value: encodingParameters
       },
+      _isRestartingIce: {
+        writable: true,
+        value: false
+      },
+      _lastIceConnectionState: {
+        writable: true,
+        value: null
+      },
       _lastStableDescriptionRevision: {
         writable: true,
         value: 0
@@ -193,6 +201,10 @@ class PeerConnectionV2 extends StateMachine {
         writable: true,
         value: false
       },
+      _shouldRestartIce: {
+        writable: true,
+        value: false
+      },
       _trackIdsToAttributes: {
         value: new Map()
       },
@@ -209,6 +221,7 @@ class PeerConnectionV2 extends StateMachine {
     encodingParameters.on('changed', oncePerTick(this.offer.bind(this)));
     peerConnection.addEventListener('datachannel', this._handleDataChannelEvent.bind(this));
     peerConnection.addEventListener('icecandidate', this._handleIceCandidateEvent.bind(this));
+    peerConnection.addEventListener('iceconnectionstatechange', this._handleIceConnectionStateChange.bind(this));
     peerConnection.addEventListener('signalingstatechange', this._handleSignalingStateChange.bind(this));
     peerConnection.addEventListener('track', this._handleTrackEvent.bind(this));
 
@@ -329,6 +342,16 @@ class PeerConnectionV2 extends StateMachine {
    * @returns {Promise<void>}
    */
   _handleGlare(offer) {
+    if (this._log) {
+      this._log.debug('Glare detected; rolling back');
+    }
+    if (this._isRestartingIce) {
+      if (this._log) {
+        this._log.debug('An ICE restart was in progress; we\'ll need to restart ICE again after rolling back');
+      }
+      this._isRestartingIce = false;
+      this._shouldRestartIce = true;
+    }
     return Promise.resolve().then(() => this._setLocalDescription({ type: 'rollback' })).then(() => this._answer(offer)).then(() => this._offer());
   }
 
@@ -354,6 +377,37 @@ class PeerConnectionV2 extends StateMachine {
       peerConnectionState.ice.complete = true;
     }
     this.emit('candidates', peerConnectionState);
+  }
+
+  /**
+   * Handle an ICE connection state change event.
+   * @private
+   * @returns {void}
+   */
+  _handleIceConnectionStateChange() {
+    const { iceConnectionState } = this._peerConnection;
+
+    if (this._log) {
+      this._log.debug(`ICE connection state is "${iceConnectionState}"`);
+    }
+
+    // Case 1: Transition to "failed".
+    if (this._lastIceConnectionState !== 'failed' && iceConnectionState === 'failed' && !this._shouldRestartIce && !this._isRestartingIce) {
+      if (this._log) {
+        this._log.warn('ICE failed; attempting to restart ICE');
+      }
+      this._shouldRestartIce = true;
+      this.offer();
+    }
+
+    // Case 2: Transition from "failed".
+    else if (this._lastIceConnectionState === 'failed' && (iceConnectionState === 'connected' || iceConnectionState === 'completed')) {
+      if (this._log) {
+        this._log.info('ICE reconnected');
+      }
+    }
+
+    this._lastIceConnectionState = iceConnectionState;
   }
 
   /**
@@ -445,7 +499,13 @@ class PeerConnectionV2 extends StateMachine {
    * @returns {Promise<void>}
    */
   _offer() {
-    return Promise.resolve().then(() => this._peerConnection.createOffer(this._offerOptions)).catch(() => {
+    const offerOptions = Object.assign({}, this._offerOptions);
+    if (this._shouldRestartIce) {
+      this._shouldRestartIce = false;
+      this._isRestartingIce = true;
+      offerOptions.iceRestart = true;
+    }
+    return Promise.resolve().then(() => this._peerConnection.createOffer(offerOptions)).catch(() => {
       throw new MediaClientLocalDescFailedError();
     }).then(offer => {
       if (!isFirefox) {
@@ -537,6 +597,12 @@ class PeerConnectionV2 extends StateMachine {
     }
     description = new this._RTCSessionDescription(description);
     return this._peerConnection.setRemoteDescription(description).catch(error => {
+      if (description.type === 'answer' && this._isRestartingIce) {
+        if (this._log) {
+          this._log.debug('An ICE restart was in-progress and is now completed');
+        }
+        this._isRestartingIce = false;
+      }
       if (this._log) {
         this._log.warn(`Calling setRemoteDescription with an RTCSessionDescription of type "${description.type}" failed with the error "${error.message}".`);
         if (description.sdp) {

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -589,11 +589,12 @@ class PeerConnectionV2 extends StateMachine {
         this._preferredVideoCodecs);
     }
     description = new this._RTCSessionDescription(description);
-    return this._peerConnection.setRemoteDescription(description).catch(error => {
+    return this._peerConnection.setRemoteDescription(description).then(() => {
       if (description.type === 'answer' && this._isRestartingIce) {
         this._log.debug('An ICE restart was in-progress and is now completed');
         this._isRestartingIce = false;
       }
+    }, error => {
       this._log.warn(`Calling setRemoteDescription with an RTCSessionDescription of type "${description.type}" failed with the error "${error.message}".`);
       if (description.sdp) {
         this._log.warn(`The SDP was ${description.sdp}`);
@@ -770,7 +771,7 @@ class PeerConnectionV2 extends StateMachine {
    * @returns {Promise<void>}
    */
   offer() {
-    if (this._needsInitialAnswer) {
+    if (this._needsInitialAnswer || this._isRestartingIce) {
       this._shouldOffer = true;
       return Promise.resolve();
     }


### PR DESCRIPTION
If an ICE failure occurs (i.e., an individual RTCPeerConnection's `iceConnectionState` transitions to "failed"), we now perform an ICE restart. Subsequent offers from the Client will block until the ICE restart has completed (not unlike what we do in the initial round of negotiation with the `_needsInitialAnswer` boolean); however, glare will still force the Client to rollback, apply the Server's answer, and then restart ICE (with yet another unique set of ICE credentials).