### PR TITLE
JSDK-2332

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -124,6 +124,8 @@ function connect(token, options) {
   options = Object.assign({
     abortOnIceServersTimeout: false,
     createLocalTracks,
+    dominantSpeaker: false,
+    networkQuality: false,
     environment: constants.DEFAULT_ENVIRONMENT,
     iceServersTimeout: constants.ICE_SERVERS_TIMEOUT_MS,
     insights: true,
@@ -231,6 +233,9 @@ function connect(token, options) {
   const networkQualityConfiguration = new NetworkQualityConfigurationImpl(
     typeof options.networkQuality === 'object' ? options.networkQuality : {}
   );
+
+  // Convert options.networkQuality to boolean to configure Media Signaling
+  options.networkQuality = typeof options.networkQuality === 'object' || options.networkQuality;
 
   // Create a CancelableRoomPromise<Room> that resolves after these steps:
   // 1 - Get the LocalTracks.

--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -367,7 +367,8 @@ class LocalParticipant extends Participant {
 
   /**
    * Sets the {@link NetworkQualityVerbosity} for the {@link LocalParticipant} and
-   * {@link RemoteParticipant}s.
+   * {@link RemoteParticipant}s. It does nothing if Network Quality is not enabled
+   * while calling {@link connect}.
    * @param {NetworkQualityConfiguration} networkQualityConfiguration - The new
    *   {@link NetworkQualityConfiguration}; If either or both of the local and
    *   remote {@link NetworkQualityVerbosity} values are absent, then the corresponding
@@ -399,7 +400,7 @@ class LocalParticipant extends Participant {
     ['local', 'remote'].forEach(prop => {
       if (prop in networkQualityConfiguration && typeof networkQualityConfiguration[prop] !== 'number') {
         // eslint-disable-next-line new-cap
-        throw E.INVALID_TYPE(`encodingParameters.${prop}`, 'number');
+        throw E.INVALID_TYPE(`networkQualityConfiguration.${prop}`, 'number');
       }
     });
     this._signaling.setNetworkQualityConfiguration(networkQualityConfiguration);

--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -368,11 +368,42 @@ class LocalParticipant extends Participant {
   /**
    * Sets the {@link NetworkQualityVerbosity} for the {@link LocalParticipant} and
    * {@link RemoteParticipant}s.
-   * @param {NetworkQualityConfiguration} networkQualityConfiguration
-   * @returns {void}
+   * @param {NetworkQualityConfiguration} networkQualityConfiguration - The new
+   *   {@link NetworkQualityConfiguration}; If either or both of the local and
+   *   remote {@link NetworkQualityVerbosity} values are absent, then the corresponding
+   *   existing values are retained
+   * @returns {this}
+   * @example
+   * // Update verbosity levels for both LocalParticipant and RemoteParticipants
+   * localParticipant.setNetworkQualityConfiguration({
+   *   local: 1,
+   *   remote: 2
+   * });
+   * @example
+   * // Update verbosity level for only the LocalParticipant
+   * localParticipant.setNetworkQualityConfiguration({
+   *   local: 1
+   * });
+   *  @example
+   * // Update verbosity level for only the RemoteParticipants
+   * localParticipant.setNetworkQualityConfiguration({
+   *   remote: 2
+   * });
    */
   setNetworkQualityConfiguration(networkQualityConfiguration) {
+    if (typeof networkQualityConfiguration !== 'object'
+      || networkQualityConfiguration === null) {
+      // eslint-disable-next-line new-cap
+      throw E.INVALID_TYPE('networkQualityConfiguration', 'NetworkQualityConfiguration');
+    }
+    ['local', 'remote'].forEach(prop => {
+      if (prop in networkQualityConfiguration && typeof networkQualityConfiguration[prop] !== 'number') {
+        // eslint-disable-next-line new-cap
+        throw E.INVALID_TYPE(`encodingParameters.${prop}`, 'number');
+      }
+    });
     this._signaling.setNetworkQualityConfiguration(networkQualityConfiguration);
+    return this;
   }
 
   /**

--- a/lib/networkqualityconfiguration.js
+++ b/lib/networkqualityconfiguration.js
@@ -1,8 +1,14 @@
 'use strict';
 
-const EventEmitter = require('events').EventEmitter;
-const { DEFAULT_NQ_LEVEL_LOCAL, DEFAULT_NQ_LEVEL_REMOTE } = require('./util/constants');
-const inRange = require('./util/index').inRange;
+const { EventEmitter } = require('events');
+
+const {
+  DEFAULT_NQ_LEVEL_LOCAL,
+  DEFAULT_NQ_LEVEL_REMOTE,
+  MAX_NQ_LEVEL
+} = require('./util/constants');
+
+const { inRange } = require('./util');
 
 /**
  * {@link NetworkQualityConfigurationImpl} represents an object which notifies its
@@ -19,14 +25,23 @@ class NetworkQualityConfigurationImpl extends EventEmitter {
    */
   constructor(networkQualityConfiguration) {
     super();
-    networkQualityConfiguration = Object.assign({ local: 1, remote: 0 }, networkQualityConfiguration);
+
+    networkQualityConfiguration = Object.assign({
+      local: DEFAULT_NQ_LEVEL_LOCAL,
+      remote: DEFAULT_NQ_LEVEL_REMOTE
+    }, networkQualityConfiguration);
+
     Object.defineProperties(this, {
       local: {
-        value: networkQualityConfiguration.local,
+        value: inRange(networkQualityConfiguration.local, DEFAULT_NQ_LEVEL_LOCAL, MAX_NQ_LEVEL)
+          ? networkQualityConfiguration.local
+          : DEFAULT_NQ_LEVEL_LOCAL,
         writable: true
       },
       remote: {
-        value: networkQualityConfiguration.remote,
+        value: inRange(networkQualityConfiguration.remote, DEFAULT_NQ_LEVEL_REMOTE, MAX_NQ_LEVEL)
+          ? networkQualityConfiguration.remote
+          : DEFAULT_NQ_LEVEL_REMOTE,
         writable: true
       }
     });
@@ -37,22 +52,21 @@ class NetworkQualityConfigurationImpl extends EventEmitter {
    * {@link LocalParticipant} and {@link RemoteParticipant} with those
    * in the given {@link NetworkQualityConfiguration}.
    * @param {NetworkQualityConfiguration} networkQualityConfiguration - The new {@link NetworkQualityConfiguration}
-   * @fires NetworkQualityConfigurationImpl#changed
    */
   update(networkQualityConfiguration) {
     networkQualityConfiguration = Object.assign({
-      local: DEFAULT_NQ_LEVEL_LOCAL,
-      remote: DEFAULT_NQ_LEVEL_REMOTE
+      local: this.local,
+      remote: this.remote
     }, networkQualityConfiguration);
 
     [
-      ['local', 1, 3, DEFAULT_NQ_LEVEL_LOCAL],
-      ['remote', 0, 3, DEFAULT_NQ_LEVEL_REMOTE]
-    ].forEach(([localOrRemote, min, max, defaultLevel]) => {
+      ['local', DEFAULT_NQ_LEVEL_LOCAL, 3],
+      ['remote', DEFAULT_NQ_LEVEL_REMOTE, 3]
+    ].forEach(([localOrRemote, min, max]) => {
       this[localOrRemote] = typeof networkQualityConfiguration[localOrRemote] === 'number'
         && inRange(networkQualityConfiguration[localOrRemote], min, max)
         ? networkQualityConfiguration[localOrRemote]
-        : defaultLevel;
+        : min;
     });
   }
 }

--- a/lib/signaling/v2/localparticipant.js
+++ b/lib/signaling/v2/localparticipant.js
@@ -26,10 +26,6 @@ class LocalParticipantV2 extends LocalParticipantSignaling {
       _encodingParameters: {
         value: encodingParameters
       },
-      networkQualityConfiguration: {
-        enumerable: true,
-        value: networkQualityConfiguration
-      },
       _removeListeners: {
         value: new Map()
       },
@@ -43,6 +39,10 @@ class LocalParticipantV2 extends LocalParticipantSignaling {
       _revision: {
         writable: true,
         value: 1
+      },
+      networkQualityConfiguration: {
+        enumerable: true,
+        value: networkQualityConfiguration
       },
       revision: {
         enumerable: true,
@@ -184,7 +184,7 @@ class LocalParticipantV2 extends LocalParticipantSignaling {
    * @returns {void}
    */
   setNetworkQualityConfiguration(networkQualityConfiguration) {
-    this._networkQualityConfiguration.update(networkQualityConfiguration);
+    this.networkQualityConfiguration.update(networkQualityConfiguration);
   }
 }
 

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -82,3 +82,4 @@ module.exports.typeErrors = {
 
 module.exports.DEFAULT_NQ_LEVEL_LOCAL = 1;
 module.exports.DEFAULT_NQ_LEVEL_REMOTE = 0;
+module.exports.MAX_NQ_LEVEL = 3;

--- a/test/integration/spec/rest.js
+++ b/test/integration/spec/rest.js
@@ -68,7 +68,8 @@ describe('', () => {
     });
   });
 
-  describe('Track Subscription', () => {
+  // NOTE(mmalavalli): Disabling Track Subscription tests using deprecated REST APIs
+  describe.skip('Track Subscription', () => {
     let rooms;
     let sid;
 

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -10,6 +10,7 @@ require('./spec/createlocaltracks');
 require('./spec/ecs');
 require('./spec/encodingparameters');
 require('./spec/localparticipant');
+require('./spec/networkqualityconfiguration');
 require('./spec/room');
 require('./spec/remoteparticipant');
 require('./spec/queueingeventemitter');

--- a/test/unit/spec/localparticipant.js
+++ b/test/unit/spec/localparticipant.js
@@ -149,6 +149,49 @@ describe('LocalParticipant', () => {
     });
   });
 
+  describe('#setNetworkQualityConfiguration', () => {
+    let test;
+
+    context('when the NetworkQualityConfiguration is', () => {
+      [
+        [undefined, 'undefined'],
+        [null, 'null'],
+        ['foo', 'not an object'],
+        [{ local: 'bar', remote: 1 }, 'an object that has .local which is not a number'],
+        [{ local: 2, remote: false }, 'an object that has .remote which is not a number'],
+        [{ local: 'foo', remote: null }, 'an object which has both .local and .remote which are not numbers']
+      ].forEach(([networkQualityConfiguration, scenario]) => {
+        context(scenario, () => itShould(networkQualityConfiguration, true));
+      });
+
+      [
+        [{}, 'an object which does not have .local and .remote'],
+        [{ remote: 1 }, 'an object that does not have .local'],
+        [{ local: 2 }, 'an object that does not have .remote'],
+        [{ local: 1, remote: 2 }, 'an object which has both .local and .remote which are numbers']
+      ].forEach(([networkQualityConfiguration, scenario]) => {
+        context(scenario, () => itShould(networkQualityConfiguration, false));
+      });
+    });
+
+    function itShould(networkQualityConfiguration, throwAndFail) {
+      before(() => {
+        test = makeTest();
+      });
+
+      it(`should ${throwAndFail ? '' : 'not '}throw`, () => {
+        assert[throwAndFail ? 'throws' : 'doesNotThrow'](() => test.participant.setNetworkQualityConfiguration(networkQualityConfiguration));
+      });
+
+      it(`should ${throwAndFail ? 'not ' : ''}call .setNetworkQualityConfiguration on the underlying ParticipantSignaling`, () => {
+        sinon.assert.callCount(test.signaling.setNetworkQualityConfiguration, throwAndFail ? 0 : 1);
+        if (!throwAndFail) {
+          sinon.assert.calledWith(test.signaling.setNetworkQualityConfiguration, networkQualityConfiguration);
+        }
+      });
+    }
+  });
+
   describe('#setParameters', () => {
     let test;
 
@@ -1014,6 +1057,7 @@ function makeSignaling(options) {
     return signaling.tracks.get(track.id);
   });
   signaling.removeTrack = sinon.spy(() => {});
+  signaling.setNetworkQualityConfiguration = sinon.spy(() => {});
   signaling.setParameters = sinon.spy(() => {});
   return signaling;
 }

--- a/test/unit/spec/networkqualityconfiguration.js
+++ b/test/unit/spec/networkqualityconfiguration.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const assert = require('assert');
+
+const NetworkQualityConfigurationImpl = require('../../../lib/networkqualityconfiguration');
+
+const { combinationContext } = require('../../lib/util');
+
+describe('NetworkQualityConfigurationImpl', () => {
+  describe('constructor', () => {
+    combinationContext([
+      [
+        [undefined, 0, 1, 2, 3, 4],
+        x => `when local verbosity is ${typeof x === 'undefined' ? 'absent' : x}`
+      ],
+      [
+        [undefined, 0, 1, 2, 3, 4],
+        x => `when remote verbosity is ${typeof x === 'undefined' ? 'absent' : x}`
+      ]
+    ], ([local, remote]) => {
+      const networkQualityConfiguration = [
+        ['local', local],
+        ['remote', remote]
+      ].reduce((params, [prop, value]) => {
+        if (typeof value !== 'undefined') {
+          params[prop] = value;
+        }
+        return params;
+      }, {});
+
+      let networkQualityConfigurationImpl;
+
+      before(() => {
+        networkQualityConfigurationImpl = new NetworkQualityConfigurationImpl(networkQualityConfiguration);
+      });
+
+      it('should return an NetworkQualityConfigurationImpl instance', () => {
+        assert(networkQualityConfigurationImpl instanceof NetworkQualityConfigurationImpl);
+      });
+
+      [
+        ['local', local, 1],
+        ['remote', remote, 0]
+      ].forEach(([prop, value, defaultValue]) => {
+        const expectedValue = typeof value === 'number' ? {
+          local: { 0: 1, 1: 1, 2: 2, 3: 3, 4: 1 },
+          remote: { 0: 0, 1: 1, 2: 2, 3: 3, 4: 0 }
+        }[prop][value] : defaultValue;
+
+        it(`should set the .${prop} to ${expectedValue}`, () => {
+          assert.equal(networkQualityConfigurationImpl[prop], expectedValue);
+        });
+      });
+    });
+  });
+
+  describe('update', () => {
+    const networkQualityConfiguration = {
+      local: 1,
+      remote: 2
+    };
+
+    combinationContext([
+      [
+        [undefined, 0, 1, 2, 3, 4],
+        x => `when the new local verbosity is ${typeof x === 'undefined' ? 'absent' : x}`
+      ],
+      [
+        [undefined, 0, 1, 2, 3, 4],
+        x => `when the new remote verbosity is ${typeof x === 'undefined' ? 'absent' : x}`
+      ]
+    ], ([local, remote]) => {
+      const updatedNetworkQualityConfiguration = [
+        ['local', local],
+        ['remote', remote]
+      ].reduce((params, [prop, value]) => {
+        if (typeof value !== 'undefined') {
+          params[prop] = value;
+        }
+        return params;
+      }, {});
+
+      let networkQualityConfigurationImpl;
+
+      before(() => {
+        networkQualityConfigurationImpl = new NetworkQualityConfigurationImpl(networkQualityConfiguration);
+        networkQualityConfigurationImpl.update(updatedNetworkQualityConfiguration);
+      });
+
+      [
+        ['local', local],
+        ['remote', remote]
+      ].forEach(([prop, value]) => {
+        const expectedValue = typeof value === 'number' ? {
+          local: { 0: 1, 1: 1, 2: 2, 3: 3, 4: 1 },
+          remote: { 0: 0, 1: 1, 2: 2, 3: 3, 4: 0 }
+        }[prop][value] : networkQualityConfiguration[prop];
+
+        it(`should set the .${prop} to ${typeof value === 'number' ? expectedValue : 'its existing value'}`, () => {
+          assert.equal(networkQualityConfigurationImpl[prop], expectedValue);
+        });
+      });
+    });
+  });
+});

--- a/test/unit/spec/signaling/v2/localparticipant.js
+++ b/test/unit/spec/signaling/v2/localparticipant.js
@@ -195,7 +195,7 @@ describe('LocalParticipantV2', () => {
   });
 
   describe('#setParameters', () => {
-    it('should call .update on the underlying EncodingParametersImple', () => {
+    it('should call .update on the underlying EncodingParametersImpl', () => {
       localParticipant.setParameters({ maxAudioBitrate: 100, maxVideoBitrate: 50 });
       assert.equal(encodingParameters.maxAudioBitrate, 100);
       assert.equal(encodingParameters.maxVideoBitrate, 50);

--- a/test/unit/spec/signaling/v2/localparticipant.js
+++ b/test/unit/spec/signaling/v2/localparticipant.js
@@ -5,9 +5,9 @@ const { EventEmitter } = require('events');
 const sinon = require('sinon');
 
 const DataTrackSender = require('../../../../../lib/data/sender');
-const EncodingParameters = require('../../../../../lib/encodingparameters');
+const EncodingParametersImpl = require('../../../../../lib/encodingparameters');
 const LocalParticipantV2 = require('../../../../../lib/signaling/v2/localparticipant');
-const NetworkQualityConfiguration = require('../../../../../lib/networkqualityconfiguration');
+const NetworkQualityConfigurationImpl = require('../../../../../lib/networkqualityconfiguration');
 
 class MockLocalTrackPublicationV2 extends EventEmitter {
   constructor(trackSender, name) {
@@ -24,7 +24,9 @@ describe('LocalParticipantV2', () => {
   let LocalTrackPublicationV2Constructor;
   let localParticipant;
   let trackSender;
+  let encodingParameters;
   let name;
+  let networkQualityConfiguration;
   let publication;
 
   beforeEach(() => {
@@ -33,7 +35,9 @@ describe('LocalParticipantV2', () => {
       return publication;
     });
 
-    localParticipant = new LocalParticipantV2(new EncodingParameters(), new NetworkQualityConfiguration(), {
+    encodingParameters = new EncodingParametersImpl();
+    networkQualityConfiguration = new NetworkQualityConfigurationImpl();
+    localParticipant = new LocalParticipantV2(encodingParameters, networkQualityConfiguration, {
       LocalTrackPublicationV2: LocalTrackPublicationV2Constructor
     });
 
@@ -43,6 +47,14 @@ describe('LocalParticipantV2', () => {
   });
 
   describe('constructor', () => {
+    it('should set .networkQualityConfiguration', () => {
+      assert.equal(localParticipant.networkQualityConfiguration, networkQualityConfiguration);
+    });
+
+    it('should set .revision', () => {
+      assert.equal(localParticipant.revision, 1);
+    });
+
     it('returns an instanceof LocalParticipantV2', () => {
       assert(localParticipant instanceof LocalParticipantV2);
     });
@@ -171,6 +183,22 @@ describe('LocalParticipantV2', () => {
         localParticipant.removeTrack(trackSender);
         assert.deepEqual(events, []);
       });
+    });
+  });
+
+  describe('#setNetworkQualityConfiguration', () => {
+    it('should call .update on the underlying NetworkQualityConfigurationImpl', () => {
+      localParticipant.setNetworkQualityConfiguration({ local: 3, remote: 1 });
+      assert.equal(networkQualityConfiguration.local, 3);
+      assert.equal(networkQualityConfiguration.remote, 1);
+    });
+  });
+
+  describe('#setParameters', () => {
+    it('should call .update on the underlying EncodingParametersImple', () => {
+      localParticipant.setParameters({ maxAudioBitrate: 100, maxVideoBitrate: 50 });
+      assert.equal(encodingParameters.maxAudioBitrate, 100);
+      assert.equal(encodingParameters.maxVideoBitrate, 50);
     });
   });
 });


### PR DESCRIPTION
@syerrapragada 

This PR:

* Fixes [JSDK-2332](https://issues.corp.twilio.com/browse/JSDK-2332).
* Makes sure that "local" and "remote" verbosity levels are within range during initialization.
* Makes sure that if either "local" and "remote" are not present while updating, then existing values are preserved.
* Makes sure that `LocalParticipant.setNetworkQualityConfiguration` does some type checking.
* Adds unit tests.