### PR TITLE
JSDK-2248 Re-negotiate only if Chrome("plan-b") receives an offer from Chrome("unfied-plan").

### DIFF
--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -334,7 +334,7 @@ class PeerConnectionV2 extends StateMachine {
       }
       return this._setLocalDescription(answer);
     }).then(() => this._checkIceBox(offer)).then(() => this._peerConnection.localDescription
-      ? this._maybeReoffer(this._peerConnection.localDescription)
+      ? this._maybeReoffer(this._peerConnection.localDescription, offer)
       : Promise.resolve()).catch(error => {
       throw error instanceof MediaClientRemoteDescFailedError
         ? error
@@ -492,9 +492,10 @@ class PeerConnectionV2 extends StateMachine {
    * Conditionally re-offer.
    * @private
    * @param {RTCSessionDescriptionInit} localDescription
+   * @param {RTCSessionDescriptionInit} [receivedRemoteDescription]
    * @returns {Promise<void>}
    */
-  _maybeReoffer(localDescription) {
+  _maybeReoffer(localDescription, receivedRemoteDescription) {
     let shouldReoffer = this._shouldOffer;
 
     // NOTE(mmalavalli): For "unified-plan" sdps, if the remote RTCPeerConnection sends
@@ -517,13 +518,14 @@ class PeerConnectionV2 extends StateMachine {
         const sendersOfKind = senders.filter(isSenderOfKind.bind(null, kind));
         return shouldOffer || (mediaSections.length < sendersOfKind.length);
       }, shouldReoffer);
-    } else {
+    } else if (isChrome && localDescription.type === 'answer') {
       // NOTE(mmalavalli): When Chrome ("unified-plan") is the offerer and Chrome
       // ("plan-b") is the answerer in a peer-to-peer Room, Chrome ("unified-plan")
       // does not play back media the Chrome ("plan-b"), even though it looks like
       // the selected RTCIceCandidate pair receives the RTP packets. We work around
       // this by re-negotiating media with Chrome ("plan-b") as the offerer.
-      shouldReoffer = shouldReoffer || (isChrome && localDescription.type === 'answer');
+      const sdp = receivedRemoteDescription ? receivedRemoteDescription.sdp : '';
+      shouldReoffer = shouldReoffer || /s=cr-unified/.test(sdp);
     }
 
     // NOTE(mroberts): We also need to re-offer if we have a DataTrack to share
@@ -820,7 +822,9 @@ class PeerConnectionV2 extends StateMachine {
       revision: this._descriptionRevision
     };
     if (this._localDescription.sdp) {
-      localDescription.sdp = this._localDescription.sdp;
+      localDescription.sdp = isChrome && this._isUnifiedPlan
+        ? this._localDescription.sdp.replace(/s=.*/m, 's=cr-unified')
+        : this._localDescription.sdp;
     }
     return {
       description: localDescription,


### PR DESCRIPTION
@syerrapragada @innerverse @ramapal 

This PR uses the `s=cr-unified` line in the SDP for a Chrome("plan-b") client to re-offer if the offerer is Chrome("unified-plan").