### PR TITLE
Workaround for media problems b/w Chrome("unfied-plan") offerer and Chrome("plan-b") answerer.

### DIFF
--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -517,6 +517,13 @@ class PeerConnectionV2 extends StateMachine {
         const sendersOfKind = senders.filter(isSenderOfKind.bind(null, kind));
         return shouldOffer || (mediaSections.length < sendersOfKind.length);
       }, shouldReoffer);
+    } else {
+      // NOTE(mmalavalli): When Chrome ("unified-plan") is the offerer and Chrome
+      // ("plan-b") is the answerer in a peer-to-peer Room, Chrome ("unified-plan")
+      // does not play back media the Chrome ("plan-b"), even though it looks like
+      // the selected RTCIceCandidate pair receives the RTP packets. We work around
+      // this by re-negotiating media with Chrome ("plan-b") as the offerer.
+      shouldReoffer = shouldReoffer || (isChrome && localDescription.type === 'answer');
     }
 
     // NOTE(mroberts): We also need to re-offer if we have a DataTrack to share

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   },
   "dependencies": {
     "@twilio/sip.js": "^0.7.7",
-    "@twilio/webrtc": "twilio/twilio-webrtc.js#3.2.0-rc4",
+    "@twilio/webrtc": "twilio/twilio-webrtc.js#bbe9e4decc88dc65157ef1dfead521cbedb21fde",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },


### PR DESCRIPTION
@syerrapragada 

We work around this issue for now by triggering a re-negotiation with Chrome("plan-b") as the offerer.