### PR TITLE
JSDK-2296 Enable TCMP as the default signaling transport.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,11 @@ New Features
 
 - Previously, Room emitted "reconnecting" and "reconnected" events while recovering
   from a disruption in your media connection. Now, it will emit these events while
-  recovering from a disruption in your signaling connection as well. As of now, this
-  is an opt-in feature and can be enabled with a temporary ConnectOptions flag as follows:
+  recovering from a disruption in your signaling connection as well. You can
+  now distinguish between media related disruptions and signaling related
+  disruptions as follows:
 
   ```js
-  const { connect } = require('twilio-video');
-
-  const room = await connect(token, {
-    _useTwilioConnection: true
-  });
-
   room.on('reconnecting', error => {
     if (error.code === 53001) {
       console.log('Reconnecting your signaling connection!', error.message);
@@ -27,7 +22,7 @@ New Features
   });
   ```
 
-  When you opt in for this feature, you join a Room using our new signaling transport,
+  This is possible because you will now join a Room using our new signaling transport,
   which enables us to detect and recover from disruptions in your signaling connection.
   Whenever your signaling connection is interrupted, the signaling back-end waits
   for you to reconnect for a period of 30-45 seconds, before it determines that you
@@ -43,9 +38,19 @@ New Features
   });
   ```
 
-  After twilio-video.js@2.0.0 is generally available, we plan to make this an opt-out
-  feature in twilio-video.js@2.1.0, followed by removing our existing SIP-based
-  signaling transport altogether in twilio-video.js@2.2.0.
+  If you want to opt out of this feature and use our legacy SIP-based signaling
+  transport, you can do so in the following way:
+
+  ```js
+  const { connect } = require('twilio-video');
+
+  const room = await connect(token, {
+    _useTwilioConnection: false
+  });
+  ```
+
+  After twilio-video.js@2.0.0 is generally available, we will remove the legacy
+  SIP-based signaling transport in twilio-video.js@2.1.0.
   
   **NOTE:** The new signaling transport will reject access tokens containing configuration
   profiles, which were deprecated when we [announced](https://www.twilio.com/blog/2017/04/programmable-video-peer-to-peer-rooms-ga.html#room-based-access-control)

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -139,7 +139,7 @@ function connect(token, options) {
     preferredVideoCodecs: [],
     realm: constants.DEFAULT_REALM,
     signaling: SignalingV2,
-    _useTwilioConnection: false
+    _useTwilioConnection: true
   }, util.filterObject(options));
 
   /* eslint new-cap:0 */

--- a/lib/twilioconnection.js
+++ b/lib/twilioconnection.js
@@ -35,6 +35,7 @@ const WS_CLOSE_NORMAL = 1000;
 const WS_CLOSE_WELCOME_TIMEOUT = 3000;
 const WS_CLOSE_HEARTBEATS_MISSED = 3001;
 const WS_CLOSE_HELLO_FAILED = 3002;
+const WS_CLOSE_SEND_FAILED = 3003;
 
 const toplevel = global.window || global;
 const WebSocket = toplevel.WebSocket ? toplevel.WebSocket : require('ws');
@@ -316,7 +317,13 @@ class TwilioConnection extends StateMachine {
     if (readyState === WebSocket.OPEN) {
       const data = JSON.stringify(message);
       this._log.debug(`Outgoing: ${data}`);
-      this._ws.send(data);
+      try {
+        this._ws.send(data);
+      } catch (error) {
+        const reason = 'Failed to send message';
+        this._log.warn(`Closing: ${WS_CLOSE_SEND_FAILED} - ${reason}`);
+        this._close({ code: WS_CLOSE_SEND_FAILED, reason });
+      }
     }
   }
 

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -105,7 +105,7 @@ describe('connect', function() {
     let cancelablePromise;
 
     beforeEach(() => {
-      const iceServers = [{ url: 'turn159.148.17.9:3478', credential: 'foo' }];
+      const iceServers = [{ urls: 'turn159.148.17.9:3478', credential: 'foo' }];
       const options = Object.assign({}, defaults, { iceServers, tracks: [] });
       const token = getToken(randomName());
       cancelablePromise = connect(token, options);

--- a/test/lib/defaults.js
+++ b/test/lib/defaults.js
@@ -20,7 +20,7 @@ const defaults = [
   }
   return defaults;
 }, {
-  _useTwilioConnection: !!env.useTwilioConnection,
+  _useTwilioConnection: typeof env.useTwilioConnection === 'undefined' || env.useTwilioConnection === '1',
   dominantSpeaker: true,
   networkQuality: true,
   topology: 'peer-to-peer'

--- a/test/unit/spec/connect.js
+++ b/test/unit/spec/connect.js
@@ -6,7 +6,7 @@ const sinon = require('sinon');
 const { inherits } = require('util');
 
 const connect = require('../../../lib/connect');
-const { DEFAULT_LOG_LEVEL, WS_SERVER } = require('../../../lib/util/constants');
+const { DEFAULT_LOG_LEVEL, WS_SERVER, WS_SERVER_TWILIOCONNECTION } = require('../../../lib/util/constants');
 const Signaling = require('../../../lib/signaling');
 const RoomSignaling = require('../../../lib/signaling/room');
 
@@ -44,7 +44,9 @@ describe('connect', () => {
       const options = signaling.args[0][1];
       assert.equal(options.logLevel, DEFAULT_LOG_LEVEL);
       /* eslint new-cap:0 */
-      assert.equal(options.wsServer, WS_SERVER(options.environment, options.realm));
+      assert.equal(options.wsServer, options._useTwilioConnection
+        ? WS_SERVER_TWILIOCONNECTION(options.environment)
+        : WS_SERVER(options.environment, options.realm));
     });
   });
 


### PR DESCRIPTION
@syerrapragada 

Because the EMG and rtc-conversation-orchestrator have SIP payload limits, and coupled with the lack of support for recycling m= lines in Chrome 72+ resulting in large SDPs, the EMG terminates the signaling connection after a few rounds of publish/unpublish tracks. So, TCMP is enabled as the default transport because it does not have a payload limit.