### PR TITLE
JSDK-2025: Improve Object.keys & JSON.stringify behavior for public classes

### DIFF
--- a/lib/eventemitter.js
+++ b/lib/eventemitter.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const { EventEmitter } = require('events');
+
+const { hidePrivatePropertiesInClass } = require('./util');
+
+module.exports = hidePrivatePropertiesInClass(EventEmitter);

--- a/lib/media/track/index.js
+++ b/lib/media/track/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const EventEmitter = require('../../eventemitter');
-const buildLogLevels = require('../../util').buildLogLevels;
+const { buildLogLevels, valueToJSON } = require('../../util');
 const DEFAULT_LOG_LEVEL = require('../../util/constants').DEFAULT_LOG_LEVEL;
 const Log = require('../../util/log');
 
@@ -66,11 +66,7 @@ class Track extends EventEmitter {
   }
 
   toJSON() {
-    return {
-      id: this.id,
-      kind: this.kind,
-      name: this.name
-    };
+    return valueToJSON(this);
   }
 }
 

--- a/lib/media/track/index.js
+++ b/lib/media/track/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const EventEmitter = require('events').EventEmitter;
+const EventEmitter = require('../../eventemitter');
 const buildLogLevels = require('../../util').buildLogLevels;
 const DEFAULT_LOG_LEVEL = require('../../util/constants').DEFAULT_LOG_LEVEL;
 const Log = require('../../util/log');
@@ -10,6 +10,7 @@ let nInstances = 0;
 /**
  * A {@link Track} represents a stream of audio, video, or data.
  * @extends EventEmitter
+ * @property {Track.ID} id - The {@link Track}'s ID
  * @property {Track.Kind} kind - The {@link Track}'s kind
  * @property {string} name - The {@link Track}'s name
  */
@@ -46,6 +47,13 @@ class Track extends EventEmitter {
       _log: {
         value: log
       },
+      id: {
+        enumerable: true,
+        configurable: true,
+        get() {
+          return this._id;
+        }
+      },
       kind: {
         enumerable: true,
         value: kind
@@ -57,12 +65,12 @@ class Track extends EventEmitter {
     });
   }
 
-  /**
-   * The {@link Track}'s ID.
-   * @property {Track.ID}
-   */
-  get id() {
-    return this._id;
+  toJSON() {
+    return {
+      id: this.id,
+      kind: this.kind,
+      name: this.name
+    };
   }
 }
 

--- a/lib/media/track/localdatatrack.js
+++ b/lib/media/track/localdatatrack.js
@@ -103,6 +103,15 @@ class LocalDataTrack extends Track {
   send(data) {
     this._trackSender.send(data);
   }
+
+  toJSON() {
+    return Object.assign(super.toJSON(), {
+      maxPacketLifeTime: this.maxPacketLifeTime,
+      maxRetransmits: this.maxRetransmits,
+      ordered: this.ordered,
+      reliable: this.reliable
+    });
+  }
 }
 
 /**

--- a/lib/media/track/localdatatrack.js
+++ b/lib/media/track/localdatatrack.js
@@ -103,15 +103,6 @@ class LocalDataTrack extends Track {
   send(data) {
     this._trackSender.send(data);
   }
-
-  toJSON() {
-    return Object.assign(super.toJSON(), {
-      maxPacketLifeTime: this.maxPacketLifeTime,
-      maxRetransmits: this.maxRetransmits,
-      ordered: this.ordered,
-      reliable: this.reliable
-    });
-  }
 }
 
 /**

--- a/lib/media/track/localmediatrack.js
+++ b/lib/media/track/localmediatrack.js
@@ -39,6 +39,7 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
           }
         },
         isStopped: {
+          enumerable: true,
           get() {
             return this.mediaStreamTrack.readyState === 'ended';
           }
@@ -77,6 +78,13 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
       this.mediaStreamTrack.stop();
       this._end();
       return this;
+    }
+
+    toJSON() {
+      return Object.assign(super.toJSON(), {
+        isEnabled: this.isEnabled,
+        isStopped: this.isStopped
+      });
     }
   };
 }

--- a/lib/media/track/localmediatrack.js
+++ b/lib/media/track/localmediatrack.js
@@ -79,13 +79,6 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
       this._end();
       return this;
     }
-
-    toJSON() {
-      return Object.assign(super.toJSON(), {
-        isEnabled: this.isEnabled,
-        isStopped: this.isStopped
-      });
-    }
   };
 }
 

--- a/lib/media/track/localtrackpublication.js
+++ b/lib/media/track/localtrackpublication.js
@@ -56,14 +56,6 @@ class LocalTrackPublication extends TrackPublication {
     return `[LocalTrackPublication #${this._instanceId}: ${this.trackSid}]`;
   }
 
-  toJSON() {
-    return Object.assign(super.toJSON(), {
-      isTrackEnabled: this.isTrackEnabled,
-      kind: this.kind,
-      track: this.track ? this.track.toJSON() : null
-    });
-  }
-
   /**
    * Unpublish a {@link LocalTrackPublication}. This means that the media
    * from this {@link LocalTrackPublication} is no longer available to the

--- a/lib/media/track/localtrackpublication.js
+++ b/lib/media/track/localtrackpublication.js
@@ -5,6 +5,8 @@ const TrackPublication = require('./trackpublication');
 /**
  * A {@link LocalTrackPublication} is a {@link LocalTrack} that has been
  * published to a {@link Room}.
+ * @property {boolean} isTrackEnabled - whether the published {@link LocalTrack}
+ *   is enabled
  * @property {Track.Kind} kind - kind of the published {@link LocalTrack}
  * @property {LocalTrack} track - the {@link LocalTrack}
  */
@@ -30,6 +32,12 @@ class LocalTrackPublication extends TrackPublication {
       _unpublish: {
         value: unpublish
       },
+      isTrackEnabled: {
+        enumerable: true,
+        get() {
+          return this.track.kind === 'data' ? true : this.track.isEnabled;
+        }
+      },
       kind: {
         enumerable: true,
         value: track.kind
@@ -48,12 +56,12 @@ class LocalTrackPublication extends TrackPublication {
     return `[LocalTrackPublication #${this._instanceId}: ${this.trackSid}]`;
   }
 
-  /**
-   * Whether the published {@link LocalTrack} is enabled
-   * @property {boolean}
-   */
-  get isTrackEnabled() {
-    return this.track.kind === 'data' ? true : this.track.isEnabled;
+  toJSON() {
+    return Object.assign(super.toJSON(), {
+      isTrackEnabled: this.isTrackEnabled,
+      kind: this.kind,
+      track: this.track ? this.track.toJSON() : null
+    });
   }
 
   /**

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -39,6 +39,10 @@ class MediaTrack extends Track {
       _attachments: {
         value: new Set()
       },
+      _dummyEl: {
+        value: null,
+        writable: true
+      },
       _isStarted: {
         get() {
           return isStarted;
@@ -51,6 +55,7 @@ class MediaTrack extends Track {
         value: options.MediaStream
       },
       isStarted: {
+        enumerable: true,
         get() {
           return isStarted;
         }
@@ -239,6 +244,12 @@ class MediaTrack extends Track {
     });
 
     return els;
+  }
+
+  toJSON() {
+    return Object.assign(super.toJSON(), {
+      isStarted: this.isStarted
+    });
   }
 }
 

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -245,12 +245,6 @@ class MediaTrack extends Track {
 
     return els;
   }
-
-  toJSON() {
-    return Object.assign(super.toJSON(), {
-      isStarted: this.isStarted
-    });
-  }
 }
 
 module.exports = MediaTrack;

--- a/lib/media/track/remotedatatrack.js
+++ b/lib/media/track/remotedatatrack.js
@@ -128,16 +128,6 @@ class RemoteDataTrack extends Track {
       this.emit('unsubscribed', this);
     }
   }
-
-  toJSON() {
-    return Object.assign(super.toJSON(), {
-      maxPacketLifeTime: this.maxPacketLifeTime,
-      maxRetransmits: this.maxRetransmits,
-      ordered: this.ordered,
-      reliable: this.reliable,
-      sid: this.sid
-    });
-  }
 }
 
 /**

--- a/lib/media/track/remotedatatrack.js
+++ b/lib/media/track/remotedatatrack.js
@@ -8,6 +8,8 @@ const Track = require('./');
  * {@link RemoteParticipant}.
  * @extends Track
  * @property {boolean} isEnabled - true
+ * @property {boolean} isSubscribed - Whether the {@link RemoteDataTrack} is
+ *   subscribed to
  * @property {Track.Kind} kind - "data"
  * @property {?number} maxPacketLifeTime - If non-null, this represents a time
  *   limit (in milliseconds) during which data will be transmitted or
@@ -22,6 +24,7 @@ const Track = require('./');
  *   null. In other words, if this is true, there is no bound on packet lifetime
  *   or the number of retransmits that will be attempted, ensuring "reliable"
  *   transmission.
+ * @property {Track.SID} sid - The SID assigned to the {@link RemoteDataTrack}
  * @emits RemoteDataTrack#message
  * @emits RemoteDataTrack#unsubscribed
  */
@@ -43,9 +46,27 @@ class RemoteDataTrack extends Track {
         value: null,
         writable: true
       },
+      id: {
+        enumerable: true,
+        get() {
+          this._log.deprecated('RemoteDataTrack#id has been deprecated and is '
+            + 'scheduled for removal in twilio-video.js@2.0.0. Use the parent '
+            + 'RemoteTrackPublication\'s .trackName or .trackSid instead.');
+          return this._id;
+        }
+      },
       isEnabled: {
         enumerable: true,
         value: true
+      },
+      isSubscribed: {
+        enumerable: true,
+        get() {
+          this._log.deprecated('RemoteDataTrack#isSubscribed has been deprecated and is '
+            + 'scheduled for removal in twilio-video.js@2.0.0. Use the '
+            + 'parent RemoteTrackPublication\'s .isSubscribed instead.');
+          return this._isSubscribed;
+        }
       },
       maxPacketLifeTime: {
         enumerable: true,
@@ -63,6 +84,12 @@ class RemoteDataTrack extends Track {
         enumerable: true,
         value: dataTrackReceiver.maxPacketLifeTime === null
           && dataTrackReceiver.maxRetransmits === null
+      },
+      sid: {
+        enumerable: true,
+        get() {
+          return this._sid;
+        }
       }
     });
 
@@ -73,40 +100,6 @@ class RemoteDataTrack extends Track {
     dataTrackReceiver.on('message', data => {
       this.emit('message', data, this);
     });
-  }
-
-  /**
-   * The {@link RemoteDataTrack}'s ID.
-   * @property {Track.ID}
-   * @deprecated Use the parent {@link RemoteTrackPublication}'s .trackName
-   *   or .trackSid instead
-   */
-  get id() {
-    this._log.deprecated('RemoteDataTrack#id has been deprecated and is '
-      + 'scheduled for removal in twilio-video.js@2.0.0. Use the parent '
-      + 'RemoteTrackPublication\'s .trackName or .trackSid instead.');
-    return this._id;
-  }
-
-  /**
-   * Whether the {@link RemoteDataTrack} is subscribed to
-   * @property {boolean}
-   * @deprecated Use the parent {@link RemoteTrackPublication}'s .isSubscribed
-   *   instead
-   */
-  get isSubscribed() {
-    this._log.deprecated('RemoteDataTrack#isSubscribed has been deprecated and is '
-      + 'scheduled for removal in twilio-video.js@2.0.0. Use the '
-      + 'parent RemoteTrackPublication\'s .isSubscribed instead.');
-    return this._isSubscribed;
-  }
-
-  /**
-   * The SID assigned to the {@link RemoteMediaTrack}
-   * @property {Track.SID}
-   */
-  get sid() {
-    return this._sid;
   }
 
   /**
@@ -134,6 +127,16 @@ class RemoteDataTrack extends Track {
       this._isSubscribed = false;
       this.emit('unsubscribed', this);
     }
+  }
+
+  toJSON() {
+    return Object.assign(super.toJSON(), {
+      maxPacketLifeTime: this.maxPacketLifeTime,
+      maxRetransmits: this.maxRetransmits,
+      ordered: this.ordered,
+      reliable: this.reliable,
+      sid: this.sid
+    });
   }
 }
 

--- a/lib/media/track/remotemediatrack.js
+++ b/lib/media/track/remotemediatrack.js
@@ -100,14 +100,6 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
         this.emit('unsubscribed', this);
       }
     }
-
-    toJSON() {
-      return Object.assign(super.toJSON(), {
-        isEnabled: this.isEnabled,
-        isSubscribed: this.isSubscribed,
-        sid: this.sid
-      });
-    }
   };
 }
 

--- a/lib/media/track/remotemediatrack.js
+++ b/lib/media/track/remotemediatrack.js
@@ -32,54 +32,42 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
         _sid: {
           value: null,
           writable: true
+        },
+        id: {
+          enumerable: true,
+          get() {
+            this._log.deprecated('RemoteMediaTrack#id has been deprecated and is '
+              + 'scheduled for removal in twilio-video.js@2.0.0. Use the parent '
+              + 'RemoteTrackPublication\'s .trackName or .trackSid instead.');
+            return this._id;
+          }
+        },
+        isEnabled: {
+          enumerable: true,
+          get() {
+            return this._isEnabled;
+          }
+        },
+        isSubscribed: {
+          enumerable: true,
+          get() {
+            this._log.deprecated('RemoteMediaTrack#isSubscribed has been deprecated and is '
+              + 'scheduled for removal in twilio-video.js@2.0.0. Use the '
+              + 'parent RemoteTrackPublication\'s .isSubscribed instead.');
+            return this._isSubscribed;
+          }
+        },
+        sid: {
+          enumerable: true,
+          get() {
+            return this._sid;
+          }
         }
       });
 
       deprecateEvents('RemoteMediaTrack', this, new Map([
         ['unsubscribed', null]
       ]), this._log);
-    }
-
-    /**
-     * The {@link RemoteMediaTrack}'s ID.
-     * @property {Track.ID}
-     * @deprecated Use the parent {@link RemoteTrackPublication}'s .trackName or
-     *   .trackSid instead
-     */
-    get id() {
-      this._log.deprecated('RemoteMediaTrack#id has been deprecated and is '
-        + 'scheduled for removal in twilio-video.js@2.0.0. Use the parent '
-        + 'RemoteTrackPublication\'s .trackName or .trackSid instead.');
-      return this._id;
-    }
-
-    /**
-     * Whether the {@link RemoteMediaTrack} is enabled
-     * @property {boolean}
-     */
-    get isEnabled() {
-      return this._isEnabled;
-    }
-
-    /**
-     * Whether the {@link RemoteMediaTrack} is subscribed to
-     * @property {boolean}
-     * @deprecated Use the parent {@link RemoteTrackPublication}'s .isSubscribed
-     *   instead
-     */
-    get isSubscribed() {
-      this._log.deprecated('RemoteMediaTrack#isSubscribed has been deprecated and is '
-        + 'scheduled for removal in twilio-video.js@2.0.0. Use the '
-        + 'parent RemoteTrackPublication\'s .isSubscribed instead.');
-      return this._isSubscribed;
-    }
-
-    /**
-     * The SID assigned to the {@link RemoteMediaTrack}
-     * @property {Track.SID}
-     */
-    get sid() {
-      return this._sid;
     }
 
     /**
@@ -111,6 +99,14 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
         this._isSubscribed = false;
         this.emit('unsubscribed', this);
       }
+    }
+
+    toJSON() {
+      return Object.assign(super.toJSON(), {
+        isEnabled: this.isEnabled,
+        isSubscribed: this.isSubscribed,
+        sid: this.sid
+      });
     }
   };
 }

--- a/lib/media/track/remotetrackpublication.js
+++ b/lib/media/track/remotetrackpublication.js
@@ -5,7 +5,13 @@ const TrackPublication = require('./trackpublication');
 /**
  * A {@link RemoteTrackPublication} represents a {@link RemoteTrack} that has
  * been published to a {@link Room}.
+ * @property {boolean} isSubscribed - whether the published {@link RemoteTrack}
+ *   is subscribed to
+ * @property {boolean} isTrackEnabled - whether the published
+ *   {@link RemoteTrack} is enabled
  * @property {Track.Kind} kind - kind of the published {@link RemoteTrack}
+ * @property {?RemoteTrack} track - Unless you have subscribed to the
+ *   {@link RemoteTrack}, this property is null
  * @emits RemoteTrackPublication#subscribed
  * @emits RemoteTrackPublication#trackDisabled
  * @emits RemoteTrackPublication#trackEnabled
@@ -29,9 +35,27 @@ class RemoteTrackPublication extends TrackPublication {
         value: null,
         writable: true
       },
+      isSubscribed: {
+        enumerable: true,
+        get() {
+          return !!this._track;
+        }
+      },
+      isTrackEnabled: {
+        enumerable: true,
+        get() {
+          return this._signaling.isEnabled;
+        }
+      },
       kind: {
         enumerable: true,
         value: signaling.kind
+      },
+      track: {
+        enumerable: true,
+        get() {
+          return this._track;
+        }
       }
     });
 
@@ -49,30 +73,6 @@ class RemoteTrackPublication extends TrackPublication {
 
   toString() {
     return `[RemoteTrackPublication #${this._instanceId}: ${this.trackSid}]`;
-  }
-
-  /**
-   * Whether the published {@link RemoteTrack} is subscribed to
-   * @property {boolean}
-   */
-  get isSubscribed() {
-    return !!this._track;
-  }
-
-  /**
-   * Whether the published {@link RemoteTrack} is enabled
-   * @property {boolean}
-   */
-  get isTrackEnabled() {
-    return this._signaling.isEnabled;
-  }
-
-  /**
-   * Unless you have subscribed to the {@link RemoteTrack}, this property is null
-   * @property {?RemoteTrack}
-   */
-  get track() {
-    return this._track;
   }
 
   /**
@@ -96,6 +96,15 @@ class RemoteTrackPublication extends TrackPublication {
       track._unsubscribe();
       this.emit('unsubscribed', track);
     }
+  }
+
+  toJSON() {
+    return Object.assign(super.toJSON(), {
+      isSubscribed: this.isSubscribed,
+      isTrackEnabled: this.isTrackEnabled,
+      kind: this.kind,
+      track: this.track ? this.track.toJSON() : null
+    });
   }
 }
 

--- a/lib/media/track/remotetrackpublication.js
+++ b/lib/media/track/remotetrackpublication.js
@@ -97,15 +97,6 @@ class RemoteTrackPublication extends TrackPublication {
       this.emit('unsubscribed', track);
     }
   }
-
-  toJSON() {
-    return Object.assign(super.toJSON(), {
-      isSubscribed: this.isSubscribed,
-      isTrackEnabled: this.isTrackEnabled,
-      kind: this.kind,
-      track: this.track ? this.track.toJSON() : null
-    });
-  }
 }
 
 /**

--- a/lib/media/track/trackpublication.js
+++ b/lib/media/track/trackpublication.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { EventEmitter } = require('events');
+const EventEmitter = require('../../eventemitter');
 const { buildLogLevels } = require('../../util');
 const { DEFAULT_LOG_LEVEL } = require('../../util/constants');
 const Log = require('../../util/log');
@@ -38,12 +38,21 @@ class TrackPublication extends EventEmitter {
         value: options.log || new Log('default', this, logLevels)
       },
       trackName: {
+        enumerable: true,
         value: trackName
       },
       trackSid: {
+        enumerable: true,
         value: trackSid
       }
     });
+  }
+
+  toJSON() {
+    return {
+      trackName: this.trackName,
+      trackSid: this.trackSid
+    };
   }
 
   toString() {

--- a/lib/media/track/trackpublication.js
+++ b/lib/media/track/trackpublication.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const EventEmitter = require('../../eventemitter');
-const { buildLogLevels } = require('../../util');
+const { buildLogLevels, valueToJSON } = require('../../util');
 const { DEFAULT_LOG_LEVEL } = require('../../util/constants');
 const Log = require('../../util/log');
 let nInstances = 0;
@@ -49,10 +49,7 @@ class TrackPublication extends EventEmitter {
   }
 
   toJSON() {
-    return {
-      trackName: this.trackName,
-      trackSid: this.trackSid
-    };
+    return valueToJSON(this);
   }
 
   toString() {

--- a/lib/media/track/videotrack.js
+++ b/lib/media/track/videotrack.js
@@ -145,6 +145,12 @@ class VideoTrack extends MediaTrack {
   detach() {
     return super.detach.apply(this, arguments);
   }
+
+  toJSON() {
+    return Object.assign(super.toJSON(), {
+      dimensions: this.dimensions
+    });
+  }
 }
 
 const DIMENSIONS_CHANGED = VideoTrack.DIMENSIONS_CHANGED = 'dimensionsChanged';

--- a/lib/media/track/videotrack.js
+++ b/lib/media/track/videotrack.js
@@ -145,12 +145,6 @@ class VideoTrack extends MediaTrack {
   detach() {
     return super.detach.apply(this, arguments);
   }
-
-  toJSON() {
-    return Object.assign(super.toJSON(), {
-      dimensions: this.dimensions
-    });
-  }
 }
 
 const DIMENSIONS_CHANGED = VideoTrack.DIMENSIONS_CHANGED = 'dimensionsChanged';

--- a/lib/participant.js
+++ b/lib/participant.js
@@ -1,12 +1,12 @@
 'use strict';
 
+const EventEmitter = require('./eventemitter');
 const RemoteAudioTrack = require('./media/track/remoteaudiotrack');
 const RemoteAudioTrackPublication = require('./media/track/remoteaudiotrackpublication');
 const RemoteDataTrack = require('./media/track/remotedatatrack');
 const RemoteDataTrackPublication = require('./media/track/remotedatatrackpublication');
 const RemoteVideoTrack = require('./media/track/remotevideotrack');
 const RemoteVideoTrackPublication = require('./media/track/remotevideotrackpublication');
-const EventEmitter = require('events').EventEmitter;
 const util = require('./util');
 
 let nInstances = 0;
@@ -28,6 +28,8 @@ let nInstances = 0;
  * @property {Map<Track.SID, DataTrackPublication>} dataTrackPublications -
  *    The {@link Participant}'s {@link DataTrackPublication}s.
  * @property {Participant.Identity} identity - The identity of the {@link Participant}
+ * @property {?NetworkQualityLevel} networkQualityLevel - The
+ *    {@link Participant}'s current {@link NetworkQualityLevel}, if any
  * @property {Participant.SID} sid - The {@link Participant}'s SID
  * @property {string} state - "connected", "disconnected" or "failed"
  * @property {Map<Track.ID, Track>} tracks -
@@ -132,6 +134,12 @@ class Participant extends EventEmitter {
           return signaling.identity;
         }
       },
+      networkQualityLevel: {
+        enumerable: true,
+        get() {
+          return this._signaling.networkQualityLevel;
+        }
+      },
       sid: {
         enumerable: true,
         get() {
@@ -192,14 +200,6 @@ class Participant extends EventEmitter {
     // re-emitted from the RemoteTrackPublication instead of RemoteTrack
     // in twilio-video.js@2.0.0 onwards.
     return [];
-  }
-
-  /**
-   * Get the current {@link NetworkQualityLevel}, if any.
-   * @returns {?NetworkQualityLevel} networkQualityLevel - initially null
-   */
-  get networkQualityLevel() {
-    return this._signaling.networkQualityLevel;
   }
 
   /**
@@ -447,6 +447,32 @@ class Participant extends EventEmitter {
     log.debug(`${util.trackPublicationClass(publication)}:`, publication);
     return publication;
   }
+
+  toJSON() {
+    return {
+      audioTracks: tracksOrTrackPublicationsToJSON(this.audioTracks),
+      audioTrackPublications: tracksOrTrackPublicationsToJSON(this.audioTrackPublications),
+      dataTracks: tracksOrTrackPublicationsToJSON(this.dataTracks),
+      dataTrackPublications: tracksOrTrackPublicationsToJSON(this.dataTrackPublications),
+      identity: this.identity,
+      networkQualityLevel: this.networkQualityLevel,
+      sid: this.sid,
+      state: this.state,
+      tracks: tracksOrTrackPublicationsToJSON(this.tracks),
+      trackPublications: tracksOrTrackPublicationsToJSON(this.trackPublications),
+      videoTracks: tracksOrTrackPublicationsToJSON(this.videoTracks),
+      videoTrackPublications: tracksOrTrackPublicationsToJSON(this.videoTrackPublications)
+    };
+  }
+}
+
+/**
+ * @param {Map<string, Track|TrackPublication>} tracksOrTrackPublications
+ * @returns {Object} json
+ */
+function tracksOrTrackPublicationsToJSON(tracksOrTrackPublications) {
+  return [...tracksOrTrackPublications.entries()].reduce((object, [key, value]) =>
+    Object.assign({ [key]: value.toJSON() }, object), {});
 }
 
 /**

--- a/lib/participant.js
+++ b/lib/participant.js
@@ -449,30 +449,8 @@ class Participant extends EventEmitter {
   }
 
   toJSON() {
-    return {
-      audioTracks: tracksOrTrackPublicationsToJSON(this.audioTracks),
-      audioTrackPublications: tracksOrTrackPublicationsToJSON(this.audioTrackPublications),
-      dataTracks: tracksOrTrackPublicationsToJSON(this.dataTracks),
-      dataTrackPublications: tracksOrTrackPublicationsToJSON(this.dataTrackPublications),
-      identity: this.identity,
-      networkQualityLevel: this.networkQualityLevel,
-      sid: this.sid,
-      state: this.state,
-      tracks: tracksOrTrackPublicationsToJSON(this.tracks),
-      trackPublications: tracksOrTrackPublicationsToJSON(this.trackPublications),
-      videoTracks: tracksOrTrackPublicationsToJSON(this.videoTracks),
-      videoTrackPublications: tracksOrTrackPublicationsToJSON(this.videoTrackPublications)
-    };
+    return util.valueToJSON(this);
   }
-}
-
-/**
- * @param {Map<string, Track|TrackPublication>} tracksOrTrackPublications
- * @returns {Object} json
- */
-function tracksOrTrackPublicationsToJSON(tracksOrTrackPublications) {
-  return [...tracksOrTrackPublications.entries()].reduce((object, [key, value]) =>
-    Object.assign({ [key]: value.toJSON() }, object), {});
 }
 
 /**

--- a/lib/room.js
+++ b/lib/room.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const EventEmitter = require('events').EventEmitter;
+const EventEmitter = require('./eventemitter');
 const RemoteParticipant = require('./remoteparticipant');
 const StatsReport = require('./stats/statsreport');
 const { deprecateEvents } = require('./util');
@@ -148,6 +148,27 @@ class Room extends EventEmitter {
       });
     });
   }
+
+  toJSON() {
+    return {
+      dominantSpeaker: this.dominantSpeaker ? this.dominantSpeaker.toJSON() : null,
+      isRecording: this.isRecording,
+      localParticipant: this.localParticipant.toJSON(),
+      name: this.name,
+      participants: participantsToJSON(this.participants),
+      sid: this.sid,
+      state: this.state
+    };
+  }
+}
+
+/**
+ * @param {Map<string, Participant>} participants
+ * @returns {Object} json
+ */
+function participantsToJSON(participants) {
+  return [...participants.entries()].reduce((object, [key, value]) =>
+    Object.assign({ [key]: value.toJSON() }, object), {});
 }
 
 /**

--- a/lib/room.js
+++ b/lib/room.js
@@ -3,7 +3,7 @@
 const EventEmitter = require('./eventemitter');
 const RemoteParticipant = require('./remoteparticipant');
 const StatsReport = require('./stats/statsreport');
-const { deprecateEvents } = require('./util');
+const { deprecateEvents, valueToJSON } = require('./util');
 const { MediaConnectionError } = require('./util/twilio-video-errors');
 
 let nInstances = 0;
@@ -150,25 +150,8 @@ class Room extends EventEmitter {
   }
 
   toJSON() {
-    return {
-      dominantSpeaker: this.dominantSpeaker ? this.dominantSpeaker.toJSON() : null,
-      isRecording: this.isRecording,
-      localParticipant: this.localParticipant.toJSON(),
-      name: this.name,
-      participants: participantsToJSON(this.participants),
-      sid: this.sid,
-      state: this.state
-    };
+    return valueToJSON(this);
   }
-}
-
-/**
- * @param {Map<string, Participant>} participants
- * @returns {Object} json
- */
-function participantsToJSON(participants) {
-  return [...participants.entries()].reduce((object, [key, value]) =>
-    Object.assign({ [key]: value.toJSON() }, object), {});
 }
 
 /**

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -475,6 +475,21 @@ function checkIfSdpSemanticsIsSupported() {
   }
 }
 
+/**
+ * Sets all underscore-prefixed properties on `object` non-enumerable.
+ * @param {Object} object
+ * @returns {void}
+ */
+function hidePrivateProperties(object) {
+  Object.getOwnPropertyNames(object).forEach(name => {
+    if (name.startsWith('_')) {
+      const descriptor = Object.getOwnPropertyDescriptor(object, name);
+      descriptor.enumerable = false;
+      Object.defineProperty(object, name, descriptor);
+    }
+  });
+}
+
 exports.constants = constants;
 exports.asLocalTrack = asLocalTrack;
 exports.asLocalTrackPublication = asLocalTrackPublication;
@@ -485,6 +500,7 @@ exports.filterObject = filterObject;
 exports.flatMap = flatMap;
 exports.getUserAgent = getUserAgent;
 exports.guessBrowser = guessBrowser;
+exports.hidePrivateProperties = hidePrivateProperties;
 exports.makeClientSIPURI = makeClientSIPURI;
 exports.makeServerSIPURI = makeServerSIPURI;
 exports.makeUUID = makeUUID;

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -507,6 +507,68 @@ function hidePrivatePropertiesInClass(klass) {
   };
 }
 
+/**
+ * Convert an Array of values to an Array of JSON values by calling
+ * `valueToJSON` on each value.
+ * @param {Array<*>} array
+ * @returns {Array<*>}
+ */
+function arrayToJSON(array) {
+  return array.map(valueToJSON);
+}
+
+/**
+ * Convert a Set of values to an Array of JSON values by calling `valueToJSON`
+ * on each value.
+ * @param {Set<*>} set
+ * @returns {Array<*>}
+ */
+function setToJSON(set) {
+  return arrayToJSON([...set]);
+}
+
+/**
+ * Convert a Map from strings to values to an object of JSON values by calling
+ * `valueToJSON` on each value.
+ * @param {Map<string, *>} map
+ * @returns {object}
+ */
+function mapToJSON(map) {
+  return [...map.entries()].reduce((json, [key, value]) => {
+    return Object.assign({ [key]: valueToJSON(value) }, json);
+  }, {});
+}
+
+/**
+ * Convert an object to a JSON value by calling `valueToJSON` on its enumerable
+ * keys.
+ * @param {object} object
+ * @returns {object}
+ */
+function objectToJSON(object) {
+  return Object.entries(object).reduce((json, [key, value]) => {
+    return Object.assign({ [key]: valueToJSON(value) }, json);
+  }, {});
+}
+
+/**
+ * Convert a value into a JSON value.
+ * @param {*} value
+ * @returns {*}
+ */
+function valueToJSON(value) {
+  if (Array.isArray(value)) {
+    return arrayToJSON(value);
+  } else if (value instanceof Set) {
+    return setToJSON(value);
+  } else if (value instanceof Map) {
+    return mapToJSON(value);
+  } else if (value && typeof value === 'object') {
+    return objectToJSON(value);
+  }
+  return value;
+}
+
 exports.constants = constants;
 exports.asLocalTrack = asLocalTrack;
 exports.asLocalTrackPublication = asLocalTrackPublication;
@@ -534,3 +596,4 @@ exports.trackClass = trackClass;
 exports.trackPublicationClass = trackPublicationClass;
 exports.validateLocalTrack = validateLocalTrack;
 exports.getSdpFormat = getSdpFormat;
+exports.valueToJSON = valueToJSON;

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -490,6 +490,23 @@ function hidePrivateProperties(object) {
   });
 }
 
+/**
+ * Creates a new subclass which, in the constructor, sets all
+ * underscore-prefixed properties non-enumerable. This is useful for patching up
+ * classes like EventEmitter which may set properties like `_events`.
+ * @param {Function} klass
+ * @returns {Function} subclass
+ */
+function hidePrivatePropertiesInClass(klass) {
+  // NOTE(mroberts): We do this to avoid giving the class a name.
+  return class extends klass {
+    constructor(...args) {
+      super(...args);
+      hidePrivateProperties(this);
+    }
+  };
+}
+
 exports.constants = constants;
 exports.asLocalTrack = asLocalTrack;
 exports.asLocalTrackPublication = asLocalTrackPublication;
@@ -501,6 +518,7 @@ exports.flatMap = flatMap;
 exports.getUserAgent = getUserAgent;
 exports.guessBrowser = guessBrowser;
 exports.hidePrivateProperties = hidePrivateProperties;
+exports.hidePrivatePropertiesInClass = hidePrivatePropertiesInClass;
 exports.makeClientSIPURI = makeClientSIPURI;
 exports.makeServerSIPURI = makeServerSIPURI;
 exports.makeUUID = makeUUID;

--- a/test/unit/spec/localparticipant.js
+++ b/test/unit/spec/localparticipant.js
@@ -974,6 +974,56 @@ describe('LocalParticipant', () => {
       });
     });
   });
+
+  describe('Object.keys', () => {
+    let participant;
+
+    before(() => {
+      participant = new LocalParticipant(makeSignaling(), [], { log });
+    });
+
+    it('only returns public properties', () => {
+      assert.deepEqual(Object.keys(participant), [
+        'audioTracks',
+        'audioTrackPublications',
+        'dataTracks',
+        'dataTrackPublications',
+        'identity',
+        'networkQualityLevel',
+        'sid',
+        'state',
+        'tracks',
+        'trackPublications',
+        'videoTracks',
+        'videoTrackPublications'
+      ]);
+    });
+  });
+
+  describe('#toJSON', () => {
+    let participant;
+
+    before(() => {
+      participant = new LocalParticipant(makeSignaling(), [], { log });
+    });
+
+    it('only returns public properties', () => {
+      assert.deepEqual(participant.toJSON(), {
+        audioTracks: {},
+        audioTrackPublications: {},
+        dataTracks: {},
+        dataTrackPublications: {},
+        identity: participant.identity,
+        networkQualityLevel: participant.networkQualityLevel,
+        sid: participant.sid,
+        state: participant.state,
+        tracks: {},
+        trackPublications: {},
+        videoTracks: {},
+        videoTrackPublications: {}
+      });
+    });
+  });
 });
 
 function makeLocalTrackConstructors(options) {

--- a/test/unit/spec/media/track/localdatatrack.js
+++ b/test/unit/spec/media/track/localdatatrack.js
@@ -129,4 +129,44 @@ describe('LocalDataTrack', () => {
       sinon.assert.calledWith(dataTrackSender.send, data);
     });
   });
+
+  describe('Object.keys', () => {
+    let track;
+
+    before(() => {
+      track = new LocalDataTrack();
+    });
+
+    it('only returns public properties', () => {
+      assert.deepEqual(Object.keys(track), [
+        'id',
+        'kind',
+        'name',
+        'maxPacketLifeTime',
+        'maxRetransmits',
+        'ordered',
+        'reliable'
+      ]);
+    });
+  });
+
+  describe('#toJSON', () => {
+    let track;
+
+    before(() => {
+      track = new LocalDataTrack();
+    });
+
+    it('only returns public properties', () => {
+      assert.deepEqual(track.toJSON(), {
+        id: track.id,
+        kind: track.kind,
+        maxPacketLifeTime: track.maxPacketLifeTime,
+        maxRetransmits: track.maxRetransmits,
+        name: track.name,
+        ordered: track.ordered,
+        reliable: track.reliable
+      });
+    });
+  });
 });

--- a/test/unit/spec/media/track/localmediatrack.js
+++ b/test/unit/spec/media/track/localmediatrack.js
@@ -174,6 +174,70 @@ const log = require('../../../../lib/fakelog');
         track.emit('started', track);
       });
     });
+
+    describe('Object.keys', () => {
+      let track;
+
+      before(() => {
+        track = createLocalMediaTrack(LocalMediaTrack, '1', kind[description]);
+      });
+
+      it('only returns public properties', () => {
+        if (kind[description] === 'audio') {
+          assert.deepEqual(Object.keys(track), [
+            'id',
+            'kind',
+            'name',
+            'isStarted',
+            'mediaStreamTrack',
+            'isEnabled',
+            'isStopped'
+          ]);
+        } else {
+          assert.deepEqual(Object.keys(track), [
+            'id',
+            'kind',
+            'name',
+            'isStarted',
+            'mediaStreamTrack',
+            'dimensions',
+            'isEnabled',
+            'isStopped'
+          ]);
+        }
+      });
+    });
+
+    describe('#toJSON', () => {
+      let track;
+
+      before(() => {
+        track = createLocalMediaTrack(LocalMediaTrack, '1', kind[description]);
+      });
+
+      it('only returns public properties', () => {
+        if (kind[description] === 'audio') {
+          assert.deepEqual(track.toJSON(), {
+            id: track.id,
+            isEnabled: track.isEnabled,
+            isStarted: track.isStarted,
+            isStopped: track.isStopped,
+            kind: track.kind,
+            name: track.name
+          });
+        } else {
+          assert.deepEqual(track.toJSON(), {
+            id: track.id,
+            isEnabled: track.isEnabled,
+            isStarted: track.isStarted,
+            isStopped: track.isStopped,
+            dimensions: track.dimensions,
+            kind: track.kind,
+            name: track.name
+          });
+        }
+      });
+    });
   });
 });
 

--- a/test/unit/spec/media/track/localmediatrack.js
+++ b/test/unit/spec/media/track/localmediatrack.js
@@ -223,6 +223,7 @@ const log = require('../../../../lib/fakelog');
             isStarted: track.isStarted,
             isStopped: track.isStopped,
             kind: track.kind,
+            mediaStreamTrack: track.mediaStreamTrack,
             name: track.name
           });
         } else {
@@ -233,6 +234,7 @@ const log = require('../../../../lib/fakelog');
             isStopped: track.isStopped,
             dimensions: track.dimensions,
             kind: track.kind,
+            mediaStreamTrack: track.mediaStreamTrack,
             name: track.name
           });
         }

--- a/test/unit/spec/media/track/localtrackpublication.js
+++ b/test/unit/spec/media/track/localtrackpublication.js
@@ -103,5 +103,41 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
         });
       });
     }
+
+    describe('Object.keys', () => {
+      let publication;
+
+      before(() => {
+        publication = new LocalTrackPublication('foo', localTrack, () => {});
+      });
+
+      it('only returns public properties', () => {
+        assert.deepEqual(Object.keys(publication), [
+          'trackName',
+          'trackSid',
+          'isTrackEnabled',
+          'kind',
+          'track'
+        ]);
+      });
+    });
+
+    describe('#toJSON', () => {
+      let publication;
+
+      before(() => {
+        publication = new LocalTrackPublication('foo', localTrack, () => {});
+      });
+
+      it('only returns public properties', () => {
+        assert.deepEqual(publication.toJSON(), {
+          isTrackEnabled: publication.isTrackEnabled,
+          kind: publication.kind,
+          track: publication.track.toJSON(),
+          trackName: publication.trackName,
+          trackSid: publication.trackSid
+        });
+      });
+    });
   });
 });

--- a/test/unit/spec/media/track/remotedatatrack.js
+++ b/test/unit/spec/media/track/remotedatatrack.js
@@ -103,6 +103,8 @@ describe('RemoteDataTrack', () => {
     it('only returns public properties', () => {
       assert.deepEqual(track.toJSON(), {
         id: track.id,
+        isEnabled: track.isEnabled,
+        isSubscribed: track.isSubscribed,
         kind: track.kind,
         maxPacketLifeTime: track.maxPacketLifeTime,
         maxRetransmits: track.maxRetransmits,

--- a/test/unit/spec/media/track/remotedatatrack.js
+++ b/test/unit/spec/media/track/remotedatatrack.js
@@ -69,6 +69,50 @@ describe('RemoteDataTrack', () => {
       assert.equal(actualData, expectedData);
     });
   });
+
+  describe('Object.keys', () => {
+    let track;
+
+    before(() => {
+      track = new RemoteDataTrack(dataTrackReceiver);
+    });
+
+    it('only returns public properties', () => {
+      assert.deepEqual(Object.keys(track), [
+        'id',
+        'kind',
+        'name',
+        'isEnabled',
+        'isSubscribed',
+        'maxPacketLifeTime',
+        'maxRetransmits',
+        'ordered',
+        'reliable',
+        'sid'
+      ]);
+    });
+  });
+
+  describe('#toJSON', () => {
+    let track;
+
+    before(() => {
+      track = new RemoteDataTrack(dataTrackReceiver);
+    });
+
+    it('only returns public properties', () => {
+      assert.deepEqual(track.toJSON(), {
+        id: track.id,
+        kind: track.kind,
+        maxPacketLifeTime: track.maxPacketLifeTime,
+        maxRetransmits: track.maxRetransmits,
+        name: track.name,
+        ordered: track.ordered,
+        reliable: track.reliable,
+        sid: track.sid
+      });
+    });
+  });
 });
 
 function makeDataChannel() {

--- a/test/unit/spec/media/track/remotemediatrack.js
+++ b/test/unit/spec/media/track/remotemediatrack.js
@@ -107,6 +107,74 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
         });
       });
     });
+
+    describe('Object.keys', () => {
+      let track;
+
+      before(() => {
+        track = makeTrack('foo', kind, true, null, RemoteTrack);
+      });
+
+      it('only returns public properties', () => {
+        if (kind === 'audio') {
+          assert.deepEqual(Object.keys(track), [
+            'id',
+            'kind',
+            'name',
+            'isStarted',
+            'mediaStreamTrack',
+            'isEnabled',
+            'isSubscribed',
+            'sid'
+          ]);
+        } else {
+          assert.deepEqual(Object.keys(track), [
+            'id',
+            'kind',
+            'name',
+            'isStarted',
+            'mediaStreamTrack',
+            'dimensions',
+            'isEnabled',
+            'isSubscribed',
+            'sid'
+          ]);
+        }
+      });
+    });
+
+    describe('#toJSON', () => {
+      let track;
+
+      before(() => {
+        track = makeTrack('foo', kind, true, null, RemoteTrack);
+      });
+
+      it('only returns public properties', () => {
+        if (kind === 'audio') {
+          assert.deepEqual(track.toJSON(), {
+            id: track.id,
+            isEnabled: track.isEnabled,
+            isStarted: track.isStarted,
+            isSubscribed: track.isSubscribed,
+            kind: track.kind,
+            name: track.name,
+            sid: track.sid
+          });
+        } else {
+          assert.deepEqual(track.toJSON(), {
+            dimensions: track.dimensions,
+            id: track.id,
+            isEnabled: track.isEnabled,
+            isStarted: track.isStarted,
+            isSubscribed: track.isSubscribed,
+            kind: track.kind,
+            name: track.name,
+            sid: track.sid
+          });
+        }
+      });
+    });
   });
 });
 

--- a/test/unit/spec/media/track/remotemediatrack.js
+++ b/test/unit/spec/media/track/remotemediatrack.js
@@ -158,6 +158,7 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
             isStarted: track.isStarted,
             isSubscribed: track.isSubscribed,
             kind: track.kind,
+            mediaStreamTrack: track.mediaStreamTrack,
             name: track.name,
             sid: track.sid
           });
@@ -169,6 +170,7 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
             isStarted: track.isStarted,
             isSubscribed: track.isSubscribed,
             kind: track.kind,
+            mediaStreamTrack: track.mediaStreamTrack,
             name: track.name,
             sid: track.sid
           });

--- a/test/unit/spec/media/track/remotetrackpublication.js
+++ b/test/unit/spec/media/track/remotetrackpublication.js
@@ -214,6 +214,44 @@ const RemoteVideoTrackPublication = require('../../../../../lib/media/track/remo
         });
       });
     });
+
+    describe('Object.keys', () => {
+      let publication;
+
+      before(() => {
+        publication = new RemoteTrackPublication(makeSignaling(true, kind, 'MT123'));
+      });
+
+      it('only returns public properties', () => {
+        assert.deepEqual(Object.keys(publication), [
+          'trackName',
+          'trackSid',
+          'isSubscribed',
+          'isTrackEnabled',
+          'kind',
+          'track'
+        ]);
+      });
+    });
+
+    describe('#toJSON', () => {
+      let publication;
+
+      before(() => {
+        publication = new RemoteTrackPublication(makeSignaling(true, kind, 'MT123'));
+      });
+
+      it('only returns public properties', () => {
+        assert.deepEqual(publication.toJSON(), {
+          isSubscribed: publication.isSubscribed,
+          isTrackEnabled: publication.isTrackEnabled,
+          kind: publication.kind,
+          track: null,
+          trackName: publication.trackName,
+          trackSid: publication.trackSid
+        });
+      });
+    });
   });
 });
 

--- a/test/unit/spec/remoteparticipant.js
+++ b/test/unit/spec/remoteparticipant.js
@@ -1523,6 +1523,56 @@ describe('RemoteParticipant', () => {
       });
     });
   });
+
+  describe('Object.keys', () => {
+    let participant;
+
+    before(() => {
+      participant = new RemoteParticipant(makeSignaling(), { log });
+    });
+
+    it('only returns public properties', () => {
+      assert.deepEqual(Object.keys(participant), [
+        'audioTracks',
+        'audioTrackPublications',
+        'dataTracks',
+        'dataTrackPublications',
+        'identity',
+        'networkQualityLevel',
+        'sid',
+        'state',
+        'tracks',
+        'trackPublications',
+        'videoTracks',
+        'videoTrackPublications'
+      ]);
+    });
+  });
+
+  describe('#toJSON', () => {
+    let participant;
+
+    before(() => {
+      participant = new RemoteParticipant(makeSignaling(), { log });
+    });
+
+    it('only returns public properties', () => {
+      assert.deepEqual(participant.toJSON(), {
+        audioTracks: {},
+        audioTrackPublications: {},
+        dataTracks: {},
+        dataTrackPublications: {},
+        identity: participant.identity,
+        networkQualityLevel: participant.networkQualityLevel,
+        sid: participant.sid,
+        state: participant.state,
+        tracks: {},
+        trackPublications: {},
+        videoTracks: {},
+        videoTrackPublications: {}
+      });
+    });
+  });
 });
 
 
@@ -1608,11 +1658,12 @@ function makeTest(options) {
 }
 
 function makeSignaling(options) {
+  options = options || {};
   const signaling = new EventEmitter();
   signaling.sid = options.sid;
   signaling.identity = options.identity;
   signaling.state = options.state;
-  signaling.tracks = options.trackSignalings;
+  signaling.tracks = options.trackSignalings || [];
   return signaling;
 }
 

--- a/test/unit/spec/room.js
+++ b/test/unit/spec/room.js
@@ -4,6 +4,7 @@ const assert = require('assert');
 const sinon = require('sinon');
 
 const Room = require('../../../lib/room');
+const LocalParticipant = require('../../../lib/localparticipant');
 const ParticipantSignaling = require('../../../lib/signaling/participant');
 const RemoteParticipantSignaling = require('../../../lib/signaling/remoteparticipant');
 const RoomSignaling = require('../../../lib/signaling/room');
@@ -275,6 +276,52 @@ describe('Room', () => {
       signaling.preempt('connected');
       assert.equal(spy.callCount, 1);
       assert.equal(room.state, 'connected');
+    });
+  });
+
+  describe('Object.keys', () => {
+    let room;
+
+    beforeEach(() => {
+      const localParticipantSignaling = new ParticipantSignaling('PAXXX', 'client');
+      const localParticipant = new LocalParticipant(localParticipantSignaling, [], { log });
+      const signaling = new RoomSignaling(localParticipant, 'RM123', 'foo');
+      room = new Room(localParticipant, signaling, options);
+    });
+
+    it('only returns public properties', () => {
+      assert.deepEqual(Object.keys(room), [
+        'dominantSpeaker',
+        'isRecording',
+        'localParticipant',
+        'name',
+        'participants',
+        'sid',
+        'state'
+      ]);
+    });
+  });
+
+  describe('#toJSON', () => {
+    let room;
+
+    beforeEach(() => {
+      const localParticipantSignaling = new ParticipantSignaling('PAXXX', 'client');
+      const localParticipant = new LocalParticipant(localParticipantSignaling, [], { log });
+      const signaling = new RoomSignaling(localParticipant, 'RM123', 'foo');
+      room = new Room(localParticipant, signaling, options);
+    });
+
+    it('only returns public properties', () => {
+      assert.deepEqual(room.toJSON(), {
+        dominantSpeaker: room.dominantSpeaker ? room.dominantSpeaker.toJSON() : null,
+        isRecording: room.isRecording,
+        localParticipant: room.localParticipant.toJSON(),
+        name: room.name,
+        participants: {},
+        sid: room.sid,
+        state: room.state
+      });
     });
   });
 });

--- a/test/unit/spec/util/index.js
+++ b/test/unit/spec/util/index.js
@@ -4,9 +4,22 @@ const assert = require('assert');
 const { EventEmitter } = require('events');
 const sinon = require('sinon');
 
-const { makeUUID, promiseFromEvents } = require('../../../../lib/util');
+const {
+  hidePrivateProperties,
+  makeUUID,
+  promiseFromEvents
+} = require('../../../../lib/util');
 
 describe('util', () => {
+  describe('hidePrivateProperties', () => {
+    it('should do what it says', () => {
+      const object = { foo: 'bar', _baz: 'qux' };
+      assert.deepEqual(Object.keys(object), ['foo', '_baz']);
+      hidePrivateProperties(object);
+      assert.deepEqual(Object.keys(object), ['foo']);
+    });
+  });
+
   describe('makeUUID', () => {
     it('should generate a unique UUID', () => {
       const uuid1 = makeUUID();

--- a/test/unit/spec/util/index.js
+++ b/test/unit/spec/util/index.js
@@ -6,6 +6,7 @@ const sinon = require('sinon');
 
 const {
   hidePrivateProperties,
+  hidePrivatePropertiesInClass,
   makeUUID,
   promiseFromEvents
 } = require('../../../../lib/util');
@@ -17,6 +18,27 @@ describe('util', () => {
       assert.deepEqual(Object.keys(object), ['foo', '_baz']);
       hidePrivateProperties(object);
       assert.deepEqual(Object.keys(object), ['foo']);
+    });
+  });
+
+  describe('hidePrivatePropertiesInClass', () => {
+    it('should do what it says', () => {
+      class Foo1 {
+        constructor() {
+          this.args = [].slice.call(arguments);
+          this._foo = 'bar';
+          this._baz = 'qux';
+        }
+      }
+
+      const foo1 = new Foo1(1, 2, 3);
+      assert.deepEqual(Object.keys(foo1), ['args', '_foo', '_baz']);
+      assert.deepEqual(foo1.args, [1, 2, 3]);
+
+      const Foo2 = hidePrivatePropertiesInClass(Foo1);
+      const foo2 = new Foo2(1, 2, 3);
+      assert.deepEqual(Object.keys(foo2), ['args']);
+      assert.deepEqual(foo2.args, [1, 2, 3]);
     });
   });
 


### PR DESCRIPTION
_Work-in-progress. Not ready to merge._

When we moved to ES6 classes, we didn't really think about the effect of adopting ES6 class getters. These differ from the instance getters we previously defined, because they don't show up when calling `Object.getOwnProperties(instance)`. This is because they are defined on the `prototype`. As a consequence of this, `Object.assign` and object spread (`{ ...foo }`) might not copy all the properties we're interested in. Of course, you can always pick out the properties by hand, but it'd be nice if we could support this syntax. To do so, we'd have to abandon ES6 getters and move these back into the constructor.

So, open question, would we consider moving away from ES6 getters? I haven't begun implementing in this PR yet. **EDIT:** Based on discussion today, we're OK with it.

Changes included in this PR:

* [x] Adding `toJSON` (which is used by `JSON.stringify`) to public classes
* [x] Cleaning up enumerable, "own" properties (as returned by `Object.getOwnProperties(instances)`), and filtering out "extra" properties (including those set by EventEmitter's constructor).
* [x] Moving class-level getters back into constructors.