### PR TITLE
JSDK-1228 Publish ICE candidate pair stats to Insights.

### DIFF
--- a/lib/room.js
+++ b/lib/room.js
@@ -2,6 +2,7 @@
 
 const EventEmitter = require('events').EventEmitter;
 const RemoteParticipant = require('./remoteparticipant');
+const StatsReport = require('./stats/statsreport');
 const { MediaConnectionError } = require('./util/twilio-video-errors');
 
 let nInstances = 0;
@@ -125,7 +126,11 @@ class Room extends EventEmitter {
    * @returns {Promise.<Array<StatsReport>>}
    */
   getStats() {
-    return this._signaling.getStats();
+    return this._signaling.getStats().then(responses => {
+      return Array.from(responses).map(([id, response]) => {
+        return new StatsReport(id, response);
+      });
+    });
   }
 }
 

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -18,7 +18,6 @@ const MediaClientRemoteDescFailedError = require('../../util/twilio-video-errors
 const DataTrackReceiver = require('../../data/receiver');
 const MediaTrackReceiver = require('../../media/track/receiver');
 const StateMachine = require('../../statemachine');
-const StatsReport = require('../../stats/statsreport');
 const { buildLogLevels } = require('../../util');
 const { DEFAULT_LOG_LEVEL } = require('../../util/constants');
 const Log = require('../../util/log');
@@ -873,10 +872,10 @@ class PeerConnectionV2 extends StateMachine {
 
   /**
    * Get the {@link PeerConnectionV2}'s media statistics.
-   * @returns {Promise<StatsReport>}
+   * @returns {Promise<StandardizedStatsResponse>}
    */
   getStats() {
-    return getStatistics(this._peerConnection).then(statsResponse => new StatsReport(this.id, statsResponse));
+    return getStatistics(this._peerConnection);
   }
 }
 

--- a/lib/signaling/v2/peerconnectionmanager.js
+++ b/lib/signaling/v2/peerconnectionmanager.js
@@ -282,11 +282,14 @@ class PeerConnectionManager extends QueueingEventEmitter {
 
   /**
    * Get the {@link PeerConnectionManager}'s media statistics.
-   * @returns {Promise.<Array<StatsReport>>}
+   * @returns {Promise.<Map<PeerConnectionV2#id, StandardizedStatsResponse>>}
    */
   getStats() {
     const peerConnections = Array.from(this._peerConnections.values());
-    return Promise.all(peerConnections.map(peerConnection => peerConnection.getStats()));
+    return Promise.all(peerConnections.map(peerConnection => peerConnection.getStats().then(response => [
+      peerConnection.id,
+      response
+    ]))).then(responses => new Map(responses));
   }
 }
 

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -272,6 +272,7 @@ class RoomV2 extends RoomSignaling {
     }
 
     return this._peerConnectionManager.getStats().then(reports => reports.map(report => Object.assign({}, report, {
+      _activeIceCandidatePair: report._activeIceCandidatePair,
       localAudioTrackStats: report.localAudioTrackStats.filter(filterLocalTrackStats),
       localVideoTrackStats: report.localVideoTrackStats.filter(filterLocalTrackStats),
       remoteAudioTrackStats: report.remoteAudioTrackStats.filter(filterRemoteTrackStats),

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -367,6 +367,9 @@ function periodicallyPublishStats(roomV2, localParticipant, transport, intervalM
           roomSid: roomV2.sid,
           videoTrackStats: report.remoteVideoTrackStats
         });
+        transport.publishEvent('quality',
+          'active-ice-candidate-pair',
+          report._activeIceCandidatePair);
       });
     }, () => {
       // Do nothing.

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -377,9 +377,14 @@ function periodicallyPublishStats(roomV2, localParticipant, transport, intervalM
           videoTrackStats: report.remoteVideoTrackStats
         });
 
-        transport.publishEvent('quality', 'active-ice-candidate-pair', Object.assign({
-          peerConnectionId: report.peerConnectionId,
-        }, response.activeIceCandidatePair));
+        // NOTE(mmalavalli): null properties of the "active-ice-candidate-pair"
+        // payload are assigned default values until the Insights gateway
+        // accepts null values.
+        const activeIceCandidatePair = replaceNullsWithDefaults(
+          response.activeIceCandidatePair,
+          report.peerConnectionId);
+
+        transport.publishEvent('quality', 'active-ice-candidate-pair', activeIceCandidatePair);
       });
     }, () => {
       // Do nothing.
@@ -405,4 +410,54 @@ function handleSubscriptionFailures(room) {
     }
   });
 }
+
+function replaceNullsWithDefaults(activeIceCandidatePair, peerConnectionId) {
+  activeIceCandidatePair = Object.assign({
+    availableIncomingBitrate: 0,
+    availableOutgoingBitrate: 0,
+    bytesReceived: 0,
+    bytesSent: 0,
+    consentRequestsSent: 0,
+    currentRoundTripTime: 0,
+    lastPacketReceivedTimestamp: 0,
+    lastPacketSentTimestamp: 0,
+    nominated: false,
+    peerConnectionId: peerConnectionId,
+    priority: 0,
+    readable: false,
+    requestsReceived: 0,
+    requestsSent: 0,
+    responsesReceived: 0,
+    responsesSent: 0,
+    retransmissionsReceived: 0,
+    retransmissionsSent: 0,
+    state: 'failed',
+    totalRoundTripTime: 0,
+    transportId: '',
+    writable: false
+  }, util.filterObject(activeIceCandidatePair || {}, null));
+
+  activeIceCandidatePair.localCandidate = Object.assign({
+    candidateType: 'host',
+    deleted: false,
+    ip: '',
+    port: 0,
+    priority: 0,
+    protocol: 'udp',
+    relayProtocol: 'udp',
+    url: ''
+  }, util.filterObject(activeIceCandidatePair.localCandidate || {}, null));
+
+  activeIceCandidatePair.remoteCandidate = Object.assign({
+    candidateType: 'host',
+    ip: '',
+    port: 0,
+    priority: 0,
+    protocol: 'udp',
+    url: ''
+  }, util.filterObject(activeIceCandidatePair.remoteCandidate || {}, null));
+
+  return activeIceCandidatePair;
+}
+
 module.exports = RoomV2;

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -3,6 +3,7 @@
 const RecordingV2 = require('./recording');
 const RoomSignaling = require('../room');
 const RemoteParticipantV2 = require('./remoteparticipant');
+const StatsReport = require('../../stats/statsreport');
 const util = require('../../util');
 const createTwilioError = require('../../util/twilio-video-errors').createTwilioError;
 
@@ -258,7 +259,7 @@ class RoomV2 extends RoomSignaling {
 
   /**
    * Get the {@link RoomV2}'s media statistics.
-   * @returns {Promise.<Array<StatsReport>>}
+   * @returns {Promise.<Map<PeerConnectionV2#id, StandardizedStatsResponse>>}
    */
   getStats() {
     const self = this;
@@ -271,13 +272,15 @@ class RoomV2 extends RoomSignaling {
       return self._subscribed.has(trackStats.trackId);
     }
 
-    return this._peerConnectionManager.getStats().then(reports => reports.map(report => Object.assign({}, report, {
-      _activeIceCandidatePair: report._activeIceCandidatePair,
-      localAudioTrackStats: report.localAudioTrackStats.filter(filterLocalTrackStats),
-      localVideoTrackStats: report.localVideoTrackStats.filter(filterLocalTrackStats),
-      remoteAudioTrackStats: report.remoteAudioTrackStats.filter(filterRemoteTrackStats),
-      remoteVideoTrackStats: report.remoteVideoTrackStats.filter(filterRemoteTrackStats),
-    })));
+    return this._peerConnectionManager.getStats().then(responses => {
+      responses.forEach(response => {
+        response.localAudioTrackStats = response.localAudioTrackStats.filter(filterLocalTrackStats);
+        response.localVideoTrackStats = response.localVideoTrackStats.filter(filterLocalTrackStats);
+        response.remoteAudioTrackStats = response.remoteAudioTrackStats.filter(filterRemoteTrackStats);
+        response.remoteVideoTrackStats = response.remoteVideoTrackStats.filter(filterRemoteTrackStats);
+      });
+      return responses;
+    });
   }
 }
 
@@ -285,7 +288,7 @@ class RoomV2 extends RoomSignaling {
  * @typedef {object} RoomV2#Representation
  * @property {string} name
  * @property {LocalParticipantV2#Representation} participant
- * @property {?Array<ParticipantV2#Representation>} participants
+ * @property {?Array<RemoteParticipantV2#Representation>} participants
  * @property {?Array<PeerConnectionV2#Representation>} peer_connections
  * @property {?RecordingV2#Representation} recording
  * @property {string} sid
@@ -358,7 +361,12 @@ function handleTransportEvents(roomV2, transport) {
 function periodicallyPublishStats(roomV2, localParticipant, transport, intervalMs) {
   const interval = setInterval(() => {
     roomV2.getStats().then(stats => {
-      stats.forEach(report => {
+      stats.forEach((response, id) => {
+        // NOTE(mmalavalli): A StatsReport is used to publish a "stats-report"
+        // event instead of using StandardizedStatsResponse directly because
+        // StatsReport will add nulls to properties that do not exist.
+        const report = new StatsReport(id, response);
+
         transport.publishEvent('quality', 'stats-report', {
           audioTrackStats: report.remoteAudioTrackStats,
           localAudioTrackStats: report.localAudioTrackStats,
@@ -368,9 +376,10 @@ function periodicallyPublishStats(roomV2, localParticipant, transport, intervalM
           roomSid: roomV2.sid,
           videoTrackStats: report.remoteVideoTrackStats
         });
-        transport.publishEvent('quality',
-          'active-ice-candidate-pair',
-          report._activeIceCandidatePair);
+
+        transport.publishEvent('quality', 'active-ice-candidate-pair', Object.assign({
+          peerConnectionId: report.peerConnectionId,
+        }, response.activeIceCandidatePair));
       });
     }, () => {
       // Do nothing.

--- a/lib/stats/statsreport.js
+++ b/lib/stats/statsreport.js
@@ -7,6 +7,7 @@ const RemoteVideoTrackStats = require('./remotevideotrackstats');
 
 /**
  * Statistics report for an RTCPeerConnection.
+ * @property {string} peerConnectionId - ID of the RTCPeerConnection
  * @property {Array<LocalAudioTrackStats>} localAudioTrackStats - List of {@link LocalAudioTrackStats}
  * @property {Array<LocalVideoTrackStats>} localVideoTrackStats - List of {@link LocalVideoTrackStats}
  * @property {Array<RemoteAudioTrackStats>} remoteAudioTrackStats - List of {@link RemoteAudioTrackStats}
@@ -23,8 +24,9 @@ class StatsReport {
     }
 
     Object.defineProperties(this, {
-      _activeIceCandidatePair: {
-        value: statsResponse.activeIceCandidatePair
+      peerConnectionId: {
+        value: peerConnectionId,
+        enumerable: true
       },
       localAudioTrackStats: {
         value: statsResponse.localAudioTrackStats.map(report => new LocalAudioTrackStats(report.trackId, report)),
@@ -32,10 +34,6 @@ class StatsReport {
       },
       localVideoTrackStats: {
         value: statsResponse.localVideoTrackStats.map(report => new LocalVideoTrackStats(report.trackId, report)),
-        enumerable: true
-      },
-      peerConnectionId: {
-        value: peerConnectionId,
         enumerable: true
       },
       remoteAudioTrackStats: {

--- a/lib/stats/statsreport.js
+++ b/lib/stats/statsreport.js
@@ -23,9 +23,8 @@ class StatsReport {
     }
 
     Object.defineProperties(this, {
-      peerConnectionId: {
-        value: peerConnectionId,
-        enumerable: true
+      _activeIceCandidatePair: {
+        value: statsResponse.activeIceCandidatePair
       },
       localAudioTrackStats: {
         value: statsResponse.localAudioTrackStats.map(report => new LocalAudioTrackStats(report.trackId, report)),
@@ -33,6 +32,10 @@ class StatsReport {
       },
       localVideoTrackStats: {
         value: statsResponse.localVideoTrackStats.map(report => new LocalVideoTrackStats(report.trackId, report)),
+        enumerable: true
+      },
+      peerConnectionId: {
+        value: peerConnectionId,
         enumerable: true
       },
       remoteAudioTrackStats: {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   },
   "dependencies": {
     "@twilio/sip.js": "^0.7.7",
-    "@twilio/webrtc": "^2.0.0",
+    "@twilio/webrtc": "twilio/twilio-webrtc.js#2.0.1-rc1",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },

--- a/test/unit/spec/signaling/v2/room.js
+++ b/test/unit/spec/signaling/v2/room.js
@@ -143,7 +143,18 @@ describe('RoomV2', () => {
         ]
       ];
       await wait(175);
-      assert.deepEqual(test.transport.publishEvent.args.slice(0, 4), expectedArgs);
+      test.transport.publishEvent.args.slice(0, 4).forEach(([, name, payload], i) => {
+        if (name === 'stats-report') {
+          assert.deepEqual(payload, expectedArgs[i][2]);
+          return;
+        }
+        assert.equal(payload.peerConnectionId, expectedArgs[i][2].peerConnectionId);
+        const payloadProp = {
+          foo: 'baz',
+          bar: 'zee'
+        }[expectedArgs[i][2].peerConnectionId];
+        assert.equal(payload[payloadProp], expectedArgs[i][2][payloadProp]);
+      });
     });
 
     context('.participants', () => {

--- a/test/unit/spec/signaling/v2/room.js
+++ b/test/unit/spec/signaling/v2/room.js
@@ -97,6 +97,11 @@ describe('RoomV2', () => {
         ],
         [
           'quality',
+          'active-ice-candidate-pair',
+          { baz: 'zee' }
+        ],
+        [
+          'quality',
           'stats-report',
           {
             audioTrackStats: [],
@@ -107,10 +112,15 @@ describe('RoomV2', () => {
             roomSid: test.sid,
             videoTrackStats: []
           }
+        ],
+        [
+          'quality',
+          'active-ice-candidate-pair',
+          { baz: 'zee' }
         ]
       ];
       await wait(175);
-      assert.deepEqual(test.transport.publishEvent.args.slice(0, 2), expectedArgs);
+      assert.deepEqual(test.transport.publishEvent.args.slice(0, 4), expectedArgs);
     });
 
     context('.participants', () => {
@@ -345,6 +355,7 @@ describe('RoomV2', () => {
       ];
       assert.deepEqual(reports, [
         {
+          _activeIceCandidatePair: { baz: 'zee' },
           localAudioTrackStats,
           localVideoTrackStats,
           peerConnectionId: 'foo',
@@ -352,6 +363,7 @@ describe('RoomV2', () => {
           remoteVideoTrackStats
         },
         {
+          _activeIceCandidatePair: { baz: 'zee' },
           localAudioTrackStats,
           localVideoTrackStats,
           peerConnectionId: 'bar',
@@ -1264,12 +1276,14 @@ function makePeerConnectionManager(getRoom) {
       ]);
 
     return [{
+      _activeIceCandidatePair: { baz: 'zee' },
       localAudioTrackStats,
       localVideoTrackStats,
       peerConnectionId: 'foo',
       remoteAudioTrackStats,
       remoteVideoTrackStats
     }, {
+      _activeIceCandidatePair: { baz: 'zee' },
       localAudioTrackStats,
       localVideoTrackStats,
       peerConnectionId: 'bar',


### PR DESCRIPTION
@markandrus For now, the active ICE candidate pair will be behind a private property `._activeIceCandidatePair` of `StatsReport`. Once we decide to implement the IDL spec, we will
then make this property public.