### PR TITLE
Upgrading to twilio-webrtc.js@2.2.0-rc1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   },
   "dependencies": {
     "@twilio/sip.js": "^0.7.7",
-    "@twilio/webrtc": "twilio/twilio-webrtc.js#c72f9e5e508206e0f81d4f5e7b5b970c6770258a",
+    "@twilio/webrtc": "twilio/twilio-webrtc.js#2.2.0-rc1",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },


### PR DESCRIPTION
@syerrapragada 

This RC contains [changes](https://github.com/twilio/twilio-webrtc.js/tree/2.2.0-rc1/CHANGELOG.md) required for JSDK-2146.