### PR TITLE
JSDK-2219 Avoid changing mids of RTCRtpTransceivers during negotiation.

### DIFF
--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -318,7 +318,7 @@ class PeerConnectionV2 extends StateMachine {
    * Create an answer and set it on the {@link PeerConnectionV2}.
    * @private
    * @param {RTCSessionDescriptionInit} offer
-   * @returns {Promise<void>}
+   * @returns {Promise<boolean>}
    */
   _answer(offer) {
     return Promise.resolve().then(() => {
@@ -335,7 +335,7 @@ class PeerConnectionV2 extends StateMachine {
       return this._setLocalDescription(answer);
     }).then(() => this._checkIceBox(offer)).then(() => this._peerConnection.localDescription
       ? this._maybeReoffer(this._peerConnection.localDescription)
-      : Promise.resolve()).catch(error => {
+      : Promise.resolve(false)).catch(error => {
       throw error instanceof MediaClientRemoteDescFailedError
         ? error
         : new MediaClientLocalDescFailedError();
@@ -700,7 +700,7 @@ class PeerConnectionV2 extends StateMachine {
           return this._handleGlare(description);
         }
         this._descriptionRevision = description.revision;
-        return this._answer(description);
+        return this._answer(description).then(() => {});
       default:
         // Do nothing.
     }
@@ -718,7 +718,7 @@ class PeerConnectionV2 extends StateMachine {
     }).then(() => this._queuedDescription && this._updateDescription(this._queuedDescription)).then(() => {
       this._queuedDescription = null;
       return this._peerConnection.localDescription
-        ? this._maybeReoffer(this._peerConnection.localDescription)
+        ? this._maybeReoffer(this._peerConnection.localDescription).then(() => {})
         : Promise.resolve();
     });
   }
@@ -1019,12 +1019,13 @@ function getTransceiverDirection(sdp, mid) {
 
 /**
  * @param {string} sdp
- * @returns {Array<string>} mids
+ * @returns {{audio: Array<string>, video: Array<string>}} mids
  */
 function getMids(sdp) {
-  return sdp.match(/\r\na=mid:.+$/mg)
-    .map(match => match.split(':')[1])
-    .filter(mid => mid);
+  return ['audio', 'video'].reduce((mids, kind) => {
+    mids[kind] = getMediaSections(sdp, kind).map(section => section.match(/^a=mid:(.+)$/m)[1]);
+    return mids;
+  }, {});
 }
 
 /**
@@ -1042,7 +1043,7 @@ function shouldStopTransceiver(description, transceiver) {
   // NOTE(mroberts): We don't want to stop the initial two audio and video
   // RTCRtpTransceivers that everyone negotiates with.
   const mids = getMids(description.sdp);
-  if (transceiver.mid === mids[0] || transceiver.mid === mids[1]) {
+  if (transceiver.mid === mids.audio[0] || transceiver.mid === mids.video[0]) {
     return false;
   }
 

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -387,7 +387,9 @@ class PeerConnectionV2 extends StateMachine {
       this._isRestartingIce = false;
       this._shouldRestartIce = true;
     }
-    return Promise.resolve().then(() => this._setLocalDescription({ type: 'rollback' })).then(() => this._answer(offer)).then(() => this._offer());
+    return Promise.resolve().then(() => this._setLocalDescription({ type: 'rollback' }))
+      .then(() => this._answer(offer))
+      .then(didReoffer => didReoffer ? Promise.resolve() : this._offer());
   }
 
   /**
@@ -492,7 +494,7 @@ class PeerConnectionV2 extends StateMachine {
    * Conditionally re-offer.
    * @private
    * @param {RTCSessionDescriptionInit} localDescription
-   * @returns {Promise<void>}
+   * @returns {Promise<boolean>}
    */
   _maybeReoffer(localDescription) {
     let shouldReoffer = this._shouldOffer;
@@ -526,7 +528,8 @@ class PeerConnectionV2 extends StateMachine {
     const needsApplicationMediaSection = hasDataTrack && !hasApplicationMediaSection;
     shouldReoffer = shouldReoffer || needsApplicationMediaSection;
 
-    return shouldReoffer ? this._offer() : Promise.resolve();
+    const promise = shouldReoffer ? this._offer() : Promise.resolve();
+    return promise.then(() => shouldReoffer);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   },
   "dependencies": {
     "@twilio/sip.js": "^0.7.7",
-    "@twilio/webrtc": "^3.2.0",
+    "@twilio/webrtc": "twilio/twilio-webrtc.js#JSDK-2219-chrome-73",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   },
   "dependencies": {
     "@twilio/sip.js": "^0.7.7",
-    "@twilio/webrtc": "twilio/twilio-webrtc.js#JSDK-2219-chrome-73",
+    "@twilio/webrtc": "twilio/twilio-webrtc.js#b81069d1bb1da7e17c3605e1226055626073931b",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -34,6 +34,7 @@ const {
   randomName,
   tracksSubscribed,
   tracksPublished,
+  tracksUnpublished,
   tracksUnsubscribed,
   trackStarted,
   waitForTracks
@@ -541,7 +542,7 @@ describe('LocalParticipant', function() {
           thisParticipant.unpublishTrack(thisTrack);
 
           await Promise.all(thoseParticipants.map(thatParticipant => {
-            return tracksUnsubscribed(thatParticipant, thisParticipant._tracks.size);
+            return tracksUnpublished(thatParticipant, thisParticipant._tracks.size);
           }));
 
           await Promise.all([

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -247,6 +247,18 @@ async function tracksPublished(participant, n, kind) {
 }
 
 /**
+ * Wait for {@link RemoteTrack}s of a {@link RemoteParticipant} to be unpublished.
+ * @param {RemoteParticipant} participant - the {@link RemoteParticipant}
+ * @param {number} n - the final number of {@link RemoteTrack}s to count down to
+ * @returns Promise<void>
+ */
+async function tracksUnpublished(participant, n) {
+  while (participant.tracks.size > n) {
+    await new Promise(resolve => participant.once('trackUnpublished', resolve));
+  }
+}
+
+/**
  * Wait for {@link RemoteTrack}s of a {@link RemoteParticipant} to be unsubscribed from.
  * @param {RemoteParticipant} participant - the {@link RemoteParticipant}
  * @param {number} n - the final number of {@link RemoteTrack}s to count down to
@@ -330,6 +342,7 @@ exports.randomBoolean = randomBoolean;
 exports.randomName = randomName;
 exports.tracksSubscribed = tracksSubscribed;
 exports.tracksPublished = tracksPublished;
+exports.tracksUnpublished = tracksUnpublished;
 exports.tracksUnsubscribed = tracksUnsubscribed;
 exports.trackStarted = trackStarted;
 exports.waitForTracks = waitForTracks;


### PR DESCRIPTION
@syerrapragada 

Starting from Chrome 73 and Firefox 64, calling createOffer() a second time without calling setLocalDescription() on the first offer will change the mids of those RTCRtpTransceivers that have not yet been fully negotiated (gone through an offer --> answer cycle).

Also, `offerToReceive{Audio,Video}` reuses the first m= line of its kind, thereby generating a new mid for it.

This PR does the following to handle the above behaviors:
* Reduce instances of `createOffer` being called more than once per negotiation.
* Ensure that the first audio and video m= lines are never recycled (Firefox only).
This PR does the following to handle the above behaviors:
* Reduce instances of `createOffer` being called more than once per negotiation.
* Ensure that the first audio and video m= lines are never recycled (Firefox only).