### PR TITLE
Add `ice_servers` property to "connect" message

### DIFF
--- a/lib/iceserversource/constant.js
+++ b/lib/iceserversource/constant.js
@@ -35,7 +35,11 @@ class ConstantIceServerSource extends EventEmitter {
         get() {
           return this._isStarted;
         }
-      }
+      },
+      status: {
+        enumerable: true,
+        value: 'overrode'
+      },
     });
   }
 

--- a/lib/iceserversource/index.js
+++ b/lib/iceserversource/index.js
@@ -18,7 +18,7 @@ const IceServerSourceStatus = {
  * @extends {EventEmitter}
  *   servers, if any
  * @property {boolean} isStarted
- * @property {IceServerSourceStatus} status
+ * @property {?IceServerSourceStatus} status
  * @emits IceServerSource#iceServers
  */
 

--- a/lib/iceserversource/index.js
+++ b/lib/iceserversource/index.js
@@ -1,12 +1,24 @@
 'use strict';
 
 /**
+ * Indicate whether the {@link IceServerSource} succeeded or not.
+ * @enum {string}
+ */
+// eslint-disable-next-line
+const IceServerSourceStatus = {
+  overrode: 'overrode',
+  success: 'success',
+  failure: 'failure'
+};
+
+/**
  * An implementation of {@link IceServerSource} can be used to provide ICE
  * servers when participating in {@link Room}s.
  * @interface IceServerSource
  * @extends {EventEmitter}
  *   servers, if any
  * @property {boolean} isStarted
+ * @property {IceServerSourceStatus} status
  * @emits IceServerSource#iceServers
  */
 

--- a/lib/iceserversource/nts.js
+++ b/lib/iceserversource/nts.js
@@ -93,7 +93,7 @@ class NTSIceServerSource extends EventEmitter {
         value: log
       },
       _status: {
-        value: 'failure',
+        value: null,
         writable: true
       },
       // This Deferred remains unresolved until `stop` is called. We use it to
@@ -110,23 +110,19 @@ class NTSIceServerSource extends EventEmitter {
       // This is the Access Token NTSIceServerSource makes requests to ECS with.
       _token: {
         value: token
-      },
-      isStarted: {
-        enumerable: true,
-        get() {
-          return !!this._currentPoll;
-        }
-      },
-      status: {
-        enumerable: true,
-        get() {
-          return this._status;
-        }
-      },
+      }
     });
 
     this._log.info('Created a new NTSIceServerSource');
     this._log.debug('ECS server:', this._ecsServer);
+  }
+
+  get isStarted() {
+    return !!this._currentPoll;
+  }
+
+  get status() {
+    return this._status;
   }
 
   start() {

--- a/lib/iceserversource/nts.js
+++ b/lib/iceserversource/nts.js
@@ -92,6 +92,10 @@ class NTSIceServerSource extends EventEmitter {
       _log: {
         value: log
       },
+      _status: {
+        value: 'failure',
+        writable: true
+      },
       // This Deferred remains unresolved until `stop` is called. We use it to
       // short-circuit in `poll`.
       _stopped: {
@@ -112,7 +116,13 @@ class NTSIceServerSource extends EventEmitter {
         get() {
           return !!this._currentPoll;
         }
-      }
+      },
+      status: {
+        enumerable: true,
+        get() {
+          return this._status;
+        }
+      },
     });
 
     this._log.info('Created a new NTSIceServerSource');
@@ -206,8 +216,11 @@ function poll(client) {
     if (!config) {
       throw alreadyStopped;
     }
-    return parseECSConfig(client, config);
+    const iceServersAndTTL = parseECSConfig(client, config);
+    client._status = 'success';
+    return iceServersAndTTL;
   }).catch(error => {
+    client._status = 'failure';
     if (!client.isStarted) {
       throw alreadyStopped;
     } else if (configWithTimeout.isTimedOut) {

--- a/lib/signaling/v2/cancelableroomsignalingpromise.js
+++ b/lib/signaling/v2/cancelableroomsignalingpromise.js
@@ -59,6 +59,7 @@ function createCancelableRoomSignalingPromise(token, ua, localParticipant, iceSe
           environment: options.environment,
           negotiateDominantSpeaker: options._enableDominantSpeaker,
           negotiateNetworkQuality: options._enableNetworkQualityLevel,
+          iceServerSourceStatus: iceServerSource.status,
           insights: options.insights,
           realm: options.realm
         }, transportOptions);

--- a/lib/signaling/v2/transport.js
+++ b/lib/signaling/v2/transport.js
@@ -93,7 +93,7 @@ class Transport extends StateMachine {
       eventPublisherOptions.gateway = options.wsServerInsights;
     }
 
-    const session = createSession(this, name, accessToken, localParticipant, peerConnectionManager, ua, options.SIPJSMediaHandler, options.negotiateNetworkQuality, options.negotiateDominantSpeaker);
+    const session = createSession(this, name, accessToken, localParticipant, peerConnectionManager, ua, options.SIPJSMediaHandler, options.iceServerSourceStatus, options.negotiateNetworkQuality, options.negotiateDominantSpeaker);
     const EventPublisher = options.insights ? options.InsightsPublisher : options.NullInsightsPublisher;
     Object.defineProperties(this, {
       _eventPublisher: {
@@ -206,7 +206,7 @@ class Transport extends StateMachine {
  * @param {object} state
  */
 
-function createSession(transport, name, accessToken, localParticipant, peerConnectionManager, ua, SIPJSMediaHandler, negotiateNetworkQuality, negotiateDominantSpeaker) {
+function createSession(transport, name, accessToken, localParticipant, peerConnectionManager, ua, SIPJSMediaHandler, iceServerSourceStatus, negotiateNetworkQuality, negotiateDominantSpeaker) {
   const target = `sip:${util.makeServerSIPURI()}`;
   return ua.invite(target, {
     extraHeaders: [
@@ -235,6 +235,7 @@ function createSession(transport, name, accessToken, localParticipant, peerConne
         };
 
         if (message.type === 'connect') {
+          message.ice_servers = iceServerSourceStatus;
           message.publisher = {
             name: SDK_NAME,
             sdk_version: SDK_VERSION,


### PR DESCRIPTION
This property will indicate if

* `iceServers` was overridden in ConnectOptions, and therefore ECS was bypassed;
* Acquiring ICE servers from ECS succeeded; or
* Acquiring ICE servers from ECS failed.

**EDIT**: I've now manually tested the "success" case, the "failure" case, and the "overrode" case.