### PR TITLE
JSDK-2097: Always add dummyAudioTrack first

### DIFF
--- a/lib/signaling/v2/peerconnectionmanager.js
+++ b/lib/signaling/v2/peerconnectionmanager.js
@@ -247,11 +247,10 @@ class PeerConnectionManager extends QueueingEventEmitter {
    */
   setTrackSenders(trackSenders) {
     const dataTrackSenders = new Set(trackSenders.filter(trackSender => trackSender.kind === 'data'));
-    const mediaTrackSenders = new Set(trackSenders.filter(trackSender => trackSender.kind === 'audio' || trackSender.kind === 'video'));
 
-    if (this._dummyAudioTrackSender) {
-      mediaTrackSenders.add(this._dummyAudioTrackSender);
-    }
+    const mediaTrackSenders = new Set([this._dummyAudioTrackSender]
+      .concat(trackSenders)
+      .filter(trackSender => trackSender && (trackSender.kind === 'audio' || trackSender.kind === 'video')));
 
     const changes = getTrackSenderChanges(this, dataTrackSenders, mediaTrackSenders);
     this._dataTrackSenders = dataTrackSenders;

--- a/test/unit/spec/signaling/v2/peerconnectionmanager.js
+++ b/test/unit/spec/signaling/v2/peerconnectionmanager.js
@@ -613,7 +613,7 @@ describe('PeerConnectionManager', () => {
         context(`when AudioContext is ${isAudioContextSupported ? '' : 'not'} supported`, () => {
           it(`calls addMediaTrackSender for the MediaTrackSenders containing any previously-added MediaStreamTracks ${isAudioContextSupported ? ' and the dummy audio MediaTrackSender' : ''} on the new PeerConnectionV2`, async () => {
             const test = makeTest({ isAudioContextSupported });
-            const mediaStream = makeMediaStream();
+            const mediaStream = makeMediaStream({ video: 1 });
             const trackSenders = mediaStream.getTracks().map(makeTrackSender);
 
             test.peerConnectionManager.setTrackSenders(trackSenders);
@@ -624,6 +624,9 @@ describe('PeerConnectionManager', () => {
             const addedMediaTracks = test.peerConnectionV2s[0].addMediaTrackSender.args.map(([sender]) => sender.track);
             const dummyAudioTrack = (test.peerConnectionManager._dummyAudioTrackSender || { track: null }).track;
             assert.deepEqual(addedMediaTracks.filter(track => dummyAudioTrack !== track), mediaStream.getTracks());
+            if (dummyAudioTrack) {
+              assert.equal(addedMediaTracks[0], dummyAudioTrack, 'the dummy audio MediaTrackSender should be added first');
+            }
           });
         });
       });


### PR DESCRIPTION
Notes:

* I had to update the call to `makeMediaStream`; otherwise, the test trivially passed because no other MediaStreamTracks were added, meaning the dummy MediaStreamTrack was always first.
* In the future, we should eliminate the dummy MediaStreamTrack in favor of a single call to `addTransceiver('audio')`.