### PR TITLE
Prepare for 1.13.1 rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
-1.13.0 (July 30, 2018)
+1.13.1 (in progress)
 ====================
+
+Bug Fixes
+---------
+
+- Worked around Firefox [Bug 1480277](https://bugzilla.mozilla.org/show_bug.cgi?id=1480277).
+
+1.13.0 (July 30, 2018)
+======================
 
 New Features
 ------------

--- a/lib/data/transport.js
+++ b/lib/data/transport.js
@@ -38,6 +38,8 @@ class DataTransport extends EventEmitter {
         // Do nothing.
       }
     });
+
+    this.publish({ type: 'ready' });
   }
 
   /**

--- a/lib/signaling/v2/dominantspeakersignaling.js
+++ b/lib/signaling/v2/dominantspeakersignaling.js
@@ -21,8 +21,6 @@ class DominantSpeakerSignaling extends EventEmitter {
       },
     });
 
-    mediaSignalingTransport.publish({ type: 'ready' });
-
     mediaSignalingTransport.on('message', message => {
       switch (message.type) {
         case 'active_speaker':

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   },
   "dependencies": {
     "@twilio/sip.js": "^0.7.7",
-    "@twilio/webrtc": "^2.1.1",
+    "@twilio/webrtc": "twilio/twilio-webrtc.js#2.1.2-rc1",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },

--- a/test/unit/spec/data/transport.js
+++ b/test/unit/spec/data/transport.js
@@ -7,6 +7,14 @@ const DataTransport = require('../../../../lib/data/transport');
 const EventTarget = require('../../../../lib/eventtarget');
 
 describe('DataTransport', () => {
+  describe('constructor', () => {
+    it('sends a "ready" message over the underlying RTCDataChannel', () => {
+      const dataChannel = mockRTCDataChannel();
+      new DataTransport(dataChannel);
+      sinon.assert.calledWith(dataChannel.send, JSON.stringify({ type: 'ready' }));
+    });
+  });
+
   describe('"message"', () => {
     describe('when the underlying RTCDataChannel emits a "message" event containing a JSON string', () => {
       it('emits a "message" event with the result of JSON.parse', () => {


### PR DESCRIPTION
This bumps the twilio-webrtc.js dependency for the RC, and it includes the fix for JSDK-2095.