### PR TITLE
JSDK-2276 Alternate method of re-using m= lines.

### DIFF
--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -13,7 +13,7 @@ const oncePerTick = require('../../util').oncePerTick;
 const setBitrateParameters = require('../../util/sdp').setBitrateParameters;
 const setCodecPreferences = require('../../util/sdp').setCodecPreferences;
 const setSimulcast = require('../../util/sdp').setSimulcast;
-const unifiedPlanSetLocalMediaStreamTrackIds = require('../../util/sdp').unifiedPlanSetLocalMediaStreamTrackIds;
+const unifiedPlanRewriteTrackIds = require('../../util/sdp').unifiedPlanRewriteTrackIds;
 const IceBox = require('./icebox');
 const MediaClientLocalDescFailedError = require('../../util/twilio-video-errors').MediaClientLocalDescFailedError;
 const MediaClientRemoteDescFailedError = require('../../util/twilio-video-errors').MediaClientRemoteDescFailedError;
@@ -311,11 +311,12 @@ class PeerConnectionV2 extends StateMachine {
    * @returns {RTCRtpTransceiver}
    */
   _addOrUpdateTransceiver(track) {
-    const transceiver = this._peerConnection.getTransceivers().find(({ direction, receiver, stopped }) => !stopped
-      && direction === 'recvonly'
-      && receiver
-      && receiver.track
-      && receiver.track.kind === track.kind);
+    const transceiver = this._peerConnection.getTransceivers().find(({ currentDirection, direction, mid, receiver, stopped }) =>
+      currentDirection && mid && !stopped
+        && direction === 'recvonly'
+        && receiver
+        && receiver.track
+        && receiver.track.kind === track.kind);
 
     if (transceiver && transceiver.sender) {
       this._replaceTrackPromises.push(transceiver.sender.replaceTrack(track).catch(() => {
@@ -611,6 +612,24 @@ class PeerConnectionV2 extends StateMachine {
   }
 
   /**
+   * Rewrite local MediaStreamTrack IDs in the given RTCSessionDescription.
+   * @private
+   * @param {RTCSessionDescription} description
+   * @return {RTCSessionDescription}
+   */
+  _rewriteLocalTrackIds(description) {
+    const midsToTrackIds = new Map(this._peerConnection.getTransceivers().filter(({ mid, sender, stopped }) => {
+      return !stopped && mid && sender && sender.track;
+    }).map(({ mid, sender }) => {
+      return [mid, sender.track.id];
+    }));
+    return new this._RTCSessionDescription({
+      sdp: unifiedPlanRewriteTrackIds(description.sdp, midsToTrackIds),
+      type: description.type
+    });
+  }
+
+  /**
    * Set a local description on the {@link PeerConnectionV2}.
    * @private
    * @param {RTCSessionDescription|RTCSessionDescriptionInit} description
@@ -641,16 +660,7 @@ class PeerConnectionV2 extends StateMachine {
       throw new MediaClientLocalDescFailedError();
     }).then(() => {
       if (description.type !== 'rollback') {
-        if (isUnifiedPlan) {
-          const midsToLocalMediaStreamTrackIds = new Map(this._peerConnection.getTransceivers()
-            .filter(({ mid, sender, stopped }) => !stopped && mid && sender && sender.track)
-            .map(({ mid, sender }) => [mid, sender.track.id]));
-          description = new this._RTCSessionDescription({
-            sdp: unifiedPlanSetLocalMediaStreamTrackIds(description.sdp, midsToLocalMediaStreamTrackIds),
-            type: description.type
-          });
-        }
-        this._localDescription = description;
+        this._localDescription = isUnifiedPlan ? this._rewriteLocalTrackIds(description) : description;
         this._localCandidates = [];
         if (description.type === 'offer') {
           this._descriptionRevision++;

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -319,6 +319,7 @@ class PeerConnectionV2 extends StateMachine {
         && receiver.track.kind === track.kind);
 
     if (transceiver && transceiver.sender) {
+      console.log(this._peerConnection.signalingState, transceiver.mid, transceiver.currentDirection);
       this._replaceTrackPromises.push(transceiver.sender.replaceTrack(track).catch(() => {
         // Do nothing.
       }));

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -319,7 +319,6 @@ class PeerConnectionV2 extends StateMachine {
         && receiver.track.kind === track.kind);
 
     if (transceiver && transceiver.sender) {
-      console.log(this._peerConnection.signalingState, transceiver.mid, transceiver.currentDirection);
       this._replaceTrackPromises.push(transceiver.sender.replaceTrack(track).catch(() => {
         // Do nothing.
       }));

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -13,6 +13,7 @@ const oncePerTick = require('../../util').oncePerTick;
 const setBitrateParameters = require('../../util/sdp').setBitrateParameters;
 const setCodecPreferences = require('../../util/sdp').setCodecPreferences;
 const setSimulcast = require('../../util/sdp').setSimulcast;
+const unifiedPlanSetLocalMediaStreamTrackIds = require('../../util/sdp').unifiedPlanSetLocalMediaStreamTrackIds;
 const IceBox = require('./icebox');
 const MediaClientLocalDescFailedError = require('../../util/twilio-video-errors').MediaClientLocalDescFailedError;
 const MediaClientRemoteDescFailedError = require('../../util/twilio-video-errors').MediaClientRemoteDescFailedError;
@@ -205,6 +206,9 @@ class PeerConnectionV2 extends StateMachine {
         writable: true,
         value: null
       },
+      _replaceTrackPromises: {
+        value: []
+      },
       _remoteCandidates: {
         writable: true,
         value: new IceBox()
@@ -297,6 +301,30 @@ class PeerConnectionV2 extends StateMachine {
    */
   _addIceCandidates(candidates) {
     return Promise.all(candidates.map(this._addIceCandidate, this)).then(() => {});
+  }
+
+  /**
+   * Add a new RTCRtpTransceiver or update an existing RTCRtpTransceiver for the
+   * given MediaStreamTrack.
+   * @private
+   * @param {MediaStreamTrack} track
+   * @returns {RTCRtpTransceiver}
+   */
+  _addOrUpdateTransceiver(track) {
+    const transceiver = this._peerConnection.getTransceivers().find(({ direction, receiver, stopped }) => !stopped
+      && direction === 'recvonly'
+      && receiver
+      && receiver.track
+      && receiver.track.kind === track.kind);
+
+    if (transceiver && transceiver.sender) {
+      this._replaceTrackPromises.push(transceiver.sender.replaceTrack(track).catch(() => {
+        // Do nothing.
+      }));
+      transceiver.direction = 'sendrecv';
+      return transceiver;
+    }
+    return this._peerConnection.addTransceiver(track);
   }
 
   /**
@@ -557,7 +585,7 @@ class PeerConnectionV2 extends StateMachine {
       this._isRestartingIce = true;
       offerOptions.iceRestart = true;
     }
-    return Promise.resolve().then(() => {
+    return Promise.all(this._replaceTrackPromises.splice(0)).then(() => {
       return this._peerConnection.createOffer(offerOptions);
     }).catch(() => {
       throw new MediaClientLocalDescFailedError();
@@ -613,6 +641,15 @@ class PeerConnectionV2 extends StateMachine {
       throw new MediaClientLocalDescFailedError();
     }).then(() => {
       if (description.type !== 'rollback') {
+        if (isUnifiedPlan) {
+          const midsToLocalMediaStreamTrackIds = new Map(this._peerConnection.getTransceivers()
+            .filter(({ mid, sender, stopped }) => !stopped && mid && sender && sender.track)
+            .map(({ mid, sender }) => [mid, sender.track.id]));
+          description = new this._RTCSessionDescription({
+            sdp: unifiedPlanSetLocalMediaStreamTrackIds(description.sdp, midsToLocalMediaStreamTrackIds),
+            type: description.type
+          });
+        }
         this._localDescription = description;
         this._localCandidates = [];
         if (description.type === 'offer') {
@@ -656,13 +693,6 @@ class PeerConnectionV2 extends StateMachine {
       if (description.type === 'answer' && this._isRestartingIce) {
         this._log.debug('An ICE restart was in-progress and is now completed');
         this._isRestartingIce = false;
-      }
-      if (isUnifiedPlan) {
-        this._peerConnection.getTransceivers().forEach(transceiver => {
-          if (shouldStopTransceiver(description, transceiver)) {
-            transceiver.stop();
-          }
-        });
       }
     }, error => {
       this._log.warn(`Calling setRemoteDescription with an RTCSessionDescription of type "${description.type}" failed with the error "${error.message}".`);
@@ -790,7 +820,7 @@ class PeerConnectionV2 extends StateMachine {
       this._localMediaStream.addTrack(mediaTrackSender.track);
       sender = this._peerConnection.addTrack(mediaTrackSender.track, this._localMediaStream);
     } else {
-      const transceiver = this._peerConnection.addTransceiver(mediaTrackSender.track);
+      const transceiver = this._addOrUpdateTransceiver(mediaTrackSender.track);
       sender = transceiver.sender;
     }
     mediaTrackSender.addSender(sender);
@@ -1000,7 +1030,7 @@ function getConfiguration(configuration) {
  * MediaStreamTrack of a given kind.
  * @private
  * @param {string} kind
- * @param {RTCRTPSender} sender
+ * @param {RTCRtpSender} sender
  * @return {boolean}
  */
 function isSenderOfKind(kind, sender) {
@@ -1017,64 +1047,6 @@ function isSenderOfKind(kind, sender) {
 
 function filterOutMediaStreamIds(sdp) {
   return sdp.replace(/a=msid:[^ ]+ /g, 'a=msid:- ');
-}
-
-/**
- * @param {string} sdp
- * @param {string} mid
- * @returns {?string} direction
- */
-function getTransceiverDirection(sdp, mid) {
-  const section = getMediaSections(sdp).find(section => section.match(`a=mid:${mid}`));
-  if (!section) {
-    return null;
-  }
-  const match = section.match(/a=(sendrecv|sendonly|recvonly|inactive)/);
-  return match ? match[1] : null;
-}
-
-/**
- * @param {string} sdp
- * @returns {{audio: Array<string>, video: Array<string>}} mids
- */
-function getMids(sdp) {
-  return ['audio', 'video'].reduce((mids, kind) => {
-    mids[kind] = getMediaSections(sdp, kind).map(section => section.match(/^a=mid:(.+)$/m)[1]);
-    return mids;
-  }, {});
-}
-
-/**
- * @param {RTCSessionDescription} description
- * @param {RTCRtpTransceiver} transceiver
- * @returns {boolean} shouldStop
- */
-function shouldStopTransceiver(description, transceiver) {
-  if (!transceiver.stop
-    || transceiver.stopped
-    || !transceiver.mid) {
-    return false;
-  }
-
-  // NOTE(mroberts): We don't want to stop the initial two audio and video
-  // RTCRtpTransceivers that everyone negotiates with.
-  const mids = getMids(description.sdp);
-  if (transceiver.mid === mids.audio[0] || transceiver.mid === mids.video[0]) {
-    return false;
-  }
-
-  if (transceiver.currentDirection === 'inactive') {
-    return true;
-  }
-
-  const direction = getTransceiverDirection(description.sdp, transceiver.mid);
-  if (direction === 'inactive') {
-    return true;
-  } else if (direction === 'recvonly' && !transceiver.sender.track && description.type === 'answer') {
-    return true;
-  }
-
-  return false;
 }
 
 module.exports = PeerConnectionV2;

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -260,12 +260,15 @@ function setSimulcast(sdp, sdpFormat, trackIdsToAttributes) {
  * @returns {string}
  */
 function unifiedPlanRewriteTrackIds(sdp, midsToTrackIds) {
-  return Array.from(midsToTrackIds).reduce((sdp, [mid, localId]) => {
+  return Array.from(midsToTrackIds).reduce((sdp, [mid, trackId]) => {
     const midRegex = new RegExp(`a=mid:${mid}`);
     const section = getMediaSections(sdp).find(section => midRegex.test(section));
     if (section) {
-      const id = (section.match(/^a=msid:.+ (.+)$/m) || [])[1];
-      return id ? sdp.replace(new RegExp(id, 'g'), localId) : sdp;
+      const trackIdToRewrite = (section.match(/^a=msid:.+ (.+)$/m) || [])[1];
+      if (trackIdToRewrite) {
+        const msidRegex = new RegExp(`msid:(.+) ${trackIdToRewrite}$`, 'gm');
+        sdp = sdp.replace(msidRegex, `msid:$1 ${trackId}`);
+      }
     }
     return sdp;
   }, sdp);

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -252,14 +252,15 @@ function setSimulcast(sdp, sdpFormat, trackIdsToAttributes) {
 }
 
 /**
- * Replace the MediaStreamTrack IDs in the given SDP with their corresponding
- * local MediaStreamTrack IDs. These can be different in Unified Plan SDPs.
+ * Rewrite MSIDs in the given Unified Plan SDP with their corresponding local
+ * MediaStreamTrack IDs. These can be different when MediaStreamTracks are added
+ * using RTCRtpSender.replaceTrack().
  * @param {string} sdp
- * @param {Map<string, string>} midsToLocalMediaStreamTrackIds
+ * @param {Map<string, string>} midsToTrackIds
  * @returns {string}
  */
-function unifiedPlanSetLocalMediaStreamTrackIds(sdp, midsToLocalMediaStreamTrackIds) {
-  return Array.from(midsToLocalMediaStreamTrackIds).reduce((sdp, [mid, localId]) => {
+function unifiedPlanRewriteTrackIds(sdp, midsToTrackIds) {
+  return Array.from(midsToTrackIds).reduce((sdp, [mid, localId]) => {
     const midRegex = new RegExp(`a=mid:${mid}`);
     const section = getMediaSections(sdp).find(section => midRegex.test(section));
     if (section) {
@@ -281,4 +282,4 @@ exports.getMediaSections = getMediaSections;
 exports.setBitrateParameters = setBitrateParameters;
 exports.setCodecPreferences = setCodecPreferences;
 exports.setSimulcast = setSimulcast;
-exports.unifiedPlanSetLocalMediaStreamTrackIds = unifiedPlanSetLocalMediaStreamTrackIds;
+exports.unifiedPlanRewriteTrackIds = unifiedPlanRewriteTrackIds;

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -252,6 +252,25 @@ function setSimulcast(sdp, sdpFormat, trackIdsToAttributes) {
 }
 
 /**
+ * Replace the MediaStreamTrack IDs in the given SDP with their corresponding
+ * local MediaStreamTrack IDs. These can be different in Unified Plan SDPs.
+ * @param {string} sdp
+ * @param {Map<string, string>} midsToLocalMediaStreamTrackIds
+ * @returns {string}
+ */
+function unifiedPlanSetLocalMediaStreamTrackIds(sdp, midsToLocalMediaStreamTrackIds) {
+  return Array.from(midsToLocalMediaStreamTrackIds).reduce((sdp, [mid, localId]) => {
+    const midRegex = new RegExp(`a=mid:${mid}`);
+    const section = getMediaSections(sdp).find(section => midRegex.test(section));
+    if (section) {
+      const id = (section.match(/^a=msid:.+ (.+)$/m) || [])[1];
+      return id ? sdp.replace(new RegExp(id, 'g'), localId) : sdp;
+    }
+    return sdp;
+  }, sdp);
+}
+
+/**
  * Codec Payload Type.
  * @typedef {number} PayloadType
  */
@@ -262,3 +281,4 @@ exports.getMediaSections = getMediaSections;
 exports.setBitrateParameters = setBitrateParameters;
 exports.setCodecPreferences = setCodecPreferences;
 exports.setSimulcast = setSimulcast;
+exports.unifiedPlanSetLocalMediaStreamTrackIds = unifiedPlanSetLocalMediaStreamTrackIds;

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   },
   "dependencies": {
     "@twilio/sip.js": "^0.7.7",
-    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#4.0.0-rc1",
+    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#0fb1871dcf943b8a512d197816b2f64026500965",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },

--- a/scripts/karma.js
+++ b/scripts/karma.js
@@ -19,7 +19,7 @@ function getTestPaths(path) {
   return [path];
 }
 
-const files = getTestPaths(integrationTests);
+const files = getTestPaths(integrationTests).filter(path => /localparticipant/.test(path));
 
 // NOTE(mroberts): We have a memory leak, either in twilio-video.js or in
 // Firefox, that causes Firefox to slow down after running a bunch of tests that

--- a/scripts/karma.js
+++ b/scripts/karma.js
@@ -19,7 +19,7 @@ function getTestPaths(path) {
   return [path];
 }
 
-const files = getTestPaths(integrationTests).filter(path => /localparticipant/.test(path));
+const files = getTestPaths(integrationTests);
 
 // NOTE(mroberts): We have a memory leak, either in twilio-video.js or in
 // Firefox, that causes Firefox to slow down after running a bunch of tests that

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -213,8 +213,9 @@ describe('LocalParticipant', function() {
         x => `that has ${x} been published`
       ]
     ], ([isEnabled, kind, withName, when]) => {
-      // TODO(mroberts): Remove me when VMS-920 is fixed.
-      if (kind === 'data' && when !== 'published' && defaults.topology !== 'peer-to-peer') {
+      // TODO(mmalavalli): Enable this scenario for Firefox when the following
+      // bug is fixed: https://bugzilla.mozilla.org/show_bug.cgi?id=1526253
+      if (isFirefox && kind === 'data' && when === 'previously') {
         return;
       }
 
@@ -297,6 +298,8 @@ describe('LocalParticipant', function() {
             return tracksUnpublished(thatParticipant, thisParticipant._tracks.size);
           }));
         }
+
+        await new Promise(resolve => setTimeout(resolve, 100));
 
         [thisLocalTrackPublication, thoseTracksPublished, thoseTracksSubscribed] = await Promise.all([
           thisParticipant.publishTrack(thisTrack),

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -481,9 +481,9 @@ describe('LocalParticipant', function() {
         x => 'that was ' + x
       ]
     ], ([isEnabled, kind, when]) => {
-      // TODO(mroberts): Remove me when VMS-920 is fixed.
-      // eslint-disable-next-line
-      if (kind === 'data' && when !== 'published' && process.env.TOPOLOGY === 'SFU') {
+      // TODO(mmalavalli): Enable this scenario for Firefox when the following
+      // bug is fixed: https://bugzilla.mozilla.org/show_bug.cgi?id=1526253
+      if (isFirefox && kind === 'data' && when === 'previously') {
         return;
       }
 

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -483,7 +483,7 @@ describe('LocalParticipant', function() {
     ], ([isEnabled, kind, when]) => {
       // TODO(mmalavalli): Enable this scenario for Firefox when the following
       // bug is fixed: https://bugzilla.mozilla.org/show_bug.cgi?id=1526253
-      if (isFirefox && kind === 'data' && when === 'previously') {
+      if (isFirefox && kind === 'data' && when !== 'published') {
         return;
       }
 

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -1010,10 +1010,7 @@ describe('LocalParticipant', function() {
     });
   });
 
-  // NOTE(mmalavalli): This test runs the scenario specified in JSDK-2219. We disable
-  // this test in Chrome (unified-plan) with SIP as the transport because, for some
-  // reason, it stalls without finishing.
-  (isChrome && sdpFormat === 'unified' && !defaults._useTwilioConnection ? describe.skip : describe)('#publishTrack and #unpublishTrack, when called in rapid succession', () => {
+  describe('#publishTrack and #unpublishTrack, when called in rapid succession', () => {
     let error;
     let publication;
 

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -37,7 +37,6 @@ const {
   tracksSubscribed,
   tracksPublished,
   tracksUnpublished,
-  tracksUnsubscribed,
   trackStarted,
   waitForTracks
 } = require('../../lib/util');
@@ -295,7 +294,7 @@ describe('LocalParticipant', function() {
           thisParticipant.unpublishTrack(thisTrack);
 
           await Promise.all(thoseParticipants.map(thatParticipant => {
-            return tracksUnsubscribed(thatParticipant, thisParticipant._tracks.size);
+            return tracksUnpublished(thatParticipant, thisParticipant._tracks.size);
           }));
         }
 

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -27,7 +27,7 @@ const {
   participantsConnected,
   randomName,
   tracksSubscribed,
-  tracksUnsubscribed,
+  tracksUnpublished,
   waitForTracks
 } = require('../../lib/util');
 
@@ -117,7 +117,7 @@ describe('LocalTrackPublication', function() {
           thisParticipant.unpublishTrack(thisTrack);
 
           await Promise.all(thoseParticipants.map(thatParticipant => {
-            return tracksUnsubscribed(thatParticipant, thisParticipant._tracks.size);
+            return tracksUnpublished(thatParticipant, thisParticipant._tracks.size);
           }));
 
           await Promise.all([

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -19,6 +19,7 @@ const { flatMap } = require('../../../lib/util');
 const { createRoom, completeRoom } = require('../../lib/rest');
 const defaults = require('../../lib/defaults');
 const getToken = require('../../lib/token');
+const { isFirefox } = require('../../lib/guessbrowser');
 
 const {
   capitalize,
@@ -49,9 +50,9 @@ describe('LocalTrackPublication', function() {
         x => 'that was ' + x
       ]
     ], ([isEnabled, kind, when]) => {
-      // TODO(mroberts): Remove me when VMS-920 is fixed.
-      // eslint-disable-next-line
-      if (kind === 'data' && when !== 'published' && process.env.TOPOLOGY === 'SFU') {
+      // TODO(mmalavalli): Enable this scenario for Firefox when the following
+      // bug is fixed: https://bugzilla.mozilla.org/show_bug.cgi?id=1526253
+      if (isFirefox && kind === 'data' && when !== 'published') {
         return;
       }
 

--- a/test/unit/spec/util/sdp/index.js
+++ b/test/unit/spec/util/sdp/index.js
@@ -3,7 +3,14 @@
 const assert = require('assert');
 
 const { flatMap } = require('../../../../../lib/util');
-const { setBitrateParameters, setCodecPreferences, setSimulcast } = require('../../../../../lib/util/sdp');
+
+const {
+  getMediaSections,
+  setBitrateParameters,
+  setCodecPreferences,
+  setSimulcast,
+  unifiedPlanRewriteTrackIds
+} = require('../../../../../lib/util/sdp');
 
 const { makeSdpForSimulcast, makeSdpWithTracks } = require('../../../../lib/mocksdp');
 const { combinationContext } = require('../../../../lib/util');
@@ -479,6 +486,20 @@ a=ssrc:0000000000 label:d8b9a935-da54-4d21-a8de-522c87258244\r
 
       const ssrcs2 = new Set(simSdp2.match(/a=ssrc:[0-9]+/g).map(line => line.match(/a=ssrc:([0-9]+)/)[1]));
       assert.equal(ssrcs2.size, 3, 'RTX is disabled; therefore, there should be just 3 SSRCs in the SDP');
+    });
+  });
+});
+
+describe('unifiedPlanRewriteTrackIds', () => {
+  it('should rewrite Track IDs with the IDs of MediaStreamTracks associated with RTCRtpTransceivers', () => {
+    const sdp = makeSdpWithTracks('unified', { audio: ['foo'], video: ['bar'] });
+    const midsToTrackIds = new Map([['mid_foo', 'baz'], ['mid_bar', 'zee']]);
+    const newSdp = unifiedPlanRewriteTrackIds(sdp, midsToTrackIds);
+    const sections = getMediaSections(newSdp);
+    midsToTrackIds.forEach((trackId, mid) => {
+      const section = sections.find(section => new RegExp(`^a=mid:${mid}$`, 'm').test(section));
+      assert.equal(section.match(/^a=msid:.+ (.+)$/m)[1], trackId);
+      assert.equal(section.match(/^a=ssrc:.+ msid:.+ (.+)$/m)[1], trackId);
     });
   });
 });


### PR DESCRIPTION
@innerverse @syerrapragada 

In order to prevent ever-increasing SDP sizes on Chrome 72+ (`RTCRtpTransceiver.stop()` has not been implemented), we use the following alternate method to re-use m= lines in unified plan browsers:

* Re-use any available "recvonly" RTCRtpTransceivers while adding a MediaStreamTrack.
* Make sure all calls to RTCRtpSender.replaceTrack() resolve before creating the offer.
* Make sure that SDPs sent to the remote peer contain the local IDs for the MediaStreamTracks added using RTCRtpSender.replaceTrack().

## Checklist

- [x] Lint successful
- [x] Unit tests written and passed
- [x] Integration tests passed
- [x] Smoke test with local version of simpler-signaling