### PR TITLE
Add TrackSid to TrackStats public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ New Features
   });
   ```
 
+- Added `trackSid` to TrackStats, so now, when you call `getStats` on a Room,
+  the TrackStats will include Track SIDs for local and remote Tracks.
+
 Bug Fixes
 ---------
 

--- a/lib/stats/trackstats.js
+++ b/lib/stats/trackstats.js
@@ -2,11 +2,16 @@
 
 /**
  * Statistics for a {@link Track}.
- * @property {string} trackId - MediaStreamTrack ID
- * @property {number} timestamp - The Unix timestamp in milliseconds
- * @property {string} ssrc - SSRC of the MediaStreamTrack
- * @property {?number} packetsLost - Then number of packets lost
- * @property {?string} codec - Name of the codec used to encode the MediaStreamTrack's media
+ * @property {Track.ID} trackId - The {@link Track} ID
+ * @property {Track.SID} trackSid - The {@link Track}'s SID when published in
+ *  in a {@link Room}
+ * @property {number} timestamp - A Unix timestamp in milliseconds indicating
+ *   when the {@link TrackStats} were gathered
+ * @property {string} ssrc - The {@link Track}'s SSRC when transmitted over the
+ *   RTCPeerConnection
+ * @property {?number} packetsLost - The number of packets lost
+ * @property {?string} codec - The name of the codec used to encode the
+ *   {@link Track}'s media
  */
 class TrackStats {
   /**
@@ -21,6 +26,10 @@ class TrackStats {
     Object.defineProperties(this, {
       trackId: {
         value: trackId,
+        enumerable: true
+      },
+      trackSid: {
+        value: statsReport.trackSid,
         enumerable: true
       },
       timestamp: {

--- a/test/unit/spec/signaling/v2/room.js
+++ b/test/unit/spec/signaling/v2/room.js
@@ -85,14 +85,14 @@ describe('RoomV2', () => {
 
       const reports = {
         bar: new StatsReport('bar', {
-          localAudioTrackStats: [{ trackId: '1' }],
-          localVideoTrackStats: [{ trackId: '2' }],
+          localAudioTrackStats: [{ trackId: '1', trackSid: 'MT1' }],
+          localVideoTrackStats: [{ trackId: '2', trackSid: 'MT2' }],
           remoteAudioTrackStats: [],
           remoteVideoTrackStats: []
         }),
         foo: new StatsReport('foo', {
-          localAudioTrackStats: [{ trackId: '1' }],
-          localVideoTrackStats: [{ trackId: '2' }],
+          localAudioTrackStats: [{ trackId: '1', trackSid: 'MT1' }],
+          localVideoTrackStats: [{ trackId: '2', trackSid: 'MT2' }],
           remoteAudioTrackStats: [],
           remoteVideoTrackStats: []
         })


### PR DESCRIPTION
https://github.com/twilio/twilio-video.js/pull/302 started sending `trackSid` to insights, but this PR adds it to the public API.