### PR TITLE
Add `dominantSpeaker` and `networkQuality` ConnectOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+1.14.0 (in progress)
+====================
+
+New Features
+------------
+
+- Added a new property to ConnectOptions, `dominantSpeaker`, for enabling the
+  Dominant Speaker API. Once the Dominant Speaker API is generally available,
+  you will need to set the `dominantSpeaker` property to `true`. This will only
+  take effect in Group Rooms.
+- Added a new property to ConnectOptions, `networkQuality`, for enabling the
+  Network Quality API. Once the Network Quality API is generally available,
+  you will need to set the `networkQuality` property to `true`. This will only
+  take effect in Group Rooms.
+
+For example, here is how you can enable both APIs:
+
+```js
+connect(token, {
+  dominantSpeaker: true,
+  networkQuality: true
+});
+```
+
+Please note that these features are still in beta and not generally available.
+
 1.13.1 (August 7, 2018)
 =======================
 

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -267,6 +267,8 @@ function connect(token, options) {
  * @property {boolean|CreateLocalTrackOptions} [audio=true] - Whether or not to
  *   get local audio with <code>getUserMedia</code> when <code>tracks</code>
  *   are not provided.
+ * @property {boolean} [dominantSpeaker=false] - Whether to enable the Dominant
+ *   Speaker API or not. This only takes effect in Group Rooms.
  * @property {Array<RTCIceServer>} iceServers - Override the STUN and TURN
  *   servers used when connecting to {@link Room}s
  * @property {number} [iceServersTimeout=3000] - Override the amount of time, in
@@ -284,6 +286,8 @@ function connect(token, options) {
  *   as a hint for variable bitrate codecs, but will not take effect for fixed
  *   bitrate codecs
  * @property {?string} [name=null] - Set to connect to a {@link Room} by name
+ * @property {boolean} [networkQuality=false] - Whether to enable the Network
+ *   Quality API or not. This only takes effect in Group Rooms.
  * @property {Array<AudioCodec>} [preferredAudioCodecs=[]] - Preferred audio codecs;
  *  An empty array preserves the current audio codec preference order.
  * @property {Array<VideoCodec|VideoCodecSettings>} [preferredVideoCodecs=[]] -

--- a/lib/signaling/v2/cancelableroomsignalingpromise.js
+++ b/lib/signaling/v2/cancelableroomsignalingpromise.js
@@ -56,8 +56,9 @@ function createCancelableRoomSignalingPromise(token, ua, localParticipant, iceSe
         }
 
         transportOptions = Object.assign({
+          dominantSpeaker: options.dominantSpeaker,
           environment: options.environment,
-          negotiateNetworkQuality: options._enableNetworkQualityLevel,
+          networkQuality: options.networkQuality,
           iceServerSourceStatus: iceServerSource.status,
           insights: options.insights,
           realm: options.realm,

--- a/lib/signaling/v2/transport.js
+++ b/lib/signaling/v2/transport.js
@@ -130,7 +130,8 @@ class Transport extends StateMachine {
           ua,
           options.SIPJSMediaHandler,
           options.iceServerSourceStatus,
-          options.negotiateNetworkQuality)
+          options.dominantSpeaker,
+          options.networkQuality)
       }
     });
     setupEventListeners(this, this._session, ua);
@@ -221,7 +222,7 @@ class Transport extends StateMachine {
  * @param {object} state
  */
 
-function createSession(transport, name, accessToken, localParticipant, peerConnectionManager, ua, SIPJSMediaHandler, iceServerSourceStatus, negotiateNetworkQuality) {
+function createSession(transport, name, accessToken, localParticipant, peerConnectionManager, ua, SIPJSMediaHandler, iceServerSourceStatus, dominantSpeaker, networkQuality) {
   const target = `sip:${util.makeServerSIPURI()}`;
   return ua.invite(target, {
     extraHeaders: [
@@ -257,19 +258,20 @@ function createSession(transport, name, accessToken, localParticipant, peerConne
             user_agent: transport._userAgent
           };
           message.media_signaling = {};
-          if (negotiateNetworkQuality) {
+          if (networkQuality) {
             message.media_signaling.network_quality = {
               transports: [
                 { type: 'data-channel' }
               ]
             };
           }
-
-          message.media_signaling.active_speaker = {
-            transports: [
-              { type: 'data-channel' }
-            ]
-          };
+          if (dominantSpeaker) {
+            message.media_signaling.active_speaker = {
+              transports: [
+                { type: 'data-channel' }
+              ]
+            };
+          }
         }
 
         const sdpFormat = util.getSdpFormat(transport._sdpSemantics);


### PR DESCRIPTION
Per discussion today. **EDIT:** Rather than ship this by default to all users at once, we'll let users opt-in to these features. This also means, if you don't want the Dominant Speaker or Network Quality APIs, you don't need to enable them.