### PR TITLE
JSDK-1931

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ printNetworkQualityLevel(participant.networkQualityLevel);
 participant.on('networkQualityLevelChanged', printNetworkQualityLevel);
 ```
 
+Bug Fixes
+---------
+
+- Fixed a bug where if a Firefox or Safari Participant gets disconnected from a
+  group Room due to duplicate identity error, a "disconnected" event is
+  emitted on the Room without the corresponding TwilioError. (JSDK-1931)
+
 1.10.0 (May 30, 2018)
 =====================
 

--- a/lib/signaling/room.js
+++ b/lib/signaling/room.js
@@ -178,13 +178,13 @@ class RoomSignaling extends StateMachine {
  * @param {RoomSignaling} roomSignaling
  */
 function maybeUpdateState(roomSignaling) {
-  if (roomSignaling.state === 'disconnected') {
+  if (roomSignaling.state === 'disconnected' || roomSignaling.signalingConnectionState === 'disconnected') {
     return;
   }
 
   let newState;
 
-  if (roomSignaling.signalingConnectionState === 'reconnecting' || roomSignaling.signalingConnectionState === 'disconnected') {
+  if (roomSignaling.signalingConnectionState === 'reconnecting') {
     newState = roomSignaling.signalingConnectionState;
   } else if (roomSignaling.mediaConnectionState === 'failed') {
     roomSignaling._mediaConnectionIsReconnecting = true;

--- a/test/unit/spec/signaling/room.js
+++ b/test/unit/spec/signaling/room.js
@@ -18,8 +18,7 @@ const mediaConnectionStates = [
 
 const signalingConnectionStates = [
   'connected',
-  'reconnecting',
-  'disconnected'
+  'reconnecting'
 ];
 
 class RoomSignalingImpl extends RoomSignaling {


### PR DESCRIPTION
@markandrus 

In Firefox and Safari (SFU Room) for some reason, the `RoomSignaling#mediaConnectionState` transitions to "closed" before TransportV2 transitions to "disconnected". This will result in `maybeUpdateState()` in `lib/signaling/room.js` to transition the RoomSignaling's `.state` to "disconnected" without passing the `TwilioError`, which it doesn't have access to anyway.

So, the solution for this is to let the transition to "disconnected" be managed by `handleTransportEvents()` in `lib/signaling/v2/room.js` and ignore it in `maybeUpdateState()`.

Please let me know if this solution might affect other transitions which I might have missed.