### PR TITLE
Use unified sdpFormat for Edge

### DIFF
--- a/karma/makeconf.js
+++ b/karma/makeconf.js
@@ -20,7 +20,8 @@ function makeConf(defaultFile, browserNoActivityTimeout, requires) {
     let browsers = {
       chrome: ['ChromeWebRTC'],
       firefox: ['FirefoxWebRTC'],
-      safari: ['SafariTechPreview']
+      safari: ['SafariTechPreview'],
+      edge: ['Edge']
     };
 
     if (process.env.BROWSER) {

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -449,7 +449,8 @@ function validateLocalTrack(track, options) {
  * @returns {string} SDP format
  */
 function getSdpFormat(sdpSemantics) {
-  return typeof mozRTCPeerConnection !== 'undefined'
+  return guessBrowser() === 'firefox'
+      || guessBrowser() === 'edge'
       || (sdpSemantics === 'unified-plan' && checkIfSdpSemanticsIsSupported())
     ? 'unified'
     : 'planb';

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -1,4 +1,3 @@
-/* globals mozRTCPeerConnection */
 'use strict';
 
 const constants = require('./constants');

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "karma": "^1.6.0",
     "karma-browserify": "^5.1.1",
     "karma-chrome-launcher": "^2.0.0",
+    "karma-edge-launcher": "^0.4.2",
     "karma-firefox-launcher": "^1.0.1",
     "karma-mocha": "^1.3.0",
     "karma-safaritechpreview-launcher": "0.0.6",
@@ -116,7 +117,7 @@
   },
   "dependencies": {
     "@twilio/sip.js": "^0.7.7",
-    "@twilio/webrtc": "^3.0.0",
+    "@twilio/webrtc": "twilio/twilio-webrtc.js#edge-support",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },


### PR DESCRIPTION
@manjeshbhargav @markandrus 
Should we care about sdpSemantics in the connect options?

I still need to test by passing sdpSemantics='plan-b' and check how Edge behaves. 