### PR TITLE
JSDK-2156 Stopping all the cloned MediaTrackSenders upon disconnect.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+2.0.0-beta2 (in progress)
+=========================
+
+Bug Fixes
+---------
+
+- Fixed a bug where calling a LocalVideoTrack's `stop` method did not stop the
+  video capture, and thereby did not turn the camera light off. (JSDK-2156)
+
 2.0.0-beta1 (August 10, 2018)
 =============================
 

--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -196,6 +196,7 @@ class LocalParticipant extends Participant {
         self.removeListener('trackDisabled', localTrackDisabled);
         self.removeListener('trackEnabled', localTrackEnabled);
         self.removeListener('trackStopped', localTrackStopped);
+        self._tracks.forEach(localTrackStopped);
 
         log.info(`LocalParticipant disconnected. Stopping ${self._tracksToStop.size} automatically-acquired LocalTracks`);
         self._tracksToStop.forEach(track => {


### PR DESCRIPTION
@mhuynh5757 

This PR fixes a bug where calling `LocalVideoTrack#stop()` does not turn the camera light off. This is due to the fact that when a `LocalParticipant` disconnects from the `Room`, we do not stop all the cloned `MediaTrackSender`s that are published to the `Room`. So, even if `LocalVideoTrack#stop()` stops the `MediaTrackSender` associated with it, the cloned `MediaTrackSender`s are still capturing media.

These changes will fix the behavior described [here](https://github.com/twilio/video-quickstart-js/issues/53).