### PR TITLE
JSDK-2096: Documenting "subscriptionFailed" event

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ twilio-video.js
 
 twilio-video.js allows you to add real-time voice and video to your web apps.
 
-* [API Docs](//media.twiliocdn.com/sdk/js/video/v1/docs)
+* [API Docs](//media.twiliocdn.com/sdk/js/video/releases/2.0.0-beta1/docs)
 * [Quickstart and Examples](//github.com/twilio/video-quickstart-js)
 * [Common Issues](https://github.com/twilio/twilio-video.js/blob/master/COMMON_ISSUES.md)
 
@@ -56,7 +56,7 @@ Releases of twilio-video.js are hosted on a CDN, and you can include these
 directly in your web app using a &lt;script&gt; tag.
 
 ```html
-<script src="//media.twiliocdn.com/sdk/js/video/v1/twilio-video.min.js"></script>
+<script src="//media.twiliocdn.com/sdk/js/video/releases/2.0.0-beta1/twilio-video.min.js"></script>
 ```
 
 Using this method, twilio-video.js will set a browser global:
@@ -69,7 +69,7 @@ Usage
 -----
 
 The following is a simple example for connecting to a Room. For more information, refer to the
-[API Docs](//media.twiliocdn.com/sdk/js/video/v1/docs).
+[API Docs](//media.twiliocdn.com/sdk/js/video/releases/2.0.0-beta1/docs).
 
 ```js
 const Video = require('twilio-video');

--- a/lib/media/track/remoteaudiotrackpublication.js
+++ b/lib/media/track/remoteaudiotrackpublication.js
@@ -9,6 +9,7 @@ const RemoteTrackPublication = require('./remotetrackpublication');
  * @property {?RemoteAudioTrack} track - unless you have subscribed to the
  *   {@link RemoteAudioTrack}, this property is null
  * @emits RemoteAudioTrackPublication#subscribed
+ * @emits RemoteAudioTrackPublication#subscriptionFailed
  * @emits RemoteAudioTrackPublication#trackDisabled
  * @emits RemoteAudioTrackPublication#trackEnabled
  * @emits RemoteAudioTrackPublication#unsubscribed
@@ -33,6 +34,13 @@ class RemoteAudioTrackPublication extends RemoteTrackPublication {
  * Your {@link LocalParticipant} subscribed to the {@link RemoteAudioTrack}.
  * @param {RemoteAudioTrack} track - the {@link RemoteAudioTrack} that was subscribed to
  * @event RemoteAudioTrackPublication#subscribed
+ */
+
+/**
+ * Your {@link LocalParticipant failed to subscribe to the {@link RemoteAudioTrack}.
+ * @param {TwilioError} error - the reason the {@link RemoteAudioTrack} could not be
+ *   subscribed to
+ * @event RemoteAudioTrackPublication#subscriptionFailed
  */
 
 /**

--- a/lib/media/track/remotedatatrackpublication.js
+++ b/lib/media/track/remotedatatrackpublication.js
@@ -9,6 +9,7 @@ const RemoteTrackPublication = require('./remotetrackpublication');
  * @property {?RemoteDataTrack} track - unless you have subscribed to the
  *   {@link RemoteDataTrack}, this property is null
  * @emits RemoteDataTrackPublication#subscribed
+ * @emits RemoteDataTrackPublication#subscriptionFailed
  * @emits RemoteDataTrackPublication#unsubscribed
  */
 class RemoteDataTrackPublication extends RemoteTrackPublication {
@@ -31,6 +32,13 @@ class RemoteDataTrackPublication extends RemoteTrackPublication {
  * Your {@link LocalParticipant} subscribed to the {@link RemoteDataTrack}.
  * @param {RemoteDataTrack} track - the {@link RemoteDataTrack} that was subscribed to
  * @event RemoteDataTrackPublication#subscribed
+ */
+
+/**
+ * Your {@link LocalParticipant failed to subscribe to the {@link RemoteDataTrack}.
+ * @param {TwilioError} error - the reason the {@link RemoteDataTrack} could not be
+ *   subscribed to
+ * @event RemoteDataTrackPublication#subscriptionFailed
  */
 
 /**

--- a/lib/media/track/remotetrackpublication.js
+++ b/lib/media/track/remotetrackpublication.js
@@ -7,6 +7,7 @@ const TrackPublication = require('./trackpublication');
  * been published to a {@link Room}.
  * @property {Track.Kind} kind - kind of the published {@link RemoteTrack}
  * @emits RemoteTrackPublication#subscribed
+ * @emits RemoteTrackPublication#subscriptionFailed
  * @emits RemoteTrackPublication#trackDisabled
  * @emits RemoteTrackPublication#trackEnabled
  * @emits RemoteTrackPublication#unsubscribed
@@ -102,6 +103,13 @@ class RemoteTrackPublication extends TrackPublication {
  * Your {@link LocalParticipant} subscribed to the {@link RemoteTrack}.
  * @param {RemoteTrack} track - the {@link RemoteTrack} that was subscribed to
  * @event RemoteTrackPublication#subscribed
+ */
+
+/**
+ * Your {@link LocalParticipant failed to subscribe to the {@link RemoteTrack}.
+ * @param {TwilioError} error - the reason the {@link RemoteTrack} could not be
+ *   subscribed to
+ * @event RemoteTrackPublication#subscriptionFailed
  */
 
 /**

--- a/lib/media/track/remotevideotrackpublication.js
+++ b/lib/media/track/remotevideotrackpublication.js
@@ -9,6 +9,7 @@ const RemoteTrackPublication = require('./remotetrackpublication');
  * @property {?RemoteVideoTrack} track - unless you have subscribed to the
  *   {@link RemoteVideoTrack}, this property is null
  * @emits RemoteVideoTrackPublication#subscribed
+ * @emits RemoteVideoTrackPublication#subscriptionFailed
  * @emits RemoteVideoTrackPublication#trackDisabled
  * @emits RemoteVideoTrackPublication#trackEnabled
  * @emits RemoteVideoTrackPublication#unsubscribed
@@ -33,6 +34,13 @@ class RemoteVideoTrackPublication extends RemoteTrackPublication {
  * Your {@link LocalParticipant} subscribed to the {@link RemoteVideoTrack}.
  * @param {RemoteVideoTrack} track - the {@link RemoteVideoTrack} that was subscribed to
  * @event RemoteVideoTrackPublication#subscribed
+ */
+
+/**
+ * Your {@link LocalParticipant failed to subscribe to the {@link RemoteVideoTrack}.
+ * @param {TwilioError} error - the reason the {@link RemoteVideoTrack} could not be
+ *   subscribed to
+ * @event RemoteVideoTrackPublication#subscriptionFailed
  */
 
 /**


### PR DESCRIPTION
@markandrus 

Corollary: Also updated README.md links to point to `2.0.0-beta1`.