### PR TITLE
JSDK-2098 (2.x)

### DIFF
--- a/lib/data/transport.js
+++ b/lib/data/transport.js
@@ -20,7 +20,14 @@ class DataTransport extends EventEmitter {
     Object.defineProperties(this, {
       _dataChannel: {
         value: dataChannel
+      },
+      _messageQueue: {
+        value: []
       }
+    });
+
+    dataChannel.addEventListener('open', () => {
+      this._messageQueue.splice(0).forEach(message => this._publish(message));
     });
 
     dataChannel.addEventListener('message', ({ data }) => {
@@ -34,18 +41,30 @@ class DataTransport extends EventEmitter {
   }
 
   /**
+   * @param message
+   * @private
+   */
+  _publish(message) {
+    const data = JSON.stringify(message);
+    this._dataChannel.send(data);
+  }
+
+  /**
    * Publish a message. Returns true if calling the method resulted in
    * publishing (or eventually publishing) the update.
    * @param {object} message
    * @returns {boolean}
    */
   publish(message) {
-    try {
-      const data = JSON.stringify(message);
-      this._dataChannel.send(data);
-    } catch (error) {
+    const dataChannel = this._dataChannel;
+    if (dataChannel.readyState === 'closing' || dataChannel.readyState === 'closed') {
       return false;
     }
+    if (dataChannel.readyState === 'connecting') {
+      this._messageQueue.push(message);
+      return true;
+    }
+    this._publish(message);
     return true;
   }
 }

--- a/test/integration/spec/room.js
+++ b/test/integration/spec/room.js
@@ -246,6 +246,38 @@ describe('Room', function() {
     });
   });
 
+  // eslint-disable-next-line
+  (process.env.TOPOLOGY === 'SFU' ? describe : describe.skip)('"dominantSpeakerChanged" event', () => {
+    const _enableDominantSpeaker = true;
+    const name = randomName();
+    const options = Object.assign({ _enableDominantSpeaker, name }, defaults);
+    let thisRoom;
+    let thatRoom;
+    let dominantSpeaker;
+
+    before(async () => {
+      thisRoom = await connect(getToken(randomName()), Object.assign({ tracks: [] }, options));
+      const promise = new Promise(resolve => thisRoom.on('dominantSpeakerChanged', resolve));
+
+      const tracks = await createLocalTracks({ audio: true, fake: true });
+      thatRoom = await connect(getToken(randomName()), Object.assign({ tracks }, options));
+      dominantSpeaker = await promise;
+    });
+
+    it('is raised whenever the dominant speaker in the Room changes', () => {
+      assert.equal(dominantSpeaker, thisRoom.participants.get(dominantSpeaker.sid));
+    });
+
+    after(() => {
+      if (thisRoom) {
+        thisRoom.disconnect();
+      }
+      if (thatRoom) {
+        thatRoom.disconnect();
+      }
+    });
+  });
+
   describe('"participantConnected" event', () => {
     let thisRoom;
     let thatRoom;

--- a/test/integration/spec/room.js
+++ b/test/integration/spec/room.js
@@ -248,9 +248,7 @@ describe('Room', function() {
 
   // eslint-disable-next-line
   (process.env.TOPOLOGY === 'SFU' ? describe : describe.skip)('"dominantSpeakerChanged" event', () => {
-    const _enableDominantSpeaker = true;
-    const name = randomName();
-    const options = Object.assign({ _enableDominantSpeaker, name }, defaults);
+    const options = Object.assign({ name: randomName() }, defaults);
     let thisRoom;
     let thatRoom;
     let dominantSpeaker;

--- a/test/unit/spec/data/transport.js
+++ b/test/unit/spec/data/transport.js
@@ -10,7 +10,7 @@ describe('DataTransport', () => {
   describe('"message"', () => {
     describe('when the underlying RTCDataChannel emits a "message" event containing a JSON string', () => {
       it('emits a "message" event with the result of JSON.parse', () => {
-        const dataChannel = new EventTarget();
+        const dataChannel = mockRTCDataChannel();
         const dataTransport = new DataTransport(dataChannel);
         const expectedMessage = { foo: 'bar' };
         let actualMessage;
@@ -22,7 +22,7 @@ describe('DataTransport', () => {
 
     describe('when the underlying RTCDataChannel emits a "message" event containing something other than a JSON string', () => {
       it('does not emit a "message" event', () => {
-        const dataChannel = new EventTarget();
+        const dataChannel = mockRTCDataChannel();
         const dataTransport = new DataTransport(dataChannel);
         let didEmitMessage = false;
         dataTransport.once('message', () => { didEmitMessage = true; });
@@ -32,14 +32,63 @@ describe('DataTransport', () => {
     });
   });
 
-  describe('#publish', () => {
-    it('calls #send on the RTCDataChannel with the result of JSON.stringify', () => {
-      const dataChannel = new EventTarget();
-      dataChannel.send = sinon.spy();
-      const dataTransport = new DataTransport(dataChannel);
-      const message = { foo: 'bar' };
-      dataTransport.publish(message);
-      assert(dataChannel.send.calledWith(JSON.stringify(message)));
+  describe('#publish, called when the underlying RTCDataChannel\'s .readyState is', () => {
+    ['connecting', 'open', 'closing', 'closed'].forEach(readyState => {
+      context(`"${readyState}"`, () => {
+        let dataChannel;
+        let dataTransport;
+        let ret;
+
+        before(() => {
+          dataChannel = mockRTCDataChannel(readyState);
+          dataTransport = new DataTransport(dataChannel);
+          ret = dataTransport.publish({ foo: 'bar' });
+        });
+
+        const expectedRet = readyState === 'connecting' || readyState === 'open';
+        it(`should return ${expectedRet}`, () => {
+          assert.equal(ret, expectedRet);
+        });
+
+        if (readyState === 'open') {
+          it('should call #send on the underlying RTCDataChannel', () => {
+            sinon.assert.calledWith(dataChannel.send, JSON.stringify({ foo: 'bar' }));
+          });
+          return;
+        }
+
+        it('should not call #send on the underlying RTCDataChannel', () => {
+          sinon.assert.notCalled(dataChannel.send);
+        });
+
+        if (readyState === 'connecting') {
+          context('when the underlying RTCDataChannel\'s .readyState transitions to "open"', () => {
+            before(() => {
+              dataChannel.open();
+            });
+
+            it('should call #send on the underlying RTCDataChannel', () => {
+              sinon.assert.calledWith(dataChannel.send, JSON.stringify({ foo: 'bar' }));
+            });
+          });
+        }
+      });
     });
   });
 });
+
+function mockRTCDataChannel(readyState = 'open') {
+  const dataChannel = new EventTarget();
+  dataChannel.readyState = readyState;
+
+  dataChannel.open = () => {
+    if (dataChannel.readyState === 'open') {
+      return;
+    }
+    dataChannel.readyState = 'open';
+    dataChannel.dispatchEvent({ type: 'open' });
+  };
+
+  dataChannel.send = sinon.spy(() => {});
+  return dataChannel;
+}


### PR DESCRIPTION
@markandrus

This PR fixes [JSDK-2098](https://issues.corp.twilio.com/browse/JSDK-2098) by ensuring that the DataTransport's RTCDataChannel's .readyState is "open" before sending the "ready" message.