### PR TITLE
JSDK-2146 Using addTransceiver for unified plan Chrome.

### DIFF
--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -497,7 +497,7 @@ class PeerConnectionV2 extends StateMachine {
   _maybeReoffer(localDescription) {
     let shouldReoffer = this._shouldOffer;
 
-    // NOTE(mmalavalli): In Firefox, if the remote RTCPeerConnection sends
+    // NOTE(mmalavalli): For "unified-plan" sdps, if the remote RTCPeerConnection sends
     // an offer with fewer audio m= lines than the number of audio RTCRTPSenders
     // in the local RTCPeerConnection, then the local RTCPeerConnection creates
     // an answer with the same number of audio m= lines as in the offer. This
@@ -510,7 +510,7 @@ class PeerConnectionV2 extends StateMachine {
     // We can reduce the number of cases where renegotiation is needed by
     // re-introducing 'offerToReceiveAudio' to the default RTCOfferOptions with a
     // value > 1.
-    if (isFirefox) {
+    if (this._sdpFormat === 'unified') {
       const senders = this._peerConnection.getSenders().filter(sender => sender.track);
       shouldReoffer = ['audio', 'video'].reduce((shouldOffer, kind) => {
         const mediaSections = getMediaSections(localDescription.sdp, kind, '(sendrecv|sendonly)');

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -101,12 +101,16 @@ class PeerConnectionV2 extends StateMachine {
     const peerConnection = new RTCPeerConnection(configuration, options.chromeSpecificConstraints);
     const sdpFormat = getSdpFormat(options.sdpSemantics);
 
-    const localMediaStream = isFirefox && RTCPeerConnection.prototype.addTransceiver
+    const localMediaStream = sdpFormat === 'unified' && RTCPeerConnection.prototype.addTransceiver
       ? null
       : new options.MediaStream();
 
     if (options.dummyAudioMediaStreamTrack) {
-      peerConnection.addTrack(options.dummyAudioMediaStreamTrack, localMediaStream || new MediaStream());
+      if (localMediaStream) {
+        peerConnection.addTrack(options.dummyAudioMediaStreamTrack, localMediaStream);
+      } else {
+        peerConnection.addTransceiver(options.dummyAudioMediaStreamTrack);
+      }
     }
 
     // NOTE(mroberts): We do this to workaround the following bug:

--- a/lib/util/sdp/simulcast.js
+++ b/lib/util/sdp/simulcast.js
@@ -24,7 +24,8 @@ class TrackAttributes {
   /**
    * Construct a {@link MediaStreamTrack} attribute store.
    * @param {Track.ID} trackId - The MediaStreamTrack ID
-   * @param {string} streamId - The MediaStream ID
+   * @param {?string} streamId - The MediaStream ID for "plan-b",
+   *   null for "unified-plan"
    * @param {string} cName - The MediaStream cname
    */
   constructor(trackId, streamId, cName) {
@@ -109,10 +110,15 @@ class TrackAttributes {
     const simSSRCs = Array.from(this.primarySSRCs.values());
     const ssrcs = rtxPairs.length ? flatMap(rtxPairs) : simSSRCs;
 
+    const msidAttrPrefix = this.streamId
+      ? `${this.streamId} `
+      : '';
+
     const attrLines = flatMap(ssrcs, ssrc => [
       `a=ssrc:${ssrc} cname:${this.cName}`,
-      `a=ssrc:${ssrc} msid:${this.streamId} ${this.trackId}`
+      `a=ssrc:${ssrc} msid:${msidAttrPrefix}${this.trackId}`
     ]);
+
     const rtxPairLines = rtxPairs.map(rtxPair => `a=ssrc-group:FID ${rtxPair.join(' ')}`);
     const simGroupLines = [
       `a=ssrc-group:SIM ${simSSRCs.join(' ')}`
@@ -178,6 +184,18 @@ function createTrackIdsToAttributes(section) {
   const simSSRCs = getSimulcastSSRCs(section);
   const ssrcAttrTuples = getMatches(section, '^a=ssrc:([0-9]+) msid:([^\\s]+) ([^\\s]+)$');
   const rtxPairs = getSSRCRtxPairs(section);
+
+  // If no line of the form "a=ssrc:123 msid:foo bar" exists, then we are most
+  // probably dealing with a "unified-plan" m= section.
+  if (ssrcAttrTuples.length === 0) {
+    const trackId = flatMap(getMatches(section, '^a=msid:.+ (.+)$'))[0];
+    const ssrcs = flatMap(getMatches(section, '^a=ssrc:(.+) cname:.+$'));
+    if (trackId) {
+      ssrcs.map(ssrc => [ssrc, null, trackId]).forEach(tuple => {
+        ssrcAttrTuples.push(tuple);
+      });
+    }
+  }
 
   return ssrcAttrTuples.reduce((trackIdsToSSRCs, tuple) => {
     const ssrc = tuple[0];

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   },
   "dependencies": {
     "@twilio/sip.js": "^0.7.7",
-    "@twilio/webrtc": "^3.0.0",
+    "@twilio/webrtc": "twilio/twilio-webrtc.js#JSDK-2164",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },

--- a/test/env.js
+++ b/test/env.js
@@ -13,6 +13,7 @@ const processEnv = {
   LOG_LEVEL: process.env.LOG_LEVEL,
   ENABLE_REST_API_TESTS: process.env.ENABLE_REST_API_TESTS,
   USE_TWILIO_CONNECTION: process.env.USE_TWILIO_CONNECTION,
+  SDP_SEMANTICS: process.env.SDP_SEMANTICS,
   TOPOLOGY: process.env.TOPOLOGY
 };
 
@@ -28,6 +29,7 @@ const env = [
   ['LOG_LEVEL',                 'logLevel'],
   ['ENABLE_REST_API_TESTS',     'enableRestApiTests'],
   ['USE_TWILIO_CONNECTION',     'useTwilioConnection'],
+  ['SDP_SEMANTICS',             'sdpSemantics'],
   ['TOPOLOGY',                  'topology']
 ].reduce((env, [processEnvKey, envKey]) => {
   if (processEnvKey in processEnv) {

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -755,7 +755,7 @@ describe('connect', function() {
     it('should add Simulcast SSRCs to the video m= section of all local descriptions', () => {
       flatMap(peerConnections, pc => {
         assert(pc.localDescription.sdp);
-        return getMediaSections(pc.localDescription.sdp, 'video');
+        return getMediaSections(pc.localDescription.sdp, 'video', '(sendonly|sendrecv)');
       }).forEach(section => {
         const flowSSRCs = new Set(flatMap(section.match(/^a=ssrc-group:FID .+$/gm), line => {
           return line.split(' ').slice(1);

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -22,7 +22,7 @@ const { getMediaSections } = require('../../../lib/util/sdp');
 const { TrackNameIsDuplicatedError, TrackNameTooLongError } = require('../../../lib/util/twilio-video-errors');
 
 const defaults = require('../../lib/defaults');
-const { isFirefox, isSafari } = require('../../lib/guessbrowser');
+const { isChrome, isFirefox, isSafari } = require('../../lib/guessbrowser');
 const { createRoom, completeRoom } = require('../../lib/rest');
 const getToken = require('../../lib/token');
 const { smallVideoConstraints } = require('../../lib/util');
@@ -726,17 +726,17 @@ describe('LocalParticipant', function() {
       });
     });
 
-    it('should eventually raise a "trackUnsubscribed" event with the unpublished LocalVideoTrack', () => {
+    it('should eventually raise a "trackUnsubscribed" event for the unpublished LocalVideoTrack', () => {
       const thatTrack = thatTracksUnpublished.trackUnsubscribed;
       assert.equal(thatTrack.sid, thisLocalTrackPublication1.trackSid);
       assert.equal(thatTrack.kind, thisLocalTrackPublication1.kind);
       assert.equal(thatTrack.enabled, thisLocalTrackPublication1.enabled);
-      if (!isFirefox && !isSafari) {
+      if (isChrome && defaults.sdpSemantics !== 'unified-plan') {
         assert.equal(thatTrack.mediaStreamTrack.readyState, 'ended');
       }
     });
 
-    it('should eventually raise a "trackSubscribed" event with the published LocalVideoTrack', () => {
+    it('should eventually raise a "trackSubscribed" event for the published LocalVideoTrack', () => {
       const thatTrack = thatTracksPublished.trackSubscribed;
       assert.equal(thatTrack.sid, thisLocalTrackPublication2.trackSid);
       assert.equal(thatTrack.kind, thisLocalTrackPublication2.kind);

--- a/test/lib/defaults.js
+++ b/test/lib/defaults.js
@@ -8,6 +8,7 @@ const defaults = [
   'ecsServer',
   'environment',
   'logLevel',
+  'sdpSemantics',
   'topology',
   'wsServer',
   'wsServerInsights'

--- a/test/lib/mocksdp.js
+++ b/test/lib/mocksdp.js
@@ -18,7 +18,7 @@
 
 /**
  * Create an SDP string.
- * @params {string} type - 'planb' | 'unified'
+ * @param {'planb' | 'unified'} type
  * @param {TracksByKind} kinds
  * @param {number} [maxAudioBitrate]
  * @param {number} [maxVideoBitrate]
@@ -73,20 +73,26 @@ a=mid:mid_${id}\r
 a=msid:stream ${id}\r
 `) + `\
 a=ssrc:${ssrc} cname:0\r
-a=ssrc:${ssrc} msid:stream ${id}\r
+a=ssrc:${ssrc} msid:${type === 'planb' ? 'stream ' : ''}${id}\r
 `;
     }, sdp + (type === 'planb' ? media : ''));
   }, session);
 }
 
-function makeSdpForSimulcast(ssrcs) {
-  const sdp = makeSdpWithTracks('planb', {
+/**
+ * Make an sdp to test simulcast.
+ * @param {'planb' | 'unified'} type
+ * @param {Array<string>} ssrcs
+ * @returns {string} sdp
+ */
+function makeSdpForSimulcast(type, ssrcs) {
+  const sdp = makeSdpWithTracks(type, {
     audio: ['audio-1'],
     video: [{ id: 'video-1', ssrc: ssrcs[0] }]
   });
   const ssrcSdpLines = ssrcs.length === 2 ? [
     `a=ssrc:${ssrcs[1]} cname:0`,
-    `a=ssrc:${ssrcs[1]} msid:stream video-1`
+    `a=ssrc:${ssrcs[1]} msid:${type === 'planb' ? 'stream ' : ''}video-1`
   ] : [];
   const fidSdpLines = ssrcs.length === 2
     ? [`a=ssrc-group:FID ${ssrcs.join(' ')}`]

--- a/test/unit/spec/util/sdp/index.js
+++ b/test/unit/spec/util/sdp/index.js
@@ -142,6 +142,10 @@ describe('setCodecPreferences', () => {
 describe('setSimulcast', () => {
   combinationContext([
     [
+      ['planb', 'unified'],
+      x => `when called with a ${x} sdp`
+    ],
+    [
       [true, false],
       x => `when the SDP ${x ? 'already has' : 'does not already have'} simulcast SSRCs`
     ],
@@ -153,14 +157,14 @@ describe('setSimulcast', () => {
       [new Set(['01234']), new Set(['01234', '56789'])],
       x => `when retransmission is${x.size === 2 ? '' : ' not'} supported`
     ]
-  ], ([areSimSSRCsAlreadyPresent, isVP8PayloadTypePresent, ssrcs]) => {
+  ], ([sdpType, areSimSSRCsAlreadyPresent, isVP8PayloadTypePresent, ssrcs]) => {
     let sdp;
     let simSdp;
     let trackIdsToAttributes;
 
     before(() => {
       ssrcs = Array.from(ssrcs.values());
-      sdp = makeSdpForSimulcast(ssrcs);
+      sdp = makeSdpForSimulcast(sdpType, ssrcs);
       trackIdsToAttributes = new Map();
 
       if (!isVP8PayloadTypePresent) {


### PR DESCRIPTION
@markandrus 

This PR enables the use of RTCPeerConnection's `addTransceiver` method for unified plan Chrome.
This depends on a version of twilio-webrtc.js which does not suppress the native RTCTrackEvent.