### PR TITLE
Add workaroundWebKitBug180748 option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ New Features
   the feature is enabled.** Participants will also emit a
   "networkQualityLevelChanged" event when this value changes. See the Network
   Quality Level Guide below for more information on this feature.
+- Added a workaround for
+  [WebKit Bug 180748](https://bugs.webkit.org/show_bug.cgi?id=180748), where, in
+  Safari, `getUserMedia` may return a silent MediaStreamTrack. The workaround
+  works by detecting the silence (this takes up to 250 ms) and retrying
+  `getUserMedia` (up to 3 times). Enable it by setting the
+  `workaroundWebKitBug180748` property to `true` in CreateLocalTrackOptions:
+
+  ```js
+  connect(token, { audio: { workaroundWebKitBug180748: true } });
+  createLocalAudioTrack({ workaroundWebKitBug180748: true });
+  createLocalTracks({ audio: { workaroundWebKitBug180748: true } });
+  ```
 
 Network Quality Level Guide
 ---------------------------

--- a/lib/createlocaltrack.js
+++ b/lib/createlocaltrack.js
@@ -91,6 +91,10 @@ function createLocalVideoTrack(options) {
  * @property {LogLevel|LogLevels} logLevel
  * @property {string} [name] - The {@link LocalTrack}'s name; by default,
  *   it is set to the {@link LocalTrack}'s ID.
+ * @property {boolean} [workaroundWebKitBug180748=false] - Only valid for
+ *   {@link LocalAudioTrack}s; setting this attempts to workaround WebKit Bug
+ *   180748, where, in Safari, getUserMedia may return a silent audio
+ *   MediaStreamTrack.
  */
 
 module.exports = {

--- a/lib/createlocaltracks.js
+++ b/lib/createlocaltracks.js
@@ -9,6 +9,7 @@ const LocalVideoTrack = require('./media/track/es5/localvideotrack');
 const MediaStreamTrack = require('@twilio/webrtc').MediaStreamTrack;
 const Log = require('./util/log');
 const DEFAULT_LOG_LEVEL = require('./util/constants').DEFAULT_LOG_LEVEL;
+const workaround180748 = require('./webaudio/workaround180748');
 
 // This is used to make out which createLocalTracks() call a particular Log
 // statement belongs to. Each call to createLocalTracks() increments this
@@ -103,10 +104,18 @@ function createLocalTracks(options) {
     delete options.video.name;
   }
 
-  return options.getUserMedia({
+  const mediaStreamConstraints = {
     audio: options.audio,
     video: options.video
-  }).then(mediaStream => {
+  };
+
+  const workaroundWebKitBug180748 = options.audio && options.audio.workaroundWebKitBug180748;
+
+  const mediaStreamPromise = workaroundWebKitBug180748
+    ? workaround180748(options.getUserMedia, mediaStreamConstraints)
+    : options.getUserMedia(mediaStreamConstraints);
+
+  return mediaStreamPromise.then(mediaStream => {
     const mediaStreamTracks = mediaStream.getAudioTracks().concat(mediaStream.getVideoTracks());
 
     log.info('Call to getUserMedia successful; got MediaStreamTracks:',

--- a/lib/createlocaltracks.js
+++ b/lib/createlocaltracks.js
@@ -112,7 +112,7 @@ function createLocalTracks(options) {
   const workaroundWebKitBug180748 = options.audio && options.audio.workaroundWebKitBug180748;
 
   const mediaStreamPromise = workaroundWebKitBug180748
-    ? workaround180748(options.getUserMedia, mediaStreamConstraints)
+    ? workaround180748(log, options.getUserMedia, mediaStreamConstraints)
     : options.getUserMedia(mediaStreamConstraints);
 
   return mediaStreamPromise.then(mediaStream => {

--- a/lib/webaudio/detectsilence.js
+++ b/lib/webaudio/detectsilence.js
@@ -1,0 +1,57 @@
+'use strict';
+
+/**
+ * Return a Promise that resolves after `timeout` milliseconds.
+ * @param {?number} [timeout=0]
+ * @returns {Promise<void>}
+ */
+function delay(timeout) {
+  timeout = typeof timeout === 'number' ? timeout : 0;
+  return new Promise(resolve => setTimeout(resolve, timeout));
+}
+
+/**
+ * Attempt to detect silence. The Promise returned by this function returns
+ * false as soon as audio is detected or true after `timeout` milliseconds.
+ * @param {AudioContext} audioContext
+ * @param {MediaStream} stream
+ * @param {?number} [timeout=250]
+ * @returns {Promise<boolean>}
+ */
+function detectSilence(audioContext, stream, timeout) {
+  timeout = typeof timeout === 'number' ? timeout : 250;
+
+  const source = audioContext.createMediaStreamSource(stream);
+  const analyser = audioContext.createAnalyser();
+  analyser.fftSize = 2048;
+  source.connect(analyser);
+
+  const samples = new Uint8Array(analyser.fftSize);
+
+  let timeoutDidFire = false;
+  setTimeout(() => { timeoutDidFire = true; }, timeout);
+
+  /**
+   * We can't use async/await yet, so I need to factor this out.
+   * @returns {Promise<boolean>}
+   */
+  function doDetectSilence() {
+    if (timeoutDidFire) {
+      return Promise.resolve(true);
+    }
+    analyser.getByteTimeDomainData(samples);
+    return samples.some(sample => sample)
+      ? Promise.resolve(false)
+      : delay().then(doDetectSilence);
+  }
+
+  return doDetectSilence().then(isSilent => {
+    source.disconnect();
+    return isSilent;
+  }, error => {
+    source.disconnect();
+    throw error;
+  });
+}
+
+module.exports = detectSilence;

--- a/lib/webaudio/workaround180748.js
+++ b/lib/webaudio/workaround180748.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const AudioContextFactory = require('./audiocontext');
+const detectSilence = require('./detectsilence');
+
+/**
+ * This function attempts to workaround WebKit Bug 180748. It does so by
+ *
+ *   1. Calling `getUserMedia`, and
+ *   2. Checking to see if the resulting MediaStream is silent.
+ *   3. If so, repeat Step 1; otherwise, return the MediaStream.
+ *
+ * The function only repeats up to `n` times, and it only waits `timeout`
+ * milliseconds when detecting silence. Assuming `getUserMedia` is
+ * instantaneous, in the best case, this function returns a Promise that
+ * resolves immediately; in the worst case, this function returns a Promise that
+ * resolves in `n` * `timeout` milliseconds.
+ *
+ * @param {function(MediaStreamConstraints): Promise<MediaStream>} getUserMedia
+ * @param {MediaStreamConstraints} constraints
+ * @param {number} [n=3]
+ * @param {number} [timeout=250]
+ * @returns Promise<MediaStream>
+ */
+function workaround(getUserMedia, constraints, n, timeout) {
+  n = typeof n === 'number' ? n : 3;
+
+  const holder = {};
+  const audioContext = AudioContextFactory.getOrCreate(holder);
+
+  /**
+   * We can't use async/await yet, so I need to factor this out.
+   * @returns {Promise<MediaStream>}
+   */
+  function doWorkaround() {
+    return getUserMedia(constraints).then(stream => {
+      const isSilentPromise = constraints.audio
+        ? detectSilence(audioContext, stream, timeout).catch(() => true)
+        : Promise.resolve(false);
+      return isSilentPromise.then(isSilent => {
+        if (!isSilent || n <= 0) {
+          return stream;
+        }
+        stream.getTracks().forEach(track => track.stop());
+        n--;
+        return doWorkaround();
+      });
+    });
+  }
+
+  return doWorkaround().then(stream => {
+    AudioContextFactory.release(holder);
+    return stream;
+  }, error => {
+    AudioContextFactory.release(holder);
+    throw error;
+  });
+}
+
+module.exports = workaround;

--- a/lib/webaudio/workaround180748.js
+++ b/lib/webaudio/workaround180748.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const AudioContextFactory = require('./audiocontext');
 const detectSilence = require('./detectsilence');
 
 /**
@@ -27,6 +26,9 @@ function workaround(log, getUserMedia, constraints, n, timeout) {
   n = typeof n === 'number' ? n : 3;
   let retry = 0;
 
+  // NOTE(mroberts): We have to delay require-ing AudioContextFactory, because
+  // it exports a default instance whose constructor calls Object.assign.
+  const AudioContextFactory = require('./audiocontext');
   const holder = {};
   const audioContext = AudioContextFactory.getOrCreate(holder);
 

--- a/lib/webaudio/workaround180748.js
+++ b/lib/webaudio/workaround180748.js
@@ -16,14 +16,16 @@ const detectSilence = require('./detectsilence');
  * resolves immediately; in the worst case, this function returns a Promise that
  * resolves in `n` * `timeout` milliseconds.
  *
+ * @param {Log} log
  * @param {function(MediaStreamConstraints): Promise<MediaStream>} getUserMedia
  * @param {MediaStreamConstraints} constraints
  * @param {number} [n=3]
  * @param {number} [timeout=250]
  * @returns Promise<MediaStream>
  */
-function workaround(getUserMedia, constraints, n, timeout) {
+function workaround(log, getUserMedia, constraints, n, timeout) {
   n = typeof n === 'number' ? n : 3;
+  let retry = 0;
 
   const holder = {};
   const audioContext = AudioContextFactory.getOrCreate(holder);
@@ -38,9 +40,17 @@ function workaround(getUserMedia, constraints, n, timeout) {
         ? detectSilence(audioContext, stream, timeout).catch(() => true)
         : Promise.resolve(false);
       return isSilentPromise.then(isSilent => {
-        if (!isSilent || n <= 0) {
+        if (!isSilent) {
+          log.info('Got a non-silent audio MediaStreamTrack; returning it.');
+          return stream;
+        } else if (n <= 0) {
+          log.warn('Got a silent audio MediaStreamTrack. Normally we would try \
+to get a new one, but we\'ve run out of retries; returning it anyway.');
           return stream;
         }
+        log.warn(`Got a silent audio MediaStreamTrack. Stopping all \
+MediaStreamTracks and calling getUserMedia again. This is retry \
+#${++retry}.`);
         stream.getTracks().forEach(track => track.stop());
         n--;
         return doWorkaround();


### PR DESCRIPTION
_Not ready to merge. Still needs testing._

---

You can specify this in any of the following ways:

```js
connect(token, { audio: { workaroundWebKitBug180748: true });
createLocalAudioTrack({ workaroundWebKitBug180748: true });
createLocalTracks({ audio: { workaroundWebKitBug180748: true } });
```

In Safari, this *might* workaround [WebKit Bug 180748](https://bugs.webkit.org/show_bug.cgi?id=180748). In the worst case, it will slow down LocalAudioTrack creation.