### PR TITLE
Revert "Include "a=x-google-flag:conference" for Simulcast"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,9 @@
-1.14.1 (in progress)
-====================
+1.14.1 (October 10, 2018)
+=========================
 
 Bug Fixes
 ---------
 
-- Fixed a bug where LocalVideoTracks representing screenshares were not taking
-  full advantage of simulcast. (JSDK-2163)
 - Fixed a bug where twilio-video.js was internally using the deprecated
   RemoteTrack's `id` property. (JSDK-2173)
 

--- a/lib/util/sdp/simulcast.js
+++ b/lib/util/sdp/simulcast.js
@@ -228,14 +228,8 @@ function setSimulcastInMediaSection(section, trackIdsToAttributes) {
   // Add the simulcast SSRC SDP lines to the media section. The Set ensures
   // that the duplicates of the SSRC SDP lines that are in both "section" and
   // "relevantSdpLines" are removed.
-  const sectionLines = flatMap(new Set(section.split('\r\n').concat(relevantSdpLines)));
-
-  const xGoogleFlagConference = 'a=x-google-flag:conference';
-  if (!section.match(xGoogleFlagConference)) {
-    sectionLines.push(xGoogleFlagConference);
-  }
-
-  return sectionLines.join('\r\n');
+  const sectionLines = new Set(section.split('\r\n').concat(relevantSdpLines));
+  return flatMap(sectionLines).join('\r\n');
 }
 
 /**

--- a/test/unit/spec/util/sdp/index.js
+++ b/test/unit/spec/util/sdp/index.js
@@ -202,10 +202,6 @@ describe('setSimulcast', () => {
       }
     });
 
-    it('should include "a=x-google-flag:conference"', () => {
-      assert(simSdp.match(/a=x-google-flag:conference/));
-    });
-
     context('when the SDP contains a previously added MediaStreamTrack ID', () => {
       before(() => {
         simSdp = setSimulcast(sdp, trackIdsToAttributes);


### PR DESCRIPTION
This reverts commit 51a2cb26c3cbcd58873abfbb53adc1ea156e6cd8.