### PR TITLE
JSDK-2169 Stopping the cloned MediaTrackSender instead of the original.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Bug Fixes
 - Fixed a bug where calling a LocalVideoTrack's `stop` method did not stop the
   video capture, and thereby did not turn the camera light off. (JSDK-2156)
 
+- Fixed a bug where calling LocalParticipant's `unpublishTrack` on a LocalTrack
+  that was being published to a Room also stopped the LocalTrack. (JSDK-2169) 
+
 2.0.0-beta1 (August 10, 2018)
 =============================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Bug Fixes
 
 - Fixed a bug where calling a LocalVideoTrack's `stop` method did not stop the
   video capture, and thereby did not turn the camera light off. (JSDK-2156)
-
 - Fixed a bug where calling LocalParticipant's `unpublishTrack` on a LocalTrack
   that was being published to a Room also stopped the LocalTrack. (JSDK-2169) 
 

--- a/lib/signaling/localparticipant.js
+++ b/lib/signaling/localparticipant.js
@@ -56,7 +56,7 @@ class LocalParticipantSignaling extends ParticipantSignaling {
     this._publicationsToTrackSenders.delete(publication);
     const didDelete = super.removeTrack(publication);
     if (didDelete) {
-      trackSender.stop();
+      publication.stop();
     }
     return publication;
   }


### PR DESCRIPTION
@markandrus 