### PR TITLE
JSDK-2281 Add COMMON_ISSUES.md entry for FF63+ and WebRTC 57 mobile clients.

### DIFF
--- a/COMMON_ISSUES.md
+++ b/COMMON_ISSUES.md
@@ -14,7 +14,7 @@ Incompatibility between Mobile 1.x/2.x and Javascript on Firefox 63+ in Peer-to-
 Mozilla [announced](https://blog.mozilla.org/webrtc/how-to-avoid-data-channel-breaking/)
 a change in July 2018 related to how RTCDataChannels are negotiated in Firefox 63+.
 Unfortunately, this has caused an incompatibility with versions of our Android and
-iOS Video SDKs that use WebRTC 57 and below.
+iOS Video SDKs that use Chromium WebRTC 57 and below.
 
 ### What is the impact?
 

--- a/COMMON_ISSUES.md
+++ b/COMMON_ISSUES.md
@@ -16,7 +16,7 @@ a change in July 2018 related to how RTCDataChannels are negotiated in Firefox 6
 Unfortunately, this has caused an incompatibility with those versions of our Android
 and iOS Video SDKs that use WebRTC 57 and below.
 
-###What is the impact?
+### What is the impact?
 
 Firefox 63+ Participants that join a Peer-to-Peer Room that also has Android and
 iOS Participants with the affected versions of the Video SDK, will not be able to
@@ -24,7 +24,7 @@ publish their local media Tracks. The mobile Participants can see the Firefox 63
 Participants in the Room but no Tracks are ever published, as a result no media
 is ever published/visible from those Participants.
                                                                      
-###Is my app impacted?
+### Is my app impacted?
 
 If you use one of the following Twilio Video Android or iOS SDK versions with any
 version of the Twilio Video Javascript SDK on Firefox 63+ then your application
@@ -35,7 +35,7 @@ will be impacted:
 | Android SDK | 1.x & 2.x         | 3.0.0+             |
 | iOS SDK     | 1.0.0 - 2.2.2     | 2.3.0+             |
 
-###If my app is impacted, how can I overcome it?
+### If my app is impacted, how can I overcome it?
 
 Upgrade to a release of Twilio Video Android or iOS SDK as noted above. You can
 find more information about any changes introduced in these releases by reviewing

--- a/COMMON_ISSUES.md
+++ b/COMMON_ISSUES.md
@@ -8,6 +8,42 @@ known or a workaround is available. Please also take a look at the
 release. If your issue hasn't been reported, consider submitting
 [a new issue](https://github.com/twilio/twilio-video.js/issues/new).
 
+Incompatibility between Mobile 1.x/2.x and Javascript on Firefox 63+ in Peer-to-Peer Rooms
+------------------------------------------------------------------------------------------
+
+Mozilla [announced](https://blog.mozilla.org/webrtc/how-to-avoid-data-channel-breaking/)
+a change in July 2018 related to how RTCDataChannels are negotiated in Firefox 63+.
+Unfortunately, this has caused an incompatibility with those versions of our Android
+and iOS Video SDKs that use WebRTC 57 and below.
+
+###What is the impact?
+
+Firefox 63+ Participants that join a Peer-to-Peer Room that also has Android and
+iOS Participants with the affected versions of the Video SDK, will not be able to
+publish their local media Tracks. The mobile Participants can see the Firefox 63+
+Participants in the Room but no Tracks are ever published, as a result no media
+is ever published/visible from those Participants.
+                                                                     
+###Is my app impacted?
+
+If you use one of the following Twilio Video Android or iOS SDK versions with any
+version of the Twilio Video Javascript SDK on Firefox 63+ then your application
+will be impacted:
+
+| Twilio SDK  | Affected Versions | Upgrade Path       |
+| ----------- | ----------------- | ------------------ |
+| Android SDK | 1.x & 2.x         | 3.0.0+             |
+| iOS SDK     | 1.0.0 - 2.2.2     | 2.3.0+             |
+
+###If my app is impacted, how can I overcome it?
+
+Upgrade to a release of Twilio Video Android or iOS SDK as noted above. You can
+find more information about any changes introduced in these releases by reviewing
+the changelogs:
+
+* [Twilio Video Android SDK 3.x](https://www.twilio.com/docs/video/changelog-twilio-video-android-3x)
+* [Twilio Video iOS SDK 2.x](https://www.twilio.com/docs/video/changelog-twilio-video-ios-version-2x)
+
 Chrome and Firefox Beta, Canary, Nightly, etc., Releases
 --------------------------------------------------------
 

--- a/COMMON_ISSUES.md
+++ b/COMMON_ISSUES.md
@@ -13,8 +13,8 @@ Incompatibility between Mobile 1.x/2.x and Javascript on Firefox 63+ in Peer-to-
 
 Mozilla [announced](https://blog.mozilla.org/webrtc/how-to-avoid-data-channel-breaking/)
 a change in July 2018 related to how RTCDataChannels are negotiated in Firefox 63+.
-Unfortunately, this has caused an incompatibility with those versions of our Android
-and iOS Video SDKs that use WebRTC 57 and below.
+Unfortunately, this has caused an incompatibility with versions of our Android and
+iOS Video SDKs that use WebRTC 57 and below.
 
 ### What is the impact?
 


### PR DESCRIPTION
@idelgado @anna-vasilko 

This entry is based on this [paper doc](https://paper.dropbox.com/doc/Firefox-63Mobile-WebRTC-57-Compatibility-Issue--AXTPxhC6ozZIrJMw189c5PVyAg-gE0UAL0lv4JGHg8s50fCl). Please leave your feedback where appropriate.