### PR TITLE
JSDK-2323 Removing dependency on "mute" event to remove unpublished MediaTrackReceivers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ New Features
 ------------
 
 - twilio-video.js will now support the Unified Plan SDP format for Google Chrome.
-  Starting from version 72, Google Chrome will enable Unified Plan as the default
-  SDP format. In December 2018, we published an [advisory](https://support.twilio.com/hc/en-us/articles/360012782494-Breaking-Changes-in-Twilio-Video-JavaScript-SDKs-December-2018-)
+  Google Chrome enabled Unified Plan as the default SDP format starting from version 72.
+  In December 2018, we published an [advisory](https://support.twilio.com/hc/en-us/articles/360012782494-Breaking-Changes-in-Twilio-Video-JavaScript-SDKs-December-2018-)
   recommending customers to upgrade to the latest versions of twilio-video.js
   in order to not be affected by Google Chrome switching to Unified Plan starting
   from version 72. The way we ensured support of newer versions of Google Chrome

--- a/karma/makeconf.js
+++ b/karma/makeconf.js
@@ -61,6 +61,7 @@ function makeConf(defaultFile, browserNoActivityTimeout, requires) {
         ChromeWebRTC: {
           base: 'Chrome',
           flags: [
+            '--ignore-autoplay-restrictions',
             '--use-fake-device-for-media-stream',
             '--use-fake-ui-for-media-stream'
           ]

--- a/karma/makeconf.js
+++ b/karma/makeconf.js
@@ -61,7 +61,7 @@ function makeConf(defaultFile, browserNoActivityTimeout, requires) {
         ChromeWebRTC: {
           base: 'Chrome',
           flags: [
-            '--ignore-autoplay-restrictions',
+            '--autoplay-policy=no-user-gesture-required',
             '--use-fake-device-for-media-stream',
             '--use-fake-ui-for-media-stream'
           ]

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -521,11 +521,20 @@ class PeerConnectionV2 extends StateMachine {
     const mediaStreamTrack = event.track;
     const signaledTrackId = this._trackMatcher.match(event) || mediaStreamTrack.id;
     const mediaTrackReceiver = new MediaTrackReceiver(signaledTrackId, mediaStreamTrack);
-    this._mediaTrackReceivers.add(mediaTrackReceiver);
 
-    const removeMediaTrackReceiver = () => this._mediaTrackReceivers.delete(mediaTrackReceiver);
-    mediaStreamTrack.addEventListener('ended', removeMediaTrackReceiver);
-    mediaStreamTrack.addEventListener('mute', removeMediaTrackReceiver);
+    // NOTE(mmalavalli): In unified plan mode, "ended" is not fired on the remote
+    // MediaStreamTrack when the remote peer removes a track. So, when this
+    // MediaStreamTrack is re-used for a different track due to the remote peer
+    // calling RTCRtpSender.replaceTrack(), we delete the previous MediaTrackReceiver
+    // that owned this MediaStreamTrack before adding the new MediaTrackReceiver.
+    this._mediaTrackReceivers.forEach(trackReceiver => {
+      if (trackReceiver.track.id === mediaTrackReceiver.track.id) {
+        this._mediaTrackReceivers.delete(trackReceiver);
+      }
+    });
+
+    this._mediaTrackReceivers.add(mediaTrackReceiver);
+    mediaStreamTrack.addEventListener('ended', () => this._mediaTrackReceivers.delete(mediaTrackReceiver));
     this.emit('trackAdded', mediaTrackReceiver);
   }
 

--- a/test/integration/spec/room.js
+++ b/test/integration/spec/room.js
@@ -271,7 +271,15 @@ describe('Room', function() {
       thisRoom = await connect(getToken(randomName()), Object.assign({ tracks: [] }, options));
       const promise = new Promise(resolve => thisRoom.on('dominantSpeakerChanged', resolve));
 
-      const tracks = await createLocalTracks({ audio: true, fake: true });
+      const tracks = typeof AudioContext !== 'undefined' && 'createMediaStreamDestination' in AudioContext.prototype ? (() => {
+        const audioContext = new AudioContext();
+        const oscillator = audioContext.createOscillator();
+        const dest = audioContext.createMediaStreamDestination();
+        oscillator.connect(dest);
+        oscillator.start(0);
+        return dest.stream.getTracks();
+      })() : await createLocalTracks({ audio: true, fake: true });
+
       thatRoom = await connect(getToken(randomName()), Object.assign({ tracks }, options));
       dominantSpeaker = await promise;
     });


### PR DESCRIPTION
@syerrapragada 

This PR fixes [JSDK-2323](https://issues.corp.twilio.com/browse/JSDK-2323), which is happening due to "muted" being  sometimes fired on the MediaStreamTrack (currently happening in Chrome only, probably a bug), which removes the corresponding MediaTrackReceiver from the collection, resulting in getStats() no longer containing an entry for that particular Track. We no longer depend on "muted" and manually updated the collection of MediaTrackReceivers.