### PR TITLE
JSDK-2267, JSDK-2268

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 Bug Fixes
 ---------
 
+- Fixed a bug where `Room.getStats` was throwing a TypeError in Electron 2.x and 3.x. (JSDK-2267)
 - Fixed a bug where RemoteTrack subscription events were not firing in Electron 2.x. (JSDK-2266)
 
 1.15.0 (January 11, 2019)

--- a/lib/media/track/localmediatrack.js
+++ b/lib/media/track/localmediatrack.js
@@ -15,7 +15,7 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
   return class LocalMediaTrack extends AudioOrVideoTrack {
     /**
      * Construct a {@link LocalMediaTrack} from a MediaStreamTrack.
-     * @param {MediaStream} mediaStreamTrack - The underlying MediaStreamTrack
+     * @param {MediaStreamTrack} mediaStreamTrack - The underlying MediaStreamTrack
      * @param {LocalTrackOptions} [options] - {@link LocalTrack} options
      */
     constructor(mediaStreamTrack, options) {
@@ -35,12 +35,12 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
         isEnabled: {
           enumerable: true,
           get() {
-            return this.mediaStreamTrack.enabled;
+            return mediaStreamTrack.enabled;
           }
         },
         isStopped: {
           get() {
-            return this.mediaStreamTrack.readyState === 'ended';
+            return mediaStreamTrack.readyState === 'ended';
           }
         }
       });

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   },
   "dependencies": {
     "@twilio/sip.js": "^0.7.7",
-    "@twilio/webrtc": "twilio/twilio-webrtc.js#2.2.1-rc1",
+    "@twilio/webrtc": "twilio/twilio-webrtc.js#e5a038f505c7d004e6b5514b6e761be0d209aa02",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },


### PR DESCRIPTION
@syerrapragada 

This PR fixes:

JSDK-2267: getStats support for Electron 2.x and 3.x.
JSDK-2268: Safari console's object explorer throws TypeError for `isEnabled` and `isStopped`.