### PR TITLE
JSDK-2265 Using default SDP format.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+1.16.0 (in progress)
+====================
+
+New Features
+------------
+
+- twilio-video.js will now use the Unified Plan SDP format where available.
+  Google Chrome, starting from version 72, has and Safari, starting from version
+  12.1, will enable Unified Plan as the default SDP format. We highly recommend
+  that you upgrade your twilio-video.js dependency to this version so that your
+  application continues to work on the above mentioned browser versions.
+
+  In December 2018, we published an [advisory](https://support.twilio.com/hc/en-us/articles/360012782494-Breaking-Changes-in-Twilio-Video-JavaScript-SDKs-December-2018-)
+  recommending customers to upgrade to the latest versions of twilio-video.js
+  in order to not be affected by Google Chrome switching to Unified Plan starting
+  from version 72. The way we ensured support of newer versions of Google Chrome
+  in the versions of twilio-video.js released between December 2018 and now was
+  by overriding the default SDP format to Plan B. Starting with this version,
+  twilio-video.js will use Unified Plan where available, while also maintaining
+  support for earlier browser versions with Plan B as the default SDP format. (JSDK-2265)
+
 1.15.2 (February 7, 2019)
 =========================
 

--- a/karma/makeconf.js
+++ b/karma/makeconf.js
@@ -70,8 +70,9 @@ function makeConf(defaultFile, browserNoActivityTimeout, requires) {
           prefs: {
             'media.gstreamer.enabled': false,
             'media.navigator.permission.disabled': true,
-            'media.navigator.streams.fake': true
-          }
+            'media.navigator.streams.fake': true,
+            'media.autoplay.enabled.user-gestures-needed': false,
+            'media.block-autoplay-until-in-foreground': false          }
         }
       }
     });

--- a/karma/makeconf.js
+++ b/karma/makeconf.js
@@ -72,7 +72,8 @@ function makeConf(defaultFile, browserNoActivityTimeout, requires) {
             'media.navigator.permission.disabled': true,
             'media.navigator.streams.fake': true,
             'media.autoplay.enabled.user-gestures-needed': false,
-            'media.block-autoplay-until-in-foreground': false          }
+            'media.block-autoplay-until-in-foreground': false
+          }
         }
       }
     });

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { guessBrowser } = require('@twilio/webrtc/lib/util');
 const CancelablePromise = require('./util/cancelablepromise');
 const createCancelableRoomPromise = require('./cancelableroompromise');
 const createLocalTracks = require('./createlocaltracks');
@@ -8,7 +9,6 @@ const constants = require('./util/constants');
 const Room = require('./room');
 const E = require('./util/constants').typeErrors;
 const EncodingParametersImpl = require('./encodingparameters');
-const guessBrowser = require('./util').guessBrowser;
 const LocalAudioTrack = require('./media/track/es5/localaudiotrack');
 const LocalDataTrack = require('./media/track/es5/localdatatrack');
 const LocalParticipant = require('./localparticipant');

--- a/lib/signaling/v2/cancelableroomsignalingpromise.js
+++ b/lib/signaling/v2/cancelableroomsignalingpromise.js
@@ -15,10 +15,6 @@ function createCancelableRoomSignalingPromise(token, ua, localParticipant, iceSe
     Transport: DefaultTransport
   }, options);
 
-  if (options._sdpSemantics) {
-    options.sdpSemantics = options._sdpSemantics;
-  }
-
   let transport;
 
   const PeerConnectionManager = options.PeerConnectionManager;
@@ -65,8 +61,7 @@ function createCancelableRoomSignalingPromise(token, ua, localParticipant, iceSe
           networkQuality: options.networkQuality,
           iceServerSourceStatus: iceServerSource.status,
           insights: options.insights,
-          realm: options.realm,
-          sdpSemantics: options.sdpSemantics
+          realm: options.realm
         }, transportOptions);
 
         const Transport = options.Transport;

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1,13 +1,14 @@
 'use strict';
 
 const WebRTC = require('@twilio/webrtc');
+const { guessBrowser } = require('@twilio/webrtc/lib/util');
+const { getSdpFormat } = require('@twilio/webrtc/lib/util/sdp');
 const DefaultMediaStream = WebRTC.MediaStream;
 const DefaultRTCIceCandidate = WebRTC.RTCIceCandidate;
 const DefaultRTCPeerConnection = WebRTC.RTCPeerConnection;
 const DefaultRTCSessionDescription = WebRTC.RTCSessionDescription;
 const getStatistics = WebRTC.getStats;
 const getMediaSections = require('../../util/sdp').getMediaSections;
-const guessBrowser = require('../../util').guessBrowser;
 const oncePerTick = require('../../util').oncePerTick;
 const setBitrateParameters = require('../../util/sdp').setBitrateParameters;
 const setCodecPreferences = require('../../util/sdp').setCodecPreferences;
@@ -18,7 +19,7 @@ const MediaClientRemoteDescFailedError = require('../../util/twilio-video-errors
 const DataTrackReceiver = require('../../data/receiver');
 const MediaTrackReceiver = require('../../media/track/receiver');
 const StateMachine = require('../../statemachine');
-const { buildLogLevels, getSdpFormat, makeUUID } = require('../../util');
+const { buildLogLevels, makeUUID } = require('../../util');
 const { DEFAULT_LOG_LEVEL } = require('../../util/constants');
 const Log = require('../../util/log');
 const IdentityTrackMatcher = require('../../util/sdp/trackmatcher/identity');
@@ -29,7 +30,8 @@ const workaroundIssue8329 = require('../../util/sdp/issue8329');
 const isChrome = guessBrowser() === 'chrome';
 const isFirefox = guessBrowser() === 'firefox';
 const isSafari = guessBrowser() === 'safari';
-
+const sdpFormat = getSdpFormat();
+const isUnifiedPlan = sdpFormat === 'unified';
 /*
 PeerConnectionV2 States
 -----------------------
@@ -99,8 +101,6 @@ class PeerConnectionV2 extends StateMachine {
     const logLevels = buildLogLevels(options.logLevel);
     const RTCPeerConnection = options.RTCPeerConnection;
     const peerConnection = new RTCPeerConnection(configuration, options.chromeSpecificConstraints);
-    const sdpFormat = getSdpFormat(options.sdpSemantics);
-    const isUnifiedPlan = sdpFormat === 'unified';
 
     const localMediaStream = isUnifiedPlan && RTCPeerConnection.prototype.addTransceiver
       ? null
@@ -135,9 +135,6 @@ class PeerConnectionV2 extends StateMachine {
       _isRestartingIce: {
         writable: true,
         value: false
-      },
-      _isUnifiedPlan: {
-        value: isUnifiedPlan
       },
       _lastIceConnectionState: {
         writable: true,
@@ -205,9 +202,6 @@ class PeerConnectionV2 extends StateMachine {
       _remoteCandidates: {
         writable: true,
         value: new IceBox()
-      },
-      _sdpFormat: {
-        value: sdpFormat
       },
       _setBitrateParameters: {
         value: options.setBitrateParameters
@@ -484,9 +478,7 @@ class PeerConnectionV2 extends StateMachine {
         // support, we have to use the same hacky solution as Safari. Revisit
         // this when RTCRtpTransceivers and MIDs land. We should be able to use
         // the same technique as Firefox.
-        : isSafari || this._isUnifiedPlan
-          ? new OrderedTrackMatcher()
-          : new IdentityTrackMatcher();
+        : isSafari || isUnifiedPlan ? new OrderedTrackMatcher() : new IdentityTrackMatcher();
     }
 
     // NOTE(mmalavalli): For unified plan sdps, calling addTransceiver with
@@ -539,7 +531,7 @@ class PeerConnectionV2 extends StateMachine {
       // We can reduce the number of cases where renegotiation is needed by
       // re-introducing 'offerToReceiveAudio' to the default RTCOfferOptions with a
       // value > 1.
-      if (this._isUnifiedPlan && localDescription.type === 'answer') {
+      if (isUnifiedPlan && localDescription.type === 'answer') {
         const senders = this._peerConnection.getSenders().filter(sender => sender.track);
         shouldReoffer = ['audio', 'video'].reduce((shouldOffer, kind) => {
           const mediaSections = getMediaSections(localDescription.sdp, kind, '(sendrecv|sendonly)');
@@ -615,7 +607,7 @@ class PeerConnectionV2 extends StateMachine {
         description = {
           type: description.type,
           sdp: isChrome && vp8SimulcastRequested
-            ? this._setSimulcast(description.sdp, this._sdpFormat, this._trackIdsToAttributes)
+            ? this._setSimulcast(description.sdp, sdpFormat, this._trackIdsToAttributes)
             : description.sdp
         };
       }
@@ -673,7 +665,7 @@ class PeerConnectionV2 extends StateMachine {
         this._log.debug('An ICE restart was in-progress and is now completed');
         this._isRestartingIce = false;
       }
-      if (this._isUnifiedPlan) {
+      if (isUnifiedPlan) {
         this._peerConnection.getTransceivers().forEach(transceiver => {
           if (shouldStopTransceiver(description.sdp, transceiver)) {
             transceiver.stop();

--- a/lib/signaling/v2/peerconnectionmanager.js
+++ b/lib/signaling/v2/peerconnectionmanager.js
@@ -1,11 +1,12 @@
 'use strict';
 
+const { guessBrowser } = require('@twilio/webrtc/lib/util');
 const PeerConnectionV2 = require('./peerconnection');
 const MediaTrackSender = require('../../media/track/sender');
 const QueueingEventEmitter = require('../../queueingeventemitter');
 const util = require('../../util');
 
-const isFirefox = util.guessBrowser() === 'firefox';
+const isFirefox = guessBrowser() === 'firefox';
 
 /**
  * {@link PeerConnectionManager} manages multiple {@link PeerConnectionV2}s.

--- a/lib/signaling/v2/transport.js
+++ b/lib/signaling/v2/transport.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { getSdpFormat } = require('@twilio/webrtc/lib/util/sdp');
 const constants = require('../../util/constants');
 const packageInfo = require('../../../package.json');
 const InsightsPublisher = require('../../util/insightspublisher');
@@ -84,8 +85,8 @@ class Transport extends StateMachine {
     options = Object.assign({
       InsightsPublisher,
       NullInsightsPublisher,
-      sdpSemantics: null,
       SIPJSMediaHandler: DefaultSIPJSMediaHandler,
+      sdpFormat: getSdpFormat(),
       userAgent: util.getUserAgent()
     }, options);
     super('connecting', states);
@@ -106,8 +107,8 @@ class Transport extends StateMachine {
           options.realm,
           eventPublisherOptions)
       },
-      _sdpSemantics: {
-        value: options.sdpSemantics
+      _sdpFormat: {
+        value: options.sdpFormat
       },
       _updatesReceived: {
         value: []
@@ -274,7 +275,7 @@ function createSession(transport, name, accessToken, localParticipant, peerConne
           }
         }
 
-        const sdpFormat = util.getSdpFormat(transport._sdpSemantics);
+        const sdpFormat = transport._sdpFormat;
         if (type === 'connect' && sdpFormat) {
           message.format = sdpFormat;
         }

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -1,4 +1,3 @@
-/* globals mozRTCPeerConnection, RTCRtpTransceiver */
 'use strict';
 
 const constants = require('./constants');
@@ -139,24 +138,6 @@ function getUserAgent() {
   return typeof navigator !== 'undefined' && navigator.userAgent
     ? navigator.userAgent
     : 'Unknown';
-}
-
-/**
- * Guess the browser.
- * @returns {?string} browser - "chrome", "firefox", "safari", or null
- */
-function guessBrowser() {
-  if (typeof webkitRTCPeerConnection !== 'undefined') {
-    return 'chrome';
-  } else if (typeof mozRTCPeerConnection !== 'undefined') {
-    return 'firefox';
-  } else if (typeof RTCPeerConnection !== 'undefined') {
-    if (getUserAgent().match(/AppleWebKit\/(\d+)\./)) {
-      return 'safari';
-    }
-    // NOTE(mroberts): Could be Edge.
-  }
-  return null;
 }
 
 /**
@@ -437,68 +418,6 @@ function validateLocalTrack(track, options) {
   }
 }
 
-/**
- * @typedef {'plan-b' | 'unified-plan'} SdpSemantics
- */
-/**
- * @typedef {'planb' | 'unified'} SdpFormat
- */
-
-/**
- * Use unified plan SDP format on Firefox
- * @param {?SdpSemantics} [sdpSemantics]
- * @returns {SdpFormat} SDP format
- */
-function getSdpFormat(sdpSemantics) {
-  const browser = guessBrowser();
-  if (browser === 'firefox') {
-    return 'unified';
-  }
-  if (browser === 'safari') {
-    return 'currentDirection' in RTCRtpTransceiver.prototype
-      ? 'unified'
-      : 'planb';
-  }
-  if (checkIfSdpSemanticsIsSupported()) {
-    return {
-      'plan-b': 'planb',
-      'unified-plan': 'unified'
-    }[sdpSemantics || 'plan-b'];
-  }
-  // NOTE(mmalavalli): Once Chrome stops supporting "plan-b" SDPs, it will
-  // ignore the "sdpSemantics" flag. So, in order to differentiate between
-  // versions of Chrome which support only "plan-b" SDPs and versions of Chrome
-  // which support only "unified-plan" SDPs, which check whether PeerConnection's
-  // addStream() method is present.
-  return RTCPeerConnection.prototype.addStream ? 'planb' : 'unified';
-}
-
-// NOTE(mroberts): We need to cache this result so that we don't create too many
-// RTCPeerConnections.
-let sdpSemanticsIsSupported;
-
-/**
- * Check whether or not `sdpSemantics` is supported.
- * @returns {boolean}
- */
-function checkIfSdpSemanticsIsSupported() {
-  if (typeof sdpSemanticsIsSupported === 'boolean') {
-    return sdpSemanticsIsSupported;
-  }
-  if (typeof RTCPeerConnection === 'undefined') {
-    sdpSemanticsIsSupported = false;
-    return sdpSemanticsIsSupported;
-  }
-  try {
-    new RTCPeerConnection({ sdpSemantics: 'bogus' });
-    sdpSemanticsIsSupported = false;
-    return sdpSemanticsIsSupported;
-  } catch (error) {
-    sdpSemanticsIsSupported = true;
-    return sdpSemanticsIsSupported;
-  }
-}
-
 exports.constants = constants;
 exports.asLocalTrack = asLocalTrack;
 exports.asLocalTrackPublication = asLocalTrackPublication;
@@ -508,7 +427,6 @@ exports.difference = difference;
 exports.filterObject = filterObject;
 exports.flatMap = flatMap;
 exports.getUserAgent = getUserAgent;
-exports.guessBrowser = guessBrowser;
 exports.makeClientSIPURI = makeClientSIPURI;
 exports.makeServerSIPURI = makeServerSIPURI;
 exports.makeUUID = makeUUID;
@@ -523,4 +441,3 @@ exports.buildLogLevels = buildLogLevels;
 exports.trackClass = trackClass;
 exports.trackPublicationClass = trackPublicationClass;
 exports.validateLocalTrack = validateLocalTrack;
-exports.getSdpFormat = getSdpFormat;

--- a/lib/util/support.js
+++ b/lib/util/support.js
@@ -1,7 +1,7 @@
 /* globals RTCPeerConnection, webkitRTCPeerConnection, mozRTCPeerConnection, navigator */
 'use strict';
 
-const guessBrowser = require('./').guessBrowser;
+const { guessBrowser } = require('@twilio/webrtc/lib/util');
 
 /**
  * Check whether PeerConnection API is supported.

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "karma-spec-reporter": "^0.0.31",
     "mocha": "^3.2.0",
     "npm-run-all": "^4.0.2",
-    "phantom": "^4.0.2",
+    "puppeteer": "^1.12.2",
     "release-tool": "^0.2.2",
     "requirejs": "^2.3.3",
     "rimraf": "^2.6.1",
@@ -116,7 +116,7 @@
   },
   "dependencies": {
     "@twilio/sip.js": "^0.7.7",
-    "@twilio/webrtc": "2.2.1",
+    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#a4bc09dd70d8a239dd8818e952361bcb3b7e77d2",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },

--- a/test/env.js
+++ b/test/env.js
@@ -12,8 +12,7 @@ const processEnv = {
   WS_SERVER: process.env.WS_SERVER,
   WS_SERVER_INSIGHTS: process.env.WS_SERVER_INSIGHTS,
   LOG_LEVEL: process.env.LOG_LEVEL,
-  ENABLE_REST_API_TESTS: process.env.ENABLE_REST_API_TESTS,
-  SDP_SEMANTICS: process.env.SDP_SEMANTICS
+  ENABLE_REST_API_TESTS: process.env.ENABLE_REST_API_TESTS
 };
 
 // Copy environment variables
@@ -27,8 +26,7 @@ const env = [
   ['WS_SERVER',                 'wsServer'],
   ['WS_SERVER_INSIGHTS',        'wsServerInsights'],
   ['LOG_LEVEL',                 'logLevel'],
-  ['ENABLE_REST_API_TESTS',     'enableRestApiTests'],
-  ['SDP_SEMANTICS',             'sdpSemantics']
+  ['ENABLE_REST_API_TESTS',     'enableRestApiTests']
 ].reduce((env, [processEnvKey, envKey]) => {
   if (processEnvKey in processEnv) {
     env[envKey] = processEnv[processEnvKey];

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const sdpFormat = require('@twilio/webrtc/lib/util/sdp').getSdpFormat();
 
 const {
   connect,
@@ -753,7 +754,7 @@ describe('LocalParticipant', function() {
         assert.equal(thatTrack.sid, thisLocalTrackPublication1.trackSid);
         assert.equal(thatTrack.kind, thisLocalTrackPublication1.kind);
         assert.equal(thatTrack.enabled, thisLocalTrackPublication1.enabled);
-        if (isChrome && defaults._sdpSemantics !== 'unified-plan') {
+        if (isChrome && sdpFormat === 'planb') {
           assert.equal(thatTrack.mediaStreamTrack.readyState, 'ended');
         }
       });
@@ -1035,7 +1036,7 @@ describe('LocalParticipant', function() {
 
   // NOTE(mmalavalli): This test runs the scenario described in JSDK-2219. It is
   // disabled on Chrome (unified-plan) due to JSDK-2276.
-  (isChrome && defaults._sdpSemantics === 'unified-plan' ? describe.skip : describe)('#publishTrack and #unpublishTrack, when called in rapid succession', () => {
+  (isChrome && sdpFormat === 'unified' ? describe.skip : describe)('#publishTrack and #unpublishTrack, when called in rapid succession', () => {
     let error;
     let publication;
 

--- a/test/integration/spec/util/simulcast.js
+++ b/test/integration/spec/util/simulcast.js
@@ -1,14 +1,13 @@
 'use strict';
 
 const assert = require('assert');
-const { _sdpSemantics } = require('../../../lib/defaults');
-const { getSdpFormat, guessBrowser } = require('../../../../lib/util');
+const { guessBrowser } = require('@twilio/webrtc/lib/util');
+const { getSdpFormat } = require('@twilio/webrtc/lib/util/sdp');
 const { getMediaSections, setSimulcast } = require('../../../../lib/util/sdp');
 const { RTCPeerConnection, RTCSessionDescription } = require('@twilio/webrtc');
 
 const isChrome = guessBrowser() === 'chrome';
-const sdpSemantics = _sdpSemantics;
-const sdpFormat = getSdpFormat(sdpSemantics);
+const sdpFormat = getSdpFormat();
 
 describe('setSimulcast', () => {
   let answer1;
@@ -30,9 +29,9 @@ describe('setSimulcast', () => {
       before(async () => {
         const constraints = { audio: true, video: true };
         stream = await makeStream(constraints);
-        pc1 = new RTCPeerConnection({ iceServers: [], sdpSemantics });
+        pc1 = new RTCPeerConnection({ iceServers: [] });
         pc1.addStream(stream);
-        pc2 = new RTCPeerConnection({ iceServers: [], sdpSemantics });
+        pc2 = new RTCPeerConnection({ iceServers: [] });
         pc2.addStream(stream);
         trackIdsToAttributes = new Map();
 
@@ -91,7 +90,7 @@ describe('setSimulcast', () => {
     before(async () => {
       const constraints = { audio: true, video: true };
       stream = await makeStream(constraints);
-      pc1 = new RTCPeerConnection({ iceServers: [], sdpSemantics });
+      pc1 = new RTCPeerConnection({ iceServers: [] });
       pc1.addStream(stream);
       trackIdsToAttributes = new Map();
 

--- a/test/lib/defaults.js
+++ b/test/lib/defaults.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { guessBrowser } = require('../../lib/util');
+const { guessBrowser } = require('@twilio/webrtc/lib/util');
 
 const env = require('../env');
 
@@ -18,7 +18,6 @@ const defaults = [
   }
   return defaults;
 }, {
-  _sdpSemantics: env.sdpSemantics,
   dominantSpeaker: true,
   networkQuality: true
 });

--- a/test/lib/guessbrowser.js
+++ b/test/lib/guessbrowser.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const guess = require('../../lib/util').guessBrowser();
+const guess = require('@twilio/webrtc/lib/util').guessBrowser();
 
 module.exports = {
   isChrome: guess === 'chrome',

--- a/test/umd/require-browser/index.html
+++ b/test/umd/require-browser/index.html
@@ -3,7 +3,7 @@
   <head></head>
 
   <body>
-    <script data-main="js/main" src="js/require.js"/></script>
+    <script data-main="js/main" src="js/require.js"></script>
     <script>
       var publicVars = [
         'connect',
@@ -17,21 +17,21 @@
       ];
       require(['../../../../dist/twilio-video'], function(video) {
         try {
-          if (publicVars.every(function(publicVar) {
+          if (typeof video !== 'undefined' && publicVars.every(function(publicVar) {
             return publicVar in video;
           })) {
-            window.callPhantom({
+            console.log({
               status: 'success',
               version: video.version
             });
           } else {
-            window.callPhantom({
+            console.log({
               status: 'failure',
               reason: 'Video undefined'
             });
           }
         } catch(e) {
-          window.callPhantom({
+          console.log({
             status: 'failure',
             reason: e.message || e
           });

--- a/test/umd/require-browser/min.html
+++ b/test/umd/require-browser/min.html
@@ -3,7 +3,7 @@
   <head></head>
 
   <body>
-    <script data-main="js/main" src="js/require.js"/></script>
+    <script data-main="js/main" src="js/require.js"></script>
     <script>
       var publicVars = [
         'connect',
@@ -17,21 +17,21 @@
       ];
       require(['../../../../dist/twilio-video.min'], function(video) {
         try {
-          if (publicVars.every(function(publicVar) {
+          if (typeof video !== 'undefined' && publicVars.every(function(publicVar) {
             return publicVar in video;
           })) {
-            window.callPhantom({
+            console.log({
               status: 'success',
               version: video.version
             });
           } else {
-            window.callPhantom({
+            console.log({
               status: 'failure',
               reason: 'Video undefined'
             });
           }
         } catch(e) {
-          window.callPhantom({
+          console.log({
             status: 'failure',
             reason: e.message || e
           });

--- a/test/unit/spec/signaling/v2/transport.js
+++ b/test/unit/spec/signaling/v2/transport.js
@@ -23,7 +23,7 @@ describe('Transport', () => {
     let test;
 
     beforeEach(() => {
-      test = makeTest();
+      test = makeTest({ sdpFormat: 'foo' });
     });
 
     it('sets the .state to "connecting"', () => {
@@ -111,6 +111,10 @@ describe('Transport', () => {
 
             it('has .type "connect"', () => {
               assert.equal('connect', message.type);
+            });
+
+            it('has .format "foo"', () => {
+              assert.equal('foo', message.format);
             });
 
             it('has .publisher.name "twilio-video.js"', () => {


### PR DESCRIPTION
@syerrapragada 

* Removing plan-b enforcement (twilio-webrtc.js#JSDK-2265-2.x).
* Since PhantomJS is no longer supported, the UMD test is re-written with puppeteer + headless Chrome.
* Disabling autoplay policy in Firefox 66+ for tests.
* Updating CHANGELOG.md to include Unified Plan Guide.