### PR TITLE
Prep for 2.0.0-rc11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 New Features
 ------------
 
+- `Room.getStats` on Firefox will now consume the spec-compliant `RTCIceCandidateStats`
+  available in [versions 65 and above](https://www.fxsitecompat.com/en-CA/docs/2018/rtcicecandidatestats-has-been-updated-to-the-latest-spec/). (JSDK-2235)
+
 - Participants will now be able to stay in the Room and recover their media
   connections if the media server becomes unresponsive, instead of being
   disconnected. (JSDK-2245)

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   },
   "dependencies": {
     "@twilio/sip.js": "^0.7.7",
-    "@twilio/webrtc": "twilio/twilio-webrtc.js#bbe9e4decc88dc65157ef1dfead521cbedb21fde",
+    "@twilio/webrtc": "twilio/twilio-webrtc.js#3.2.0-rc5",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },


### PR DESCRIPTION
This PR is for preparing for twilio-video.js@2.0.0-rc11.