### PR TITLE
JSDK-2212 Ensure LocalTrackPublicationV2 is not null.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ New Features
   gets disconnected and reconnected, but also when signaling gets disconnected
   and reconnected.
 
+Bug Fixes
+---------
+
+- Fixed a bug where unpublishing a LocalTrack from within one if its event
+  listeners that have been added before publishing it to the Room throws a
+  TypeError. (JSDK-2212)
+
 2.0.0-beta2 (October 1, 2018)
 =============================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
-2.0.0 (in progress)
-===================
-
-New Features
-------------
-
-- The Room now emits "reconnecting" and "reconnected" events not only when media
-  gets disconnected and reconnected, but also when signaling gets disconnected
-  and reconnected.
+2.0.0-beta3 (in progress)
+=========================
 
 Bug Fixes
 ---------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 Bug Fixes
 ---------
 
-- Fixed a bug where unpublishing a LocalTrack from within one if its event
+- Fixed a bug where unpublishing a LocalTrack from within one of its event
   listeners that have been added before publishing it to the Room throws a
   TypeError. (JSDK-2212)
 

--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -159,21 +159,27 @@ class LocalParticipant extends Participant {
 
     function localTrackDisabled(localTrack) {
       const trackSignaling = signaling.getPublication(localTrack._trackSender);
-      trackSignaling.disable();
-      log.debug(`Disabled the ${util.trackClass(localTrack, true)}:`, localTrack.id);
+      if (trackSignaling) {
+        trackSignaling.disable();
+        log.debug(`Disabled the ${util.trackClass(localTrack, true)}:`, localTrack.id);
+      }
     }
 
     function localTrackEnabled(localTrack) {
       const trackSignaling = signaling.getPublication(localTrack._trackSender);
-      trackSignaling.enable();
-      log.debug(`Enabled the ${util.trackClass(localTrack, true)}:`, localTrack.id);
+      if (trackSignaling) {
+        trackSignaling.enable();
+        log.debug(`Enabled the ${util.trackClass(localTrack, true)}:`, localTrack.id);
+      }
     }
 
     function localTrackStopped(localTrack) {
       // NOTE(mroberts): We shouldn't need to check for `stop`, since DataTracks
       // do not emit "stopped".
       const trackSignaling = signaling.getPublication(localTrack._trackSender);
-      trackSignaling.stop();
+      if (trackSignaling) {
+        trackSignaling.stop();
+      }
     }
 
     this.on('trackDisabled', localTrackDisabled);

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -976,4 +976,34 @@ describe('LocalParticipant', function() {
       });
     });
   });
+
+  // NOTE (mmalavalli): This test ensures that the behavior described in
+  // https://issues.corp.twilio.com/browse/JSDK-2212 is not observed.
+  describe('JSDK-2212', () => {
+    [
+      ['disabled', 'disable'],
+      ['enabled', 'enable'],
+      ['stopped', 'stop']
+    ].forEach(([event, action]) => {
+      context(`when a LocalTrack is unpublished in a "${event}" event listener`, () => {
+        context('when the listener is added to the LocalTrack before publishing it to the Room', () => {
+          it('should not throw', async () => {
+            let room;
+            const track = await createLocalAudioTrack();
+            if (event === 'enabled') {
+              track.disable();
+            }
+            track.once(event, () => {
+              room.localParticipant.unpublishTrack(track);
+            });
+            room = await connect(getToken('foo'), {
+              name: randomName(),
+              tracks: [track]
+            });
+            assert.doesNotThrow(() => track[action]());
+          });
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
@syerrapragada 

This PR fixes [JSDK-2212](https://issues.corp.twilio.com/browse/JSDK-2212).