### PR TITLE
JSDK-2266 Fixing broken Electron 2.x support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+1.15.1 (in progress)
+====================
+
+Bug Fixes
+---------
+
+- Fixed a bug where RemoteTrack subscription events were not firing in Electron 2.x. (JSDK-2266)
+
 1.15.0 (January 11, 2019)
 =========================
 

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   },
   "dependencies": {
     "@twilio/sip.js": "^0.7.7",
-    "@twilio/webrtc": "^2.2.0",
+    "@twilio/webrtc": "twilio/twilio-webrtc.js#JSDK-2266",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   },
   "dependencies": {
     "@twilio/sip.js": "^0.7.7",
-    "@twilio/webrtc": "twilio/twilio-webrtc.js#JSDK-2266",
+    "@twilio/webrtc": "twilio/twilio-webrtc.js#55de34656af4e3424ae91186d0756ace7a9ff175",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },


### PR DESCRIPTION
@syerrapragada 

This PR addresses [this issue](https://github.com/twilio/twilio-video.js/issues/507) raised by a customer.