### PR TITLE
JSDK-2219 Queueing calls to createOffer() until the current negotiation is complete.

### DIFF
--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -177,7 +177,7 @@ class PeerConnectionV2 extends StateMachine {
       _mediaTrackReceivers: {
         value: new Set()
       },
-      _needsInitialAnswer: {
+      _needsAnswer: {
         writable: true,
         value: false
       },
@@ -553,6 +553,7 @@ class PeerConnectionV2 extends StateMachine {
    */
   _offer() {
     const offerOptions = Object.assign({}, this._offerOptions);
+    this._needsAnswer = true;
     if (this._shouldRestartIce) {
       this._shouldRestartIce = false;
       this._isRestartingIce = true;
@@ -573,7 +574,6 @@ class PeerConnectionV2 extends StateMachine {
       this._shouldOffer = false;
       if (!this._negotiationRole) {
         this._negotiationRole = 'offerer';
-        this._needsInitialAnswer = true;
       }
       return this._setLocalDescription({
         type: 'offer',
@@ -694,7 +694,7 @@ class PeerConnectionV2 extends StateMachine {
       case 'create-offer':
         if (description.revision <= this._lastStableDescriptionRevision) {
           return Promise.resolve();
-        } else if (this._needsInitialAnswer) {
+        } else if (this._needsAnswer) {
           this._queuedDescription = description;
           return Promise.resolve();
         }
@@ -706,7 +706,7 @@ class PeerConnectionV2 extends StateMachine {
           return Promise.resolve();
         }
         if (this._peerConnection.signalingState === 'have-local-offer') {
-          if (this._needsInitialAnswer) {
+          if (this._needsAnswer && this._descriptionRevision === 1) {
             this._queuedDescription = description;
             return Promise.resolve();
           }
@@ -730,7 +730,7 @@ class PeerConnectionV2 extends StateMachine {
       throw new MediaClientRemoteDescFailedError();
     }).then(() => {
       if (description.type === 'answer') {
-        this._needsInitialAnswer = false;
+        this._needsAnswer = false;
       }
       return this._checkIceBox(description);
     }).then(() => this._queuedDescription && this._updateDescription(this._queuedDescription)).then(() => {
@@ -847,7 +847,7 @@ class PeerConnectionV2 extends StateMachine {
    * @returns {Promise<void>}
    */
   offer() {
-    if (this._needsInitialAnswer || this._isRestartingIce) {
+    if (this._needsAnswer || this._isRestartingIce) {
       this._shouldOffer = true;
       return Promise.resolve();
     }

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -867,7 +867,8 @@ class PeerConnectionV2 extends StateMachine {
 
     return this.bracket('offering', key => {
       this.transition('updating', key);
-      return this._offer().then(() => {
+      const promise = this._needsAnswer || this._isRestartingIce ? Promise.resolve() : this._offer();
+      return promise.then(() => {
         this.tryTransition('open', key);
       }, error => {
         this.tryTransition('open', key);

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -336,7 +336,6 @@ class PeerConnectionV2 extends StateMachine {
       }
       return this._setLocalDescription(answer);
     }).then(() => {
-      this._needsAnswer = false;
       return this._checkIceBox(offer);
     }).then(() => {
       return this._queuedDescription
@@ -399,6 +398,7 @@ class PeerConnectionV2 extends StateMachine {
     return Promise.resolve().then(() => {
       return this._setLocalDescription({ type: 'rollback' });
     }).then(() => {
+      this._needsAnswer = false;
       return this._answer(offer);
     }).then(didReoffer => {
       return didReoffer ? Promise.resolve() : this._offer();
@@ -746,7 +746,8 @@ class PeerConnectionV2 extends StateMachine {
       this._needsAnswer = false;
       return this._checkIceBox(description);
     }).then(() => {
-      return this._queuedDescription && this._updateDescription(this._queuedDescription);
+      return this._queuedDescription
+        && this._updateDescription(this._queuedDescription);
     }).then(() => {
       this._queuedDescription = null;
       return this._maybeReoffer(this._peerConnection.localDescription).then(() => {});

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -328,14 +328,23 @@ class PeerConnectionV2 extends StateMachine {
       return this._setRemoteDescription(offer);
     }).catch(() => {
       throw new MediaClientRemoteDescFailedError();
-    }).then(() => this._peerConnection.createAnswer()).then(answer => {
+    }).then(() => {
+      return this._peerConnection.createAnswer();
+    }).then(answer => {
       if (!isFirefox) {
         answer = workaroundIssue8329(answer);
       }
       return this._setLocalDescription(answer);
-    }).then(() => this._checkIceBox(offer)).then(() => this._peerConnection.localDescription
-      ? this._maybeReoffer(this._peerConnection.localDescription)
-      : Promise.resolve(false)).catch(error => {
+    }).then(() => {
+      this._needsAnswer = false;
+      return this._checkIceBox(offer);
+    }).then(() => {
+      return this._queuedDescription
+        && this._updateDescription(this._queuedDescription);
+    }).then(() => {
+      this._queuedDescription = null;
+      return this._maybeReoffer(this._peerConnection.localDescription);
+    }).catch(error => {
       throw error instanceof MediaClientRemoteDescFailedError
         ? error
         : new MediaClientLocalDescFailedError();
@@ -387,9 +396,13 @@ class PeerConnectionV2 extends StateMachine {
       this._isRestartingIce = false;
       this._shouldRestartIce = true;
     }
-    return Promise.resolve().then(() => this._setLocalDescription({ type: 'rollback' }))
-      .then(() => this._answer(offer))
-      .then(didReoffer => didReoffer ? Promise.resolve() : this._offer());
+    return Promise.resolve().then(() => {
+      return this._setLocalDescription({ type: 'rollback' });
+    }).then(() => {
+      return this._answer(offer);
+    }).then(didReoffer => {
+      return didReoffer ? Promise.resolve() : this._offer();
+    });
   }
 
   /**
@@ -445,7 +458,6 @@ class PeerConnectionV2 extends StateMachine {
   /**
    * Handle a signaling state change event.
    * @private
-   * @param {Event}
    * @returns {void}
    */
   _handleSignalingStateChange() {
@@ -507,40 +519,42 @@ class PeerConnectionV2 extends StateMachine {
   /**
    * Conditionally re-offer.
    * @private
-   * @param {RTCSessionDescriptionInit} localDescription
+   * @param {?RTCSessionDescriptionInit} localDescription
    * @returns {Promise<boolean>}
    */
   _maybeReoffer(localDescription) {
     let shouldReoffer = this._shouldOffer;
 
-    // NOTE(mmalavalli): For "unified-plan" sdps, if the remote RTCPeerConnection sends
-    // an offer with fewer audio m= lines than the number of audio RTCRTPSenders
-    // in the local RTCPeerConnection, then the local RTCPeerConnection creates
-    // an answer with the same number of audio m= lines as in the offer. This
-    // behavior was triggered by the removal of 'offerToReceiveAudio' from the
-    // default RTCOfferOptions. Ideally, the local RTCPeerConnection should create
-    // an answer with the same number of audio m= lines as the number of
-    // RTCRTPSenders. In order to achieve this,the local RTCPeerConnection
-    // initiates renegotiation.
-    //
-    // We can reduce the number of cases where renegotiation is needed by
-    // re-introducing 'offerToReceiveAudio' to the default RTCOfferOptions with a
-    // value > 1.
-    if (this._isUnifiedPlan && localDescription.type === 'answer') {
-      const senders = this._peerConnection.getSenders().filter(sender => sender.track);
-      shouldReoffer = ['audio', 'video'].reduce((shouldOffer, kind) => {
-        const mediaSections = getMediaSections(localDescription.sdp, kind, '(sendrecv|sendonly)');
-        const sendersOfKind = senders.filter(isSenderOfKind.bind(null, kind));
-        return shouldOffer || (mediaSections.length < sendersOfKind.length);
-      }, shouldReoffer);
-    }
+    if (localDescription && localDescription.sdp) {
+      // NOTE(mmalavalli): For "unified-plan" sdps, if the remote RTCPeerConnection sends
+      // an offer with fewer audio m= lines than the number of audio RTCRTPSenders
+      // in the local RTCPeerConnection, then the local RTCPeerConnection creates
+      // an answer with the same number of audio m= lines as in the offer. This
+      // behavior was triggered by the removal of 'offerToReceiveAudio' from the
+      // default RTCOfferOptions. Ideally, the local RTCPeerConnection should create
+      // an answer with the same number of audio m= lines as the number of
+      // RTCRTPSenders. In order to achieve this,the local RTCPeerConnection
+      // initiates renegotiation.
+      //
+      // We can reduce the number of cases where renegotiation is needed by
+      // re-introducing 'offerToReceiveAudio' to the default RTCOfferOptions with a
+      // value > 1.
+      if (this._isUnifiedPlan && localDescription.type === 'answer') {
+        const senders = this._peerConnection.getSenders().filter(sender => sender.track);
+        shouldReoffer = ['audio', 'video'].reduce((shouldOffer, kind) => {
+          const mediaSections = getMediaSections(localDescription.sdp, kind, '(sendrecv|sendonly)');
+          const sendersOfKind = senders.filter(isSenderOfKind.bind(null, kind));
+          return shouldOffer || (mediaSections.length < sendersOfKind.length);
+        }, shouldReoffer);
+      }
 
-    // NOTE(mroberts): We also need to re-offer if we have a DataTrack to share
-    // but no m= application section.
-    const hasDataTrack = this._dataChannels.size > 0;
-    const hasApplicationMediaSection = getMediaSections(localDescription.sdp, 'application').length > 0;
-    const needsApplicationMediaSection = hasDataTrack && !hasApplicationMediaSection;
-    shouldReoffer = shouldReoffer || needsApplicationMediaSection;
+      // NOTE(mroberts): We also need to re-offer if we have a DataTrack to share
+      // but no m= application section.
+      const hasDataTrack = this._dataChannels.size > 0;
+      const hasApplicationMediaSection = getMediaSections(localDescription.sdp, 'application').length > 0;
+      const needsApplicationMediaSection = hasDataTrack && !hasApplicationMediaSection;
+      shouldReoffer = shouldReoffer || needsApplicationMediaSection;
+    }
 
     const promise = shouldReoffer ? this._offer() : Promise.resolve();
     return promise.then(() => shouldReoffer);
@@ -559,7 +573,9 @@ class PeerConnectionV2 extends StateMachine {
       this._isRestartingIce = true;
       offerOptions.iceRestart = true;
     }
-    return Promise.resolve().then(() => this._peerConnection.createOffer(offerOptions)).catch(() => {
+    return Promise.resolve().then(() => {
+      return this._peerConnection.createOffer(offerOptions);
+    }).catch(() => {
       throw new MediaClientLocalDescFailedError();
     }).then(offer => {
       if (!isFirefox) {
@@ -722,22 +738,18 @@ class PeerConnectionV2 extends StateMachine {
     // Handle answer or pranswer.
     const revision = description.revision;
     return Promise.resolve().then(() => {
-      if (description.type === 'answer') {
-        this._lastStableDescriptionRevision = revision;
-      }
       return this._setRemoteDescription(description);
     }).catch(() => {
       throw new MediaClientRemoteDescFailedError();
     }).then(() => {
-      if (description.type === 'answer') {
-        this._needsAnswer = false;
-      }
+      this._lastStableDescriptionRevision = revision;
+      this._needsAnswer = false;
       return this._checkIceBox(description);
-    }).then(() => this._queuedDescription && this._updateDescription(this._queuedDescription)).then(() => {
+    }).then(() => {
+      return this._queuedDescription && this._updateDescription(this._queuedDescription);
+    }).then(() => {
       this._queuedDescription = null;
-      return this._peerConnection.localDescription
-        ? this._maybeReoffer(this._peerConnection.localDescription).then(() => {})
-        : Promise.resolve();
+      return this._maybeReoffer(this._peerConnection.localDescription).then(() => {});
     });
   }
 

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -1055,7 +1055,7 @@ describe('LocalParticipant', function() {
         for (let i = 0; i < 10; i++) {
           videoTrack = videoTrack ? new LocalVideoTrack(videoTrack.mediaStreamTrack.clone()) : await createLocalVideoTrack();
           publication = await rooms[0].localParticipant.publishTrack(videoTrack);
-          publication.unpublish();
+          rooms[0].localParticipant.unpublishTrack(videoTrack);
         }
       } catch (e) {
         error = e;

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -356,14 +356,10 @@ describe('PeerConnectionV2', () => {
   describe('#offer', () => {
     combinationContext([
       [
-        [true, false],
-        x => `${x ? 'before' : 'after'} the initial round of negotiation`
-      ],
-      [
         ['stable', 'have-local-offer'],
         x => `in signaling state "${x}"`
       ]
-    ], ([initial, signalingState]) => {
+    ], ([signalingState]) => {
       let test;
       let descriptions;
       let rev;
@@ -371,7 +367,7 @@ describe('PeerConnectionV2', () => {
       let signalingStateBefore;
       let result;
 
-      if (signalingState === 'have-local-offer' && initial) {
+      if (signalingState === 'have-local-offer') {
         beforeEach(setup);
         return itShouldEventuallyCreateOffer();
       }
@@ -383,14 +379,6 @@ describe('PeerConnectionV2', () => {
         test = makeTest({ offers: [makeOffer({ session: 1 }), makeOffer({ session: 2 }), makeOffer({ session: 3 })] });
         descriptions = [];
         rev = 0;
-
-        if (!initial) {
-          await test.pcv2.offer();
-          const answer = makeAnswer();
-          const answerDescription = test.state().setDescription(answer, 1);
-          await test.pcv2.update(answerDescription);
-          rev++;
-        }
 
         switch (signalingState) {
           case 'stable':
@@ -412,15 +400,9 @@ describe('PeerConnectionV2', () => {
 
       function itShouldCreateOffer() {
         const expectedOfferIndex = {
-          'stable': {
-            true: 0,
-            false: 1
-          },
-          'have-local-offer': {
-            true: 1,
-            false: 2
-          }
-        }[signalingState][initial];
+          'stable': 0,
+          'have-local-offer': 1
+        }[signalingState];
 
         it('returns a Promise that resolves to undefined', () => {
           assert.equal(result);
@@ -844,7 +826,7 @@ describe('PeerConnectionV2', () => {
               break;
             }
             beforeEach(setup);
-            if (signalingState === 'have-local-offer' && initial) {
+            if (signalingState === 'have-local-offer') {
               return itShouldEventuallyCreateOffer();
             }
             return itShouldCreateOffer();
@@ -1087,10 +1069,10 @@ describe('PeerConnectionV2', () => {
 
         itDoesNothing();
 
-        context('then, once the initial answer is received', () => {
+        context(`then, once the ${initial ? 'initial ' : ' '}answer is received`, () => {
           beforeEach(async () => {
             const answer = makeAnswer();
-            const answerDescription = test.state().setDescription(answer, 1);
+            const answerDescription = test.state().setDescription(answer, initial ? 1 : 2);
             await test.pcv2.update(answerDescription);
           });
 


### PR DESCRIPTION
@syerrapragada 

~~WIP.~~

While #518 reduced the instances of SDPs with changing mids for the same m= sections during negotiation, it did not fully eliminate them because we still can create an offer in the middle of a negotiation (that is while an offer has already been sent and awaiting an answer).

This PR makes sure that calls to createOffer() are queued until the existing offer <--> answer negotiation is complete.