### PR TITLE
JSDK-2313, JSDK-2318

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 For 2.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/master/CHANGELOG.md).
 
+1.18.0 (in progress)
+====================
+
+New Features
+------------
+
+- twilio-video.js will now support the Unified Plan SDP format for Google Chrome.
+  Google Chrome enabled Unified Plan as the default SDP format starting from version 72.
+  In December 2018, we published an [advisory](https://support.twilio.com/hc/en-us/articles/360012782494-Breaking-Changes-in-Twilio-Video-JavaScript-SDKs-December-2018-)
+  recommending customers to upgrade to the latest versions of twilio-video.js
+  in order to not be affected by Google Chrome switching to Unified Plan starting
+  from version 72. The way we ensured support of newer versions of Google Chrome
+  in the versions of twilio-video.js released between December 2018 and now was
+  by overriding the default SDP format to Plan B. Starting with this version,
+  twilio-video.js will use Unified Plan where available, while also maintaining
+  support for earlier browser versions with Plan B as the default SDP format. (JSDK-2313)
+
+Bug Fixes
+---------
+
+- Fixed a bug where, the local and remote AudioTracks' audioLevels returned by 
+  `Room.getStats()` were not in the range [0-32767]. (JSDK-2318)
+
 1.17.0 (April 1, 2019)
 ======================
 

--- a/karma/makeconf.js
+++ b/karma/makeconf.js
@@ -62,7 +62,6 @@ function makeConf(defaultFile, browserNoActivityTimeout, requires) {
           base: 'Chrome',
           flags: [
             '--autoplay-policy=no-user-gesture-required',
-            '--ignore-autoplay-restrictions',
             '--use-fake-device-for-media-stream',
             '--use-fake-ui-for-media-stream'
           ]

--- a/karma/makeconf.js
+++ b/karma/makeconf.js
@@ -61,6 +61,7 @@ function makeConf(defaultFile, browserNoActivityTimeout, requires) {
         ChromeWebRTC: {
           base: 'Chrome',
           flags: [
+            '--ignore-autoplay-restrictions',
             '--use-fake-device-for-media-stream',
             '--use-fake-ui-for-media-stream'
           ]

--- a/karma/makeconf.js
+++ b/karma/makeconf.js
@@ -61,6 +61,7 @@ function makeConf(defaultFile, browserNoActivityTimeout, requires) {
         ChromeWebRTC: {
           base: 'Chrome',
           flags: [
+            '--autoplay-policy=no-user-gesture-required',
             '--ignore-autoplay-restrictions',
             '--use-fake-device-for-media-stream',
             '--use-fake-ui-for-media-stream'

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -13,6 +13,8 @@ const oncePerTick = require('../../util').oncePerTick;
 const setBitrateParameters = require('../../util/sdp').setBitrateParameters;
 const setCodecPreferences = require('../../util/sdp').setCodecPreferences;
 const setSimulcast = require('../../util/sdp').setSimulcast;
+const unifiedPlanRewriteNewTrackIds = require('../../util/sdp').unifiedPlanRewriteNewTrackIds;
+const unifiedPlanRewriteTrackIds = require('../../util/sdp').unifiedPlanRewriteTrackIds;
 const IceBox = require('./icebox');
 const MediaClientLocalDescFailedError = require('../../util/twilio-video-errors').MediaClientLocalDescFailedError;
 const MediaClientRemoteDescFailedError = require('../../util/twilio-video-errors').MediaClientRemoteDescFailedError;
@@ -205,6 +207,15 @@ class PeerConnectionV2 extends StateMachine {
         writable: true,
         value: null
       },
+      _recycledTransceivers: {
+        value: {
+          audio: [],
+          video: []
+        }
+      },
+      _replaceTrackPromises: {
+        value: []
+      },
       _remoteCandidates: {
         writable: true,
         value: new IceBox()
@@ -297,6 +308,26 @@ class PeerConnectionV2 extends StateMachine {
    */
   _addIceCandidates(candidates) {
     return Promise.all(candidates.map(this._addIceCandidate, this)).then(() => {});
+  }
+
+  /**
+   * Add a new RTCRtpTransceiver or update an existing RTCRtpTransceiver for the
+   * given MediaStreamTrack.
+   * @private
+   * @param {MediaStreamTrack} track
+   * @returns {RTCRtpTransceiver}
+   */
+  _addOrUpdateTransceiver(track) {
+    const transceiver = this._recycledTransceivers[track.kind].shift();
+    if (transceiver && transceiver.sender) {
+      this._replaceTrackPromises.push(transceiver.sender.replaceTrack(track).then(() => {
+        transceiver.direction = 'sendrecv';
+      }, () => {
+        // Do nothing.
+      }));
+      return transceiver;
+    }
+    return this._peerConnection.addTransceiver(track);
   }
 
   /**
@@ -487,19 +518,6 @@ class PeerConnectionV2 extends StateMachine {
         : isSafari || isUnifiedPlan ? new OrderedTrackMatcher() : new IdentityTrackMatcher();
     }
 
-    // NOTE(mmalavalli): For unified plan sdps, calling addTransceiver with
-    // the same MediaStreamTrack a second time will generate sdps where the
-    // MediaStreamTrack ID does not match the MSID in the corresponding
-    // m= section. Due to this, MIDTrackMatcher#update will not update the
-    // mid corresponding to the MediaStreamTrack ID. Therefore, "trackSubscribed"
-    // will not be fired for the corresponding RemoteTrack.
-    //
-    // Chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=894231
-    // Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1498036
-    //
-    // TODO(mmalavalli): Revisit this either when the bugs are fixed or when we
-    // get clarification about spec-compliant behavior of addTransceiver.
-    //
     this._trackMatcher.update(sdp);
 
     const mediaStreamTrack = event.track;
@@ -507,10 +525,9 @@ class PeerConnectionV2 extends StateMachine {
     const mediaTrackReceiver = new MediaTrackReceiver(signaledTrackId, mediaStreamTrack);
     this._mediaTrackReceivers.add(mediaTrackReceiver);
 
-    mediaStreamTrack.addEventListener('ended', () => {
-      this._mediaTrackReceivers.delete(mediaTrackReceiver);
-    });
-
+    const removeMediaTrackReceiver = () => this._mediaTrackReceivers.delete(mediaTrackReceiver);
+    mediaStreamTrack.addEventListener('ended', removeMediaTrackReceiver);
+    mediaStreamTrack.addEventListener('mute', removeMediaTrackReceiver);
     this.emit('trackAdded', mediaTrackReceiver);
   }
 
@@ -571,7 +588,7 @@ class PeerConnectionV2 extends StateMachine {
       this._isRestartingIce = true;
       offerOptions.iceRestart = true;
     }
-    return Promise.resolve().then(() => {
+    return Promise.all(this._replaceTrackPromises.splice(0)).then(() => {
       return this._peerConnection.createOffer(offerOptions);
     }).catch(() => {
       throw new MediaClientLocalDescFailedError();
@@ -593,6 +610,41 @@ class PeerConnectionV2 extends StateMachine {
         type: 'offer',
         sdp: updatedSdp
       });
+    });
+  }
+
+  /**
+   * Rewrite local MediaStreamTrack IDs in the given RTCSessionDescription.
+   * @private
+   * @param {RTCSessionDescription} description
+   * @return {RTCSessionDescription}
+   */
+  _rewriteLocalTrackIds(description) {
+    const transceivers = this._peerConnection.getTransceivers();
+    const activeTransceivers = transceivers.filter(({ sender, stopped }) => !stopped && sender && sender.track);
+
+    // NOTE(mmalavalli): MediaStreamTracks that are added to a recycled RTCRtpTransceiver
+    // using RTCRtpSender.replaceTrack() will result in a different MSID in the
+    // corresponding m= section. We re-write them here so that the m= sections
+    // contain the actual MediaStreamTrack IDs.
+    const assignedTransceivers = activeTransceivers.filter(({ mid }) => mid);
+    const midsToTrackIds = new Map(assignedTransceivers.map(({ mid, sender }) => [mid, sender.track.id]));
+    const sdp1 = unifiedPlanRewriteTrackIds(description.sdp, midsToTrackIds);
+
+    // NOTE(mmalavalli): In Chrome and Safari, since we do not apply the offer
+    // until we get an answer, any re-added MediaStreamTracks will result in a
+    // different MSID in their corresponding m= sections. We re-write them
+    // here so that the m= sections contain the actual MediaStreamTrack IDs.
+    const unassignedTransceivers = activeTransceivers.filter(({ mid }) => !mid);
+    const newTrackIdsByKind = new Map(['audio', 'video'].map(kind => [
+      kind,
+      unassignedTransceivers.filter(({ sender }) => sender.track.kind === kind).map(({ sender }) => sender.track.id)
+    ]));
+    const sdp2 = unifiedPlanRewriteNewTrackIds(sdp1, newTrackIdsByKind);
+
+    return new this._RTCSessionDescription({
+      sdp: sdp2,
+      type: description.type
     });
   }
 
@@ -627,12 +679,15 @@ class PeerConnectionV2 extends StateMachine {
       throw new MediaClientLocalDescFailedError();
     }).then(() => {
       if (description.type !== 'rollback') {
-        this._localDescription = description;
+        this._localDescription = isUnifiedPlan ? this._rewriteLocalTrackIds(description) : description;
         this._localCandidates = [];
         if (description.type === 'offer') {
           this._descriptionRevision++;
         } else if (description.type === 'answer') {
           this._lastStableDescriptionRevision = this._descriptionRevision;
+          if (isUnifiedPlan) {
+            updateRecycledTransceivers(this);
+          }
         }
         this._localUfrag = getUfrag(description);
         this.emit('description', this.getState());
@@ -671,12 +726,8 @@ class PeerConnectionV2 extends StateMachine {
         this._log.debug('An ICE restart was in-progress and is now completed');
         this._isRestartingIce = false;
       }
-      if (isUnifiedPlan) {
-        this._peerConnection.getTransceivers().forEach(transceiver => {
-          if (shouldStopTransceiver(description.sdp, transceiver)) {
-            transceiver.stop();
-          }
-        });
+      if (description.type === 'answer' && isUnifiedPlan) {
+        updateRecycledTransceivers(this);
       }
     }, error => {
       this._log.warn(`Calling setRemoteDescription with an RTCSessionDescription of type "${description.type}" failed with the error "${error.message}".`);
@@ -804,7 +855,7 @@ class PeerConnectionV2 extends StateMachine {
       this._localMediaStream.addTrack(mediaTrackSender.track);
       sender = this._peerConnection.addTrack(mediaTrackSender.track, this._localMediaStream);
     } else {
-      const transceiver = this._peerConnection.addTransceiver(mediaTrackSender.track);
+      const transceiver = this._addOrUpdateTransceiver(mediaTrackSender.track);
       sender = transceiver.sender;
     }
     mediaTrackSender.addSender(sender);
@@ -1034,61 +1085,29 @@ function filterOutMediaStreamIds(sdp) {
 }
 
 /**
- * @param {string} sdp
- * @param {string} mid
- * @returns {?string} direction
- */
-function getTransceiverDirection(sdp, mid) {
-  const section = getMediaSections(sdp).find(section => section.match(`a=mid:${mid}`));
-  if (!section) {
-    return null;
-  }
-  const match = section.match(/a=(sendrecv|sendonly|recvonly|inactive)/);
-  return match ? match[1] : null;
-}
-
-/**
- * @param {string} sdp
- * @returns {{audio: Array<string>, video: Array<string>}} mids
- */
-function getMids(sdp) {
-  return ['audio', 'video'].reduce((mids, kind) => {
-    mids[kind] = getMediaSections(sdp, kind).map(section => section.match(/^a=mid:(.+)$/m)[1]);
-    return mids;
-  }, {});
-}
-
-/**
- * @param {string} sdp
+ * Whether an RTCRtpTransceiver can be recycled.
  * @param {RTCRtpTransceiver} transceiver
- * @returns {boolean} shouldStop
+ * @returns {boolean}
  */
-function shouldStopTransceiver(sdp, transceiver) {
-  if (!transceiver.stop
-    || transceiver.stopped
-    || !transceiver.mid) {
-    return false;
-  }
+function shouldRecycleTransceiver(transceiver) {
+  return !transceiver.stopped && (transceiver.currentDirection === 'inactive'
+    || transceiver.currentDirection === 'recvonly'
+    || transceiver.direction === 'recvonly');
+}
 
-  // NOTE(mroberts): We don't want to stop the initial two audio and video
-  // RTCRtpTransceivers that everyone negotiates with.
-  const mids = getMids(sdp);
-  if (transceiver.mid === mids.audio[0] || transceiver.mid === mids.video[0]) {
-    return false;
-  }
-
-  if (transceiver.currentDirection === 'inactive') {
-    return true;
-  }
-
-  const direction = getTransceiverDirection(sdp, transceiver.mid);
-  if (direction === 'inactive') {
-    return true;
-  } else if (direction === 'recvonly' && !transceiver.sender.track) {
-    return true;
-  }
-
-  return false;
+/**
+ * Update the list of recycled RTCRtpTransceivers.
+ * @param {PeerConnectionV2} pcv2
+ */
+function updateRecycledTransceivers(pcv2) {
+  pcv2._recycledTransceivers.audio = [];
+  pcv2._recycledTransceivers.video = [];
+  pcv2._peerConnection.getTransceivers().forEach(transceiver => {
+    if (shouldRecycleTransceiver(transceiver)) {
+      const track = transceiver.receiver.track;
+      pcv2._recycledTransceivers[track.kind].push(transceiver);
+    }
+  });
 }
 
 module.exports = PeerConnectionV2;

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -523,11 +523,20 @@ class PeerConnectionV2 extends StateMachine {
     const mediaStreamTrack = event.track;
     const signaledTrackId = this._trackMatcher.match(event) || mediaStreamTrack.id;
     const mediaTrackReceiver = new MediaTrackReceiver(signaledTrackId, mediaStreamTrack);
-    this._mediaTrackReceivers.add(mediaTrackReceiver);
 
-    const removeMediaTrackReceiver = () => this._mediaTrackReceivers.delete(mediaTrackReceiver);
-    mediaStreamTrack.addEventListener('ended', removeMediaTrackReceiver);
-    mediaStreamTrack.addEventListener('mute', removeMediaTrackReceiver);
+    // NOTE(mmalavalli): In unified plan mode, "ended" is not fired on the remote
+    // MediaStreamTrack when the remote peer removes a track. So, when this
+    // MediaStreamTrack is re-used for a different track due to the remote peer
+    // calling RTCRtpSender.replaceTrack(), we delete the previous MediaTrackReceiver
+    // that owned this MediaStreamTrack before adding the new MediaTrackReceiver.
+    this._mediaTrackReceivers.forEach(trackReceiver => {
+      if (trackReceiver.track.id === mediaTrackReceiver.track.id) {
+        this._mediaTrackReceivers.delete(trackReceiver);
+      }
+    });
+
+    this._mediaTrackReceivers.add(mediaTrackReceiver);
+    mediaStreamTrack.addEventListener('ended', () => this._mediaTrackReceivers.delete(mediaTrackReceiver));
     this.emit('trackAdded', mediaTrackReceiver);
   }
 

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -252,6 +252,57 @@ function setSimulcast(sdp, sdpFormat, trackIdsToAttributes) {
 }
 
 /**
+ * Rewrite MSIDs for new m= sections in the given Unified Plan SDP with their
+ * corresponding local MediaStreamTrack IDs. These can be different when previously
+ * removed MediaStreamTracks are added back.
+ * @param {string} sdp
+ * @param {Map<Track.Kind, Array<Track.ID>>} trackIdsByKind
+ * @returns {string}
+ */
+function unifiedPlanRewriteNewTrackIds(sdp, trackIdsByKind) {
+  return Array.from(trackIdsByKind).reduce((sdp, [kind, trackIds]) => {
+    const sections = getMediaSections(sdp, kind);
+    // NOTE(mmalavalli): The m= sections for the new MediaStreamTracks are usually
+    // present after the m= sections for the existing MediaStreamTracks, in order
+    // of addition.
+    const sdpTrackIds = sections.slice(sections.length - trackIds.length).map(section => {
+      return (section.match(/^a=msid:.+ (.+)$/m) || [])[1];
+    });
+
+    return sdpTrackIds.reduce((sdp, sdpTrackId, i) => {
+      if (sdpTrackId) {
+        const msidRegex = new RegExp(`msid:(.+) ${sdpTrackId}$`, 'gm');
+        sdp = sdp.replace(msidRegex, `msid:$1 ${trackIds[i]}`);
+      }
+      return sdp;
+    }, sdp);
+  }, sdp);
+}
+
+/**
+ * Rewrite MSIDs in the given Unified Plan SDP with their corresponding local
+ * MediaStreamTrack IDs. These can be different when MediaStreamTracks are added
+ * using RTCRtpSender.replaceTrack().
+ * @param {string} sdp
+ * @param {Map<string, Track.ID>} midsToTrackIds
+ * @returns {string}
+ */
+function unifiedPlanRewriteTrackIds(sdp, midsToTrackIds) {
+  return Array.from(midsToTrackIds).reduce((sdp, [mid, trackId]) => {
+    const midRegex = new RegExp(`a=mid:${mid}`);
+    const section = getMediaSections(sdp).find(section => midRegex.test(section));
+    if (section) {
+      const trackIdToRewrite = (section.match(/^a=msid:.+ (.+)$/m) || [])[1];
+      if (trackIdToRewrite) {
+        const msidRegex = new RegExp(`msid:(.+) ${trackIdToRewrite}$`, 'gm');
+        sdp = sdp.replace(msidRegex, `msid:$1 ${trackId}`);
+      }
+    }
+    return sdp;
+  }, sdp);
+}
+
+/**
  * Codec Payload Type.
  * @typedef {number} PayloadType
  */
@@ -262,3 +313,5 @@ exports.getMediaSections = getMediaSections;
 exports.setBitrateParameters = setBitrateParameters;
 exports.setCodecPreferences = setCodecPreferences;
 exports.setSimulcast = setSimulcast;
+exports.unifiedPlanRewriteNewTrackIds = unifiedPlanRewriteNewTrackIds;
+exports.unifiedPlanRewriteTrackIds = unifiedPlanRewriteTrackIds;

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   },
   "dependencies": {
     "@twilio/sip.js": "^0.7.7",
-    "@twilio/webrtc": "2.3.0",
+    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#cr-unified-plan-audiolevel-2.x",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   },
   "dependencies": {
     "@twilio/sip.js": "^0.7.7",
-    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#cr-unified-plan-audiolevel-2.x",
+    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#758b03dfef98cded851e04c506e6ebdaee852ef5",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -791,7 +791,7 @@ describe('connect', function() {
     });
   });
 
-  (isChrome || safariVersion >= 12.1 ? describe.only : describe.skip)('VP8 simulcast', () => {
+  (isChrome || safariVersion >= 12.1 ? describe : describe.skip)('VP8 simulcast', () => {
     let peerConnections;
     let thisRoom;
     let thoseRooms;
@@ -804,7 +804,6 @@ describe('connect', function() {
 
     it('should add Simulcast SSRCs to the video m= section of all local descriptions', () => {
       flatMap(peerConnections, pc => {
-        console.log(pc.localDescription);
         assert(pc.localDescription.sdp);
         return getMediaSections(pc.localDescription.sdp, 'video', '(sendonly|sendrecv)');
       }).forEach(section => {

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -804,6 +804,7 @@ describe('connect', function() {
 
     it('should add Simulcast SSRCs to the video m= section of all local descriptions', () => {
       flatMap(peerConnections, pc => {
+        console.log(pc.localDescription);
         assert(pc.localDescription.sdp);
         return getMediaSections(pc.localDescription.sdp, 'video', '(sendonly|sendrecv)');
       }).forEach(section => {

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -791,7 +791,7 @@ describe('connect', function() {
     });
   });
 
-  (isChrome || safariVersion >= 12.1 ? describe : describe.skip)('VP8 simulcast', () => {
+  (isChrome || safariVersion >= 12.1 ? describe.only : describe.skip)('VP8 simulcast', () => {
     let peerConnections;
     let thisRoom;
     let thoseRooms;
@@ -861,5 +861,15 @@ async function setup(testOptions, otherOptions, nTracks, alone) {
   const thoseParticipants = [...thisRoom.participants.values()];
   await Promise.all(thoseParticipants.map(participant => tracksAdded(participant, typeof nTracks === 'number' ? nTracks : 2)));
   const peerConnections = [...thisRoom._signaling._peerConnectionManager._peerConnections.values()].map(pcv2 => pcv2._peerConnection);
+
+  await Promise.all(peerConnections.map(pc => pc.signalingState === 'stable' ? Promise.resolve() : new Promise(resolve => {
+    pc.onsignalingstatechange = () => {
+      if (pc.signalingState === 'stable') {
+        pc.onsignalingstatechange = null;
+        resolve();
+      }
+    };
+  })));
+
   return [thisRoom, thoseRooms, peerConnections];
 }

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -1034,9 +1034,7 @@ describe('LocalParticipant', function() {
     });
   });
 
-  // NOTE(mmalavalli): This test runs the scenario described in JSDK-2219. It is
-  // disabled on Chrome (unified-plan) due to JSDK-2276.
-  (isChrome && sdpFormat === 'unified' ? describe.skip : describe)('#publishTrack and #unpublishTrack, when called in rapid succession', () => {
+  describe('#publishTrack and #unpublishTrack, when called in rapid succession', () => {
     let error;
     let publication;
 

--- a/test/integration/spec/room.js
+++ b/test/integration/spec/room.js
@@ -311,7 +311,15 @@ describe('Room', function() {
       thisRoom = await connect(getToken(randomName()), Object.assign({ tracks: [] }, options));
       const promise = new Promise(resolve => thisRoom.on('dominantSpeakerChanged', resolve));
 
-      const tracks = await createLocalTracks({ audio: true, fake: true });
+      const tracks = typeof AudioContext !== 'undefined' && 'createMediaStreamDestination' in AudioContext.prototype ? (() => {
+        const audioContext = new AudioContext();
+        const oscillator = audioContext.createOscillator();
+        const dest = audioContext.createMediaStreamDestination();
+        oscillator.connect(dest);
+        oscillator.start(0);
+        return dest.stream.getTracks();
+      })() : await createLocalTracks({ audio: true, fake: true });
+
       thatRoom = await connect(getToken(randomName()), Object.assign({ tracks }, options));
       dominantSpeaker = await promise;
     });

--- a/test/integration/spec/util/insightspublisher.js
+++ b/test/integration/spec/util/insightspublisher.js
@@ -14,7 +14,10 @@ const tokens = new Map([
   ['valid', getToken('foo')]
 ]);
 
-const options = Object.assign({}, defaults);
+const options = Object.assign({
+  environment: 'prod'
+}, defaults);
+
 if (defaults.wsServerInsights) {
   options.gateway = defaults.wsServerInsights;
 }
@@ -32,7 +35,7 @@ describe('InsightsPublisher', function() {
           publisher = new InsightsPublisher(tokens.get(tokenType),
             'twilio-video.js',
             '1.2.3',
-            'prod',
+            options.environment,
             'us1',
             options);
         });
@@ -66,7 +69,7 @@ describe('InsightsPublisher', function() {
       const publisher = new InsightsPublisher(tokens.get('valid'),
         'twilio-video.js',
         '1.2.3',
-        'prod',
+        options.environment,
         'us1',
         options);
 

--- a/test/unit/spec/util/sdp/index.js
+++ b/test/unit/spec/util/sdp/index.js
@@ -3,7 +3,15 @@
 const assert = require('assert');
 
 const { flatMap } = require('../../../../../lib/util');
-const { setBitrateParameters, setCodecPreferences, setSimulcast } = require('../../../../../lib/util/sdp');
+
+const {
+  getMediaSections,
+  setBitrateParameters,
+  setCodecPreferences,
+  setSimulcast,
+  unifiedPlanRewriteNewTrackIds,
+  unifiedPlanRewriteTrackIds
+} = require('../../../../../lib/util/sdp');
 
 const { makeSdpForSimulcast, makeSdpWithTracks } = require('../../../../lib/mocksdp');
 const { combinationContext } = require('../../../../lib/util');
@@ -475,6 +483,38 @@ a=ssrc:0000000000 label:d8b9a935-da54-4d21-a8de-522c87258244\r
 
       const ssrcs2 = new Set(simSdp2.match(/a=ssrc:[0-9]+/g).map(line => line.match(/a=ssrc:([0-9]+)/)[1]));
       assert.equal(ssrcs2.size, 3, 'RTX is disabled; therefore, there should be just 3 SSRCs in the SDP');
+    });
+  });
+});
+
+describe('unifiedPlanRewriteNewTrackIds', () => {
+  it('should rewrite Track IDs with the IDs of MediaStreamTracks associated with unassigned RTCRtpTransceivers', () => {
+    const sdp = makeSdpWithTracks('unified', { audio: ['foo', 'bar'], video: ['baz', 'zee'] });
+    const newTrackIdsByKind = new Map([['audio', ['yyy']], ['video', ['zzz']]]);
+    const newSdp = unifiedPlanRewriteNewTrackIds(sdp, newTrackIdsByKind);
+    const trackIdAndKinds = getMediaSections(newSdp).map(section => [
+      section.match(/^a=msid:.+ (.+)/m)[1],
+      section.match(/^m=(audio|video)/)[1]
+    ]);
+    assert.deepEqual(trackIdAndKinds, [
+      ['foo', 'audio'],
+      ['yyy', 'audio'],
+      ['baz', 'video'],
+      ['zzz', 'video']
+    ]);
+  });
+});
+
+describe('unifiedPlanRewriteTrackIds', () => {
+  it('should rewrite Track IDs with the IDs of MediaStreamTracks associated with recycled RTCRtpTransceivers', () => {
+    const sdp = makeSdpWithTracks('unified', { audio: ['foo'], video: ['bar'] });
+    const midsToTrackIds = new Map([['mid_foo', 'baz'], ['mid_bar', 'zee']]);
+    const newSdp = unifiedPlanRewriteTrackIds(sdp, midsToTrackIds);
+    const sections = getMediaSections(newSdp);
+    midsToTrackIds.forEach((trackId, mid) => {
+      const section = sections.find(section => new RegExp(`^a=mid:${mid}$`, 'm').test(section));
+      assert.equal(section.match(/^a=msid:.+ (.+)$/m)[1], trackId);
+      assert.equal(section.match(/^a=ssrc:.+ msid:.+ (.+)$/m)[1], trackId);
     });
   });
 });


### PR DESCRIPTION
@syerrapragada 

* JSDK-2313 - Enable unified plan support for Chrome.
* JSDK-2318 - Convert audioLevel fron 0-1 to 0-32767.

### NOTE:
In 2.x, since we clone MediaStreamTracks, when a previously added LocalTrack is re-added, a new MediaStreamTrack is added to the new transceiver's sender, so the MSID in the corresponding m= section will be equal to the MediaStreamTrack ID.

However, in 1.x, since we re-add the same MediaStreamTrack to the new transceiver's sender, it will generate a different MSID in the corresponding m= section. So, the track id rewrite logic is a bit different here.