### PR TITLE
Workaround a case where Chrome failed to set description due to dupli…

### DIFF
--- a/lib/util/sdp/issue8329.js
+++ b/lib/util/sdp/issue8329.js
@@ -191,7 +191,7 @@ function createAssociatedPtToRtxPt(rtxPtToAssociatedPt, invalidRtxPts) {
  * @returns {string} newMediaSection
  */
 function deleteFmtpAttributesForRtxPt(mediaSection, rtxPt) {
-  const pattern = new RegExp(`a=fmtp:${rtxPt} apt=.*\r\n`, 'gm');
+  const pattern = new RegExp(`a=fmtp:${rtxPt}.*\r\n`, 'gm');
   return mediaSection.replace(pattern, '');
 }
 
@@ -201,7 +201,7 @@ function deleteFmtpAttributesForRtxPt(mediaSection, rtxPt) {
  * @returns {string} newMediaSection
  */
 function deleteRtpmapAttributesForRtxPt(mediaSection, rtxPt) {
-  const pattern = new RegExp(`a=rtpmap:${rtxPt} rtx.*\r\n`, 'gm');
+  const pattern = new RegExp(`a=rtpmap:${rtxPt}.*\r\n`, 'gm');
   return mediaSection.replace(pattern, '');
 }
 

--- a/lib/util/sdp/issue8329.js
+++ b/lib/util/sdp/issue8329.js
@@ -96,33 +96,16 @@ function mediaSectionWorkaround(mediaSection) {
 function deleteDuplicateRtxPts(mediaSection, ptToCodecName) {
   // NOTE(syerrapragada): In some cases Chrome produces an offer/answer
   // with duplicate "rtx" payload mapping in media section. When applied,
-  // Chrome rejects the SDP. We work around this by deleting duplicate
+  // Chrome rejects the SDP. We workaround this by deleting duplicate
   // "rtx" mappings found in SDP.
-  Array.from(ptToCodecName.keys()).forEach(pt => {
-    // 1. Find if there are duplicate PTs
-    const rtpmapPattern = new RegExp(`a=rtpmap:${pt}.*`, 'g');
-    const matches = mediaSection.match(rtpmapPattern);
-    if (matches && matches.length > 1) {
-      // 2. If orig is not 'rtx' type, delete all duplicate 'rtx' pts
-      if (ptToCodecName.get(pt) !== 'rtx') {
-        mediaSection = deleteFmtpAttributesForRtxPt(mediaSection, pt);
-        mediaSection = deleteRtpmapAttributesForRtxPt(mediaSection, pt);
-      } else {
-        // 3. if Orig is a 'rtx' type, delete all except first
-        const rtpMapPattern = new RegExp(`a=rtpmap:${pt} rtx.*\r\n`, 'gm');
-        const fmtpPattern = new RegExp(`a=fmtp:${pt} apt=.*\r\n`, 'gm');
-        var counter = 0;
-        mediaSection = mediaSection.replace(rtpMapPattern, rtpMapLine => {
-          return ++counter > 1 ? '' : rtpMapLine;
-        });
-        counter = 0;
-        mediaSection = mediaSection.replace(fmtpPattern, fmtpLine => {
-          return ++counter > 1 ? '' : fmtpLine;
-        });
-      }
-    }
-  });
-  return mediaSection;
+  return Array.from(ptToCodecName.keys()).reduce((section, pt) => {
+    const rtpmapRegex = new RegExp(`^a=rtpmap:${pt} rtx.+$`, 'gm');
+    return (section.match(rtpmapRegex) || []).slice(ptToCodecName.get(pt) === 'rtx' ? 1 : 0).reduce((section, rtpmap) => {
+      const rtpmapRegex = new RegExp(`\r\n${rtpmap}`);
+      const fmtpmapRegex = new RegExp(`\r\na=fmtp:${pt} apt=[0-9]+`);
+      return section.replace(rtpmapRegex, '').replace(fmtpmapRegex, '');
+    }, section);
+  }, mediaSection);
 }
 
 /**

--- a/lib/util/sdp/issue8329.js
+++ b/lib/util/sdp/issue8329.js
@@ -51,6 +51,7 @@ function sdpWorkaround(sdp) {
  */
 function mediaSectionWorkaround(mediaSection) {
   const ptToCodecName = createPtToCodecName(mediaSection);
+  mediaSection = deleteDuplicateRtxPts(mediaSection, ptToCodecName);
   const codecNameToPts = createCodecNameToPts(ptToCodecName);
   const rtxPts = codecNameToPts.get('rtx') || new Set();
 
@@ -84,6 +85,43 @@ function mediaSectionWorkaround(mediaSection) {
     mediaSection = deleteRtpmapAttributesForRtxPt(mediaSection, rtxPt);
   });
 
+  return mediaSection;
+}
+
+/**
+ * @param {string} mediaSection
+ * @param {Map<PT, Codec>} ptToCodecName
+ * @returns @param {string} newMediaSection
+ */
+function deleteDuplicateRtxPts(mediaSection, ptToCodecName) {
+  // NOTE(syerrapragada): In some cases Chrome produces an offer/answer
+  // with duplicate "rtx" payload mapping in media section. When applied,
+  // Chrome rejects the SDP. We work around this by deleting duplicate
+  // "rtx" mappings found in SDP.
+  Array.from(ptToCodecName.keys()).forEach(pt => {
+    // 1. Find if there are duplicate PTs
+    const rtpmapPattern = new RegExp(`a=rtpmap:${pt}.*`, 'g');
+    const matches = mediaSection.match(rtpmapPattern);
+    if (matches && matches.length > 1) {
+      // 2. If orig is not 'rtx' type, delete all duplicate 'rtx' pts
+      if (ptToCodecName.get(pt) !== 'rtx') {
+        mediaSection = deleteFmtpAttributesForRtxPt(mediaSection, pt);
+        mediaSection = deleteRtpmapAttributesForRtxPt(mediaSection, pt);
+      } else {
+        // 3. if Orig is a 'rtx' type, delete all except first
+        const rtpMapPattern = new RegExp(`a=rtpmap:${pt} rtx.*\r\n`, 'gm');
+        const fmtpPattern = new RegExp(`a=fmtp:${pt} apt=.*\r\n`, 'gm');
+        var counter = 0;
+        mediaSection = mediaSection.replace(rtpMapPattern, rtpMapLine => {
+          return ++counter > 1 ? '' : rtpMapLine;
+        });
+        counter = 0;
+        mediaSection = mediaSection.replace(fmtpPattern, fmtpLine => {
+          return ++counter > 1 ? '' : fmtpLine;
+        });
+      }
+    }
+  });
   return mediaSection;
 }
 
@@ -170,7 +208,7 @@ function createAssociatedPtToRtxPt(rtxPtToAssociatedPt, invalidRtxPts) {
  * @returns {string} newMediaSection
  */
 function deleteFmtpAttributesForRtxPt(mediaSection, rtxPt) {
-  const pattern = new RegExp(`a=fmtp:${rtxPt}.*\r\n`, 'gm');
+  const pattern = new RegExp(`a=fmtp:${rtxPt} apt=.*\r\n`, 'gm');
   return mediaSection.replace(pattern, '');
 }
 
@@ -180,7 +218,7 @@ function deleteFmtpAttributesForRtxPt(mediaSection, rtxPt) {
  * @returns {string} newMediaSection
  */
 function deleteRtpmapAttributesForRtxPt(mediaSection, rtxPt) {
-  const pattern = new RegExp(`a=rtpmap:${rtxPt}.*\r\n`, 'gm');
+  const pattern = new RegExp(`a=rtpmap:${rtxPt} rtx.*\r\n`, 'gm');
   return mediaSection.replace(pattern, '');
 }
 

--- a/lib/util/sdp/issue8329.js
+++ b/lib/util/sdp/issue8329.js
@@ -91,7 +91,7 @@ function mediaSectionWorkaround(mediaSection) {
 /**
  * @param {string} mediaSection
  * @param {Map<PT, Codec>} ptToCodecName
- * @returns @param {string} newMediaSection
+ * @returns {string} newMediaSection
  */
 function deleteDuplicateRtxPts(mediaSection, ptToCodecName) {
   // NOTE(syerrapragada): In some cases Chrome produces an offer/answer

--- a/test/unit/spec/util/sdp/issue8329.js
+++ b/test/unit/spec/util/sdp/issue8329.js
@@ -140,8 +140,6 @@ a=rtcp-fb:126 goog-remb
 a=fmtp:126 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f
 a=rtpmap:97 rtx/90000
 a=fmtp:97 apt=120
-a=rtpmap:99 rtx/90000
-a=fmtp:99 apt=121
 a=rtpmap:101 rtx/90000
 a=rtpmap:102 red/90000
 a=rtpmap:123 rtx/90000
@@ -156,7 +154,9 @@ a=rtcp-fb:124 transport-cc
 a=fmtp:124 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=420032
 a=rtpmap:122 rtx/90000
 a=fmtp:122 apt=124
-a=fmtp:101 apt=126
+a=rtpmap:99 rtx/90000
+a=fmtp:99 apt=126
+a=fmtp:101 apt=121
 `.split('\n').join('\r\n');
 
 const invalidSdp = `v=0

--- a/test/unit/spec/util/sdp/issue8329.js
+++ b/test/unit/spec/util/sdp/issue8329.js
@@ -222,6 +222,8 @@ a=rtcp-fb:121 ccm fir
 a=rtcp-fb:121 nack
 a=rtcp-fb:121 nack pli
 a=rtcp-fb:121 goog-remb
+a=rtpmap:121 rtx/90000
+a=fmtp:121 apt=120
 a=rtpmap:126 H264/90000
 a=rtcp-fb:126 ccm fir
 a=rtcp-fb:126 nack
@@ -247,6 +249,8 @@ a=rtcp-fb:124 transport-cc
 a=fmtp:124 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=420032
 a=rtpmap:122 rtx/90000
 a=fmtp:122 apt=124
+a=rtpmap:99 rtx/90000
+a=fmtp:99 apt=98
 `.split('\n').join('\r\n');
 
 const validSdp2 = `v=0


### PR DESCRIPTION
@manjeshbhargav 

This PR is a workaround for a case where Chrome produces an Offer/Answer with duplicate `rtx` payload mappings.

Excerpts from an Offer SDP with duplicate rtx mappings:
Case 1:
.....
**a=rtpmap:99 rtx/90000
a=fmtp:99 apt=126**
a=rtpmap:101 rtx/90000
a=fmtp:101 apt=100
a=rtpmap:97 rtx/90000
a=fmtp:97 apt=96
**a=rtpmap:99 rtx/90000
a=fmtp:99 apt=98**
a=rtpmap:121 rtx/90000
a=fmtp:121 apt=102
....

Case 2: 
....
a=rtpmap:97 H264/90000
a=rtcp-fb:97 goog-remb
a=rtcp-fb:97 ccm fir
a=rtcp-fb:97 nack
a=rtcp-fb:97 nack pli
a=fmtp:97 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f
**a=rtpmap:97 rtx/90000
a=fmtp:97 apt=96**
....

This PR detects duplicate mappings and deletes them:

1. If the original PT is mapped to a non-rtx stream, we will delete all duplicate rtx mapping from SDP
2. If the original PT is mapped to a rtx stream, we will preserve the first mapping and delete rest from SDP

