### PR TITLE
Fix tests after RTX change

### DIFF
--- a/test/lib/mocksdp.js
+++ b/test/lib/mocksdp.js
@@ -37,7 +37,7 @@ a=fingerprint:sha-256 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:0
   return ['audio', 'video'].reduce((sdp, kind) => {
     const codecs = {
       audio: '109 9 0 8 101',
-      video: '120 121 126 97'
+      video: '120 121 126 97 99'
     }[kind];
 
     const bLine = kind === 'audio' && typeof maxAudioBitrate === 'number'
@@ -54,7 +54,8 @@ ${kind === 'video'
       ? 'a=rtpmap:120 VP8/90000\r\n' +
         'a=rtpmap:121 VP9/90000\r\n' +
         'a=rtpmap:126 H264/90000\r\n' +
-        'a=rtpmap:97 H264/180000'
+        'a=rtpmap:97 H264/180000\r\n' +
+        'a=rtpmap:99 rtx/8000'
       : 'a=rtpmap:109 opus/48000/2\r\n' +
         'a=rtpmap:9 G722/8000/1\r\n' +
         'a=rtpmap:0 PCMU/8000\r\n' +

--- a/test/unit/spec/util/sdp/index.js
+++ b/test/unit/spec/util/sdp/index.js
@@ -131,8 +131,8 @@ describe('setCodecPreferences', () => {
           ? ['8', '101', '9', '109', '0']
           : ['109', '9', '0', '8', '101'];
         const expectedVideoCodecIds = preferredVideoCodecs.length
-          ? ['126', '97', '121', '120']
-          : ['120', '121', '126', '97'];
+          ? ['126', '97', '121', '120', '99']
+          : ['120', '121', '126', '97', '99'];
         itShouldHaveCodecOrder(sdpType, preferredAudioCodecs, preferredVideoCodecs, expectedAudioCodecIds, expectedVideoCodecIds);
       });
     });
@@ -230,7 +230,7 @@ describe('setSimulcast', () => {
     });
   });
 
-  describe.only('when a subsequent offer disables RTX', () => {
+  describe('when a subsequent offer disables RTX', () => {
     it('does not add RTX SSRCs, FID groups, etc.', () => {
       const sdp1 = `\
 v=0\r
@@ -469,7 +469,6 @@ a=ssrc:0000000000 label:d8b9a935-da54-4d21-a8de-522c87258244\r
 
       assert(!simSdp2.match(/a=ssrc-group:FID/), 'RTX is disabled; therefore, there should be no FID groups in the SDP');
 
-      console.log(simSdp2);
       const ssrcs2 = new Set(simSdp2.match(/a=ssrc:[0-9]+/g).map(line => line.match(/a=ssrc:([0-9]+)/)[1]));
       assert.equal(ssrcs2.size, 3, 'RTX is disabled; therefore, there should be just 3 SSRCs in the SDP');
     });


### PR DESCRIPTION
@manjeshbhargav i made a mistake in merging the previous RTX PR. I had `only` enabled (and forgot to remove a `console.log`). Also, the `only` masked the fact that we needed to update other tests.