### PR TITLE
Fix JSDoc issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Bug Fixes
 
 - Fixed a bug that cause `remoteAudioTrackStats` and `remoteVideoTrackStats` to
   always be empty Arrays in Firefox. (JSDK-1927)
+- LogLevel was accidentally omitted from the API docs. (JSDK-1701)
 
 RemoteTrackPublication Guide
 ----------------------------

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -336,6 +336,7 @@ function connect(token, options) {
  * Names of the supported audio codecs.
  * @enum {string}
  */
+// eslint-disable-next-line
 const AudioCodec = {
   isac: 'isac',
   opus: 'opus',
@@ -347,6 +348,7 @@ const AudioCodec = {
  * Names of the supported video codecs.
  * @enum {string}
  */
+// eslint-disable-next-line
 const VideoCodec = {
   H264: 'H264',
   VP8: 'VP8',
@@ -357,7 +359,7 @@ const VideoCodec = {
  * Levels for logging verbosity.
  * @enum {string}
  */
-/* eslint no-unused-vars:0 */
+// eslint-disable-next-line
 const LogLevel = {
   debug: 'debug',
   info: 'info',

--- a/lib/participant.js
+++ b/lib/participant.js
@@ -546,6 +546,7 @@ function reemitTrackEvents(participant, track) {
 
 /**
  * Re-emit {@link TrackPublication} events.
+ * @private
  * @param {Participant} participant
  * @param {TrackPublication} publication
  */


### PR DESCRIPTION
* One method was not marked private
* An ESLint comment was excluding LogLevel from the JSDoc

---

@manjeshbhargav as these are only JSDoc changes and 1.10.0-rc2 passed QE, I think we can release 1.10.0 without another RC.