### PR TITLE
JSDK-2232 Unified Plan support for Safari 12.1.

### DIFF
--- a/karma/makeconf.js
+++ b/karma/makeconf.js
@@ -20,7 +20,7 @@ function makeConf(defaultFile, browserNoActivityTimeout, requires) {
     let browsers = {
       chrome: ['ChromeWebRTC'],
       firefox: ['FirefoxWebRTC'],
-      safari: ['SafariTechPreview']
+      safari: ['Safari']
     };
 
     if (process.env.BROWSER) {
@@ -29,7 +29,7 @@ function makeConf(defaultFile, browserNoActivityTimeout, requires) {
         throw new Error('Unknown browser');
       }
     } else if (process.platform === 'darwin') {
-      browsers = ['ChromeWebRTC', 'FirefoxWebRTC', 'SafariTechPreview'];
+      browsers = ['ChromeWebRTC', 'FirefoxWebRTC', 'Safari'];
     } else {
       browsers = ['ChromeWebRTC', 'FirefoxWebRTC'];
     }

--- a/lib/signaling/v2/peerconnectionmanager.js
+++ b/lib/signaling/v2/peerconnectionmanager.js
@@ -5,8 +5,6 @@ const MediaTrackSender = require('../../media/track/sender');
 const QueueingEventEmitter = require('../../queueingeventemitter');
 const util = require('../../util');
 
-const isFirefox = util.guessBrowser() === 'firefox';
-
 /**
  * {@link PeerConnectionManager} manages multiple {@link PeerConnectionV2}s.
  * @extends QueueingEventEmitter
@@ -21,12 +19,15 @@ class PeerConnectionManager extends QueueingEventEmitter {
    * @param {IceServerSource} iceServerSource
    * @param {EncodingParametersImpl} encodingParameters
    * @param {PreferredCodecs} preferredCodecs
+   * @param {object} options
    */
   constructor(iceServerSource, encodingParameters, preferredCodecs, options) {
     super();
 
+    const sdpFormat = util.getSdpFormat(options.sdpSemantics);
+
     options = Object.assign({
-      audioContextFactory: isFirefox
+      audioContextFactory: sdpFormat === 'unified'
         ? require('../../webaudio/audiocontext')
         : null,
       PeerConnectionV2

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -1,4 +1,4 @@
-/* globals mozRTCPeerConnection */
+/* globals mozRTCPeerConnection, RTCRtpTransceiver */
 'use strict';
 
 const constants = require('./constants');
@@ -438,22 +438,40 @@ function validateLocalTrack(track, options) {
 }
 
 /**
+ * @typedef {'plan-b' | 'unified-plan'} SdpSemantics
+ */
+
+/**
+ * @typedef {'planb' | 'unified'} SdpFormat
+ */
+
+/**
  * Use unified plan SDP format on Firefox
  * @param {?SdpSemantics} [sdpSemantics]
- * @returns {string} SDP format
+ * @returns {SdpFormat}
  */
 function getSdpFormat(sdpSemantics) {
   const browser = guessBrowser();
+  if (browser === 'firefox') {
+    return 'unified';
+  }
+  if (browser === 'safari') {
+    return 'currentDirection' in RTCRtpTransceiver.prototype
+      ? 'unified'
+      : 'planb';
+  }
+  if (checkIfSdpSemanticsIsSupported()) {
+    return {
+      'plan-b': 'planb',
+      'unified-plan': 'unified'
+    }[sdpSemantics || 'plan-b'];
+  }
   // NOTE(mmalavalli): Once Chrome stops supporting "plan-b" SDPs, it will
   // ignore the "sdpSemantics" flag. So, in order to differentiate between
   // versions of Chrome which support only "plan-b" SDPs and versions of Chrome
   // which support only "unified-plan" SDPs, which check whether PeerConnection's
   // addStream() method is present.
-  return browser === 'firefox' || (sdpSemantics === 'unified-plan' && checkIfSdpSemanticsIsSupported())
-    ? 'unified'
-    : browser === 'safari' || RTCPeerConnection.prototype.addStream
-      ? 'planb'
-      : 'unified';
+  return RTCPeerConnection.prototype.addStream ? 'planb' : 'unified';
 }
 
 // NOTE(mroberts): We need to cache this result so that we don't create too many

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   },
   "dependencies": {
     "@twilio/sip.js": "^0.7.7",
-    "@twilio/webrtc": "twilio/twilio-webrtc.js#safari-unified-plan",
+    "@twilio/webrtc": "twilio/twilio-webrtc.js#3852f5cf1121843483b4fbbd6e57ba6d83b97a58",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "karma-chrome-launcher": "^2.0.0",
     "karma-firefox-launcher": "^1.0.1",
     "karma-mocha": "^1.3.0",
-    "karma-safaritechpreview-launcher": "0.0.6",
+    "karma-safari-launcher": "^1.0.0",
     "karma-spec-reporter": "^0.0.31",
     "mocha": "^3.2.0",
     "npm-run-all": "^4.0.2",
@@ -116,7 +116,7 @@
   },
   "dependencies": {
     "@twilio/sip.js": "^0.7.7",
-    "@twilio/webrtc": "twilio/twilio-webrtc.js#3.2.0-rc3",
+    "@twilio/webrtc": "twilio/twilio-webrtc.js#safari-unified-plan",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -3,6 +3,7 @@
 const sinon = require('sinon');
 const { EventEmitter } = require('events');
 const { capitalize } = require('../../lib/util');
+const { isSafari } = require('./guessbrowser');
 
 function a(word) {
   return word.toLowerCase().match(/^[aeiou]/) ? 'an' : 'a';
@@ -311,7 +312,9 @@ async function waitForTracks(event, participant, n) {
   });
 }
 
-const smallVideoConstraints = {
+// NOTE(mmalavalli): Safari is rejecting getUserMedia()'s Promise with an
+// OverConstrainedError. So these capture dimensions are disabled.
+const smallVideoConstraints = isSafari ? {} : {
   width: 160,
   height: 120
 };


### PR DESCRIPTION
* Replacing karma-safaritechpreview-launcher with karma-safari-launcher. You can still run Safari Tech Preview by overriding SAFARI_BIN env variable with the path to the executable.

@syerrapragada 