### PR TITLE
Prepping for 2.0.0-rc12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 New Features
 ------------
 
+- The Dominant Speaker and Network Quality APIs are generally available.
+
 - Previously, Room emitted "reconnecting" and "reconnected" events while recovering
   from a disruption in your media connection. Now, it will emit these events while
   recovering from a disruption in your signaling connection as well. As of now, this
@@ -30,6 +32,11 @@ New Features
   After twilio-video.js@2.0.0 is generally available, we plan to make this an opt-out
   feature in twilio-video.js@2.1.0, followed by removing our existing SIP-based
   signaling transport altogether in twilio-video.js@2.2.0.
+  
+  **NOTE:** The new signaling transport will reject access tokens containing configuration
+  profiles, which were deprecated when we [announced](https://www.twilio.com/blog/2017/04/programmable-video-peer-to-peer-rooms-ga.html#room-based-access-control)
+  the general availability of twilio-video.js@1.0.0. Use the [Programmable Video REST API](https://www.twilio.com/docs/video/api)
+  if you want to override the default settings while creating a Room.
 
 - twilio-video.js will now use the Unified Plan SDP format where available.
   Google Chrome, starting from version 72, has and Safari, starting from version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@
 New Features
 ------------
 
+- Previously, Room emitted "reconnecting" and "reconnected" events while recovering
+  from a disruption in your media connection. Now, it will emit these events while
+  recovering from a disruption in your signaling connection as well. As of now, this
+  is an opt-in feature and can be enabled with a temporary ConnectOptions flag as follows:
+
+  ```js
+  const { connect } = require('twilio-video');
+
+  const room = await connect(token, {
+    _useTwilioConnection: true
+  });
+
+  room.on('reconnecting', error => {
+    if (error.code === 53001) {
+      console.log('Reconnecting your signaling connection!', error.message);
+    } else if (error.code === 53405) {
+      console.log('Reconnecting your media connection!', error.message);
+    }
+  });
+  ```
+
+  When you opt in for this feature, you join a Room using our new signaling transport,
+  which enables us to detect and recover from disruptions in your signaling connection.
+  After twilio-video.js@2.0.0 is generally available, we plan to make this an opt-out
+  feature in twilio-video.js@2.1.0, followed by removing our existing SIP-based
+  signaling transport altogether in twilio-video.js@2.2.0.
+
 - twilio-video.js will now use the Unified Plan SDP format where available.
   Google Chrome, starting from version 72, has and Safari, starting from version
   12.1, will enable Unified Plan as the default SDP format. We highly recommend

--- a/COMMON_ISSUES.md
+++ b/COMMON_ISSUES.md
@@ -21,6 +21,13 @@ stable release.
 Safari
 ------
 
+### Network Quality API not working
+
+We are working to fix a bug in twilio-video.js where Safari clients do not
+receive Network Quality Score updates in a Group Room. (JSDK-2133)
+
+### Experimental support
+
 twilio-video.js 1.2.1 introduces experimental support for Safari 11 and newer.
 Support for Safari is "experimental" because, at the time of writing, Safari
 does not support VP8. This means you may experience codec issues in Group Rooms.
@@ -66,6 +73,11 @@ LocalTracks will fail.
 
 Firefox
 -------
+
+### Network Quality API not working
+
+We are working to fix a bug in twilio-video.js where Firefox clients do not
+receive Network Quality Score updates in a Group Room. (JSDK-2133)
 
 ### RemoteDataTrack Properties (`maxPacketLifeTime` and `maxRetransmits`)
 

--- a/lib/room.js
+++ b/lib/room.js
@@ -4,7 +4,6 @@ const EventEmitter = require('./eventemitter');
 const RemoteParticipant = require('./remoteparticipant');
 const StatsReport = require('./stats/statsreport');
 const { valueToJSON } = require('./util');
-const { MediaConnectionError } = require('./util/twilio-video-errors');
 
 let nInstances = 0;
 
@@ -240,17 +239,23 @@ function rewriteLocalTrackIds(room, trackStats) {
  */
 
 /**
- * Your application is reconnecting to the {@link Room}. Typically this happens
- * when there is a disruption in your media connection. When this event is
- * emitted, the {@link Room} is in state "reconnecting". If reconnecting
+ * Your application is reconnecting to the {@link Room}. This happens when there
+ * is a disruption in your signaling connection and/or your media connection. When
+ * this event is emitted, the {@link Room} is in state "reconnecting". If reconnecting
  * succeeds, the {@link Room} will emit a "reconnected" event.
- * @param {TwilioError} error - A {@link TwilioError} explaining why your
- *   application is reconnecting
+ * @param {MediaConnectionError|SignalingConnectionDisconnectedError} error - A
+ *   {@link MediaConnectionError} if your application is reconnecting due to a
+ *   disruption in your media connection, or a {@link SignalingConnectionDisconnectedError}
+ *   if your application is reconnecting due to a disruption in your signaling connection
+ * @event Room#reconnecting
  * @example
  * myRoom.on('reconnecting', error => {
- *   console.warn('Reconnecting!', error);
+ *   if (error.code === 53001) {
+ *     console.log('Reconnecting your signaling connection!', error.message);
+ *   } else if (error.code === 53405) {
+ *     console.log('Reconnecting your media connection!', error.message);
+ *   }
  * });
- * @event Room#reconnecting
  */
 
 /**
@@ -457,7 +462,7 @@ function handleSignalingEvents(room, signaling) {
         signaling.removeListener('stateChanged', stateChanged);
         break;
       case 'reconnecting':
-        room.emit('reconnecting', new MediaConnectionError());
+        room.emit('reconnecting', error);
         break;
       default:
         room.emit('reconnected');

--- a/lib/signaling/room.js
+++ b/lib/signaling/room.js
@@ -3,6 +3,11 @@
 const DefaultRecordingSignaling = require('./recording');
 const StateMachine = require('../statemachine');
 
+const {
+  MediaConnectionError,
+  SignalingConnectionDisconnectedError
+} = require('../util/twilio-video-errors');
+
 /*
 RoomSignaling States
 -----------------------
@@ -220,7 +225,13 @@ function maybeUpdateState(roomSignaling) {
     return;
   }
 
-  roomSignaling.preempt(newState);
+  if (newState === 'reconnecting') {
+    roomSignaling.preempt(newState, null, [roomSignaling.signalingConnectionState === 'reconnecting'
+      ? new SignalingConnectionDisconnectedError()
+      : new MediaConnectionError()]);
+  } else {
+    roomSignaling.preempt(newState);
+  }
 }
 
 module.exports = RoomSignaling;

--- a/test/unit/spec/room.js
+++ b/test/unit/spec/room.js
@@ -235,14 +235,22 @@ describe('Room', () => {
   });
 
   describe('RoomSignaling state changed to "reconnecting"', () => {
-    it('should trigger the same event on the Room with a TwilioError 53405, "Media Connection Failed"', () => {
-      const spy = sinon.spy();
-      room.on('reconnecting', spy);
-      signaling.preempt('reconnecting');
-      assert.equal(spy.callCount, 1);
-      assert(spy.args[0][0] instanceof MediaConnectionError);
-      assert.equal(spy.args[0][0].code, 53405);
-      assert.equal(room.state, 'reconnecting');
+    [
+      MediaConnectionError,
+      SignalingConnectionDisconnectedError
+    ].forEach(ReconnectingError => {
+      context(`with a ${ReconnectingError.name}`, () => {
+        const error = new ReconnectingError();
+        it(`should trigger the same event on the Room with the ${ReconnectingError.name} (${error.code}, "${error.message}")`, () => {
+          const spy = sinon.spy();
+          room.on('reconnecting', spy);
+          signaling.preempt('reconnecting', null, [error]);
+          assert.equal(spy.callCount, 1);
+          assert(spy.args[0][0] instanceof ReconnectingError);
+          assert.equal(spy.args[0][0], error);
+          assert.equal(room.state, 'reconnecting');
+        });
+      });
     });
   });
 


### PR DESCRIPTION
@syerrapragada @innerverse 

* Ensuring the proper TwilioError passed to the Room#reconnecting event listener ([IDL](https://code.hq.twilio.com/pages/client/video-sdk-api/idl/room.html)).
* Updating unit tests.
* Updating Room#reconnecting event documentation.
* CHANGELOG.md entry to announce the opt-in feature.

TODO
=====
- [x] CHANGELOG.md entry for **dominantSpeaker** GA.
- [x] CHANGELOG.md entry for **networkQuality** GA.
- [x] COMMON_ISSUES.md entry for **networkQuality** bug in Firefox and Safari.