### PR TITLE
twilio-webrtc.js@2.1.1-rc2

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   },
   "dependencies": {
     "@twilio/sip.js": "^0.7.7",
-    "@twilio/webrtc": "twilio/twilio-webrtc.js#2.1.1-rc1",
+    "@twilio/webrtc": "twilio/twilio-webrtc.js#2.1.1-rc2",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },


### PR DESCRIPTION
We'll cut a twilio-video.js@1.12.0-rc1 soon to validate twilio-webrtc.js@2.1.1-rc2. If that looks good, we'll publish twilio-webrtc.js@2.1.1, update twilio-video.js to depend on `^2.1.1`, then publish twilio-video.js@1.12.0.