### PR TITLE
JSDK-2265 Removing "plan-b" enforcement.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ New Features
 ------------
 
 - twilio-video.js will now use the Unified Plan SDP format where available.
-  Google Chrome, starting from version 72 has, and Safari, starting from version
-  12.1 will enable Unified Plan as the default SDP format. We highly recommend
+  Google Chrome, starting from version 72, has and Safari, starting from version
+  12.1, will enable Unified Plan as the default SDP format. We highly recommend
   that you upgrade your twilio-video.js dependency to this version so that your
   application continues to work on the above mentioned browser versions.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,24 @@
 New Features
 ------------
 
-- twilio-video.js will now support the Unified Plan SDP format where applicable.
+- twilio-video.js will now use the Unified Plan SDP format where available.
   Chrome, starting from version 72, and Safari, starting from version 12.1 will
   enable Unified Plan as the default SDP format. We highly recommend that you
   upgrade your twilio-video.js dependency to this version so that your application
-  continues to work on the above mentioned browser versions. For more details, please
-  refer to the Unified Plan Guide. (JSDK-2265)
+  continues to work on the above mentioned browser versions.
+
+  In December 2018, we published an [advisory](https://support.twilio.com/hc/en-us/articles/360012782494-Breaking-Changes-in-Twilio-Video-JavaScript-SDKs-December-2018-)
+  recommending customers to upgrade to the latest versions of twilio-video.js
+  in order to not be affected by Chrome switching to Unified Plan starting from
+  version 72. The way we ensured support for newer versions of Chrome in the
+  versions of twilio-video.js released between December 2018 and now was by
+  overriding the default SDP format to Plan B.
+
+  We also mentioned that we are working to support Unified Plan on all browsers in future
+  versions of twilio-video.js, so that we can continue to support our customers on
+  browser versions that no longer support the older Plan B SDP format. This version
+  of twilio-video.js will use Unified Plan where available, while also maintaining
+  support for earlier browser versions with Plan B as the default SDP format. (JSDK-2265)
 
 Bug Fixes
 ---------
@@ -17,24 +29,6 @@ Bug Fixes
 - Fixed a bug where `Room.getStats` was throwing a TypeError in Electron 3.x. (JSDK-2267)
 - Fixed a bug where the LocalParticipant sometimes failed to publish a LocalTrack
   to a group Room due to media negotiation failure. (JSDK-2219)
-
-Unified Plan Guide
-------------------
-
-In December 2018, we published this [advisory](https://support.twilio.com/hc/en-us/articles/360012782494-Breaking-Changes-in-Twilio-Video-JavaScript-SDKs-December-2018-),
-where we recommended customers to upgrade to the latest versions of twilio-video.js
-in order not be affected by Chrome migrating to Unified Plan as the default SDP format,
-starting from version 72. The way we ensured that we support newer versions of Chrome was
-by overriding the default SDP format to Plan B.
-
-We also mentioned that we are working to support Unified Plan on all browsers in future
-versions of twilio-video.js, so that we can continue to support our customers on
-browser versions that no longer support the older Plan B SDP format. This version
-of twilio-video.js will support Unified Plan, which is the default SDP format
-in Chrome starting from version 72 and in Safari starting from version 12.1, while
-also maintaining support for earlier browser versions with Plan B as the default SDP
-format.
-
 
 2.0.0-beta5 (January 7, 2019)
 =============================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,21 @@
 2.0.0-beta6 (in progress)
 =========================
 
+New Features
+------------
+
+- twilio-video.js will now support the Unified Plan SDP format where applicable.
+  Chrome, starting from version 72, and Safari, starting from version 12.1 will
+  enable Unified Plan as the default SDP format. We highly recommend that you
+  upgrade your twilio-video.js dependency to this version so that your application
+  does not break on the above mentioned browser versions. (JSDK-2265)
+
 Bug Fixes
 ---------
 
 - Fixed a bug where `Room.getStats` was throwing a TypeError in Electron 3.x. (JSDK-2267)
+- Fixed a bug where the LocalParticipant sometimes failed to publish a LocalTrack
+  to a group Room due to media negotiation failure. (JSDK-2219)
 
 2.0.0-beta5 (January 7, 2019)
 =============================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ New Features
   Chrome, starting from version 72, and Safari, starting from version 12.1 will
   enable Unified Plan as the default SDP format. We highly recommend that you
   upgrade your twilio-video.js dependency to this version so that your application
-  does not break on the above mentioned browser versions. (JSDK-2265)
+  continues to work on the above mentioned browser versions. For more details, please
+  refer to the Unified Plan Guide. (JSDK-2265)
 
 Bug Fixes
 ---------
@@ -16,6 +17,24 @@ Bug Fixes
 - Fixed a bug where `Room.getStats` was throwing a TypeError in Electron 3.x. (JSDK-2267)
 - Fixed a bug where the LocalParticipant sometimes failed to publish a LocalTrack
   to a group Room due to media negotiation failure. (JSDK-2219)
+
+Unified Plan Guide
+------------------
+
+In December 2018, we published this [advisory](https://support.twilio.com/hc/en-us/articles/360012782494-Breaking-Changes-in-Twilio-Video-JavaScript-SDKs-December-2018-),
+where we recommended customers to upgrade to the latest versions of twilio-video.js
+in order not be affected by Chrome migrating to Unified Plan as the default SDP format,
+starting from version 72. The way we ensured that we support newer versions of Chrome was
+by overriding the default SDP format to Plan B.
+
+We also mentioned that we are working to support Unified Plan on all browsers in future
+versions of twilio-video.js, so that we can continue to support our customers on
+browser versions that no longer support the older Plan B SDP format. This version
+of twilio-video.js will support Unified Plan, which is the default SDP format
+in Chrome starting from version 72 and in Safari starting from version 12.1, while
+also maintaining support for earlier browser versions with Plan B as the default SDP
+format.
+
 
 2.0.0-beta5 (January 7, 2019)
 =============================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,22 +5,18 @@ New Features
 ------------
 
 - twilio-video.js will now use the Unified Plan SDP format where available.
-  Chrome, starting from version 72, and Safari, starting from version 12.1 will
-  enable Unified Plan as the default SDP format. We highly recommend that you
-  upgrade your twilio-video.js dependency to this version so that your application
-  continues to work on the above mentioned browser versions.
+  Google Chrome, starting from version 72 has, and Safari, starting from version
+  12.1 will enable Unified Plan as the default SDP format. We highly recommend
+  that you upgrade your twilio-video.js dependency to this version so that your
+  application continues to work on the above mentioned browser versions.
 
   In December 2018, we published an [advisory](https://support.twilio.com/hc/en-us/articles/360012782494-Breaking-Changes-in-Twilio-Video-JavaScript-SDKs-December-2018-)
   recommending customers to upgrade to the latest versions of twilio-video.js
-  in order to not be affected by Chrome switching to Unified Plan starting from
-  version 72. The way we ensured support for newer versions of Chrome in the
-  versions of twilio-video.js released between December 2018 and now was by
-  overriding the default SDP format to Plan B.
-
-  We also mentioned that we are working to support Unified Plan on all browsers in future
-  versions of twilio-video.js, so that we can continue to support our customers on
-  browser versions that no longer support the older Plan B SDP format. This version
-  of twilio-video.js will use Unified Plan where available, while also maintaining
+  in order to not be affected by Google Chrome switching to Unified Plan starting
+  from version 72. The way we ensured support of newer versions of Google Chrome
+  in the versions of twilio-video.js released between December 2018 and now was
+  by overriding the default SDP format to Plan B. Starting with this version,
+  twilio-video.js will use Unified Plan where available, while also maintaining
   support for earlier browser versions with Plan B as the default SDP format. (JSDK-2265)
 
 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+2.0.0-beta6 (in progress)
+=========================
+
+Bug Fixes
+---------
+
+- Fixed a bug where `Room.getStats` was throwing a TypeError in Electron 3.x. (JSDK-2267)
+
 2.0.0-beta5 (January 7, 2019)
 =============================
 

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { guessBrowser } = require('@twilio/webrtc/lib/util');
 const CancelablePromise = require('./util/cancelablepromise');
 const createCancelableRoomPromise = require('./cancelableroompromise');
 const createLocalTracks = require('./createlocaltracks');
@@ -8,7 +9,6 @@ const constants = require('./util/constants');
 const Room = require('./room');
 const E = require('./util/constants').typeErrors;
 const EncodingParametersImpl = require('./encodingparameters');
-const guessBrowser = require('./util').guessBrowser;
 const LocalAudioTrack = require('./media/track/es5/localaudiotrack');
 const LocalDataTrack = require('./media/track/es5/localdatatrack');
 const LocalParticipant = require('./localparticipant');

--- a/lib/media/track/localmediatrack.js
+++ b/lib/media/track/localmediatrack.js
@@ -14,7 +14,7 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
   return class LocalMediaTrack extends AudioOrVideoTrack {
     /**
      * Construct a {@link LocalMediaTrack} from a MediaStreamTrack.
-     * @param {MediaStream} mediaStreamTrack - The underlying MediaStreamTrack
+     * @param {MediaStreamTrack} mediaStreamTrack - The underlying MediaStreamTrack
      * @param {LocalTrackOptions} [options] - {@link LocalTrack} options
      */
     constructor(mediaStreamTrack, options) {
@@ -38,13 +38,13 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
         isEnabled: {
           enumerable: true,
           get() {
-            return this.mediaStreamTrack.enabled;
+            return mediaStreamTrack.enabled;
           }
         },
         isStopped: {
           enumerable: true,
           get() {
-            return this.mediaStreamTrack.readyState === 'ended';
+            return mediaStreamTrack.readyState === 'ended';
           }
         }
       });

--- a/lib/signaling/v2/cancelableroomsignalingpromise.js
+++ b/lib/signaling/v2/cancelableroomsignalingpromise.js
@@ -16,10 +16,6 @@ function createCancelableRoomSignalingPromise(token, uaOrWsServer, localParticip
     Transport: options._useTwilioConnection ? TwilioConnectionTransport : DefaultTransport
   }, options);
 
-  if (options._sdpSemantics) {
-    options.sdpSemantics = options._sdpSemantics;
-  }
-
   let transport;
 
   const PeerConnectionManager = options.PeerConnectionManager;
@@ -67,8 +63,7 @@ function createCancelableRoomSignalingPromise(token, uaOrWsServer, localParticip
           networkQuality: options.networkQuality,
           iceServerSourceStatus: iceServerSource.status,
           insights: options.insights,
-          realm: options.realm,
-          sdpSemantics: options.sdpSemantics
+          realm: options.realm
         }, transportOptions);
 
         const Transport = options.Transport;

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -636,7 +636,7 @@ class PeerConnectionV2 extends StateMachine {
         this._log.debug('An ICE restart was in-progress and is now completed');
         this._isRestartingIce = false;
       }
-      if (isUnifiedPlan && this._peerConnection.getTransceivers) {
+      if (isUnifiedPlan) {
         this._peerConnection.getTransceivers().forEach(transceiver => {
           if (shouldStopTransceiver(description, transceiver)) {
             transceiver.stop();

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -505,7 +505,7 @@ class PeerConnectionV2 extends StateMachine {
     // We can reduce the number of cases where renegotiation is needed by
     // re-introducing 'offerToReceiveAudio' to the default RTCOfferOptions with a
     // value > 1.
-    if (isUnifiedPlan) {
+    if (isUnifiedPlan && localDescription.type === 'answer') {
       const senders = this._peerConnection.getSenders().filter(sender => sender.track);
       shouldReoffer = ['audio', 'video'].reduce((shouldOffer, kind) => {
         const mediaSections = getMediaSections(localDescription.sdp, kind, '(sendrecv|sendonly)');

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1,13 +1,14 @@
 'use strict';
 
 const WebRTC = require('@twilio/webrtc');
+const { guessBrowser } = require('@twilio/webrtc/lib/util');
+const { getSdpFormat } = require('@twilio/webrtc/lib/util/sdp');
 const DefaultMediaStream = WebRTC.MediaStream;
 const DefaultRTCIceCandidate = WebRTC.RTCIceCandidate;
 const DefaultRTCPeerConnection = WebRTC.RTCPeerConnection;
 const DefaultRTCSessionDescription = WebRTC.RTCSessionDescription;
 const getStatistics = WebRTC.getStats;
 const getMediaSections = require('../../util/sdp').getMediaSections;
-const guessBrowser = require('../../util').guessBrowser;
 const oncePerTick = require('../../util').oncePerTick;
 const setBitrateParameters = require('../../util/sdp').setBitrateParameters;
 const setCodecPreferences = require('../../util/sdp').setCodecPreferences;
@@ -18,7 +19,7 @@ const MediaClientRemoteDescFailedError = require('../../util/twilio-video-errors
 const DataTrackReceiver = require('../../data/receiver');
 const MediaTrackReceiver = require('../../media/track/receiver');
 const StateMachine = require('../../statemachine');
-const { buildLogLevels, getSdpFormat, makeUUID } = require('../../util');
+const { buildLogLevels, makeUUID } = require('../../util');
 const { DEFAULT_LOG_LEVEL } = require('../../util/constants');
 const Log = require('../../util/log');
 const IdentityTrackMatcher = require('../../util/sdp/trackmatcher/identity');
@@ -29,6 +30,8 @@ const workaroundIssue8329 = require('../../util/sdp/issue8329');
 const isChrome = guessBrowser() === 'chrome';
 const isFirefox = guessBrowser() === 'firefox';
 const isSafari = guessBrowser() === 'safari';
+const sdpFormat = getSdpFormat();
+const isUnifiedPlan = sdpFormat === 'unified';
 
 /*
 PeerConnectionV2 States
@@ -99,8 +102,6 @@ class PeerConnectionV2 extends StateMachine {
     const logLevels = buildLogLevels(options.logLevel);
     const RTCPeerConnection = options.RTCPeerConnection;
     const peerConnection = new RTCPeerConnection(configuration, options.chromeSpecificConstraints);
-    const sdpFormat = getSdpFormat(options.sdpSemantics);
-    const isUnifiedPlan = sdpFormat === 'unified';
 
     const localMediaStream = isUnifiedPlan && RTCPeerConnection.prototype.addTransceiver
       ? null
@@ -135,9 +136,6 @@ class PeerConnectionV2 extends StateMachine {
       _isRestartingIce: {
         writable: true,
         value: false
-      },
-      _isUnifiedPlan: {
-        value: isUnifiedPlan
       },
       _lastIceConnectionState: {
         writable: true,
@@ -205,9 +203,6 @@ class PeerConnectionV2 extends StateMachine {
       _remoteCandidates: {
         writable: true,
         value: new IceBox()
-      },
-      _sdpFormat: {
-        value: sdpFormat
       },
       _setBitrateParameters: {
         value: options.setBitrateParameters
@@ -472,9 +467,7 @@ class PeerConnectionV2 extends StateMachine {
         // support, we have to use the same hacky solution as Safari. Revisit
         // this when RTCRtpTransceivers and MIDs land. We should be able to use
         // the same technique as Firefox.
-        : isSafari || this._isUnifiedPlan
-          ? new OrderedTrackMatcher()
-          : new IdentityTrackMatcher();
+        : isSafari || isUnifiedPlan ? new OrderedTrackMatcher() : new IdentityTrackMatcher();
     }
     this._trackMatcher.update(sdp);
 
@@ -512,7 +505,7 @@ class PeerConnectionV2 extends StateMachine {
     // We can reduce the number of cases where renegotiation is needed by
     // re-introducing 'offerToReceiveAudio' to the default RTCOfferOptions with a
     // value > 1.
-    if (this._isUnifiedPlan) {
+    if (isUnifiedPlan) {
       const senders = this._peerConnection.getSenders().filter(sender => sender.track);
       shouldReoffer = ['audio', 'video'].reduce((shouldOffer, kind) => {
         const mediaSections = getMediaSections(localDescription.sdp, kind, '(sendrecv|sendonly)');
@@ -585,7 +578,7 @@ class PeerConnectionV2 extends StateMachine {
         description = {
           type: description.type,
           sdp: isChrome && vp8SimulcastRequested
-            ? this._setSimulcast(description.sdp, this._sdpFormat, this._trackIdsToAttributes)
+            ? this._setSimulcast(description.sdp, sdpFormat, this._trackIdsToAttributes)
             : description.sdp
         };
       }
@@ -643,7 +636,7 @@ class PeerConnectionV2 extends StateMachine {
         this._log.debug('An ICE restart was in-progress and is now completed');
         this._isRestartingIce = false;
       }
-      if (this._isUnifiedPlan && this._peerConnection.getTransceivers) {
+      if (isUnifiedPlan && this._peerConnection.getTransceivers) {
         this._peerConnection.getTransceivers().forEach(transceiver => {
           if (shouldStopTransceiver(description, transceiver)) {
             transceiver.stop();

--- a/lib/signaling/v2/peerconnectionmanager.js
+++ b/lib/signaling/v2/peerconnectionmanager.js
@@ -1,11 +1,12 @@
 'use strict';
 
+const { guessBrowser } = require('@twilio/webrtc/lib/util');
 const PeerConnectionV2 = require('./peerconnection');
 const MediaTrackSender = require('../../media/track/sender');
 const QueueingEventEmitter = require('../../queueingeventemitter');
 const util = require('../../util');
 
-const isFirefox = util.guessBrowser() === 'firefox';
+const isFirefox = guessBrowser() === 'firefox';
 
 /**
  * {@link PeerConnectionManager} manages multiple {@link PeerConnectionV2}s.

--- a/lib/signaling/v2/transport.js
+++ b/lib/signaling/v2/transport.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { getSdpFormat } = require('@twilio/webrtc/lib/util/sdp');
 const constants = require('../../util/constants');
 const packageInfo = require('../../../package.json');
 const InsightsPublisher = require('../../util/insightspublisher');
@@ -9,7 +10,6 @@ const DefaultSIPJSMediaHandler = require('./sipjsmediahandler');
 const StateMachine = require('../../statemachine');
 const {
   createMediaSignalingPayload,
-  getSdpFormat,
   getUserAgent,
   makeServerSIPURI,
   withJitter
@@ -91,8 +91,8 @@ class Transport extends StateMachine {
     options = Object.assign({
       InsightsPublisher,
       NullInsightsPublisher,
-      sdpSemantics: null,
       SIPJSMediaHandler: DefaultSIPJSMediaHandler,
+      sdpFormat: getSdpFormat(),
       userAgent: getUserAgent()
     }, options);
     super('connecting', states);
@@ -113,8 +113,8 @@ class Transport extends StateMachine {
           options.realm,
           eventPublisherOptions)
       },
-      _sdpSemantics: {
-        value: options.sdpSemantics
+      _sdpFormat: {
+        value: options.sdpFormat
       },
       _updatesReceived: {
         value: []
@@ -269,7 +269,7 @@ function createSession(transport, name, accessToken, localParticipant, peerConne
             networkQuality);
         }
 
-        const sdpFormat = getSdpFormat(transport._sdpSemantics);
+        const sdpFormat = transport._sdpFormat;
         if (type === 'connect' && sdpFormat) {
           message.format = sdpFormat;
         }

--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { getSdpFormat } = require('@twilio/webrtc/lib/util/sdp');
 const packageInfo = require('../../../package.json');
 const InsightsPublisher = require('../../util/insightspublisher');
 const NullInsightsPublisher = require('../../util/insightspublisher/null');
@@ -8,7 +9,6 @@ const TwilioConnection = require('../../twilioconnection');
 
 const {
   createMediaSignalingPayload,
-  getSdpFormat,
   getUserAgent,
   withJitter
 } = require('../../util');
@@ -91,6 +91,7 @@ class TwilioConnectionTransport extends StateMachine {
       maxReconnectAttempts: MAX_RECONNECT_ATTEMPTS,
       reconnectBackOffJitter: RECONNECT_BACKOFF_JITTER,
       reconnectBackOffMs: RECONNECT_BACKOFF_MS,
+      sdpFormat: getSdpFormat(),
       userAgent: getUserAgent()
     }, options);
     super('connecting', states);
@@ -144,9 +145,6 @@ class TwilioConnectionTransport extends StateMachine {
       },
       _reconnectBackOffMs: {
         value: options.reconnectBackOffMs
-      },
-      _sdpSemantics: {
-        value: options.sdpSemantics
       },
       _session: {
         value: null,
@@ -216,7 +214,7 @@ class TwilioConnectionTransport extends StateMachine {
         this._dominantSpeaker,
         this._networkQuality);
 
-      const sdpFormat = getSdpFormat(this._sdpSemantics);
+      const sdpFormat = this._options.sdpFormat;
       if (sdpFormat) {
         message.format = sdpFormat;
       }

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -1,4 +1,3 @@
-/* globals mozRTCPeerConnection, RTCRtpTransceiver */
 'use strict';
 
 const constants = require('./constants');
@@ -139,24 +138,6 @@ function getUserAgent() {
   return typeof navigator !== 'undefined' && navigator.userAgent
     ? navigator.userAgent
     : 'Unknown';
-}
-
-/**
- * Guess the browser.
- * @returns {?string} browser - "chrome", "firefox", "safari", or null
- */
-function guessBrowser() {
-  if (typeof webkitRTCPeerConnection !== 'undefined') {
-    return 'chrome';
-  } else if (typeof mozRTCPeerConnection !== 'undefined') {
-    return 'firefox';
-  } else if (typeof RTCPeerConnection !== 'undefined') {
-    if (getUserAgent().match(/AppleWebKit\/(\d+)\./)) {
-      return 'safari';
-    }
-    // NOTE(mroberts): Could be Edge.
-  }
-  return null;
 }
 
 /**
@@ -438,69 +419,6 @@ function validateLocalTrack(track, options) {
 }
 
 /**
- * @typedef {'plan-b' | 'unified-plan'} SdpSemantics
- */
-
-/**
- * @typedef {'planb' | 'unified'} SdpFormat
- */
-
-/**
- * Use unified plan SDP format on Firefox
- * @param {?SdpSemantics} [sdpSemantics]
- * @returns {SdpFormat}
- */
-function getSdpFormat(sdpSemantics) {
-  const browser = guessBrowser();
-  if (browser === 'firefox') {
-    return 'unified';
-  }
-  if (browser === 'safari') {
-    return 'currentDirection' in RTCRtpTransceiver.prototype
-      ? 'unified'
-      : 'planb';
-  }
-  if (checkIfSdpSemanticsIsSupported()) {
-    return {
-      'plan-b': 'planb',
-      'unified-plan': 'unified'
-    }[sdpSemantics || 'plan-b'];
-  }
-  // NOTE(mmalavalli): Once Chrome stops supporting "plan-b" SDPs, it will
-  // ignore the "sdpSemantics" flag. So, in order to differentiate between
-  // versions of Chrome which support only "plan-b" SDPs and versions of Chrome
-  // which support only "unified-plan" SDPs, which check whether PeerConnection's
-  // addStream() method is present.
-  return RTCPeerConnection.prototype.addStream ? 'planb' : 'unified';
-}
-
-// NOTE(mroberts): We need to cache this result so that we don't create too many
-// RTCPeerConnections.
-let sdpSemanticsIsSupported;
-
-/**
- * Check whether or not `sdpSemantics` is supported.
- * @returns {boolean}
- */
-function checkIfSdpSemanticsIsSupported() {
-  if (typeof sdpSemanticsIsSupported === 'boolean') {
-    return sdpSemanticsIsSupported;
-  }
-  if (typeof RTCPeerConnection === 'undefined') {
-    sdpSemanticsIsSupported = false;
-    return sdpSemanticsIsSupported;
-  }
-  try {
-    new RTCPeerConnection({ sdpSemantics: 'bogus' });
-    sdpSemanticsIsSupported = false;
-    return sdpSemanticsIsSupported;
-  } catch (error) {
-    sdpSemanticsIsSupported = true;
-    return sdpSemanticsIsSupported;
-  }
-}
-
-/**
  * Sets all underscore-prefixed properties on `object` non-enumerable.
  * @param {Object} object
  * @returns {void}
@@ -662,7 +580,6 @@ exports.difference = difference;
 exports.filterObject = filterObject;
 exports.flatMap = flatMap;
 exports.getUserAgent = getUserAgent;
-exports.guessBrowser = guessBrowser;
 exports.hidePrivateProperties = hidePrivateProperties;
 exports.hidePrivateAndCertainPublicPropertiesInClass = hidePrivateAndCertainPublicPropertiesInClass;
 exports.makeClientSIPURI = makeClientSIPURI;
@@ -679,6 +596,5 @@ exports.buildLogLevels = buildLogLevels;
 exports.trackClass = trackClass;
 exports.trackPublicationClass = trackPublicationClass;
 exports.validateLocalTrack = validateLocalTrack;
-exports.getSdpFormat = getSdpFormat;
 exports.valueToJSON = valueToJSON;
 exports.withJitter = withJitter;

--- a/lib/util/support.js
+++ b/lib/util/support.js
@@ -1,7 +1,7 @@
 /* globals RTCPeerConnection, webkitRTCPeerConnection, mozRTCPeerConnection, navigator */
 'use strict';
 
-const guessBrowser = require('./').guessBrowser;
+const { guessBrowser } = require('@twilio/webrtc/lib/util');
 
 /**
  * Check whether PeerConnection API is supported.

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   },
   "dependencies": {
     "@twilio/sip.js": "^0.7.7",
-    "@twilio/webrtc": "twilio/twilio-webrtc.js#b81069d1bb1da7e17c3605e1226055626073931b",
+    "@twilio/webrtc": "twilio/twilio-webrtc.js#JSDK-2265",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "karma-spec-reporter": "^0.0.31",
     "mocha": "^3.2.0",
     "npm-run-all": "^4.0.2",
-    "phantom": "^4.0.2",
+    "puppeteer": "^1.11.0",
     "release-tool": "^0.2.2",
     "requirejs": "^2.3.3",
     "rimraf": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   },
   "dependencies": {
     "@twilio/sip.js": "^0.7.7",
-    "@twilio/webrtc": "twilio/twilio-webrtc.js#JSDK-2265",
+    "@twilio/webrtc": "twilio/twilio-webrtc.js#7716be1c55c2bd525c72ae4a68164caec54aaaef",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },

--- a/test/env.js
+++ b/test/env.js
@@ -13,7 +13,6 @@ const processEnv = {
   LOG_LEVEL: process.env.LOG_LEVEL,
   ENABLE_REST_API_TESTS: process.env.ENABLE_REST_API_TESTS,
   USE_TWILIO_CONNECTION: process.env.USE_TWILIO_CONNECTION,
-  SDP_SEMANTICS: process.env.SDP_SEMANTICS,
   TOPOLOGY: process.env.TOPOLOGY
 };
 
@@ -29,7 +28,6 @@ const env = [
   ['LOG_LEVEL',                 'logLevel'],
   ['ENABLE_REST_API_TESTS',     'enableRestApiTests'],
   ['USE_TWILIO_CONNECTION',     'useTwilioConnection'],
-  ['SDP_SEMANTICS',             'sdpSemantics'],
   ['TOPOLOGY',                  'topology']
 ].reduce((env, [processEnvKey, envKey]) => {
   if (processEnvKey in processEnv) {

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const sdpFormat = require('@twilio/webrtc/lib/util/sdp').getSdpFormat();
 
 const {
   connect,
@@ -732,7 +733,7 @@ describe('LocalParticipant', function() {
       assert.equal(thatTrack.sid, thisLocalTrackPublication1.trackSid);
       assert.equal(thatTrack.kind, thisLocalTrackPublication1.kind);
       assert.equal(thatTrack.enabled, thisLocalTrackPublication1.enabled);
-      if (isChrome && defaults._sdpSemantics !== 'unified-plan') {
+      if (isChrome && sdpFormat === 'planb') {
         assert.equal(thatTrack.mediaStreamTrack.readyState, 'ended');
       }
     });

--- a/test/integration/spec/util/simulcast.js
+++ b/test/integration/spec/util/simulcast.js
@@ -1,14 +1,13 @@
 'use strict';
 
 const assert = require('assert');
-const { _sdpSemantics } = require('../../../lib/defaults');
-const { getSdpFormat, guessBrowser } = require('../../../../lib/util');
+const { guessBrowser } = require('@twilio/webrtc/lib/util');
+const { getSdpFormat } = require('@twilio/webrtc/lib/util/sdp');
 const { getMediaSections, setSimulcast } = require('../../../../lib/util/sdp');
 const { RTCPeerConnection, RTCSessionDescription } = require('@twilio/webrtc');
 
 const isChrome = guessBrowser() === 'chrome';
-const sdpSemantics = _sdpSemantics;
-const sdpFormat = getSdpFormat(sdpSemantics);
+const sdpFormat = getSdpFormat();
 
 describe('setSimulcast', () => {
   let answer1;
@@ -30,9 +29,9 @@ describe('setSimulcast', () => {
       before(async () => {
         const constraints = { audio: true, video: true };
         stream = await makeStream(constraints);
-        pc1 = new RTCPeerConnection({ iceServers: [], sdpSemantics });
+        pc1 = new RTCPeerConnection({ iceServers: [] });
         pc1.addStream(stream);
-        pc2 = new RTCPeerConnection({ iceServers: [], sdpSemantics });
+        pc2 = new RTCPeerConnection({ iceServers: [] });
         pc2.addStream(stream);
         trackIdsToAttributes = new Map();
 
@@ -91,7 +90,7 @@ describe('setSimulcast', () => {
     before(async () => {
       const constraints = { audio: true, video: true };
       stream = await makeStream(constraints);
-      pc1 = new RTCPeerConnection({ iceServers: [], sdpSemantics });
+      pc1 = new RTCPeerConnection({ iceServers: [] });
       pc1.addStream(stream);
       trackIdsToAttributes = new Map();
 

--- a/test/lib/defaults.js
+++ b/test/lib/defaults.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { guessBrowser } = require('../../lib/util');
+const { guessBrowser } = require('@twilio/webrtc/lib/util');
 
 const env = require('../env');
 
@@ -20,7 +20,6 @@ const defaults = [
   }
   return defaults;
 }, {
-  _sdpSemantics: env.sdpSemantics,
   _useTwilioConnection: !!env.useTwilioConnection,
   dominantSpeaker: true,
   networkQuality: true,

--- a/test/lib/guessbrowser.js
+++ b/test/lib/guessbrowser.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const guess = require('../../lib/util').guessBrowser();
+const guess = require('@twilio/webrtc/lib/util').guessBrowser();
 
 module.exports = {
   isChrome: guess === 'chrome',

--- a/test/umd/index.js
+++ b/test/umd/index.js
@@ -1,8 +1,7 @@
 'use strict';
 
-const phantom = require('phantom');
-const requirejs = require('requirejs');
-
+const { join } = require('path');
+const puppeteer = require('puppeteer');
 const version = require('../../package.json').version;
 
 const publicVars = [
@@ -19,54 +18,37 @@ const publicVars = [
 describe('UMD', function() {
   this.timeout(5000);
 
-  describe('RequireJS (browser)', function() {
+  describe('RequireJS (browser)', () => {
+    let browser;
     let page;
-    let instance;
 
-    beforeEach(function() {
-      return phantom.create([]).then(function(_instance) {
-        instance = _instance;
-        return instance.createPage();
-      }).then(function(_page) {
-        page = _page;
-      });
+    beforeEach(async () => {
+      browser = await puppeteer.launch({ headless: true });
+      page = await browser.newPage();
     });
 
-    it(`should receive a video object with ${publicVars.join(', ')} properties (unminified)`, function(done) {
-      page.on('onCallback', function(res) {
-        if (res.status === 'success') {
-          if (res.version === version) {
-            return done();
-          } else {
+    [
+      ['unminified', 'index'],
+      ['minified', 'min']
+    ].forEach(([mode, filename]) => {
+      it(`should receive a video object with ${publicVars.join(', ')} properties (${mode})`, done => {
+        page.on('console', async msg => {
+          const res = msg.args()[0] ? await msg.args()[0].jsonValue() : { reason: 'Unknown' };
+          if (res.status === 'success') {
+            if (res.version === version) {
+              return done();
+            }
             return done(new Error('Version mismatch'));
           }
-        } else {
           return done(new Error(res.reason));
-        }
+        });
+        page.goto(`file:${join(__dirname, 'require-browser', `${filename}.html`)}`);
       });
-
-      page.open(__dirname + '/require-browser/index.html');
     });
 
-    it(`should receive a video object with ${publicVars.join(', ')} properties (minified)`, function(done) {
-      page.on('onCallback', function(res) {
-        if (res.status === 'success') {
-          if (res.version === version) {
-            return done();
-          } else {
-            return done(new Error('Version mismatch'));
-          }
-        } else {
-          return done(new Error(res.reason));
-        }
-      });
-
-      page.open(__dirname + '/require-browser/min.html');
-    });
-
-    afterEach(function() {
-      page.close();
-      instance.exit();
+    afterEach(async () => {
+      await page.close();
+      await browser.close();
     });
   });
 });

--- a/test/umd/require-browser/index.html
+++ b/test/umd/require-browser/index.html
@@ -3,7 +3,7 @@
   <head></head>
 
   <body>
-    <script data-main="js/main" src="js/require.js"/></script>
+    <script data-main="js/main" src="js/require.js"></script>
     <script>
       var publicVars = [
         'connect',
@@ -17,21 +17,21 @@
       ];
       require(['../../../../dist/twilio-video'], function(video) {
         try {
-          if (publicVars.every(function(publicVar) {
+          if (typeof video !== 'undefined' && publicVars.every(function(publicVar) {
             return publicVar in video;
           })) {
-            window.callPhantom({
+            console.log({
               status: 'success',
               version: video.version
             });
           } else {
-            window.callPhantom({
+            console.log({
               status: 'failure',
               reason: 'Video undefined'
             });
           }
         } catch(e) {
-          window.callPhantom({
+          console.log({
             status: 'failure',
             reason: e.message || e
           });

--- a/test/umd/require-browser/min.html
+++ b/test/umd/require-browser/min.html
@@ -3,7 +3,7 @@
   <head></head>
 
   <body>
-    <script data-main="js/main" src="js/require.js"/></script>
+    <script data-main="js/main" src="js/require.js"></script>
     <script>
       var publicVars = [
         'connect',
@@ -17,21 +17,21 @@
       ];
       require(['../../../../dist/twilio-video.min'], function(video) {
         try {
-          if (publicVars.every(function(publicVar) {
+          if (typeof video !== 'undefined' && publicVars.every(function(publicVar) {
             return publicVar in video;
           })) {
-            window.callPhantom({
+            console.log({
               status: 'success',
               version: video.version
             });
           } else {
-            window.callPhantom({
+            console.log({
               status: 'failure',
               reason: 'Video undefined'
             });
           }
         } catch(e) {
-          window.callPhantom({
+          console.log({
             status: 'failure',
             reason: e.message || e
           });

--- a/test/unit/spec/signaling/v2/twilioconnectiontransport.js
+++ b/test/unit/spec/signaling/v2/twilioconnectiontransport.js
@@ -1526,6 +1526,7 @@ function makeTest(options) {
   options.reconnectBackOffMs = options.reconnectBackOffMs || 0;
   options.name = 'name' in options ? options.name : makeName();
   options.accessToken = options.accessToken || makeAccessToken();
+  options.sdpFormat = options.sdpFormat || 'foo';
   options.wsServer = options.wsServer || makeName();
   options.localParticipantState = options.localParticipantState || {
     revision: 1,


### PR DESCRIPTION
@syerrapragada 

This PR:

* Removes "plan-b" enforcement.
* Consumes twilio-webrtc.js#JSDK-2265 changes.