### PR TITLE
JSDK-2118: Reduce MediaStream usage in Firefox

### DIFF
--- a/lib/media/track/audiotrack.js
+++ b/lib/media/track/audiotrack.js
@@ -27,6 +27,16 @@ class AudioTrack extends MediaTrack {
   }
 
   /**
+   * @private
+   */
+  _start() {
+    super._start();
+    if (this._dummyEl) {
+      this._detachElement(this._dummyEl);
+    }
+  }
+
+  /**
    * Create an HTMLAudioElement and attach the {@link AudioTrack} to it.
    *
    * The HTMLAudioElement's <code>srcObject</code> will be set to a new

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -71,7 +71,6 @@ class MediaTrack extends Track {
     this._log.debug('Started');
     this._isStarted = true;
     if (this._dummyEl) {
-      this._detachElement(this._dummyEl);
       this._dummyEl.oncanplay = null;
     }
     // eslint-disable-next-line no-use-before-define

--- a/lib/media/track/videotrack.js
+++ b/lib/media/track/videotrack.js
@@ -36,10 +36,32 @@ class VideoTrack extends MediaTrack {
         }
       }
     });
-    Object.defineProperty(this, '_dimensionsChangedElem', {
-      value: emitDimensionsChangedEvents(this)
-    });
     return this;
+  }
+
+  /**
+   * @private
+   */
+  _initialize() {
+    super._initialize();
+    if (this._dummyEl) {
+      this._dummyEl.onloadedmetadata = () => {
+        if (dimensionsChanged(this, this._dummyEl)) {
+          this.dimensions.width = this._dummyEl.videoWidth;
+          this.dimensions.height = this._dummyEl.videoHeight;
+        }
+      };
+      this._dummyEl.onresize = () => {
+        if (dimensionsChanged(this, this._dummyEl)) {
+          this.dimensions.width = this._dummyEl.videoWidth;
+          this.dimensions.height = this._dummyEl.videoHeight;
+          if (this.isStarted) {
+            this._log.debug('Dimensions changed:', this.dimensions);
+            this.emit(VideoTrack.DIMENSIONS_CHANGED, this);
+          }
+        }
+      };
+    }
   }
 
   /**
@@ -147,34 +169,7 @@ class VideoTrack extends MediaTrack {
   }
 }
 
-const DIMENSIONS_CHANGED = VideoTrack.DIMENSIONS_CHANGED = 'dimensionsChanged';
-
-function emitDimensionsChangedEvents(track) {
-  if (typeof document === 'undefined') {
-    return null;
-  }
-  let elem = document.createElement(track.kind);
-  elem.muted = true;
-  elem.onloadedmetadata = function onloadedmetadata() {
-    if (dimensionsChanged(track, elem)) {
-      track.dimensions.width = elem.videoWidth;
-      track.dimensions.height = elem.videoHeight;
-    }
-  };
-  elem.onresize = function onresize() {
-    if (dimensionsChanged(track, elem)) {
-      track.dimensions.width = elem.videoWidth;
-      track.dimensions.height = elem.videoHeight;
-      if (track.isStarted) {
-        track._log.debug('Dimensions changed:', track.dimensions);
-        track.emit(DIMENSIONS_CHANGED, track);
-      }
-    }
-  };
-  elem = track.attach(elem);
-  track._attachments.delete(elem);
-  return elem;
-}
+VideoTrack.DIMENSIONS_CHANGED = 'dimensionsChanged';
 
 function dimensionsChanged(track, elem) {
   return track.dimensions.width !== elem.videoWidth

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -622,6 +622,13 @@ class PeerConnectionV2 extends StateMachine {
         description.sdp,
         this._preferredAudioCodecs,
         this._preferredVideoCodecs);
+      // NOTE(mroberts): Do this to reduce our MediaStream count in Firefox. By
+      // mapping MediaStream IDs in the SDP to "-", we ensure the "track" event
+      // doesn't include any new MediaStreams in Firefox. Its `streams` member
+      // will always be the empty Array.
+      if (isFirefox) {
+        description.sdp = filterOutMediaStreamIds(description.sdp);
+      }
     }
     description = new this._RTCSessionDescription(description);
     return this._peerConnection.setRemoteDescription(description).then(() => {
@@ -988,5 +995,9 @@ function isSenderOfKind(kind, sender) {
  * @property {Array<AudioCodec>} audio
  * @property {Array<VideoCodec>} video
  */
+
+function filterOutMediaStreamIds(sdp) {
+  return sdp.replace(/a=msid:[^ ]+ /g, 'a=msid:- ');
+}
 
 module.exports = PeerConnectionV2;

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -152,7 +152,7 @@ class PeerConnectionV2 extends StateMachine {
         value: null
       },
       _localMediaStream: {
-        value: isFirefox
+        value: isFirefox && RTCPeerConnection.prototype.addTransceiver
           ? null
           : new options.MediaStream()
       },
@@ -753,12 +753,14 @@ class PeerConnectionV2 extends StateMachine {
     if (this._peerConnection.signalingState === 'closed' || this._rtpSenders.has(mediaTrackSender)) {
       return;
     }
+    let sender;
     if (this._localMediaStream) {
       this._localMediaStream.addTrack(mediaTrackSender.track);
+      sender = this._peerConnection.addTrack(mediaTrackSender.track, this._localMediaStream);
+    } else {
+      const transceiver = this._peerConnection.addTransceiver(mediaTrackSender.track);
+      sender = transceiver.sender;
     }
-    const sender = this._localMediaStream
-      ? this._peerConnection.addTrack(mediaTrackSender.track, this._localMediaStream)
-      : this._peerConnection.addTrack(mediaTrackSender.track);
     mediaTrackSender.addSender(sender);
     this._rtpSenders.set(mediaTrackSender, sender);
   }

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -147,7 +147,9 @@ class PeerConnectionV2 extends StateMachine {
         value: null
       },
       _localMediaStream: {
-        value: new options.MediaStream()
+        value: isFirefox
+          ? null
+          : new options.MediaStream()
       },
       _localUfrag: {
         writable: true,
@@ -746,8 +748,12 @@ class PeerConnectionV2 extends StateMachine {
     if (this._peerConnection.signalingState === 'closed' || this._rtpSenders.has(mediaTrackSender)) {
       return;
     }
-    this._localMediaStream.addTrack(mediaTrackSender.track);
-    const sender = this._peerConnection.addTrack(mediaTrackSender.track, this._localMediaStream);
+    if (this._localMediaStream) {
+      this._localMediaStream.addTrack(mediaTrackSender.track);
+    }
+    const sender = this._localMediaStream
+      ? this._peerConnection.addTrack(mediaTrackSender.track, this._localMediaStream)
+      : this._peerConnection.addTrack(mediaTrackSender.track);
     mediaTrackSender.addSender(sender);
     this._rtpSenders.set(mediaTrackSender, sender);
   }
@@ -840,7 +846,9 @@ class PeerConnectionV2 extends StateMachine {
     }
     const sender = this._rtpSenders.get(mediaTrackSender);
     this._peerConnection.removeTrack(sender);
-    this._localMediaStream.removeTrack(mediaTrackSender.track);
+    if (this._localMediaStream) {
+      this._localMediaStream.removeTrack(mediaTrackSender.track);
+    }
     mediaTrackSender.removeSender(sender);
     this._rtpSenders.delete(mediaTrackSender);
   }

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -629,6 +629,13 @@ class PeerConnectionV2 extends StateMachine {
         this._log.debug('An ICE restart was in-progress and is now completed');
         this._isRestartingIce = false;
       }
+      if (this._sdpFormat === 'unified' && this._peerConnection.getTransceivers()) {
+        this._peerConnection.getTransceivers().forEach(transceiver => {
+          if (transceiver.currentDirection === 'inactive' && !transceiver.stopped && transceiver.stop) {
+            transceiver.stop();
+          }
+        });
+      }
     }, error => {
       this._log.warn(`Calling setRemoteDescription with an RTCSessionDescription of type "${description.type}" failed with the error "${error.message}".`);
       if (description.sdp) {

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -100,6 +100,11 @@ class PeerConnectionV2 extends StateMachine {
     const peerConnection = new RTCPeerConnection(configuration, options.chromeSpecificConstraints);
     const sdpFormat = getSdpFormat(options.sdpSemantics);
 
+    // NOTE(mroberts): We do this to keep the ICE transport open.
+    if (isFirefox && RTCPeerConnection.prototype.addTransceiver) {
+      peerConnection.addTransceiver('audio');
+    }
+
     // NOTE(mroberts): We do this to workaround the following bug:
     //
     //   https://bugzilla.mozilla.org/show_bug.cgi?id=1481335

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -18,7 +18,7 @@ const MediaClientRemoteDescFailedError = require('../../util/twilio-video-errors
 const DataTrackReceiver = require('../../data/receiver');
 const MediaTrackReceiver = require('../../media/track/receiver');
 const StateMachine = require('../../statemachine');
-const { buildLogLevels, getSdpFormat } = require('../../util');
+const { buildLogLevels, getSdpFormat, makeUUID } = require('../../util');
 const { DEFAULT_LOG_LEVEL } = require('../../util/constants');
 const Log = require('../../util/log');
 const IdentityTrackMatcher = require('../../util/sdp/trackmatcher/identity');
@@ -99,6 +99,14 @@ class PeerConnectionV2 extends StateMachine {
     const RTCPeerConnection = options.RTCPeerConnection;
     const peerConnection = new RTCPeerConnection(configuration, options.chromeSpecificConstraints);
     const sdpFormat = getSdpFormat(options.sdpSemantics);
+
+    // NOTE(mroberts): We do this to workaround the following bug:
+    //
+    //   https://bugzilla.mozilla.org/show_bug.cgi?id=1481335
+    //
+    if (isFirefox) {
+      peerConnection.createDataChannel(makeUUID());
+    }
 
     Object.defineProperties(this, {
       _dataChannels: {

--- a/lib/signaling/v2/peerconnectionmanager.js
+++ b/lib/signaling/v2/peerconnectionmanager.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { RTCPeerConnection } = require('@twilio/webrtc');
+
 const PeerConnectionV2 = require('./peerconnection');
 const MediaTrackSender = require('../../media/track/sender');
 const QueueingEventEmitter = require('../../queueingeventemitter');
@@ -26,7 +28,11 @@ class PeerConnectionManager extends QueueingEventEmitter {
     super();
 
     options = Object.assign({
-      audioContextFactory: isFirefox
+      // NOTE(mroberts): If this is Firefox, but we don't support
+      // `addTransceiver`, we're going to add a "dummy" audio track to keep the
+      // ICE transport open; otherwise, we'll just add an RTCRtpTransceiver in
+      // PeerConnectionV2.
+      audioContextFactory: isFirefox && !RTCPeerConnection.prototype.addTransceiver
         ? require('../../webaudio/audiocontext')
         : null,
       PeerConnectionV2

--- a/test/unit/spec/media/track/mediatrack.js
+++ b/test/unit/spec/media/track/mediatrack.js
@@ -87,10 +87,6 @@ describe('MediaTrack', () => {
         assert.equal(track, _track);
       });
 
-      it('should call ._detachElement with the passed element', () => {
-        assert(track._detachElement.calledWith(dummyElement));
-      });
-
       it('should set .isStarted to true', () => {
         assert(track.isStarted);
       });


### PR DESCRIPTION
I wonder if integration tests will be improved or not with these changes. I still want to do some manual testing before merging. **EDIT:** Oops, I didn't realize [Bug 1231414](https://bugzilla.mozilla.org/show_bug.cgi?id=1231414) is still a thing, so we can't just `addTrack` without a MediaStream argument.