### PR TITLE
JSDK-2254: Report network quality scores for remote participant

### DIFF
--- a/lib/signaling/v2/networkqualitymonitor.js
+++ b/lib/signaling/v2/networkqualitymonitor.js
@@ -49,6 +49,14 @@ class NetworkQualityMonitor extends EventEmitter {
   }
 
   /**
+   * Get the current {@link NetworkQualityLevels} of remote participants, if any.
+   * @returns {Map<String, NetworkQualityLevels>} remoteLevels
+   */
+  get remoteLevels() {
+    return this._signaling.remoteLevels;
+  }
+
+  /**
    * Start monitoring.
    * @returns {void}
    */

--- a/lib/signaling/v2/networkqualitysignaling.js
+++ b/lib/signaling/v2/networkqualitysignaling.js
@@ -39,7 +39,7 @@ const AsyncVar = require('../../util/asyncvar');
 /**
  * @classdesc The {@link NetworkQualitySignaling} class allows submitting
  *   {@link NetworkQualityInputs} for computing {@link NetworkQualityLevel}. It
- *   does so by sending and receivin messages over a
+ *   does so by sending and receiving messages over a
  *   {@link MediaSignalingTransport}. The exact transport used depends on the
  *   topology of the {@link Room} that {@link NetworkQualitySignaling} is being
  *   used within: for P2P Rooms, we re-use the {@link TransportV2}; and for
@@ -61,6 +61,10 @@ class NetworkQualitySignaling extends EventEmitter {
       },
       _levels: {
         value: null,
+        writable: true
+      },
+      _remoteLevels: {
+        value: new Map(),
         writable: true
       },
       _mediaSignalingTransport: {
@@ -103,6 +107,14 @@ class NetworkQualitySignaling extends EventEmitter {
   }
 
   /**
+   * Get the current {@link NetworkQualityLevels} of remote participants, if any.
+   * @returns {Map<String, NetworkQualityLevels>} remoteLevels
+   */
+  get remoteLevels() {
+    return this._remoteLevels;
+  }
+
+  /**
    * Check to see if the {@link NetworkQualityLevel} is new, and raise an
    * event if necessary.
    * @private
@@ -110,6 +122,7 @@ class NetworkQualitySignaling extends EventEmitter {
    * @returns {void}
    */
   _handleNetworkQualityMessage(message) {
+    let updated = false;
     let level = null;
     const local = message ? message.local : null;
     if (typeof local === 'number') {
@@ -131,6 +144,22 @@ class NetworkQualitySignaling extends EventEmitter {
     }
     if (level !== null && this.level !== level) {
       this._level = level;
+      updated = true;
+    }
+
+    let remoteLevels = null;
+    const remotes = message ? message.remotes : null;
+    if (remotes) {
+      remoteLevels = remotes.reduce((map, obj) => {
+        const oldObj = this._remoteLevels.get(obj.sid) || {};
+        if (oldObj.level !== obj.level) {
+          updated = true;
+        }
+        return map.set(obj.sid, obj);
+      }, new Map());
+      this._remoteLevels = remoteLevels;
+    }
+    if (updated) {
       this.emit('updated');
     }
     setTimeout(() => this._sendNetworkQualityInputs(), 1000);
@@ -169,7 +198,8 @@ class NetworkQualitySignaling extends EventEmitter {
  */
 function createNetworkQualityInputsMessage(networkQualityInputs) {
   return Object.assign({
-    type: 'network_quality'
+    type: 'network_quality',
+    remoteReportLevel: 1
   }, networkQualityInputs);
 }
 

--- a/lib/signaling/v2/networkqualitysignaling.js
+++ b/lib/signaling/v2/networkqualitysignaling.js
@@ -147,18 +147,16 @@ class NetworkQualitySignaling extends EventEmitter {
       updated = true;
     }
 
-    let remoteLevels = null;
-    const remotes = message ? message.remotes : null;
-    if (remotes) {
-      remoteLevels = remotes.reduce((map, obj) => {
-        const oldObj = this._remoteLevels.get(obj.sid) || {};
-        if (oldObj.level !== obj.level) {
-          updated = true;
-        }
-        return map.set(obj.sid, obj);
-      }, new Map());
-      this._remoteLevels = remoteLevels;
-    }
+    this._remoteLevels = message && message.remotes
+      ? message.remotes.reduce((levels, obj) => {
+          const oldObj = this._remoteLevels.get(obj.sid) || {};
+          if (oldObj.level !== obj.level) {
+            updated = true;
+          }
+          return levels.set(obj.sid, obj);
+        }, new Map())
+      : this._remoteLevels;
+
     if (updated) {
       this.emit('updated');
     }

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -372,6 +372,12 @@ class RoomV2 extends RoomSignaling {
       this.localParticipant.setNetworkQualityLevel(
         networkQualityMonitor.level,
         networkQualityMonitor.levels);
+      this.participants.forEach((participant) => {
+        const levels = networkQualityMonitor.remoteLevels.get(participant.sid);
+        if (levels) {
+          participant.setNetworkQualityLevel(levels.level, levels);
+        }
+      });
     });
     networkQualityMonitor.start();
   }
@@ -498,9 +504,15 @@ function handlePeerConnectionEvents(roomV2, peerConnectionManager) {
 
   peerConnectionManager.on('iceConnectionStateChanged', () => {
     roomV2.emit('mediaConnectionStateChanged');
-    if (roomV2.mediaConnectionState === 'failed'
-      && roomV2.localParticipant.networkQualityLevel !== null) {
-      roomV2.localParticipant.setNetworkQualityLevel(0);
+    if (roomV2.mediaConnectionState === 'failed') {
+      if (roomV2.localParticipant.networkQualityLevel !== null) {
+        roomV2.localParticipant.setNetworkQualityLevel(0);
+      }
+      roomV2.participants.forEach(participant => {
+        if (participant.networkQualityLevel !== null) {
+          participant.setNetworkQualityLevel(0);
+        }
+      });
     }
   });
 }

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -1068,4 +1068,44 @@ describe('LocalParticipant', function() {
       assert(!error);
     });
   });
+
+  // eslint-disable-next-line
+  (process.env.TOPOLOGY === 'SFU' ? describe : describe.skip)('"networkQualityLevelChanged" event', () => {
+    const options = Object.assign({ name: randomName() }, defaults);
+    let thisRoom;
+    let thatRoom;
+    let localNQLevel;
+    let remoteNQLevel;
+
+    before(async () => {
+      const thisTracks = await createLocalTracks({ audio: true, fake: true });
+      thisRoom = await connect(getToken(randomName()), Object.assign({ tracks: thisTracks }, options));
+      const localNqLevelPromise = new Promise(resolve => thisRoom.localParticipant.once('networkQualityLevelChanged', resolve));
+      const remoteNqLevelPromise = new Promise(resolve => thisRoom.on('participantConnected',
+        participant => participant.once('networkQualityLevelChanged', resolve)));
+
+      const thatTracks = await createLocalTracks({ audio: true, fake: true });
+      thatRoom = await connect(getToken(randomName()), Object.assign({ tracks: thatTracks }, options));
+
+      localNQLevel = await localNqLevelPromise;
+      remoteNQLevel = await remoteNqLevelPromise;
+    });
+
+    it('is raised whenever network quality level for the LocalParticipant changes', () => {
+      assert.equal(localNQLevel, thisRoom.localParticipant.networkQualityLevel);
+    });
+
+    it('is raised whenever network quality level for the RemoteParticipant changes', () => {
+      assert.equal(remoteNQLevel, Array.from(thisRoom.participants.values())[0].networkQualityLevel);
+    });
+
+    after(() => {
+      if (thisRoom) {
+        thisRoom.disconnect();
+      }
+      if (thatRoom) {
+        thatRoom.disconnect();
+      }
+    });
+  });
 });

--- a/test/integration/spec/room.js
+++ b/test/integration/spec/room.js
@@ -330,46 +330,6 @@ describe('Room', function() {
     });
   });
 
-  // eslint-disable-next-line
-  (process.env.TOPOLOGY === 'SFU' ? describe.only : describe.skip)('"networkQualityLevelChanged" event', () => {
-    const options = Object.assign({ name: randomName() }, defaults);
-    let thisRoom;
-    let thatRoom;
-    let localNQLevel;
-    let remoteNQLevel;
-
-    before(async () => {
-      const thisTracks = await createLocalTracks({ audio: true, fake: true });
-      thisRoom = await connect(getToken(randomName()), Object.assign({ tracks: thisTracks, networkQuality: true }, options));
-      const localNqLevelPromise = new Promise(resolve => thisRoom.localParticipant.on('networkQualityLevelChanged', resolve));
-      const remoteNqLevelPromise = new Promise(resolve => thisRoom.on('participantConnected',
-        participant => participant.on('networkQualityLevelChanged', resolve)));
-
-      const thatTracks = await createLocalTracks({ audio: true, fake: true });
-      thatRoom = await connect(getToken(randomName()), Object.assign({ tracks: thatTracks }, options));
-
-      localNQLevel = await localNqLevelPromise;
-      remoteNQLevel = await remoteNqLevelPromise;
-    });
-
-    it('is raised whenever network quality level for local participant changes', () => {
-      assert.equal(localNQLevel, thisRoom.localParticipant.networkQualityLevel);
-    });
-
-    it('is raised whenever network quality level for remote participant changes', () => {
-      assert.equal(remoteNQLevel, Array.from(thisRoom.participants.values())[0].networkQualityLevel);
-    });
-
-    after(() => {
-      if (thisRoom) {
-        thisRoom.disconnect();
-      }
-      if (thatRoom) {
-        thatRoom.disconnect();
-      }
-    });
-  });
-
   describe('"participantConnected" event', () => {
     let thisRoom;
     let thatRoom;

--- a/test/unit/spec/signaling/v2/networkqualitymonitor.js
+++ b/test/unit/spec/signaling/v2/networkqualitymonitor.js
@@ -22,6 +22,19 @@ describe('NetworkQualityMonitor', () => {
       assert.strictEqual(monitor.level, signaling.level);
     });
 
+    it('sets .remoteLevels to NetworkQualitySignaling\'s .remoteLevels', () => {
+      const signaling = new EventEmitter();
+
+      const monitor = new NetworkQualityMonitor(null, signaling);
+
+      signaling.remoteLevels = new Map();
+      assert.deepEqual(monitor.level, signaling.level);
+
+      signaling.remoteLevels = new Map().set('PA9bcf2c26f2f1ba197b06ead6ec8b1f01',
+        { sid: 'PA9bcf2c26f2f1ba197b06ead6ec8b1f01', level: 3 });
+      assert.deepEqual(monitor.remoteLevels, signaling.remoteLevels);
+    });
+
     it('re-emits NetworkQualitySignaling\'s "updated" event', () => {
       const signaling = new EventEmitter();
       const monitor = new NetworkQualityMonitor(null, signaling);

--- a/test/unit/spec/signaling/v2/networkqualitysignaling.js
+++ b/test/unit/spec/signaling/v2/networkqualitysignaling.js
@@ -284,7 +284,13 @@ function createLevels() {
     video: {
       send: Math.random(),
       recv: Math.random()
-    }
+    },
+    remotes: [
+      {
+        level: Math.random(),
+        sid: 'PA9bcf2c26f2f1ba197b06ead6ec8b1f01'
+      }
+    ]
   };
 }
 
@@ -303,7 +309,8 @@ function didNotPublish(mst) {
 function didPublish(mst) {
   sinon.assert.calledOnce(mst.publish);
   sinon.assert.calledWith(mst.publish, {
-    type: 'network_quality'
+    type: 'network_quality',
+    remoteReportLevel: 1
   });
   mst.publish.reset();
 }

--- a/test/unit/spec/signaling/v2/networkqualitysignaling.js
+++ b/test/unit/spec/signaling/v2/networkqualitysignaling.js
@@ -187,21 +187,27 @@ describe('NetworkQualitySignaling', () => {
           let level;
           let levels;
 
+          let remoteLevel;
+          let remoteLevels;
+
           beforeEach(() => {
             levels = createLevels();
             level = levels.level;
+            remoteLevels = createRemoteLevels();
+            remoteLevel = remoteLevels[0].level;
           });
 
           it('emits "updated"', () => {
             let didEmitEvent = false;
             nqs.once('updated', () => { didEmitEvent = true; });
-            receiveMessage(mst, levels);
+            receiveMessage(mst, levels, remoteLevels);
             assert(didEmitEvent);
           });
 
           it('sets .level to the new NetworkQualityLevel', () => {
-            receiveMessage(mst, levels);
+            receiveMessage(mst, levels, remoteLevels);
             assert.equal(level, nqs.level);
+            assert.equal(remoteLevel, Array.from(nqs.remoteLevels.values())[0].level);
           });
         });
 
@@ -209,22 +215,28 @@ describe('NetworkQualitySignaling', () => {
           let level;
           let levels;
 
+          let remoteLevel;
+          let remoteLevels;
+
           beforeEach(() => {
             receiveMessage(mst);
             levels = createLevels();
             level = levels.level;
+            remoteLevels = createRemoteLevels();
+            remoteLevel = remoteLevels[0].level;
           });
 
           it('emits "updated"', () => {
             let didEmitEvent = false;
             nqs.once('updated', () => { didEmitEvent = true; });
-            receiveMessage(mst, levels);
+            receiveMessage(mst, levels, remoteLevels);
             assert(didEmitEvent);
           });
 
           it('sets .level to the new NetworkQualityLevel', () => {
-            receiveMessage(mst, levels);
+            receiveMessage(mst, levels, remoteLevels);
             assert.equal(level, nqs.level);
+            assert.equal(remoteLevel, Array.from(nqs.remoteLevels.values())[0].level);
           });
         });
       });
@@ -233,22 +245,28 @@ describe('NetworkQualitySignaling', () => {
         let level;
         let levels;
 
+        let remoteLevel;
+        let remoteLevels;
+
         beforeEach(() => {
           levels = createLevels();
           level = levels.level;
-          receiveMessage(mst, levels);
+          remoteLevels = createRemoteLevels();
+          remoteLevel = remoteLevels[0].level;
+          receiveMessage(mst, levels, remoteLevels);
         });
 
         it('does not emit "updated"', () => {
           let didEmitEvent = false;
           nqs.once('updated', () => { didEmitEvent = true; });
-          receiveMessage(mst, levels);
+          receiveMessage(mst, levels, remoteLevels);
           assert(!didEmitEvent);
         });
 
         it('does not change .level', () => {
-          receiveMessage(mst, levels);
+          receiveMessage(mst, levels, remoteLevels);
           assert.equal(level, nqs.level);
+          assert.equal(remoteLevel, Array.from(nqs.remoteLevels.values())[0].level);
         });
       });
     });
@@ -284,21 +302,23 @@ function createLevels() {
     video: {
       send: Math.random(),
       recv: Math.random()
-    },
-    remotes: [
-      {
-        level: Math.random(),
-        sid: 'PA9bcf2c26f2f1ba197b06ead6ec8b1f01'
-      }
-    ]
+    }
   };
 }
 
-function createMessage(levels) {
+function createRemoteLevels() {
+  return  [{
+    level: Math.random(),
+    sid: 'PA9bcf2c26f2f1ba197b06ead6ec8b1f01'
+  }];
+}
+
+function createMessage(levels, rlevels) {
   return Object.assign({
     type: 'network_quality'
   }, {
-    local: levels || createLevels()
+    local: levels || createLevels(),
+    remotes: rlevels || createRemoteLevels()
   });
 }
 
@@ -315,8 +335,8 @@ function didPublish(mst) {
   mst.publish.reset();
 }
 
-function receiveMessage(mst, levels) {
-  mst.emit('message', createMessage(levels));
+function receiveMessage(mst, levels, rlevels) {
+  mst.emit('message', createMessage(levels, rlevels));
 }
 
 async function wait() {


### PR DESCRIPTION
@manjeshbhargav cherry-picked changes from 2.x branch.

This PR enables NQ scores for remote participants.

- Enabled remote participants scores (remoteReportLevel: 1) in MSP message.
- Added remoteLevels property in both NetworkSignaling and NetworkMonitor Objects.
- Upon updated event, Update remote participant's Network Quality scores if available.