### PR TITLE
Fix remoteAudioTrackStats/remoteVideoTrackStats in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ New Features
   });
   ```
 
+Bug Fixes
+---------
+
+- Fixed a bug that cause `remoteAudioTrackStats` and `remoteVideoTrackStats` to
+  always be empty Arrays in Firefox. (JSDK-1927)
+
 RemoteTrackPublication Guide
 ----------------------------
 

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -875,8 +875,22 @@ class PeerConnectionV2 extends StateMachine {
    * @returns {Promise<StandardizedStatsResponse>}
    */
   getStats() {
-    return getStatistics(this._peerConnection);
+    return getStatistics(this._peerConnection).then(response => rewriteTrackIds(this, response));
   }
+}
+
+function rewriteTrackId(pcv2, stats) {
+  const receiver = [...pcv2._mediaTrackReceivers]
+    .find(receiver => receiver.track.id === stats.trackId);
+  const trackId = receiver ? receiver.id : null;
+  return Object.assign(stats, { trackId });
+}
+
+function rewriteTrackIds(pcv2, response) {
+  return Object.assign(response, {
+    remoteAudioTrackStats: response.remoteAudioTrackStats.map(stats => rewriteTrackId(pcv2, stats)),
+    remoteVideoTrackStats: response.remoteVideoTrackStats.map(stats => rewriteTrackId(pcv2, stats))
+  });
 }
 
 /**


### PR DESCRIPTION
See #295 — we actually had an integration test that was failing due to this; however, we wrote it off due to the general flakiness of Firefox integration tests.