### PR TITLE
Transition to "closed" state without waiting for WebSocket's "close" event.

### DIFF
--- a/lib/twilioconnection.js
+++ b/lib/twilioconnection.js
@@ -127,7 +127,7 @@ class TwilioConnection extends StateMachine {
    * @param {{code: number, reason: string}} event
    * @private
    */
-  _close(event) {
+  _close({ code, reason }) {
     if (this.state === 'closed') {
       return;
     }
@@ -143,15 +143,21 @@ class TwilioConnection extends StateMachine {
     this._messageQueue.splice(0);
 
     const log = this._log;
-    if (event.code === WS_CLOSE_NORMAL) {
+    if (code === WS_CLOSE_NORMAL) {
       log.debug('Closed');
     } else {
-      log.warn(`Closed: ${event.code} - ${event.reason}`);
+      log.warn(`Closed: ${code} - ${reason}`);
     }
 
-    this.transition('closed', null, event.code !== WS_CLOSE_NORMAL
-      ? new Error(`WebSocket Error ${event.code}: ${event.reason}`)
+    this.transition('closed', null, code !== WS_CLOSE_NORMAL
+      ? new Error(`WebSocket Error ${code}: ${reason}`)
       : null);
+
+    const { readyState } = this._ws;
+    const { WebSocket } = this._options;
+    if (readyState !== WebSocket.CLOSING && readyState !== WebSocket.CLOSED) {
+      this._ws.close(code, reason);
+    }
   }
 
   /**
@@ -215,7 +221,6 @@ class TwilioConnection extends StateMachine {
     const log = this._log;
     if (this.state === 'connecting') {
       log.warn(`Closing: ${WS_CLOSE_HELLO_FAILED} - ${reason}`);
-      this._ws.close(WS_CLOSE_HELLO_FAILED, reason);
       this._close({ code: WS_CLOSE_HELLO_FAILED, reason });
       return;
     }
@@ -255,7 +260,6 @@ class TwilioConnection extends StateMachine {
 
     const reason = `Missed ${maxConsecutiveMissedHeartbeats} "heartbeat" messages`;
     log.warn(`Closing: ${WS_CLOSE_HEARTBEATS_MISSED} - ${reason}`);
-    this._ws.close(WS_CLOSE_HEARTBEATS_MISSED, reason);
     this._close({ code: WS_CLOSE_HEARTBEATS_MISSED, reason });
   }
 
@@ -298,8 +302,7 @@ class TwilioConnection extends StateMachine {
     }
     const reason = '"welcome" message timeout expired';
     this._log.warn(`Closing: ${WS_CLOSE_WELCOME_TIMEOUT} - ${reason}`);
-    this._ws.close(WS_CLOSE_WELCOME_TIMEOUT, reason);
-    this._close({ code: WS_CLOSE_HEARTBEATS_MISSED, reason });
+    this._close({ code: WS_CLOSE_WELCOME_TIMEOUT, reason });
   }
 
   /**

--- a/lib/twilioconnection.js
+++ b/lib/twilioconnection.js
@@ -123,6 +123,38 @@ class TwilioConnection extends StateMachine {
   }
 
   /**
+   * Close the {@link TwilioConnection}.
+   * @param {{code: number, reason: string}} event
+   * @private
+   */
+  _close(event) {
+    if (this.state === 'closed') {
+      return;
+    }
+    if (this._welcomeTimeout) {
+      this._welcomeTimeout.clear();
+    }
+    if (this._heartbeatTimeout) {
+      this._heartbeatTimeout.clear();
+    }
+    if (this._sendHeartbeatTimeout) {
+      this._sendHeartbeatTimeout.clear();
+    }
+    this._messageQueue.splice(0);
+
+    const log = this._log;
+    if (event.code === WS_CLOSE_NORMAL) {
+      log.debug('Closed');
+    } else {
+      log.warn(`Closed: ${event.code} - ${event.reason}`);
+    }
+
+    this.transition('closed', null, event.code !== WS_CLOSE_NORMAL
+      ? new Error(`WebSocket Error ${event.code}: ${event.reason}`)
+      : null);
+  }
+
+  /**
    * Connect to the TCMP server.
    * @param {string} serverUrl
    * @private
@@ -133,29 +165,7 @@ class TwilioConnection extends StateMachine {
     const ws = this._ws;
 
     log.debug('Created a new WebSocket:', ws);
-
-    ws.addEventListener('close', event => {
-      if (this._welcomeTimeout) {
-        this._welcomeTimeout.clear();
-      }
-      if (this._heartbeatTimeout) {
-        this._heartbeatTimeout.clear();
-      }
-      if (this._sendHeartbeatTimeout) {
-        this._sendHeartbeatTimeout.clear();
-      }
-      this._messageQueue.splice(0);
-
-      if (event.code === WS_CLOSE_NORMAL) {
-        log.debug('Closed');
-      } else {
-        log.warn(`Closed: ${event.code} - ${event.reason}`);
-      }
-
-      this.transition('closed', null, event.code !== WS_CLOSE_NORMAL
-        ? new Error(`WebSocket Error ${event.code}: ${event.reason}`)
-        : null);
-    });
+    ws.addEventListener('close', event => this._close(event));
 
     ws.addEventListener('message', message => {
       log.debug(`Incoming: ${message.data}`);
@@ -206,6 +216,7 @@ class TwilioConnection extends StateMachine {
     if (this.state === 'connecting') {
       log.warn(`Closing: ${WS_CLOSE_HELLO_FAILED} - ${reason}`);
       this._ws.close(WS_CLOSE_HELLO_FAILED, reason);
+      this._close({ code: WS_CLOSE_HELLO_FAILED, reason });
       return;
     }
     log.debug(`Error: ${reason}`);
@@ -241,10 +252,11 @@ class TwilioConnection extends StateMachine {
       this._heartbeatTimeout.reset();
       return;
     }
-    log.warn(`Closing: ${WS_CLOSE_HEARTBEATS_MISSED} - `
-      + `Missed ${maxConsecutiveMissedHeartbeats} "heartbeat" messages`);
-    this._ws.close(WS_CLOSE_HEARTBEATS_MISSED,
-      `Missed ${maxConsecutiveMissedHeartbeats} "heartbeat" messages`);
+
+    const reason = `Missed ${maxConsecutiveMissedHeartbeats} "heartbeat" messages`;
+    log.warn(`Closing: ${WS_CLOSE_HEARTBEATS_MISSED} - ${reason}`);
+    this._ws.close(WS_CLOSE_HEARTBEATS_MISSED, reason);
+    this._close({ code: WS_CLOSE_HEARTBEATS_MISSED, reason });
   }
 
   /**
@@ -284,8 +296,10 @@ class TwilioConnection extends StateMachine {
     if (this.state !== 'connecting') {
       return;
     }
-    this._log.warn(`Closing: ${WS_CLOSE_WELCOME_TIMEOUT} - "welcome" message timeout expired`);
-    this._ws.close(WS_CLOSE_WELCOME_TIMEOUT, '"welcome" message timeout expired');
+    const reason = '"welcome" message timeout expired';
+    this._log.warn(`Closing: ${WS_CLOSE_WELCOME_TIMEOUT} - ${reason}`);
+    this._ws.close(WS_CLOSE_WELCOME_TIMEOUT, reason);
+    this._close({ code: WS_CLOSE_HEARTBEATS_MISSED, reason });
   }
 
   /**


### PR DESCRIPTION
@markandrus 

Chrome's WebSocket sometimes takes a really long time (~1 min) to emit a `CloseEvent` after calling `WebSocket#close()` whenever there is a network problem. So, this PR makes sure that the `TwilioConnection` is closed as soon as `WebSocket#close()` is called.
