### PR TITLE
CHANGELOG.md update for 2.0.0-beta6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,14 +49,11 @@ New Features
   feature in twilio-video.js@2.1.0, followed by removing our existing SIP-based
   signaling transport altogether in twilio-video.js@2.2.0.
 
-  **NOTE:** The new signaling transport will:
+  **Non-compatible changes:** The new signaling transport will:
   - disconnect you from the Room with an [AccessTokenExpiredError](https://www.twilio.com/docs/api/errors/20104)
     if while reconnecting, it detects that your AccessToken is expired. Therefore,
-    we recommend that you create an AccessToken that is valid for the maximum
-    allowed session duration, i.e., *4 hours*.
-  - raise an [AccessTokenInvalidError](https://www.twilio.com/docs/api/errors/20101)
-    when you try to join a Room with an AccessToken created using a *non-string*
-    `identity`, instead of a [ParticipantIdentityInvalidError](https://www.twilio.com/docs/api/errors/53200).
+    we recommend that you create an AccessToken with the [ttl](https://www.twilio.com/docs/libraries/reference/twilio-node/3.29.1/AccessToken.html)
+    set to the maximum allowed session duration, which is currently *14400 seconds (4 hours)*.
   - reject AccessTokens containing configuration profiles, which were deprecated
     when we [announced](https://www.twilio.com/blog/2017/04/programmable-video-peer-to-peer-rooms-ga.html#room-based-access-control)
     the general availability of twilio-video.js@1.0.0. Use the [Programmable Video REST API](https://www.twilio.com/docs/video/api)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/suppor
 New Features
 ------------
 
-- The Dominant Speaker and Network Quality APIs are generally available.
+- The [Dominant Speaker](https://www.twilio.com/docs/video/detecting-dominant-speaker)
+  and [Network Quality](https://www.twilio.com/docs/video/using-network-quality-api)
+  APIs are generally available.
 
 - Previously, Room emitted "reconnecting" and "reconnected" events while recovering
   from a disruption in your media connection. Now, it will emit these events while
@@ -47,15 +49,22 @@ New Features
   feature in twilio-video.js@2.1.0, followed by removing our existing SIP-based
   signaling transport altogether in twilio-video.js@2.2.0.
 
-  **NOTE:** The new signaling transport will reject access tokens containing configuration
-  profiles, which were deprecated when we [announced](https://www.twilio.com/blog/2017/04/programmable-video-peer-to-peer-rooms-ga.html#room-based-access-control)
-  the general availability of twilio-video.js@1.0.0. Use the [Programmable Video REST API](https://www.twilio.com/docs/video/api)
-  if you want to override the default settings while creating a Room.
+  **NOTE:** The new signaling transport will:
+  - disconnect you from the Room with an [AccessTokenExpiredError](https://www.twilio.com/docs/api/errors/20104)
+    if while reconnecting, it detects that your AccessToken is expired. Therefore,
+    we recommend that you create an AccessToken that is valid for the maximum
+    allowed session duration, i.e., *4 hours*.
+  - raise an [AccessTokenInvalidError](https://www.twilio.com/docs/api/errors/20101)
+    when you try to join a Room with an AccessToken created using a *non-string*
+    `identity`, instead of a [ParticipantIdentityInvalidError](https://www.twilio.com/docs/api/errors/53200).
+  - reject AccessTokens containing configuration profiles, which were deprecated
+    when we [announced](https://www.twilio.com/blog/2017/04/programmable-video-peer-to-peer-rooms-ga.html#room-based-access-control)
+    the general availability of twilio-video.js@1.0.0. Use the [Programmable Video REST API](https://www.twilio.com/docs/video/api)
+    if you want to override the default settings while creating a Room.
 
-- This version of twilio-video.js will support Safari 12.1 and above which enables
-  Unified Plan as the default SDP format. We highly recommend that you upgrade your
-  twilio-video.js dependency to this version so that your application continues to
-  work on Safari versions 12.1 and above. (JSDK-2306)
+- twilio-video.js will now support versions of Safari that enable Unified Plan as
+  the default SDP format. As of now, Unified Plan is enabled by default in the latest
+  Safari Technology Preview. (JSDK-2306)
 
 Bug Fixes
 ---------
@@ -79,8 +88,9 @@ New Features
 - Participants will now be able to stay in the Room and recover their media
   connections if the media server becomes unresponsive, instead of being
   disconnected. (JSDK-2245)
-- `Room.getStats` is now supported on Safari 12.1 and above. It is not supported
-  on Safari 12.0 and below due to this [Safari bug](https://bugs.webkit.org/show_bug.cgi?id=192601).
+- `Room.getStats` is now supported on versions of Safari that enable Unified Plan
+  as the default SDP format. It is not supported on earlier versions due to this
+  [Safari bug](https://bugs.webkit.org/show_bug.cgi?id=192601).
   We have updated the documentation to reflect this behavior. (JSDK-2201)
 - `Room.getStats` on Chrome now uses the WebRTC 1.0 compliant version of the
   RTCPeerConnection's `getStats` API. (JSDK-2182)

--- a/COMMON_ISSUES.md
+++ b/COMMON_ISSUES.md
@@ -8,6 +8,14 @@ known or a workaround is available. Please also take a look at the
 release. If your issue hasn't been reported, consider submitting
 [a new issue](https://github.com/twilio/twilio-video.js/issues/new).
 
+Network Handoff (opt-in)
+------------------------
+
+If you have opted in for reconnecting to the Room when the signaling connection
+is interrupted, then the signaling back-end will raise an [AccessTokenInvalidError](https://www.twilio.com/docs/api/errors/20101)
+if the reconnect attempt takes too long. In the near future, a different TwilioError
+will be raised that better describes this behavior.
+
 Firefox 64/65 Participants may sometimes experience media loss in Group Rooms
 -----------------------------------------------------------------------------
 
@@ -36,6 +44,13 @@ stable release.
 
 Safari
 ------
+
+### Safari 12.1 Participants cannot publish Track(s) of the same kind as the unpublished Track(s)
+
+Because of this Safari 12.1 (currently in Beta) [bug](https://bugs.webkit.org/show_bug.cgi?id=195489),
+once a Participant unpublishes a MediaTrack of any kind (audio or video), it will
+not be able to publish another MediaTrack of the same kind. DataTracks are not affected.
+We have escalated this bug to the Safari Team and keeping track of related developments.
 
 ### Network Quality API not working
 
@@ -89,11 +104,6 @@ LocalTracks will fail.
 
 Firefox
 -------
-
-### Network Quality API not working
-
-We are working to fix a bug in twilio-video.js where Firefox clients do not
-receive Network Quality Score updates in a Group Room. (JSDK-2133)
 
 ### RemoteDataTrack Properties (`maxPacketLifeTime` and `maxRetransmits`)
 


### PR DESCRIPTION
@idelgado @syerrapragada 

* Describe changes in AccessToken behavior between SIP and TCMP.
* Reword Safari Unified Plan support to be version-agnostic.