### PR TITLE
JSDK-1912: Implement MediaStreamTrack cloning

### DIFF
--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -131,13 +131,13 @@ class LocalParticipant extends Participant {
     }
 
     function localTrackDisabled(localTrack) {
-      const trackSignaling = signaling.tracks.get(localTrack.id);
+      const trackSignaling = signaling.getPublication(localTrack._trackSender);
       trackSignaling.disable();
       log.debug(`Disabled the ${util.trackClass(localTrack, true)}:`, localTrack.id);
     }
 
     function localTrackEnabled(localTrack) {
-      const trackSignaling = signaling.tracks.get(localTrack.id);
+      const trackSignaling = signaling.getPublication(localTrack._trackSender);
       trackSignaling.enable();
       log.debug(`Enabled the ${util.trackClass(localTrack, true)}:`, localTrack.id);
     }
@@ -151,7 +151,7 @@ class LocalParticipant extends Participant {
     function localTrackStopped(localTrack) {
       // NOTE(mroberts): We shouldn't need to check for `stop`, since DataTracks
       // do not emit "stopped".
-      const trackSignaling = signaling.tracks.get(localTrack.id);
+      const trackSignaling = signaling.getPublication(localTrack._trackSender);
       trackSignaling.stop();
     }
 
@@ -190,6 +190,8 @@ class LocalParticipant extends Participant {
 
   /**
    * @private
+   * @param {LocalTrack} localTrack
+   * @returns {Promise<LocalTrackPublication>}
    */
   _getOrCreateLocalTrackPublication(localTrack) {
     let localTrackPublication = getTrackPublication(this.trackPublications, localTrack);
@@ -200,7 +202,7 @@ class LocalParticipant extends Participant {
     const log = this._log;
     const self = this;
 
-    const trackSignaling = this._signaling.tracks.get(localTrack.id);
+    const trackSignaling = this._signaling.getPublication(localTrack._trackSender);
     if (!trackSignaling) {
       return Promise.reject(new Error(`Unexpected error: The ${localTrack} cannot be published`));
     }
@@ -512,7 +514,7 @@ class LocalParticipant extends Participant {
       return null;
     }
 
-    const trackSignaling = this._signaling.tracks.get(localTrack.id);
+    const trackSignaling = this._signaling.getPublication(localTrack._trackSender);
     trackSignaling.publishFailed(new Error(`The ${localTrack} was unpublished`));
 
     const localTrackPublication = getTrackPublication(this.trackPublications, localTrack);

--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -148,10 +148,18 @@ class LocalParticipant extends Participant {
       log.debug(`${util.trackClass(localTrack, true)}:`, localTrack);
     }
 
+    function localTrackStopped(localTrack) {
+      // NOTE(mroberts): We shouldn't need to check for `stop`, since DataTracks
+      // do not emit "stopped".
+      const trackSignaling = signaling.tracks.get(localTrack.id);
+      trackSignaling.stop();
+    }
+
     this.on('trackAdded', localTrackAdded);
     this.on('trackDisabled', localTrackDisabled);
     this.on('trackEnabled', localTrackEnabled);
     this.on('trackRemoved', localTrackRemoved);
+    this.on('trackStopped', localTrackStopped);
 
     this.tracks.forEach(function(track) {
       localTrackAdded(track);
@@ -170,6 +178,7 @@ class LocalParticipant extends Participant {
         self.removeListener('trackDisabled', localTrackDisabled);
         self.removeListener('trackEnabled', localTrackEnabled);
         self.removeListener('trackRemoved', localTrackRemoved);
+        self.removeListener('trackStopped', localTrackStopped);
 
         log.info(`LocalParticipant disconnected. Stopping ${self._tracksToStop.size} automatically-acquired LocalTracks`);
         self._tracksToStop.forEach(track => {

--- a/lib/media/track/sender.js
+++ b/lib/media/track/sender.js
@@ -21,6 +21,15 @@ class MediaTrackSender extends MediaTrackTransceiver {
   }
 
   /**
+   * Return a new {@link MediaTrackSender} containing a clone of the underlying
+   * MediaStreamTrack. No RTCRtpSenders are copied.
+   * @returns {MediaTrackSender}
+   */
+  clone() {
+    return new MediaTrackSender(this.track.clone());
+  }
+
+  /**
    * Add an RTCRtpSender.
    * @param {RTCRtpSender} sender
    * @returns {this}

--- a/lib/room.js
+++ b/lib/room.js
@@ -128,12 +128,31 @@ class Room extends EventEmitter {
    * @returns {Promise.<Array<StatsReport>>}
    */
   getStats() {
-    return this._signaling.getStats().then(responses => {
-      return Array.from(responses).map(([id, response]) => {
-        return new StatsReport(id, response);
-      });
-    });
+    return this._signaling.getStats().then(responses =>
+      Array.from(responses).map(([id, response]) =>
+        new StatsReport(id, Object.assign({}, response, {
+          localAudioTrackStats: rewriteLocalTrackIds(this, response.localAudioTrackStats),
+          localVideoTrackStats: rewriteLocalTrackIds(this, response.localVideoTrackStats)
+        }))
+      )
+    );
   }
+}
+
+/**
+ * @param {Room} room
+ * @param {Array<LocalTrackStats>} trackStats
+ * @returns {Array<LocalTrackStats>}
+ */
+function rewriteLocalTrackIds(room, trackStats) {
+  const localParticipantSignaling = room.localParticipant._signaling;
+  return trackStats.reduce((trackStats, trackStat) => {
+    const publication = localParticipantSignaling.tracks.get(trackStat.trackId);
+    const trackSender = localParticipantSignaling.getSender(publication);
+    return trackSender
+      ? [Object.assign({}, trackStats, { trackId: trackSender.id })].concat(trackStats)
+      : trackStats;
+  }, []);
 }
 
 /**

--- a/lib/signaling/localparticipant.js
+++ b/lib/signaling/localparticipant.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const ParticipantSignaling = require('./participant');
+
+class LocalParticipantSignaling extends ParticipantSignaling {
+  constructor() {
+    super();
+    Object.defineProperties(this, {
+      _trackSendersToPublications: {
+        value: new Map()
+      }
+    });
+  }
+
+  /**
+   * @param {DataTrackSender|MediaTrackSender} trackSender
+   * @returns {LocalTrackPublicationSignaling} publication
+   */
+  addTrack(trackSender, name) {
+    const publication = this._createLocalTrackPublicationSignaling(trackSender, name);
+    this._trackSendersToPublications.set(trackSender, publication);
+    super.addTrack(publication);
+    return this;
+  }
+
+  /**
+   * @param {DataTrackSender|MediaTrackSender} trackSender
+   * @returns {?LocalTrackPublicationSignaling}
+   */
+  getPublication(trackSender) {
+    return this._trackSendersToPublications.get(trackSender) || null;
+  }
+
+  /**
+   * @param {DataTrackSender|MediaTrackSender} trackSender
+   * @returns {?LocalTrackPublicationSignaling}
+   */
+  removeTrack(trackSender) {
+    const publication = this._trackSendersToPublications.get(trackSender);
+    if (!publication) {
+      return null;
+    }
+    this._trackSendersToPublications.delete(trackSender);
+    const didDelete = super.removeTrack(publication);
+    if (didDelete) {
+      // NOTE(mroberts): Only stop MediaTrackSenders.
+      if (trackSender.stop) {
+        trackSender.stop();
+      }
+    }
+    return publication;
+  }
+}
+
+module.exports = LocalParticipantSignaling;

--- a/lib/signaling/localparticipant.js
+++ b/lib/signaling/localparticipant.js
@@ -6,6 +6,9 @@ class LocalParticipantSignaling extends ParticipantSignaling {
   constructor() {
     super();
     Object.defineProperties(this, {
+      _publicationsToTrackSenders: {
+        value: new Map()
+      },
       _trackSendersToPublications: {
         value: new Map()
       }
@@ -19,6 +22,7 @@ class LocalParticipantSignaling extends ParticipantSignaling {
   addTrack(trackSender, name) {
     const publication = this._createLocalTrackPublicationSignaling(trackSender, name);
     this._trackSendersToPublications.set(trackSender, publication);
+    this._publicationsToTrackSenders.set(publication, trackSender);
     super.addTrack(publication);
     return this;
   }
@@ -32,6 +36,14 @@ class LocalParticipantSignaling extends ParticipantSignaling {
   }
 
   /**
+   * @param {LocalTrackPublicationSignaling} publication
+   * @returns {?DataTrackSender|MediaTrackSender}
+   */
+  getSender(trackPublication) {
+    return this._publicationsToTrackSenders.get(trackPublication) || null;
+  }
+
+  /**
    * @param {DataTrackSender|MediaTrackSender} trackSender
    * @returns {?LocalTrackPublicationSignaling}
    */
@@ -41,6 +53,7 @@ class LocalParticipantSignaling extends ParticipantSignaling {
       return null;
     }
     this._trackSendersToPublications.delete(trackSender);
+    this._publicationsToTrackSenders.delete(publication);
     const didDelete = super.removeTrack(publication);
     if (didDelete) {
       // NOTE(mroberts): Only stop MediaTrackSenders.

--- a/lib/signaling/localtrackpublication.js
+++ b/lib/signaling/localtrackpublication.js
@@ -9,16 +9,16 @@ const TrackSignaling = require('./track');
  */
 class LocalTrackPublicationSignaling extends TrackSignaling {
   /**
-   * Construct a {@link LocalTrackPublicationSignaling}.
+   * Construct a {@link LocalTrackPublicationSignaling}. Any
+   * {@link MediaTrackSender}s will be cloned.
    * @param {DataTrackSender|MediaTrackSender} trackSender
    * @param {string} name
    */
   constructor(trackSender, name) {
-    const enabled = trackSender.kind === 'data'
-      ? true
-      : trackSender.track.enabled;
-    super(name, trackSender.id, trackSender.kind, enabled);
-    this.setTrackTransceiver(trackSender);
+    const { id, kind } = trackSender;
+    const enabled = trackSender.kind === 'data' ? true : trackSender.track.enabled;
+    super(name, id, kind, enabled);
+    this.setTrackTransceiver(trackSender.clone ? trackSender.clone() : trackSender);
     Object.defineProperties(this, {
       _error: {
         value: null,
@@ -31,6 +31,19 @@ class LocalTrackPublicationSignaling extends TrackSignaling {
         }
       }
     });
+  }
+
+  /**
+   * Enable (or disable) the {@link LocalTrackPublicationSignaling} if it is not
+   * already enabled (or disabled). This also updates the cloned
+   * {@link MediaTrackSender}'s MediaStreamTracks `enabled` state.
+   * @param {boolean} [enabled=true]
+   * @return {this}
+   */
+  enable(enabled) {
+    enabled = typeof enabled === 'boolean' ? enabled : true;
+    this.trackTransceiver.track.enabled = enabled;
+    return super.enable(enabled);
   }
 
   /**
@@ -50,6 +63,14 @@ class LocalTrackPublicationSignaling extends TrackSignaling {
       return this;
     }
     return super.setSid.call(this, sid);
+  }
+
+  /**
+   * Stop the cloned {@link MediaTrackSender}'s MediaStreamTrack.
+   * @returns {void}
+   */
+  stop() {
+    this.trackTransceiver.track.stop();
   }
 }
 

--- a/lib/signaling/localtrackpublication.js
+++ b/lib/signaling/localtrackpublication.js
@@ -15,10 +15,10 @@ class LocalTrackPublicationSignaling extends TrackSignaling {
    * @param {string} name
    */
   constructor(trackSender, name) {
-    const { id, kind } = trackSender;
+    trackSender = trackSender.clone ? trackSender.clone() : trackSender;
     const enabled = trackSender.kind === 'data' ? true : trackSender.track.enabled;
-    super(name, id, kind, enabled);
-    this.setTrackTransceiver(trackSender.clone ? trackSender.clone() : trackSender);
+    super(name, trackSender.id, trackSender.kind, enabled);
+    this.setTrackTransceiver(trackSender);
     Object.defineProperties(this, {
       _error: {
         value: null,

--- a/lib/signaling/participant.js
+++ b/lib/signaling/participant.js
@@ -98,15 +98,16 @@ class ParticipantSignaling extends StateMachine {
    * Remove the {@link TrackSignaling}, MediaStreamTrack, or
    * {@link DataTrackSender} from the {@link ParticipantSignaling}.
    * @param {TrackSignaling|DataTrackSender|MediaTrackSender} track
-   * @returns {boolean}
+   * @returns {?TrackSignaling}
    * @fires ParticipantSignaling#trackRemoved
    */
   removeTrack(track) {
-    const didDelete = this.tracks.delete(track.id);
-    if (didDelete) {
+    const signaling = this.tracks.get(track.id);
+    this.tracks.delete(track.id);
+    if (signaling) {
       this.emit('trackRemoved', track);
     }
-    return didDelete;
+    return signaling || null;
   }
 
   /**

--- a/lib/signaling/v2/localparticipant.js
+++ b/lib/signaling/v2/localparticipant.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const ParticipantSignaling = require('../participant');
+const LocalParticipantSignaling = require('../localparticipant');
 const LocalTrackPublicationV2 = require('./localtrackpublication');
 
 /**
@@ -8,7 +8,7 @@ const LocalTrackPublicationV2 = require('./localtrackpublication');
  * @property {number} revision
  * @emits LocalParticipantV2#updated
  */
-class LocalParticipantV2 extends ParticipantSignaling {
+class LocalParticipantV2 extends LocalParticipantSignaling {
   /**
    * Construct a {@link LocalParticipantV2}.
    * @param {EncodingParametersImpl} encodingParameters
@@ -80,6 +80,16 @@ class LocalParticipantV2 extends ParticipantSignaling {
   }
 
   /**
+   * @protected
+   * @param {DataTrackSender|MediaTrackSender} trackSender
+   * @param {string} name
+   * @returns {LocalTrackPublicationV2}
+   */
+  _createLocalTrackPublicationSignaling(trackSender, name) {
+    return new this._LocalTrackPublicationV2(trackSender, name);
+  }
+
+  /**
    * Add a {@link LocalTrackPublicationV2} for the given {@link DataTrackSender}
    * or {@link MediaTrackSender} to the {@link LocalParticipantV2}.
    * @param {DataTrackSender|MediaTrackSender} trackSender
@@ -87,8 +97,8 @@ class LocalParticipantV2 extends ParticipantSignaling {
    * @returns {this}
    */
   addTrack(trackSender, name) {
-    const publication = new this._LocalTrackPublicationV2(trackSender, name);
-    super.addTrack.call(this, publication);
+    super.addTrack(trackSender, name);
+    const publication = this.getPublication(trackSender);
 
     let { sid } = publication;
 
@@ -151,23 +161,15 @@ class LocalParticipantV2 extends ParticipantSignaling {
    * Remove the {@link LocalTrackPublicationV2} for the given {@link DataTrackSender}
    * or {@link MediaTrackSender} from the {@link LocalParticipantV2}.
    * @param {DataTrackSender|MediaTrackSender} trackSender
-   * @returns {boolean}
+   * @returns {?LocalTrackPublicationV2}
    */
   removeTrack(trackSender) {
-    const publication = this.tracks.get(trackSender.id);
-    if (!publication) {
-      return false;
-    }
-    const didDelete = super.removeTrack.call(this, publication);
-    if (didDelete) {
-      // NOTE(mroberts): Only stop MediaTrackSenders.
-      if (trackSender.stop) {
-        trackSender.stop();
-      }
+    const publication = super.removeTrack(trackSender);
+    if (publication) {
       this._removeListener(publication);
       this.didUpdate();
     }
-    return didDelete;
+    return publication;
   }
 }
 

--- a/lib/signaling/v2/localparticipant.js
+++ b/lib/signaling/v2/localparticipant.js
@@ -160,6 +160,10 @@ class LocalParticipantV2 extends ParticipantSignaling {
     }
     const didDelete = super.removeTrack.call(this, publication);
     if (didDelete) {
+      // NOTE(mroberts): Only stop MediaTrackSenders.
+      if (trackSender.stop) {
+        trackSender.stop();
+      }
       this._removeListener(publication);
       this.didUpdate();
     }

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -581,15 +581,23 @@ describe('connect', function() {
           });
         });
 
-        it(`should set each RemoteTrackPublication's .trackName to its ${names ? 'given name' : 'ID'}`, () => {
+        it(`should set each RemoteTrackPublication's .trackName to its ${names ? 'given name' : 'LocalTrack\'s ID'}`, () => {
           flatMap(thisParticipants, participant => [...participant.trackPublications.values()]).forEach(publication => {
-            assert.equal(publication.trackName, names ? names[publication.kind] : publication.track.id);
+            if (names) {
+              assert.equal(publication.trackName, names[publication.kind]);
+            } else {
+              assert(tracks.find(track => track.id === publication.trackName));
+            }
           });
         });
 
-        it(`should set each RemoteTrack's .name to its ${names ? 'given name' : 'ID'}`, () => {
+        it(`should set each RemoteTrack's .name to its ${names ? 'given name' : 'LocalTrack\'s ID'}`, () => {
           flatMap(thisParticipants, participant => [...participant.tracks.values()]).forEach(track => {
-            assert.equal(track.name, names ? names[track.kind] : track.id);
+            if (names) {
+              assert.equal(track.name, names[track.kind]);
+            } else {
+              assert(tracks.find(localTrack => localTrack.id === track.name));
+            }
           });
         });
 
@@ -649,15 +657,25 @@ describe('connect', function() {
             });
           });
 
-          it(`should set each Remote${capitalize(kind)}TrackPublication's .trackName to its ${names[kind] ? 'given name' : 'ID'}`, () => {
+          it(`should set each Remote${capitalize(kind)}TrackPublication's .trackName to its ${names[kind] ? 'given name' : 'LocalTrack\'s ID'}`, () => {
             flatMap(thisParticipants, participant => [...participant[`${kind}TrackPublications`].values()]).forEach(publication => {
-              assert.equal(publication.trackName, names[kind] || publication.track.id);
+              if (names && names[kind]) {
+                assert.equal(publication.trackName, names[kind]);
+              } else {
+                const tracks = [...thisParticipant.tracks.values()];
+                assert(tracks.find(track => track.id === publication.trackName));
+              }
             });
           });
 
-          it(`should set each Remote${capitalize(kind)}Track's .name to its ${names[kind] ? 'given name' : 'ID'}`, () => {
+          it(`should set each Remote${capitalize(kind)}Track's .name to its ${names[kind] ? 'given name' : 'its LocalTrack\'s ID'}`, () => {
             flatMap(thisParticipants, participant => [...participant[`${kind}Tracks`].values()]).forEach(track => {
-              assert.equal(track.name, names[kind] || track.id);
+              if (names && names[kind]) {
+                assert.equal(track.name, names[kind]);
+              } else {
+                const tracks = [...thisParticipant.tracks.values()];
+                assert(tracks.find(localTrack => localTrack.id === track.name));
+              }
             });
           });
         });

--- a/test/lib/fakemediastream.js
+++ b/test/lib/fakemediastream.js
@@ -81,6 +81,12 @@ class FakeMediaStreamTrack extends EventTarget {
     });
   }
 
+  clone() {
+    const clone = new FakeMediaStreamTrack(this.kind);
+    clone.enabled = this.enabled;
+    return clone;
+  }
+
   stop() {
     this.dispatchEvent({
       type: 'ended',

--- a/test/unit/spec/localparticipant.js
+++ b/test/unit/spec/localparticipant.js
@@ -15,42 +15,39 @@ const { FakeMediaStreamTrack } = require('../../lib/fakemediastream');
 const { a, capitalize } = require('../../lib/util');
 
 const LocalAudioTrack = sinon.spy(function LocalAudioTrack(mediaStreamTrack, options) {
+  mediaStreamTrack = mediaStreamTrack || new FakeMediaStreamTrack('audio');
   options = options || {};
   EventEmitter.call(this);
-  if (mediaStreamTrack) {
-    this.id = mediaStreamTrack.id;
-    this.kind = mediaStreamTrack.kind;
-    this.mediaStreamTrack = mediaStreamTrack;
-    this.name = options.name || mediaStreamTrack.id;
-    this._trackSender = new MediaTrackSender(this.mediaStreamTrack);
-  }
+  this.id = mediaStreamTrack.id;
+  this.kind = mediaStreamTrack.kind;
+  this.mediaStreamTrack = mediaStreamTrack;
+  this.name = options.name || mediaStreamTrack.id;
+  this._trackSender = new MediaTrackSender(this.mediaStreamTrack);
   this.stop = sinon.spy();
 });
 inherits(LocalAudioTrack, EventEmitter);
 
 const LocalVideoTrack = sinon.spy(function LocalVideoTrack(mediaStreamTrack, options) {
+  mediaStreamTrack = mediaStreamTrack || new FakeMediaStreamTrack('video');
   options = options || {};
   EventEmitter.call(this);
-  if (mediaStreamTrack) {
-    this.id = mediaStreamTrack.id;
-    this.kind = mediaStreamTrack.kind;
-    this.mediaStreamTrack = mediaStreamTrack;
-    this.name = options.name || mediaStreamTrack.id;
-    this._trackSender = new MediaTrackSender(this.mediaStreamTrack);
-  }
+  this.id = mediaStreamTrack.id;
+  this.kind = mediaStreamTrack.kind;
+  this.mediaStreamTrack = mediaStreamTrack;
+  this.name = options.name || mediaStreamTrack.id;
+  this._trackSender = new MediaTrackSender(this.mediaStreamTrack);
   this.stop = sinon.spy();
 });
 inherits(LocalVideoTrack, EventEmitter);
 
 const LocalDataTrack = sinon.spy(function LocalDataTrack(dataTrackSender, options) {
+  dataTrackSender = dataTrackSender || new DataTrackSender();
   options = options || {};
   EventEmitter.call(this);
-  if (dataTrackSender) {
-    this.id = dataTrackSender.id;
-    this.kind = 'data';
-    this.name = options.name || dataTrackSender.id;
-    this._trackSender = dataTrackSender;
-  }
+  this.id = dataTrackSender.id;
+  this.kind = 'data';
+  this.name = options.name || dataTrackSender.id;
+  this._trackSender = dataTrackSender;
 });
 inherits(LocalDataTrack, EventEmitter);
 
@@ -81,7 +78,7 @@ describe('LocalParticipant', () => {
 
       beforeEach(() => {
         test = makeTest();
-        test.participant[`_${method}`] = sinon.spy(() => ({ foo: 'bar', stop: sinon.spy() }));
+        test.participant[`_${method}`] = sinon.spy(() => new LocalAudioTrack());
       });
 
       context('when called with an invalid argument', () => {
@@ -101,6 +98,7 @@ describe('LocalParticipant', () => {
       ['Audio', 'Video', 'Data'].forEach(kind => {
         context(`when called with a Local${kind}Track`, () => {
           it('should not throw', () => {
+            test.participant[method](new test[`Local${kind}Track`]());
             assert.doesNotThrow(() => test.participant[method](new test[`Local${kind}Track`]()));
           });
         });
@@ -996,6 +994,9 @@ function makeSignaling(options) {
     const trackSignaling = new LocalTrackPublicationSignaling(track);
     signaling.tracks.set(track.id, trackSignaling);
     return signaling;
+  });
+  signaling.getPublication = sinon.spy(track => {
+    return signaling.tracks.get(track.id);
   });
   signaling.removeTrack = sinon.spy(() => {});
   signaling.setParameters = sinon.spy(() => {});

--- a/test/unit/spec/localparticipant.js
+++ b/test/unit/spec/localparticipant.js
@@ -742,14 +742,29 @@ describe('LocalParticipant', () => {
     context('"trackStopped" event', () => {
       context('when the LocalParticipant .state begins in "connecting"', () => {
         context('and a LocalTrack emits "stopped"', () => {
-          it('emits "trackStopped"', () => {
-            const track = new EventEmitter();
+          let track;
+          let test;
+          let trackSignaling;
+
+          beforeEach(() => {
+            track = new EventEmitter();
+            track.stop = sinon.spy();
             track._trackSender = { track: { enabled: true } };
+            test = makeTest({ tracks: [track] });
+            trackSignaling = test.signaling.tracks.get(track.id);
+            trackSignaling.stop = sinon.spy();
+          });
+
+          it('emits "trackStopped"', () => {
             let trackStopped;
-            const test = makeTest({ tracks: [track] });
             test.participant.once('trackStopped', track => { trackStopped = track; });
             track.emit('stopped', track);
             assert.equal(track, trackStopped);
+          });
+
+          it('calls .stop on the LocalTrackPublicationSignaling', () => {
+            track.emit('stopped', track);
+            assert(trackSignaling.stop.calledOnce);
           });
         });
       });

--- a/test/unit/spec/media/track/sender.js
+++ b/test/unit/spec/media/track/sender.js
@@ -1,10 +1,23 @@
+/* eslint no-use-before-define:0 */
 'use strict';
 
 const assert = require('assert');
 const MediaTrackSender = require('../../../../../lib/media/track/sender');
 
 describe('MediaTrackSender', () => {
-  const mediaStreamTrack = { id: 'bar', kind: 'baz', readyState: 'zee' };
+  const mediaStreamTrack = {
+    id: 'bar',
+    kind: 'baz',
+    readyState: 'zee',
+    clone() {
+      return clonedMediaStreamTrack;
+    }
+  };
+
+  const clonedMediaStreamTrack = Object.assign({}, mediaStreamTrack, {
+    id: 'cloned'
+  });
+
   let sender;
 
   describe('constructor', () => {
@@ -36,6 +49,16 @@ describe('MediaTrackSender', () => {
       it('should update the MediaTrackTransceiver\'s .readyState', () => {
         assert.equal(sender.readyState, newReadyState);
       });
+    });
+  });
+
+  describe('clone', () => {
+    it('returns a new MediaTrackSender containing a clone of the underlying MediaStreamTrack', () => {
+      sender = new MediaTrackSender(mediaStreamTrack);
+      const clonedSender = sender.clone();
+      assert.notEqual(clonedSender, sender);
+      assert.notEqual(clonedSender.track, sender.track);
+      assert.equal(clonedSender.track, clonedMediaStreamTrack);
     });
   });
 

--- a/test/unit/spec/signaling/v2/localparticipant.js
+++ b/test/unit/spec/signaling/v2/localparticipant.js
@@ -134,6 +134,23 @@ describe('LocalParticipantV2', () => {
         publication.emit('updated');
         assert(!didEmitUpdated);
       });
+
+      describe('and the sender is a MediaTrackSender', () => {
+        it('calls .stop on the MediaTrackSender', () => {
+          // NOTE(mroberts): I'm cheating here. The `trackSender` shared by the
+          // tests is a DataTrackSender, but we want to test that, when called
+          // with a MediaTrackSender, which defines `stop`, `stop` is called.
+          trackSender.stop = sinon.spy();
+          try {
+            localParticipant.removeTrack(trackSender);
+            assert(trackSender.stop.calledOnce);
+          } catch (error) {
+            throw error;
+          } finally {
+            delete trackSender.stop;
+          }
+        });
+      });
     });
 
     describe('not currently added', () => {

--- a/test/unit/spec/signaling/v2/localtrackpublication.js
+++ b/test/unit/spec/signaling/v2/localtrackpublication.js
@@ -43,7 +43,6 @@ describe('LocalTrackPublicationV2', () => {
     });
 
     [
-      ['id', 'id'],
       ['kind', 'kind'],
       ['isEnabled', 'enabled']
     ].forEach(([ltProp, mstProp]) => {

--- a/test/unit/spec/signaling/v2/remoteparticipant.js
+++ b/test/unit/spec/signaling/v2/remoteparticipant.js
@@ -893,10 +893,10 @@ describe('RemoteParticipantV2', () => {
 
   describe('#removeTrack', () => {
     context('when the RemoteTrackPublicationV2 to remove was previously added', () => {
-      it('returns true', () => {
+      it('returns the removed RemoteTrackPublicationV2', () => {
         const test = makeTest({ tracks: [{ id: makeId() }] });
         assert.equal(
-          true,
+          test.remoteTrackPublicationV2s[0],
           test.participant.removeTrack(test.remoteTrackPublicationV2s[0]));
       });
 
@@ -923,7 +923,7 @@ describe('RemoteParticipantV2', () => {
         const track = new RemoteTrackPublicationV2({ id: makeId() });
         const test = makeTest();
         assert.equal(
-          false,
+          null,
           test.participant.removeTrack(track));
       });
 


### PR DESCRIPTION
_This is a breaking API change, so we will not merge it until we have a plan for releasing 2.0.0._

__Why make this change?__

Whenever a LocalAudioTrack or LocalVideoTrack is published to a Room, we're going to clone the underlying MediaStreamTrack. This will ensure we're always signaling a unique MSID in SDPs and a unique Track ID in our signaling messages. Our signaling protocol doesn't work well if the same LocalAudioTrack or LocalVideoTrack is 1. published, unpublished, and then published, and 2. these messages cross on the wire. This should also let us work around issues like WebKit [Bug 174327](https://bugs.webkit.org/show_bug.cgi?id=174327).

__Why is it a breaking API change?__

Although we consider Track IDs "deprecated" in favor of Track Names or Track SIDs ([since 1.4.0](https://github.com/twilio/twilio-video.js/blob/master/CHANGELOG.md#140-october-2-2017)), Track IDs are still a part of our RemoteTrack and RemoteTrackPublication APIs. So it'd be natural to assume if you publish LocalTrack with ID "1", SID "MTxyz", and name "webcam" that you get a RemoteTrack on the other side with ID "1", SID "MTxyz" and name "webcam". However, since we'll clone the underlying MediaStreamTracks before publishing them, the ID will not equal "1"—it'll be something different. Therefore, if you relied on this property, the behavior has changed.

__What will happen in 2.0.0?__

In 2.0.0, we'll remove RemoteTrack and RemoteTrackPublication IDs entirely (LocalTrack IDs will remain). Then, the cloning behavior introduced by this PR will be unobservable. We'll also have freed ourselves up for the media server to rewrite MediaStreamTrack IDs as necessary, too. We'll add deprecation warnings for anything we plan on removing before we do this.

__Todo__

- [x] Update `getStats` — it will need to be aware of the new IDs and we'll need to surface the correct LocalTrack IDs.