### PR TITLE
JSDK-2280: Remove dummy RTCDataChannel for Firefox 65 and above. (#536)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ New Features
   twilio-video.js will use Unified Plan where available, while also maintaining
   support for earlier browser versions with Plan B as the default SDP format. (JSDK-2265)
 
+Bug Fixes
+---------
+
+- Removed workaround for this [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1481335) on Firefox 65 and above. (JSDK-2280)
+
 1.15.2 (February 7, 2019)
 =========================
 

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -27,11 +27,17 @@ const OrderedTrackMatcher = require('../../util/sdp/trackmatcher/ordered');
 const MIDTrackMatcher = require('../../util/sdp/trackmatcher/mid');
 const workaroundIssue8329 = require('../../util/sdp/issue8329');
 
-const isChrome = guessBrowser() === 'chrome';
-const isFirefox = guessBrowser() === 'firefox';
-const isSafari = guessBrowser() === 'safari';
+const guess = guessBrowser();
+const isChrome = guess === 'chrome';
+const isFirefox = guess === 'firefox';
+const isSafari = guess === 'safari';
 const sdpFormat = getSdpFormat();
 const isUnifiedPlan = sdpFormat === 'unified';
+
+const firefoxMajorVersion = isFirefox
+  ? parseInt(navigator.userAgent.match(/Firefox\/(\d+)/)[1], 10)
+  : null;
+
 /*
 PeerConnectionV2 States
 -----------------------
@@ -114,7 +120,7 @@ class PeerConnectionV2 extends StateMachine {
     //
     //   https://bugzilla.mozilla.org/show_bug.cgi?id=1481335
     //
-    if (isFirefox) {
+    if (isFirefox && firefoxMajorVersion < 65) {
       peerConnection.createDataChannel(makeUUID());
     }
 


### PR DESCRIPTION
@manjeshbhargav 
cherry-pick JSDK-2280 for 1.x branch