### PR TITLE
JSDK-2245 Bump RSP version to 2.

### DIFF
--- a/lib/participant.js
+++ b/lib/participant.js
@@ -357,7 +357,7 @@ class Participant extends EventEmitter {
     }
 
     function trackSignalingUnsubscribed(signaling) {
-      const track = self.tracks.get(signaling.id);
+      const track = util.flatMap(self.tracks).find(track => track.sid === signaling.sid);
       const publication = self.trackPublications.get(signaling.sid);
       if (track) {
         self._removeTrack(track, publication);

--- a/lib/signaling/localtrackpublication.js
+++ b/lib/signaling/localtrackpublication.js
@@ -6,6 +6,7 @@ const TrackSignaling = require('./track');
  * A {@link LocalTrackPublication} implementation
  * @extends TrackSignaling
  * @property {?Error} error - non-null if publication failed
+ * @property {Track.ID} id
  */
 class LocalTrackPublicationSignaling extends TrackSignaling {
   /**
@@ -17,7 +18,7 @@ class LocalTrackPublicationSignaling extends TrackSignaling {
     const enabled = trackSender.kind === 'data'
       ? true
       : trackSender.track.enabled;
-    super(name, trackSender.id, trackSender.kind, enabled);
+    super(name, trackSender.kind, enabled);
     this.setTrackTransceiver(trackSender);
     Object.defineProperties(this, {
       _error: {
@@ -29,6 +30,10 @@ class LocalTrackPublicationSignaling extends TrackSignaling {
         get() {
           return this._error;
         }
+      },
+      id: {
+        enumerable: true,
+        value: trackSender.id
       }
     });
   }

--- a/lib/signaling/participant.js
+++ b/lib/signaling/participant.js
@@ -30,7 +30,7 @@ const states = {
  * @property {?string} identity
  * @property {?Participant.SID} sid
  * @property {string} state - "connecting", "connected", or "disconnected"
- * @property {Map<string, TrackSignaling>} tracks
+ * @property {Map<Track.ID | Track.SID, TrackSignaling>} tracks
  * @emits ParticipantSignaling#networkQualityLevelChanged
  * @emits ParticipantSignaling#trackAdded
  * @emits ParticipantSignaling#trackRemoved
@@ -104,7 +104,7 @@ class ParticipantSignaling extends StateMachine {
    * @fires ParticipantSignaling#trackAdded
    */
   addTrack(track) {
-    this.tracks.set(track.id, track);
+    this.tracks.set(track.id || track.sid, track);
     this.emit('trackAdded', track);
     return this;
   }
@@ -129,7 +129,7 @@ class ParticipantSignaling extends StateMachine {
    * @fires ParticipantSignaling#trackRemoved
    */
   removeTrack(track) {
-    const didDelete = this.tracks.delete(track.id);
+    const didDelete = this.tracks.delete(track.id || track.sid);
     if (didDelete) {
       this.emit('trackRemoved', track);
     }

--- a/lib/signaling/remotetrackpublication.js
+++ b/lib/signaling/remotetrackpublication.js
@@ -11,12 +11,11 @@ class RemoteTrackPublicationSignaling extends TrackSignaling {
    * Construct a {@link RemoteTrackPublicationSignaling}.
    * @param {Track.SID} sid
    * @param {string} name
-   * @param {Track.ID} id
    * @param {Track.Kind} kind
    * @param {boolean} isEnabled
    */
-  constructor(sid, name, id, kind, isEnabled) {
-    super(name, id, kind, isEnabled);
+  constructor(sid, name, kind, isEnabled) {
+    super(name, kind, isEnabled);
     Object.defineProperties(this, {
       _error: {
         value: null,

--- a/lib/signaling/track.js
+++ b/lib/signaling/track.js
@@ -5,7 +5,6 @@ const { EventEmitter } = require('events');
 /**
  * A {@link Track} implementation
  * @extends EventEmitter
- * @property {Track.ID} id
  * @property {Track.Kind} kind
  * @property {string} name
  */
@@ -13,11 +12,10 @@ class TrackSignaling extends EventEmitter {
   /**
    * Construct a {@link TrackSignaling}.
    * @param {string} name
-   * @param {Track.ID} id
    * @param {Track.Kind} kind
    * @param {boolean} isEnabled
    */
-  constructor(name, id, kind, isEnabled) {
+  constructor(name, kind, isEnabled) {
     super();
     let sid = null;
     Object.defineProperties(this, {
@@ -38,10 +36,6 @@ class TrackSignaling extends EventEmitter {
             sid = _sid;
           }
         }
-      },
-      id: {
-        enumerable: true,
-        value: id
       },
       kind: {
         enumerable: true,

--- a/lib/signaling/v2/remoteparticipant.js
+++ b/lib/signaling/v2/remoteparticipant.js
@@ -48,7 +48,7 @@ class RemoteParticipantV2 extends RemoteParticipantSignaling {
    */
   _getOrCreateTrack(trackState) {
     const RemoteTrackPublicationV2 = this._RemoteTrackPublicationV2;
-    let track = this.tracks.get(trackState.id);
+    let track = this.tracks.get(trackState.sid);
     if (!track) {
       track = new RemoteTrackPublicationV2(trackState);
       this.addTrack(track);
@@ -69,33 +69,22 @@ class RemoteParticipantV2 extends RemoteParticipantSignaling {
 
     const tracksToKeep = new Set();
 
-    participantState.tracks.forEach(function(trackState) {
+    participantState.tracks.forEach(trackState => {
       const track = this._getOrCreateTrack(trackState);
       track.update(trackState);
       tracksToKeep.add(track);
-    }, this);
+    });
 
-    this.tracks.forEach(function(track) {
+    this.tracks.forEach(track => {
       if (!tracksToKeep.has(track)) {
         this.removeTrack(track);
       }
-    }, this);
+    });
 
     if (participantState.state === 'disconnected' && this.state === 'connected') {
       this.preempt('disconnected');
     }
 
-    return this;
-  }
-
-  /**
-   * Add the {@link RemoteTrackPublicationV2} to the {@link RemoteParticipantV2}.
-   * @param {RemoteTrackPublicationV2} track
-   * @returns {this}
-   */
-  addTrack(track) {
-    super.addTrack(track);
-    this._getTrackReceiver(track.id).then(track.setTrackTransceiver.bind(track));
     return this;
   }
 }

--- a/lib/signaling/v2/remotetrackpublication.js
+++ b/lib/signaling/v2/remotetrackpublication.js
@@ -11,7 +11,7 @@ class RemoteTrackPublicationV2 extends RemoteTrackPublicationSignaling {
    * @param {RemoteTrackPublicationV2#Representation} track
    */
   constructor(track) {
-    super(track.sid, track.name, track.id, track.kind, track.enabled);
+    super(track.sid, track.name, track.kind, track.enabled);
   }
 
   /**

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -237,25 +237,25 @@ class RoomV2 extends RoomSignaling {
       roomState.subscribed.tracks.forEach(function(trackState) {
         if (trackState.id) {
           this._subscriptionFailures.delete(trackState.sid);
-          this._subscribed.set(trackState.id, trackState.sid);
+          this._subscribed.set(trackState.sid, trackState.id);
         } else if (trackState.error && !this._subscriptionFailures.has(trackState.sid)) {
           this._subscriptionFailures.set(trackState.sid, trackState.error);
         }
       }, this);
 
-      const subscribedTrackIds = new Set(roomState.subscribed.tracks
+      const subscribedTrackSids = new Set(roomState.subscribed.tracks
         .filter(trackState => !!trackState.id)
-        .map(trackState => trackState.id));
+        .map(trackState => trackState.sid));
 
-      this._subscribed.forEach((trackSid, trackId) => {
-        if (!subscribedTrackIds.has(trackId)) {
-          this._subscribed.delete(trackId);
+      this._subscribed.forEach((trackId, trackSid) => {
+        if (!subscribedTrackSids.has(trackSid)) {
+          this._subscribed.delete(trackSid);
         }
       });
     }
 
     // TODO(mroberts): Remove me once the Server is fixed.
-    (roomState.participants || []).forEach(function(participantState) {
+    (roomState.participants || []).forEach(participantState => {
       if (participantState.sid === this.localParticipant.sid ||
           this._disconnectedParticipantSids.has(participantState.sid)) {
         return;
@@ -263,7 +263,7 @@ class RoomV2 extends RoomSignaling {
       const participant = this._getOrCreateRemoteParticipant(participantState);
       participant.update(participantState);
       participantsToKeep.add(participant);
-    }, this);
+    });
 
     handleSubscriptions(this);
 
@@ -442,7 +442,8 @@ function filterAndAddLocalTrackSids(roomV2, localTrackStats) {
  * @returns {Array<RemoteTrackStats>}
  */
 function filterAndAddRemoteTrackSids(roomV2, remoteTrackStats) {
-  return filterAndAddTrackSids(roomV2._subscribed, remoteTrackStats);
+  const idToSid = new Map(Array.from(roomV2._subscribed.entries()).map(([sid, id]) => [id, sid]));
+  return filterAndAddTrackSids(idToSid, remoteTrackStats);
 }
 
 /**
@@ -567,24 +568,23 @@ function periodicallyPublishStats(roomV2, localParticipant, transport, intervalM
 }
 
 function handleSubscriptions(room) {
-  const remoteTracks = new Map(util.flatMap(room.participants, participant => Array.from(participant.tracks.values()).map(track => [track.sid, track])));
+  const trackSignalings = new Map(util.flatMap(room.participants, participant => Array.from(participant.tracks.values()).map(track => [track.sid, track])));
 
   room._subscriptionFailures.forEach((error, trackSid) => {
-    const remoteTrack = remoteTracks.get(trackSid);
-    if (remoteTrack) {
+    const trackSignaling = trackSignalings.get(trackSid);
+    if (trackSignaling) {
       room._subscriptionFailures.delete(trackSid);
-      remoteTrack.subscribeFailed(createTwilioError(error.code, error.message));
+      trackSignaling.subscribeFailed(createTwilioError(error.code, error.message));
     }
   });
 
-  const subscribedTrackIds = new Set(Array.from(room._subscribed.keys()));
-  remoteTracks.forEach(remoteTrack => {
-    if (!subscribedTrackIds.has(remoteTrack.id)) {
-      remoteTrack.setTrackTransceiver(null);
-      return;
+  trackSignalings.forEach(trackSignaling => {
+    const trackId = room._subscribed.get(trackSignaling.sid);
+    if (!trackId || (trackSignaling.isSubscribed && trackSignaling.trackTransceiver.id !== trackId)) {
+      trackSignaling.setTrackTransceiver(null);
     }
-    if (!remoteTrack.isSubscribed) {
-      room._getTrackReceiver(remoteTrack.id).then(trackReceiver => remoteTrack.setTrackTransceiver(trackReceiver));
+    if (trackId) {
+      room._getTrackReceiver(trackId).then(trackReceiver => trackSignaling.setTrackTransceiver(trackReceiver));
     }
   });
 }

--- a/lib/signaling/v2/transport.js
+++ b/lib/signaling/v2/transport.js
@@ -18,9 +18,9 @@ const {
   createTwilioError,
 } = require('../../util/twilio-video-errors');
 
+const RSP_VERSION = 2;
 const SDK_NAME = `${packageInfo.name}.js`;
 const SDK_VERSION = packageInfo.version;
-const VERSION = 1;
 
 /*
 Transport States
@@ -149,7 +149,7 @@ class Transport extends StateMachine {
       this._session.terminate({
         body: JSON.stringify({
           type: 'disconnect',
-          version: VERSION
+          version: RSP_VERSION
         }),
         extraHeaders: [
           'Content-Type: application/room-signaling+json'
@@ -170,7 +170,7 @@ class Transport extends StateMachine {
   publish(update) {
     update = Object.assign({
       type: 'update',
-      version: VERSION
+      version: RSP_VERSION
     }, update);
     switch (this.state) {
       case 'connected':
@@ -235,7 +235,7 @@ function createSession(transport, name, accessToken, localParticipant, peerConne
         if (transport.state === 'disconnected') {
           return {
             type: 'disconnect',
-            version: VERSION
+            version: RSP_VERSION
           };
         }
         const type = {
@@ -247,7 +247,7 @@ function createSession(transport, name, accessToken, localParticipant, peerConne
           name,
           participant: localParticipant.getState(),
           type,
-          version: VERSION
+          version: RSP_VERSION
         };
 
         if (message.type === 'connect') {
@@ -396,7 +396,7 @@ function reduceUpdates(updates) {
     return reduced;
   }, {
     type: 'update',
-    version: VERSION
+    version: RSP_VERSION
   });
 }
 

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -581,15 +581,17 @@ describe('connect', function() {
           });
         });
 
-        it(`should set each RemoteTrackPublication's .trackName to its ${names ? 'given name' : 'ID'}`, () => {
+        it(`should set each RemoteTrackPublication's .trackName to its ${names ? 'given name' : 'corresponding LocalTrack\'s ID'}`, () => {
           flatMap(thisParticipants, participant => [...participant.trackPublications.values()]).forEach(publication => {
-            assert.equal(publication.trackName, names ? names[publication.kind] : publication.track.id);
+            const thisPublication = thisParticipant.trackPublications.get(publication.trackSid);
+            assert.equal(publication.trackName, names ? names[publication.kind] : thisPublication.track.id);
           });
         });
 
-        it(`should set each RemoteTrack's .name to its ${names ? 'given name' : 'ID'}`, () => {
+        it(`should set each RemoteTrack's .name to its ${names ? 'given name' : 'corresponding LocalTrack\'s ID'}`, () => {
           flatMap(thisParticipants, participant => [...participant.tracks.values()]).forEach(track => {
-            assert.equal(track.name, names ? names[track.kind] : track.id);
+            const thisPublication = thisParticipant.trackPublications.get(track.sid);
+            assert.equal(track.name, names ? names[track.kind] : thisPublication.track.id);
           });
         });
 
@@ -649,15 +651,17 @@ describe('connect', function() {
             });
           });
 
-          it(`should set each Remote${capitalize(kind)}TrackPublication's .trackName to its ${names[kind] ? 'given name' : 'ID'}`, () => {
+          it(`should set each Remote${capitalize(kind)}TrackPublication's .trackName to its ${names[kind] ? 'given name' : 'corresponding LocalTrack\'s ID'}`, () => {
             flatMap(thisParticipants, participant => [...participant[`${kind}TrackPublications`].values()]).forEach(publication => {
-              assert.equal(publication.trackName, names[kind] || publication.track.id);
+              const thisPublication = thisParticipant[`${kind}TrackPublications`].get(publication.trackSid);
+              assert.equal(publication.trackName, names[kind] || thisPublication.track.id);
             });
           });
 
-          it(`should set each Remote${capitalize(kind)}Track's .name to its ${names[kind] ? 'given name' : 'ID'}`, () => {
+          it(`should set each Remote${capitalize(kind)}Track's .name to its ${names[kind] ? 'given name' : 'corresponding LocalTrack\'s ID'}`, () => {
             flatMap(thisParticipants, participant => [...participant[`${kind}Tracks`].values()]).forEach(track => {
-              assert.equal(track.name, names[kind] || track.id);
+              const thisPublication = thisParticipant[`${kind}TrackPublications`].get(track.sid);
+              assert.equal(track.name, names[kind] || thisPublication.track.id);
             });
           });
         });

--- a/test/integration/spec/rest.js
+++ b/test/integration/spec/rest.js
@@ -112,7 +112,7 @@ describe('', () => {
             assert.equal(publication.track, null);
           }
           const subsequentTrack = publication.track;
-          const { id, kind } = originalTrack;
+          const { id, kind } = subscribedOrUnsubscribedTrack;
           const { trackSid } = publication;
 
           assert.equal(subscribedOrUnsubscribedTrack, trackAction === 'subscribe' ? subsequentTrack : originalTrack);

--- a/test/unit/spec/signaling/v2/remoteparticipant.js
+++ b/test/unit/spec/signaling/v2/remoteparticipant.js
@@ -33,69 +33,33 @@ describe('RemoteParticipantV2', () => {
 
     context('.tracks', () => {
       it('constructs a new RemoteTrackPublicationV2 from each trackState', () => {
-        const id1 = makeId();
-        const id2 = makeId();
+        const sid1 = makeSid();
+        const sid2 = makeSid();
         const test = makeTest({
           tracks: [
-            { id: id1 },
-            { id: id2 }
+            { sid: sid1 },
+            { sid: sid2 }
           ]
         });
-        assert.equal(id1, test.remoteTrackPublicationV2s[0].id);
-        assert.equal(id2, test.remoteTrackPublicationV2s[1].id);
+        assert.equal(sid1, test.remoteTrackPublicationV2s[0].sid);
+        assert.equal(sid2, test.remoteTrackPublicationV2s[1].sid);
       });
 
       it('adds the newly-constructed RemoteTrackPublicationV2s to the RemoteParticipantV2\'s .tracks Map', () => {
-        const id1 = makeId();
-        const id2 = makeId();
+        const sid1 = makeSid();
+        const sid2 = makeSid();
         const test = makeTest({
           tracks: [
-            { id: id1 },
-            { id: id2 }
+            { sid: sid1 },
+            { sid: sid2 }
           ]
         });
         assert.equal(
           test.remoteTrackPublicationV2s[0],
-          test.participant.tracks.get(id1));
+          test.participant.tracks.get(sid1));
         assert.equal(
           test.remoteTrackPublicationV2s[1],
-          test.participant.tracks.get(id2));
-      });
-
-      it('calls getTrackTransceiver with the newly-constructed RemoteTrackPublicationV2s\' IDs', () => {
-        const id1 = makeId();
-        const id2 = makeId();
-        const test = makeTest({
-          tracks: [
-            { id: id1 },
-            { id: id2 }
-          ]
-        });
-        assert.equal(id1, test.getTrackTransceiver.args[0][0]);
-        assert.equal(id2, test.getTrackTransceiver.args[1][0]);
-      });
-
-      it('calls setTrackTransceiver on the newly-constructed RemoteTrackPublicationV2s with the results of calling getTrackTransceiver', () => {
-        const id1 = makeId();
-        const id2 = makeId();
-        const test = makeTest({
-          tracks: [
-            { id: id1 },
-            { id: id2 }
-          ]
-        });
-        // NOTE(mroberts): Really we should provide mediaTrackReceiver1 and
-        // mediaTrackReceiver2, etc., but it is a pain to setup.
-        const mediaTrackReceiver = {};
-        test.getTrackTransceiverDeferred.resolve(mediaTrackReceiver);
-        return test.getTrackTransceiverDeferred.promise.then(() => {
-          assert.equal(
-            mediaTrackReceiver,
-            test.remoteTrackPublicationV2s[0].setTrackTransceiver.args[0][0]);
-          assert.equal(
-            mediaTrackReceiver,
-            test.remoteTrackPublicationV2s[1].setTrackTransceiver.args[0][0]);
-        });
+          test.participant.tracks.get(sid2));
       });
     });
   });
@@ -122,25 +86,25 @@ describe('RemoteParticipantV2', () => {
       context('which includes a new trackState not matching an existing RemoteTrackPublicationV2', () => {
         it('constructs a new RemoteTrackPublicationV2 from the trackState', () => {
           const test = makeTest();
-          const id = makeId();
-          const participantState = test.state(test.revision + 1).setTrack({ id: id });
+          const sid = makeSid();
+          const participantState = test.state(test.revision + 1).setTrack({ sid });
           test.participant.update(participantState);
-          assert.equal(id, test.remoteTrackPublicationV2s[0].id);
+          assert.equal(sid, test.remoteTrackPublicationV2s[0].sid);
         });
 
         it('adds the newly-constructed RemoteTrackPublicationV2 to the RemoteParticipantV2\'s .tracks Map', () => {
           const test = makeTest();
-          const id = makeId();
-          const participantState = test.state(test.revision + 1).setTrack({ id: id });
+          const sid = makeSid();
+          const participantState = test.state(test.revision + 1).setTrack({ sid });
           test.participant.update(participantState);
           assert.equal(
             test.remoteTrackPublicationV2s[0],
-            test.participant.tracks.get(id));
+            test.participant.tracks.get(sid));
         });
 
         it('emits the "trackAdded" event with the newly-constructed RemoteTrackPublicationV2', () => {
           const test = makeTest();
-          const participantState = test.state(test.revision + 1).setTrack({ id: makeId() });
+          const participantState = test.state(test.revision + 1).setTrack({ sid: makeSid() });
           let track;
           test.participant.once('trackAdded', _track => { track = _track; });
           test.participant.update(participantState);
@@ -149,62 +113,41 @@ describe('RemoteParticipantV2', () => {
             track);
         });
 
-        it('calls getTrackTransceiver with the newly-constructed RemoteTrackPublicationV2\'s ID', () => {
-          const test = makeTest();
-          const id = makeId();
-          const participantState = test.state(test.revision + 1).setTrack({ id: id });
-          test.participant.update(participantState);
-          assert.equal(id, test.getTrackTransceiver.args[0][0]);
-        });
-
-        it('calls setTrackTransceiver on the newly-constructed RemoteTrackPublicationV2 with the result of calling getTrackTransceiver', () => {
-          const test = makeTest();
-          const participantState = test.state(test.revision + 1).setTrack({ id: makeId() });
-          test.participant.update(participantState);
-          const mediaTrackReceiver = {};
-          test.getTrackTransceiverDeferred.resolve(mediaTrackReceiver);
-          return test.getTrackTransceiverDeferred.promise.then(() => {
-            assert.equal(
-              mediaTrackReceiver,
-              test.remoteTrackPublicationV2s[0].setTrackTransceiver.args[0][0]);
-          });
-        });
-
         it('calls update with the trackState on the newly-constructed RemoteTrackPublicationV2', () => {
           const test = makeTest();
-          const id = makeId();
-          const participantState = test.state(test.revision + 1).setTrack({ id: id, fizz: 'buzz' });
+          const sid = makeSid();
+          const participantState = test.state(test.revision + 1).setTrack({ sid, fizz: 'buzz' });
           test.participant.update(participantState);
           assert.deepEqual(
-            { id: id, fizz: 'buzz' },
+            { sid, fizz: 'buzz' },
             test.remoteTrackPublicationV2s[0].update.args[0][0]);
         });
       });
 
       context('which includes a trackState matching an existing RemoteTrackPublicationV2', () => {
         it('calls update with the trackState on the existing RemoteTrackPublicationV2', () => {
-          const id = makeId();
-          const test = makeTest({ tracks: [{ id: id }] });
-          const participantState = test.state(test.revision + 1).setTrack({ id: id, fizz: 'buzz' });
+          const sid = makeSid();
+          const test = makeTest({ tracks: [{ sid }] });
+          const participantState = test.state(test.revision + 1).setTrack({ sid, fizz: 'buzz' });
           test.participant.update(participantState);
           assert.deepEqual(
-            { id: id, fizz: 'buzz' },
+            { sid, fizz: 'buzz' },
             test.remoteTrackPublicationV2s[0].update.args[1][0]);
         });
       });
 
       context('which no longer includes a trackState matching an existing RemoteTrackPublicationV2', () => {
         it('deletes the RemoteTrackPublicationV2 from the RemoteParticipantV2\'s .tracks Map', () => {
-          const id = makeId();
-          const test = makeTest({ tracks: [{ id: id }] });
+          const sid = makeSid();
+          const test = makeTest({ tracks: [{ sid }] });
           const participantState = test.state(test.revision + 1);
           test.participant.update(participantState);
-          assert(!test.participant.tracks.has(id));
+          assert(!test.participant.tracks.has(sid));
         });
 
         it('emits the "trackRemoved" event with the RemoteTrackPublicationV2', () => {
-          const id = makeId();
-          const test = makeTest({ tracks: [{ id: id }] });
+          const sid = makeSid();
+          const test = makeTest({ tracks: [{ sid }] });
           const participantState = test.state(test.revision + 1);
           let track;
           test.participant.once('trackRemoved', _track => { track = _track; });
@@ -349,14 +292,14 @@ describe('RemoteParticipantV2', () => {
       context('which includes a new trackState not matching an existing RemoteTrackPublicationV2', () => {
         it('does not construct a new RemoteTrackPublicationV2 from the trackState', () => {
           const test = makeTest();
-          const participantState = test.state(test.revision).setTrack({ id: makeId() });
+          const participantState = test.state(test.revision).setTrack({ sid: makeSid() });
           test.participant.update(participantState);
           assert.equal(0, test.remoteTrackPublicationV2s.length);
         });
 
         it('does not call getTrackTransceiver with a newly-constructed RemoteTrackPublicationV2\'s ID', () => {
           const test = makeTest();
-          const participantState = test.state(test.revision).setTrack({ id: makeId() });
+          const participantState = test.state(test.revision).setTrack({ sid: makeSid() });
           test.participant.update(participantState);
           assert(!test.getTrackTransceiver.calledOnce);
         });
@@ -364,9 +307,9 @@ describe('RemoteParticipantV2', () => {
 
       context('which includes a trackState matching an existing RemoteTrackPublicationV2', () => {
         it('does not call update with the trackState on the existing RemoteTrackPublicationV2', () => {
-          const id = makeId();
-          const test = makeTest({ tracks: [{ id: id }] });
-          const participantState = test.state(test.revision).setTrack({ id: id });
+          const sid = makeSid();
+          const test = makeTest({ tracks: [{ sid }] });
+          const participantState = test.state(test.revision).setTrack({ sid });
           test.participant.update(participantState);
           assert(!test.remoteTrackPublicationV2s[0].update.calledTwice);
         });
@@ -374,18 +317,18 @@ describe('RemoteParticipantV2', () => {
 
       context('which no longer includes a trackState matching an existing RemoteTrackPublicationV2', () => {
         it('does not delete the RemoteTrackPublicationV2 from the RemoteParticipantV2\'s .tracks Map', () => {
-          const id = makeId();
-          const test = makeTest({ tracks: [{ id: id }] });
+          const sid = makeSid();
+          const test = makeTest({ tracks: [{ sid }] });
           const participantState = test.state(test.revision);
           test.participant.update(participantState);
           assert.equal(
             test.remoteTrackPublicationV2s[0],
-            test.participant.tracks.get(id));
+            test.participant.tracks.get(sid));
         });
 
         it('does not emit the "trackRemoved" event with the RemoteTrackPublicationV2', () => {
-          const id = makeId();
-          const test = makeTest({ tracks: [{ id: id }] });
+          const sid = makeSid();
+          const test = makeTest({ tracks: [{ sid }] });
           const participantState = test.state(test.revision);
           let trackRemoved;
           test.participant.once('trackRemoved', () => { trackRemoved = false; });
@@ -527,14 +470,14 @@ describe('RemoteParticipantV2', () => {
       context('which includes a new trackState not matching an existing RemoteTrackPublicationV2', () => {
         it('does not construct a new RemoteTrackPublicationV2 from the trackState', () => {
           const test = makeTest();
-          const participantState = test.state(test.revision - 1).setTrack({ id: makeId() });
+          const participantState = test.state(test.revision - 1).setTrack({ sid: makeSid() });
           test.participant.update(participantState);
           assert.equal(0, test.remoteTrackPublicationV2s.length);
         });
 
         it('does not call getTrackTransceiver with a newly-constructed RemoteTrackPublicationV2\'s ID', () => {
           const test = makeTest();
-          const participantState = test.state(test.revision - 1).setTrack({ id: makeId() });
+          const participantState = test.state(test.revision - 1).setTrack({ sid: makeSid() });
           test.participant.update(participantState);
           assert(!test.getTrackTransceiver.calledOnce);
         });
@@ -542,9 +485,9 @@ describe('RemoteParticipantV2', () => {
 
       context('which includes a trackState matching an existing RemoteTrackPublicationV2', () => {
         it('does not call update with the trackState on the existing RemoteTrackPublicationV2', () => {
-          const id = makeId();
-          const test = makeTest({ tracks: [{ id: id }] });
-          const participantState = test.state(test.revision - 1).setTrack({ id: id });
+          const sid = makeSid();
+          const test = makeTest({ tracks: [{ sid }] });
+          const participantState = test.state(test.revision - 1).setTrack({ sid });
           test.participant.update(participantState);
           assert(!test.remoteTrackPublicationV2s[0].update.calledTwice);
         });
@@ -552,18 +495,18 @@ describe('RemoteParticipantV2', () => {
 
       context('which no longer includes a trackState matching an existing RemoteTrackPublicationV2', () => {
         it('does not delete the RemoteTrackPublicationV2 from the RemoteParticipantV2\'s .tracks Map', () => {
-          const id = makeId();
-          const test = makeTest({ tracks: [{ id: id }] });
+          const sid = makeSid();
+          const test = makeTest({ tracks: [{ sid }] });
           const participantState = test.state(test.revision - 1);
           test.participant.update(participantState);
           assert.equal(
             test.remoteTrackPublicationV2s[0],
-            test.participant.tracks.get(id));
+            test.participant.tracks.get(sid));
         });
 
         it('does not emit the "trackRemoved" event with the RemoteTrackPublicationV2', () => {
-          const id = makeId();
-          const test = makeTest({ tracks: [{ id: id }] });
+          const sid = makeSid();
+          const test = makeTest({ tracks: [{ sid }] });
           const participantState = test.state(test.revision - 1);
           let trackRemoved;
           test.participant.once('trackRemoved', () => { trackRemoved = false; });
@@ -691,7 +634,7 @@ describe('RemoteParticipantV2', () => {
     it('returns the RemoteParticipantV2', () => {
       const RemoteTrackPublicationV2 = makeRemoteTrackPublicationV2Constructor();
       const test = makeTest();
-      const track = new RemoteTrackPublicationV2({ id: makeId() });
+      const track = new RemoteTrackPublicationV2({ sid: makeSid() });
       assert.equal(
         test.participant,
         test.participant.addTrack(track));
@@ -699,49 +642,25 @@ describe('RemoteParticipantV2', () => {
 
     it('adds the RemoteTrackPublicationV2 to the RemoteParticipantV2\'s .tracks Map', () => {
       const RemoteTrackPublicationV2 = makeRemoteTrackPublicationV2Constructor();
+      const sid = makeSid();
       const test = makeTest();
-      const id = makeId();
-      const track = new RemoteTrackPublicationV2({ id: id });
+      const track = new RemoteTrackPublicationV2({ sid });
       test.participant.addTrack(track);
       assert.equal(
         track,
-        test.participant.tracks.get(id));
+        test.participant.tracks.get(sid));
     });
 
     it('emits the "trackAdded" event with the RemoteTrackPublicationV2', () => {
       const RemoteTrackPublicationV2 = makeRemoteTrackPublicationV2Constructor();
       const test = makeTest();
-      const track = new RemoteTrackPublicationV2({ id: makeId() });
+      const track = new RemoteTrackPublicationV2({ sid: makeSid() });
       let trackAdded;
       test.participant.once('trackAdded', track => { trackAdded = track; });
       test.participant.addTrack(track);
       assert.equal(
         track,
         trackAdded);
-    });
-
-    it('calls getTrackTransceiver with the newly-constructed RemoteTrackPublicationV2\'s ID', () => {
-      const RemoteTrackPublicationV2 = makeRemoteTrackPublicationV2Constructor();
-      const test = makeTest();
-      const id = makeId();
-      const track = new RemoteTrackPublicationV2({ id: id });
-      test.participant.addTrack(track);
-      assert.equal(id, test.getTrackTransceiver.args[0][0]);
-    });
-
-    it('calls setTrackTransceiver on the newly-constructed RemoteTrackPublicationV2 with the result of calling getTrackTransceiver', () => {
-      const RemoteTrackPublicationV2 = makeRemoteTrackPublicationV2Constructor();
-      const test = makeTest();
-      const id = makeId();
-      const track = new RemoteTrackPublicationV2({ id: id });
-      test.participant.addTrack(track);
-      const mediaTrackReceiver = {};
-      test.getTrackTransceiverDeferred.resolve(mediaTrackReceiver);
-      return test.getTrackTransceiverDeferred.promise.then(() => {
-        assert.equal(
-          mediaTrackReceiver,
-          track.setTrackTransceiver.args[0][0]);
-      });
     });
   });
 
@@ -894,20 +813,20 @@ describe('RemoteParticipantV2', () => {
   describe('#removeTrack', () => {
     context('when the RemoteTrackPublicationV2 to remove was previously added', () => {
       it('returns true', () => {
-        const test = makeTest({ tracks: [{ id: makeId() }] });
+        const test = makeTest({ tracks: [{ id: makeSid() }] });
         assert.equal(
           true,
           test.participant.removeTrack(test.remoteTrackPublicationV2s[0]));
       });
 
       it('deletes the RemoteTrackPublicationV2 from the RemoteParticipantV2\'s .tracks Map', () => {
-        const test = makeTest({ tracks: [{ id: makeId() }] });
+        const test = makeTest({ tracks: [{ id: makeSid() }] });
         test.participant.removeTrack(test.remoteTrackPublicationV2s[0]);
         assert(!test.participant.tracks.has(test.remoteTrackPublicationV2s[0].id));
       });
 
       it('emits the "trackRemoved" event with the RemoteTrackPublicationV2', () => {
-        const test = makeTest({ tracks: [{ id: makeId() }] });
+        const test = makeTest({ tracks: [{ id: makeSid() }] });
         let trackRemoved;
         test.participant.once('trackRemoved', track => { trackRemoved = track; });
         test.participant.removeTrack(test.remoteTrackPublicationV2s[0]);
@@ -920,7 +839,7 @@ describe('RemoteParticipantV2', () => {
     context('when the RemoteTrackPublicationV2 to remove was not previously added', () => {
       it('returns false', () => {
         const RemoteTrackPublicationV2 = makeRemoteTrackPublicationV2Constructor();
-        const track = new RemoteTrackPublicationV2({ id: makeId() });
+        const track = new RemoteTrackPublicationV2({ id: makeSid() });
         const test = makeTest();
         assert.equal(
           false,
@@ -929,7 +848,7 @@ describe('RemoteParticipantV2', () => {
 
       it('does not emit the "trackRemoved" event with the RemoteTrackPublicationV2', () => {
         const RemoteTrackPublicationV2 = makeRemoteTrackPublicationV2Constructor();
-        const track = new RemoteTrackPublicationV2({ id: makeId() });
+        const track = new RemoteTrackPublicationV2({ id: makeSid() });
         const test = makeTest();
         let trackRemoved;
         test.participant.once('trackRemoved', () => { trackRemoved = true; });
@@ -939,10 +858,6 @@ describe('RemoteParticipantV2', () => {
     });
   });
 });
-
-function makeId() {
-  return Math.floor(Math.random() * 1000 + 0.5);
-}
 
 function makeIdentity() {
   return Math.random().toString(36).slice(2);
@@ -1025,7 +940,7 @@ function makeRemoteTrackPublicationV2Constructor(testOptions) {
   testOptions = testOptions || {};
   testOptions.remoteTrackPublicationV2s = testOptions.remoteTrackPublicationV2s || [];
   return function RemoteTrackPublicationV2(trackState) {
-    this.id = trackState.id;
+    this.sid = trackState.sid;
     this.setTrackTransceiver = sinon.spy(() => {});
     this.update = sinon.spy(() => this);
     testOptions.remoteTrackPublicationV2s.push(this);

--- a/test/unit/spec/signaling/v2/remotetrackpublication.js
+++ b/test/unit/spec/signaling/v2/remotetrackpublication.js
@@ -10,22 +10,10 @@ describe('RemoteTrackPublicationV2', () => {
   // -------
 
   describe('constructor', () => {
-    it('sets .id', () => {
-      const id = makeId();
-      assert.equal(id, (new RemoteTrackPublicationV2({
-        enabled: makeEnabled(),
-        id: id,
-        kind: makeKind(),
-        name: makeUUID(),
-        sid: makeSid()
-      })).id);
-    });
-
     it('sets .name', () => {
       const name = makeUUID();
       assert.equal(name, (new RemoteTrackPublicationV2({
         enabled: makeEnabled(),
-        id: makeId(),
         kind: makeKind(),
         name: name,
         sid: makeSid()
@@ -36,7 +24,6 @@ describe('RemoteTrackPublicationV2', () => {
       const sid = makeSid();
       assert.equal(sid, (new RemoteTrackPublicationV2({
         enabled: makeEnabled(),
-        id: makeId(),
         kind: makeKind(),
         name: makeUUID(),
         sid: sid
@@ -47,7 +34,6 @@ describe('RemoteTrackPublicationV2', () => {
       it('sets .isEnabled to true', () => {
         assert((new RemoteTrackPublicationV2({
           enabled: true,
-          id: makeId(),
           kind: makeKind(),
           name: makeUUID(),
           sid: makeSid()
@@ -59,7 +45,6 @@ describe('RemoteTrackPublicationV2', () => {
       it('sets .isEnabled to false', () => {
         assert(!(new RemoteTrackPublicationV2({
           enabled: false,
-          id: makeId(),
           kind: makeKind(),
           name: makeUUID(),
           sid: makeSid()
@@ -71,7 +56,6 @@ describe('RemoteTrackPublicationV2', () => {
       it('sets .kind to "audio"', () => {
         assert.equal('audio', (new RemoteTrackPublicationV2({
           enabled: makeEnabled(),
-          id: makeId(),
           kind: 'audio',
           name: makeUUID(),
           sid: makeSid()
@@ -83,7 +67,6 @@ describe('RemoteTrackPublicationV2', () => {
       it('sets .kind to "video"', () => {
         assert.equal('video', (new RemoteTrackPublicationV2({
           enabled: makeEnabled(),
-          id: makeId(),
           kind: 'video',
           name: makeUUID(),
           sid: makeSid()
@@ -97,7 +80,6 @@ describe('RemoteTrackPublicationV2', () => {
       context('enabled', () => {
         it('returns the RemoteTrackPublicationV2', () => {
           const trackState = {
-            id: makeId(),
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
@@ -110,7 +92,6 @@ describe('RemoteTrackPublicationV2', () => {
 
         it('sets .isEnabled to false', () => {
           const trackState = {
-            id: makeId(),
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
@@ -124,7 +105,6 @@ describe('RemoteTrackPublicationV2', () => {
 
         it('emits an "updated" event with .isEnabled set to false', () => {
           const trackState = {
-            id: makeId(),
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
@@ -142,7 +122,6 @@ describe('RemoteTrackPublicationV2', () => {
       context('disabled', () => {
         it('returns the RemoteTrackPublicationV2', () => {
           const trackState = {
-            id: makeId(),
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
@@ -155,7 +134,6 @@ describe('RemoteTrackPublicationV2', () => {
 
         it('.isEnabled remains false', () => {
           const trackState = {
-            id: makeId(),
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
@@ -169,7 +147,6 @@ describe('RemoteTrackPublicationV2', () => {
 
         it('"updated" does not emit', () => {
           const trackState = {
-            id: makeId(),
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
@@ -189,7 +166,6 @@ describe('RemoteTrackPublicationV2', () => {
       context('enabled', () => {
         it('returns the RemoteTrackPublicationV2', () => {
           const trackState = {
-            id: makeId(),
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
@@ -202,7 +178,6 @@ describe('RemoteTrackPublicationV2', () => {
 
         it('.isEnabled remains true', () => {
           const trackState = {
-            id: makeId(),
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
@@ -216,7 +191,6 @@ describe('RemoteTrackPublicationV2', () => {
 
         it('"updated" does not emit', () => {
           const trackState = {
-            id: makeId(),
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
@@ -234,7 +208,6 @@ describe('RemoteTrackPublicationV2', () => {
       context('disabled', () => {
         it('returns the RemoteTrackPublicationV2', () => {
           const trackState = {
-            id: makeId(),
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
@@ -247,7 +220,6 @@ describe('RemoteTrackPublicationV2', () => {
 
         it('sets .isEnabled to true', () => {
           const trackState = {
-            id: makeId(),
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
@@ -261,7 +233,6 @@ describe('RemoteTrackPublicationV2', () => {
 
         it('emits an "updated" event with .isEnabled set to true', () => {
           const trackState = {
-            id: makeId(),
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
@@ -285,7 +256,6 @@ describe('RemoteTrackPublicationV2', () => {
     context('called when the RemoteTrackPublicationV2 is enabled', () => {
       it('returns the RemoteTrackPublicationV2', () => {
         const track = new RemoteTrackPublicationV2({
-          id: makeId(),
           enabled: true,
           kind: makeKind(),
           name: makeUUID(),
@@ -296,7 +266,6 @@ describe('RemoteTrackPublicationV2', () => {
 
       it('sets .isEnabled to false', () => {
         const track = new RemoteTrackPublicationV2({
-          id: makeId(),
           enabled: true,
           kind: makeKind(),
           name: makeUUID(),
@@ -308,7 +277,6 @@ describe('RemoteTrackPublicationV2', () => {
 
       it('emits an "updated" event with .isEnabled set to false', () => {
         const track = new RemoteTrackPublicationV2({
-          id: makeId(),
           enabled: true,
           kind: makeKind(),
           name: makeUUID(),
@@ -324,7 +292,6 @@ describe('RemoteTrackPublicationV2', () => {
     context('called when the RemoteTrackPublicationV2 is disabled', () => {
       it('returns the RemoteTrackPublicationV2', () => {
         const track = new RemoteTrackPublicationV2({
-          id: makeId(),
           enabled: false,
           kind: makeKind(),
           name: makeUUID(),
@@ -335,7 +302,6 @@ describe('RemoteTrackPublicationV2', () => {
 
       it('.isEnabled remains false', () => {
         const track = new RemoteTrackPublicationV2({
-          id: makeId(),
           enabled: false,
           kind: makeKind(),
           name: makeUUID(),
@@ -347,7 +313,6 @@ describe('RemoteTrackPublicationV2', () => {
 
       it('"updated" does not emit', () => {
         const track = new RemoteTrackPublicationV2({
-          id: makeId(),
           enabled: false,
           kind: makeKind(),
           name: makeUUID(),
@@ -366,7 +331,6 @@ describe('RemoteTrackPublicationV2', () => {
       context('enabled', () => {
         it('returns the RemoteTrackPublicationV2', () => {
           const track = new RemoteTrackPublicationV2({
-            id: makeId(),
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
@@ -377,7 +341,6 @@ describe('RemoteTrackPublicationV2', () => {
 
         it('sets .isEnabled to false', () => {
           const track = new RemoteTrackPublicationV2({
-            id: makeId(),
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
@@ -389,7 +352,6 @@ describe('RemoteTrackPublicationV2', () => {
 
         it('emits an "updated" event with .isEnabled set to false', () => {
           const track = new RemoteTrackPublicationV2({
-            id: makeId(),
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
@@ -405,7 +367,6 @@ describe('RemoteTrackPublicationV2', () => {
       context('disabled', () => {
         it('returns the RemoteTrackPublicationV2', () => {
           const track = new RemoteTrackPublicationV2({
-            id: makeId(),
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
@@ -416,7 +377,6 @@ describe('RemoteTrackPublicationV2', () => {
 
         it('.isEnabled remains false', () => {
           const track = new RemoteTrackPublicationV2({
-            id: makeId(),
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
@@ -428,7 +388,6 @@ describe('RemoteTrackPublicationV2', () => {
 
         it('"updated" does not emit', () => {
           const track = new RemoteTrackPublicationV2({
-            id: makeId(),
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
@@ -446,7 +405,6 @@ describe('RemoteTrackPublicationV2', () => {
       context('enabled', () => {
         it('returns the RemoteTrackPublicationV2', () => {
           const track = new RemoteTrackPublicationV2({
-            id: makeId(),
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
@@ -457,7 +415,6 @@ describe('RemoteTrackPublicationV2', () => {
 
         it('.isEnabled remains true', () => {
           const track = new RemoteTrackPublicationV2({
-            id: makeId(),
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
@@ -469,7 +426,6 @@ describe('RemoteTrackPublicationV2', () => {
 
         it('"updated" does not emit', () => {
           const track = new RemoteTrackPublicationV2({
-            id: makeId(),
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
@@ -485,7 +441,6 @@ describe('RemoteTrackPublicationV2', () => {
       context('disabled', () => {
         it('returns the RemoteTrackPublicationV2', () => {
           const track = new RemoteTrackPublicationV2({
-            id: makeId(),
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
@@ -496,7 +451,6 @@ describe('RemoteTrackPublicationV2', () => {
 
         it('sets .isEnabled to true', () => {
           const track = new RemoteTrackPublicationV2({
-            id: makeId(),
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
@@ -508,7 +462,6 @@ describe('RemoteTrackPublicationV2', () => {
 
         it('emits an "updated" event with .isEnabled set to true', () => {
           const track = new RemoteTrackPublicationV2({
-            id: makeId(),
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
@@ -526,7 +479,6 @@ describe('RemoteTrackPublicationV2', () => {
       context('enabled', () => {
         it('returns the RemoteTrackPublicationV2', () => {
           const track = new RemoteTrackPublicationV2({
-            id: makeId(),
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
@@ -537,7 +489,6 @@ describe('RemoteTrackPublicationV2', () => {
 
         it('.isEnabled remains true', () => {
           const track = new RemoteTrackPublicationV2({
-            id: makeId(),
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
@@ -549,7 +500,6 @@ describe('RemoteTrackPublicationV2', () => {
 
         it('"updated" does not emit', () => {
           const track = new RemoteTrackPublicationV2({
-            id: makeId(),
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
@@ -565,7 +515,6 @@ describe('RemoteTrackPublicationV2', () => {
       context('disabled', () => {
         it('returns the RemoteTrackPublicationV2', () => {
           const track = new RemoteTrackPublicationV2({
-            id: makeId(),
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
@@ -576,7 +525,6 @@ describe('RemoteTrackPublicationV2', () => {
 
         it('sets .isEnabled to true', () => {
           const track = new RemoteTrackPublicationV2({
-            id: makeId(),
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
@@ -588,7 +536,6 @@ describe('RemoteTrackPublicationV2', () => {
 
         it('emits an "updated" event with .isEnabled set to true', () => {
           const track = new RemoteTrackPublicationV2({
-            id: makeId(),
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
@@ -606,7 +553,6 @@ describe('RemoteTrackPublicationV2', () => {
   describe('#setTrackTransceiver', () => {
     it('returns the RemoteTrackPublicationV2', () => {
       const track = new RemoteTrackPublicationV2({
-        id: makeId(),
         enabled: makeEnabled(),
         kind: makeKind(),
         name: makeUUID(),
@@ -618,7 +564,6 @@ describe('RemoteTrackPublicationV2', () => {
 
     it('emits "updated" with .trackTransceiver set to the given TrackReceiver', () => {
       const track = new RemoteTrackPublicationV2({
-        id: makeId(),
         enabled: makeEnabled(),
         kind: makeKind(),
         name: makeUUID(),
@@ -637,10 +582,6 @@ describe('RemoteTrackPublicationV2', () => {
 
 function makeEnabled() {
   return (Math.random() < 0.5);
-}
-
-function makeId() {
-  return makeUUID();
 }
 
 function makeKind() {

--- a/test/unit/spec/signaling/v2/transport.js
+++ b/test/unit/spec/signaling/v2/transport.js
@@ -89,8 +89,8 @@ describe('Transport', () => {
               assert.equal('update', message.type);
             });
 
-            it('has .version 1', () => {
-              assert.equal(1, message.version);
+            it('has .version 2', () => {
+              assert.equal(2, message.version);
             });
           });
 
@@ -125,8 +125,8 @@ describe('Transport', () => {
               assert.equal('string', typeof message.publisher.user_agent);
             });
 
-            it('has .version 1', () => {
-              assert.equal(1, message.version);
+            it('has .version 2', () => {
+              assert.equal(2, message.version);
             });
 
             it.skip('advertises support for Network Quality Signaling over RTCDataChannel', () => {
@@ -149,7 +149,7 @@ describe('Transport', () => {
             it('is a disconnect request', () => {
               assert.deepEqual({
                 type: 'disconnect',
-                version: 1
+                version: 2
               }, message);
             });
           });
@@ -175,8 +175,8 @@ describe('Transport', () => {
               assert.equal('sync', message.type);
             });
 
-            it('has .version 1', () => {
-              assert.equal(1, message.version);
+            it('has .version 2', () => {
+              assert.equal(2, message.version);
             });
           });
         });
@@ -245,7 +245,7 @@ describe('Transport', () => {
         it('sets the body to a disconnect RSP request', () => {
           assert.deepEqual({
             type: 'disconnect',
-            version: 1
+            version: 2
           }, JSON.parse(test.session.terminate.args[0][0].body));
         });
 
@@ -289,7 +289,7 @@ describe('Transport', () => {
         it('sets the body to a disconnect RSP request', () => {
           assert.deepEqual({
             type: 'disconnect',
-            version: 1
+            version: 2
           }, JSON.parse(test.session.terminate.args[0][0].body));
         });
 
@@ -363,7 +363,7 @@ describe('Transport', () => {
         it('sets the body to a disconnect RSP request', () => {
           assert.deepEqual({
             type: 'disconnect',
-            version: 1
+            version: 2
           }, JSON.parse(test.session.terminate.args[0][0].body));
         });
 
@@ -477,7 +477,7 @@ describe('Transport', () => {
         }
       ],
       type: 'update',
-      version: 1
+      version: 2
     };
 
     context('"connected"', () => {
@@ -504,7 +504,7 @@ describe('Transport', () => {
           assert.deepEqual({
             foo: 'bar',
             type: 'update',
-            version: 1
+            version: 2
           }, JSON.parse(test.session.sendRequest.args[0][1].body));
         });
 


### PR DESCRIPTION
@syerrapragada 

Since we consume the `published` and `subscribed` payloads in RSP, we now bump the RSP version to 2.