### PR TITLE
Fix for JSDK-1932

### DIFF
--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -75,7 +75,7 @@ class MediaTrack extends Track {
       this._dummyEl.oncanplay = null;
     }
     // eslint-disable-next-line no-use-before-define
-    this.emit(STARTED, this);
+    this.emit('started', this);
   }
 
   /**
@@ -241,9 +241,5 @@ class MediaTrack extends Track {
     return els;
   }
 }
-
-MediaTrack.DISABLED = 'disabled';
-MediaTrack.ENABLED = 'enabled';
-const STARTED = MediaTrack.STARTED = 'started';
 
 module.exports = MediaTrack;

--- a/lib/media/track/remotemediatrack.js
+++ b/lib/media/track/remotemediatrack.js
@@ -65,7 +65,7 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
     _setEnabled(isEnabled) {
       if (this._isEnabled !== isEnabled) {
         this._isEnabled = isEnabled;
-        this.emit(this._isEnabled ? 'enabled' : 'disabled');
+        this.emit(this._isEnabled ? 'enabled' : 'disabled', this);
       }
     }
 
@@ -93,11 +93,15 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
 
 /**
  * A {@link RemoteMediaTrack} was disabled.
+ * @param {RemoteMediaTrack} track - The {@link RemoteMediaTrack} that was
+ *   disabled
  * @event RemoteMediaTrack#disabled
  */
 
 /**
  * A {@link RemoteMediaTrack} was enabled.
+ * @param {RemoteMediaTrack} track - The {@link RemoteMediaTrack} that was
+ *   enabled
  * @event RemoteMediaTrack#enabled
  */
 

--- a/lib/room.js
+++ b/lib/room.js
@@ -272,7 +272,7 @@ class Room extends EventEmitter {
 
 /**
  * A {@link RemoteTrack} was published by a {@link RemoteParticipant} to the {@link Room}.
- * @event RemoteParticipant#trackPublished
+ * @event Room#trackPublished
  * @param {RemoteTrackPublication} publication - The {@link RemoteTrackPublication}
  *   which represents the published {@link RemoteTrack}
  * @param {RemoteParticipant} participant - The {@link RemoteParticipant} who
@@ -328,7 +328,7 @@ class Room extends EventEmitter {
 
 /**
  * A {@link RemoteTrack} was unpublished by a {@link RemoteParticipant} to the {@link Room}.
- * @event RemoteParticipant#trackUnpublished
+ * @event Room#trackUnpublished
  * @param {RemoteTrackPublication} publication - The {@link RemoteTrackPublication}
  *   which represents the unpublished {@link RemoteTrack}
  * @param {RemoteParticipant} participant - The {@link RemoteParticipant} who

--- a/test/unit/spec/media/track/remotemediatrack.js
+++ b/test/unit/spec/media/track/remotemediatrack.js
@@ -63,17 +63,21 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
         [false, false]
       ].forEach(([isEnabled, newIsEnabled]) => {
         context(`when .isEnabled is ${isEnabled} and the new value is ${newIsEnabled}`, () => {
+          let arg;
           let track;
           let trackDisabled;
           let trackEnabled;
 
           before(() => {
+            arg = null;
             track = makeTrack('foo', kind, isEnabled, null, RemoteTrack);
-            track.once('disabled', () => {
+            track.once('disabled', _arg => {
               trackDisabled = true;
+              arg = _arg;
             });
-            track.once('enabled', () => {
+            track.once('enabled', _arg => {
               trackEnabled = true;
+              arg = _arg;
             });
             track._setEnabled(newIsEnabled);
           });
@@ -95,9 +99,10 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
             assert.equal(track.isEnabled, newIsEnabled);
           });
 
-          it(`should emit "${newIsEnabled ? 'enabled' : 'disabled'}" on the ${name}`, () => {
+          it(`should emit "${newIsEnabled ? 'enabled' : 'disabled'}" on the ${name} with the ${name} itself`, () => {
             assert(newIsEnabled ? trackEnabled : trackDisabled);
             assert(!(newIsEnabled ? trackDisabled : trackEnabled));
+            assert.equal(arg, track);
           });
         });
       });

--- a/test/unit/spec/remoteparticipant.js
+++ b/test/unit/spec/remoteparticipant.js
@@ -406,6 +406,24 @@ describe('RemoteParticipant', () => {
         track.emit('started', track);
         assert.equal(track, trackStarted);
       });
+
+      it('re-emits "enabled" events', () => {
+        const track = new EventEmitter();
+        let trackEnabled;
+        const test = makeTest({ tracks: [track] });
+        test.participant.once('trackEnabled', track => { trackEnabled = track; });
+        track.emit('enabled', track);
+        assert.equal(track, trackEnabled);
+      });
+
+      it('re-emits "disabled" events', () => {
+        const track = new EventEmitter();
+        let trackDisabled;
+        const test = makeTest({ tracks: [track] });
+        test.participant.once('trackDisabled', track => { trackDisabled = track; });
+        track.emit('disabled', track);
+        assert.equal(track, trackDisabled);
+      });
     });
 
     context('when the RemoteParticipant .state transitions to "disconnected"', () => {
@@ -438,6 +456,26 @@ describe('RemoteParticipant', () => {
         test.participant.once('trackStarted', track => { trackStarted = track; });
         track.emit('started', track);
         assert(!trackStarted);
+      });
+
+      it('does not re-emit "enabled" events', () => {
+        const track = new EventEmitter();
+        let trackEnabled;
+        const test = makeTest({ tracks: [track] });
+        test.signaling.emit('stateChanged', 'disconnected');
+        test.participant.once('trackEnabled', track => { trackEnabled = track; });
+        track.emit('enabled', track);
+        assert(!trackEnabled);
+      });
+
+      it('does not re-emit "disabled" events', () => {
+        const track = new EventEmitter();
+        let trackDisabled;
+        const test = makeTest({ tracks: [track] });
+        test.signaling.emit('stateChanged', 'disconnected');
+        test.participant.once('trackDisabled', track => { trackDisabled = track; });
+        track.emit('disabled', track);
+        assert(!trackDisabled);
       });
 
       it('should emit "trackUnsubscribed" events for all the Participant\'s RemoteTrackPublications', () => {
@@ -475,6 +513,24 @@ describe('RemoteParticipant', () => {
         assert(!trackMessageEvent);
       });
 
+      it('does not re-emit "enabled" events', () => {
+        const track = new EventEmitter();
+        let trackEnabled;
+        const test = makeTest({ tracks: [track], state: 'disconnected' });
+        test.participant.once('trackEnabled', track => { trackEnabled = track; });
+        track.emit('enabled', track);
+        assert(!trackEnabled);
+      });
+
+      it('does not re-emit "disabled" events', () => {
+        const track = new EventEmitter();
+        let trackDisabled;
+        const test = makeTest({ tracks: [track], state: 'disconnected' });
+        test.participant.once('trackDisabled', track => { trackDisabled = track; });
+        track.emit('disabled', track);
+        assert(!trackDisabled);
+      });
+
       it('does not re-emit "started" events', () => {
         const track = new EventEmitter();
         let trackStarted;
@@ -486,8 +542,7 @@ describe('RemoteParticipant', () => {
     });
   });
 
-  // NOTE(mmalavalli): Skip these tests until we migrate to twilio-video.js@2.0.0.
-  describe.skip('.trackPublications', () => {
+  describe('.trackPublications', () => {
     context('when the RemoteParticipant begins in .state "connected"', () => {
       let publication;
       let test;
@@ -501,9 +556,10 @@ describe('RemoteParticipant', () => {
       });
 
       [
-        ['subscriptionFailed', 'trackSubscriptionFailed'],
-        ['trackDisabled', 'trackDisabled'],
-        ['trackEnabled', 'trackEnabled']
+        ['subscriptionFailed', 'trackSubscriptionFailed']
+        // NOTE(mroberts): Re-enable these tests when we migrate to twilio-video.js@2.0.0.
+        // ['trackDisabled', 'trackDisabled'],
+        // ['trackEnabled', 'trackEnabled']
       ].forEach(([publicationEvent, participantEvent]) => {
         it(`re-emits "${publicationEvent}" event`, () => {
           const error = new Error('foo');

--- a/test/unit/spec/room.js
+++ b/test/unit/spec/room.js
@@ -65,8 +65,10 @@ describe('Room', () => {
 
   describe('RemoteParticipant events', () => {
     let participants;
+    let track;
 
     beforeEach(() => {
+      track = {};
       [
         new RemoteParticipantSignaling('PA000', 'foo'),
         new RemoteParticipantSignaling('PA111', 'bar')
@@ -81,96 +83,113 @@ describe('Room', () => {
       const spy = sinon.spy();
       room.on('trackAdded', spy);
 
-      participants.foo.emit('trackAdded');
+      participants.foo.emit('trackAdded', track);
       assert.equal(spy.callCount, 1);
+      assert(spy.calledWith(track, participants.foo));
     });
 
     it('should re-emit RemoteParticipant trackDimensionsChanged for matching RemoteParticipant only', () => {
       const spy = sinon.spy();
       room.on('trackDimensionsChanged', spy);
 
-      participants.foo.emit('trackDimensionsChanged');
+      participants.foo.emit('trackDimensionsChanged', track);
       assert.equal(spy.callCount, 1);
+      assert(spy.calledWith(track, participants.foo));
     });
 
     it('should re-emit RemoteParticipant trackDisabled for matching RemoteParticipant only', () => {
       const spy = sinon.spy();
       room.on('trackDisabled', spy);
 
-      participants.foo.emit('trackDisabled');
+      participants.foo.emit('trackDisabled', track);
       assert.equal(spy.callCount, 1);
+      assert(spy.calledWith(track, participants.foo));
     });
 
     it('should re-emit RemoteParticipant trackEnabled for matching RemoteParticipant only', () => {
       const spy = sinon.spy();
       room.on('trackEnabled', spy);
 
-      participants.foo.emit('trackEnabled');
+      participants.foo.emit('trackEnabled', track);
       assert.equal(spy.callCount, 1);
+      assert(spy.calledWith(track, participants.foo));
     });
 
     it('should re-emit RemoteParticipant trackMessage for matching RemoteParticipant only', () => {
       const spy = sinon.spy();
       room.on('trackMessage', spy);
 
-      participants.foo.emit('trackMessage');
+      const message = {};
+      participants.foo.emit('trackMessage', message, track);
       assert.equal(spy.callCount, 1);
+      assert(spy.calledWith(message, track, participants.foo));
     });
 
     it('should re-emit RemoteParticipant trackPublished for matching RemoteParticipant only', () => {
       const spy = sinon.spy();
       room.on('trackPublished', spy);
 
-      participants.foo.emit('trackPublished');
+      const publication = {};
+      participants.foo.emit('trackPublished', publication);
       assert.equal(spy.callCount, 1);
+      assert(spy.calledWith(publication, participants.foo));
     });
 
     it('should re-emit RemoteParticipants trackRemoved event for matching RemoteParticipant only', () => {
       const spy = sinon.spy();
       room.on('trackRemoved', spy);
 
-      participants.bar.emit('trackRemoved');
+      participants.bar.emit('trackRemoved', track);
       assert.equal(spy.callCount, 1);
+      assert(spy.calledWith(track, participants.bar));
     });
 
     it('should re-emit RemoteParticipant trackStarted for matching RemoteParticipant only', () => {
       const spy = sinon.spy();
       room.on('trackStarted', spy);
 
-      participants.foo.emit('trackStarted');
+      participants.foo.emit('trackStarted', track);
       assert.equal(spy.callCount, 1);
+      assert(spy.calledWith(track, participants.foo));
     });
 
     it('should re-emit RemoteParticipants trackSubscribed event for matching RemoteParticipant only', () => {
       const spy = sinon.spy();
       room.on('trackSubscribed', spy);
 
-      participants.foo.emit('trackSubscribed');
+      participants.foo.emit('trackSubscribed', track);
       assert.equal(spy.callCount, 1);
+      assert(spy.calledWith(track, participants.foo));
     });
 
     it('should re-emit RemoteParticipants trackSubscriptionFailed event for matching RemoteParticipant only', () => {
       const spy = sinon.spy();
       room.on('trackSubscriptionFailed', spy);
 
-      participants.bar.emit('trackSubscriptionFailed');
+      const error = {};
+      const publication = {};
+      participants.bar.emit('trackSubscriptionFailed', error, publication);
       assert.equal(spy.callCount, 1);
+      assert(spy.calledWith(error, publication, participants.bar));
     });
 
     it('should re-emit RemoteParticipant trackUnpublished for matching RemoteParticipant only', () => {
       const spy = sinon.spy();
       room.on('trackUnpublished', spy);
 
-      participants.foo.emit('trackUnpublished');
+      const publication = {};
+      participants.foo.emit('trackUnpublished', publication);
       assert.equal(spy.callCount, 1);
+      assert(spy.calledWith(publication, participants.foo));
     });
 
     it('should re-emit RemoteParticipants trackUnsubscribed event for matching RemoteParticipant only', () => {
       const spy = sinon.spy();
       room.on('trackUnsubscribed', spy);
 
-      participants.bar.emit('trackUnsubscribed');
+      participants.bar.emit('trackUnsubscribed', track);
       assert.equal(spy.callCount, 1);
+      assert(spy.calledWith(track, participants.bar));
     });
 
     it('should not re-emit RemoteParticipant events if the RemoteParticipant is no longer in the room', () => {


### PR DESCRIPTION
@manjeshbhargav I think we missed a small change in 595b467382389d2750876e704bdfb43487314081 (the `this` argument was omitted when the emitting "enabled"/"disabled" Track event). Adding it back fixes JSDK-1932. I also took the opportunity to expand a few other unit tests and fix some JSDoc.