### PR TITLE
JSDK-2280: Remove dummy RTCDataChannel for Firefox 65 and above.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Bug Fixes
 - Fixed a bug where `Room.getStats` was throwing a TypeError in Electron 3.x. (JSDK-2267)
 - Fixed a bug where the LocalParticipant sometimes failed to publish a LocalTrack
   to a group Room due to media negotiation failure. (JSDK-2219)
+- Removed workaround for this [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1481335) on Firefox 65 and above.
 
 2.0.0-beta5 (January 7, 2019)
 =============================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ Bug Fixes
 - Fixed a bug where `Room.getStats` was throwing a TypeError in Electron 3.x. (JSDK-2267)
 - Fixed a bug where the LocalParticipant sometimes failed to publish a LocalTrack
   to a group Room due to media negotiation failure. (JSDK-2219)
-- Removed workaround for this [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1481335) on Firefox 65 and above.
+- Removed workaround for this [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1481335) on Firefox 65 and above. (JSDK-2280)
 
 2.0.0-beta5 (January 7, 2019)
 =============================

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -27,11 +27,16 @@ const OrderedTrackMatcher = require('../../util/sdp/trackmatcher/ordered');
 const MIDTrackMatcher = require('../../util/sdp/trackmatcher/mid');
 const workaroundIssue8329 = require('../../util/sdp/issue8329');
 
-const isChrome = guessBrowser() === 'chrome';
-const isFirefox = guessBrowser() === 'firefox';
-const isSafari = guessBrowser() === 'safari';
+const guess = guessBrowser();
+const isChrome = guess === 'chrome';
+const isFirefox = guess === 'firefox';
+const isSafari = guess === 'safari';
 const sdpFormat = getSdpFormat();
 const isUnifiedPlan = sdpFormat === 'unified';
+
+const firefoxMajorVersion = isFirefox
+  ? parseInt(navigator.userAgent.match(/Firefox\/(\d+)/)[1], 10)
+  : null;
 
 /*
 PeerConnectionV2 States
@@ -115,7 +120,7 @@ class PeerConnectionV2 extends StateMachine {
     //
     //   https://bugzilla.mozilla.org/show_bug.cgi?id=1481335
     //
-    if (isFirefox) {
+    if (isFirefox && firefoxMajorVersion < 65) {
       peerConnection.createDataChannel(makeUUID());
     }
 


### PR DESCRIPTION
@manjeshbhargav 
This PR removes workaround for Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1481335 on Firefox 65 and Above.