### PR TITLE
JSDK-2095: DataTransport should send "ready" message

### DIFF
--- a/lib/data/transport.js
+++ b/lib/data/transport.js
@@ -38,6 +38,8 @@ class DataTransport extends EventEmitter {
         // Do nothing.
       }
     });
+
+    this.publish({ type: 'ready' });
   }
 
   /**

--- a/lib/signaling/v2/dominantspeakersignaling.js
+++ b/lib/signaling/v2/dominantspeakersignaling.js
@@ -21,8 +21,6 @@ class DominantSpeakerSignaling extends EventEmitter {
       },
     });
 
-    mediaSignalingTransport.publish({ type: 'ready' });
-
     mediaSignalingTransport.on('message', message => {
       switch (message.type) {
         case 'active_speaker':

--- a/test/unit/spec/data/transport.js
+++ b/test/unit/spec/data/transport.js
@@ -7,6 +7,14 @@ const DataTransport = require('../../../../lib/data/transport');
 const EventTarget = require('../../../../lib/eventtarget');
 
 describe('DataTransport', () => {
+  describe('constructor', () => {
+    it('sends a "ready" message over the underlying RTCDataChannel', () => {
+      const dataChannel = mockRTCDataChannel();
+      new DataTransport(dataChannel);
+      sinon.assert.calledWith(dataChannel.send, JSON.stringify({ type: 'ready' }));
+    });
+  });
+
   describe('"message"', () => {
     describe('when the underlying RTCDataChannel emits a "message" event containing a JSON string', () => {
       it('emits a "message" event with the result of JSON.parse', () => {


### PR DESCRIPTION
Since we move sending the "ready" message into DataTransport, it'll fire for Dominant Speaker and Network Quality APIs.