### PR TITLE
JSDK-2330 Make sure preferredCodecs is honored.

### DIFF
--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -8,6 +8,7 @@ const DefaultRTCIceCandidate = WebRTC.RTCIceCandidate;
 const DefaultRTCPeerConnection = WebRTC.RTCPeerConnection;
 const DefaultRTCSessionDescription = WebRTC.RTCSessionDescription;
 const getStatistics = WebRTC.getStats;
+const createCodecMapForMediaSection = require('../../util/sdp').createCodecMapForMediaSection;
 const getMediaSections = require('../../util/sdp').getMediaSections;
 const oncePerTick = require('../../util').oncePerTick;
 const setBitrateParameters = require('../../util/sdp').setBitrateParameters;
@@ -155,6 +156,9 @@ class PeerConnectionV2 extends StateMachine {
         writable: true,
         value: []
       },
+      _localCodecs: {
+        value: new Set()
+      },
       _localCandidatesRevision: {
         writable: true,
         value: 1
@@ -174,6 +178,9 @@ class PeerConnectionV2 extends StateMachine {
         value: options.log
           ? options.log.createLog('signaling', this)
           : new Log('webrtc', this, logLevels),
+      },
+      _remoteCodecMaps: {
+        value: new Map()
       },
       _rtpSenders: {
         value: new Map()
@@ -317,7 +324,7 @@ class PeerConnectionV2 extends StateMachine {
    * @returns {RTCRtpTransceiver}
    */
   _addOrUpdateTransceiver(track) {
-    const transceiver = this._recycledTransceivers[track.kind].shift();
+    const transceiver = takeRecycledTransceiver(this, track.kind);
     if (transceiver && transceiver.sender) {
       this._replaceTrackPromises.push(transceiver.sender.replaceTrack(track).then(() => {
         transceiver.direction = 'sendrecv';
@@ -677,6 +684,8 @@ class PeerConnectionV2 extends StateMachine {
           this._lastStableDescriptionRevision = this._descriptionRevision;
           if (isUnifiedPlan) {
             updateRecycledTransceivers(this);
+            updateLocalCodecs(this);
+            updateRemoteCodecMaps(this);
           }
         }
         this._localUfrag = getUfrag(description);
@@ -718,6 +727,8 @@ class PeerConnectionV2 extends StateMachine {
       }
       if (description.type === 'answer' && isUnifiedPlan) {
         updateRecycledTransceivers(this);
+        updateLocalCodecs(this);
+        updateRemoteCodecMaps(this);
       }
     }, error => {
       this._log.warn(`Calling setRemoteDescription with an RTCSessionDescription of type "${description.type}" failed with the error "${error.message}".`);
@@ -1083,6 +1094,68 @@ function shouldRecycleTransceiver(transceiver) {
   return !transceiver.stopped && (transceiver.currentDirection === 'inactive'
     || transceiver.currentDirection === 'recvonly'
     || transceiver.direction === 'recvonly');
+}
+
+/**
+ * Take a recycled RTCRtpTransceiver if available.
+ * @param {PeerConnectionV2} pcv2
+ * @param {Track.Kind} kind
+ * @returns {?RTCRtpTransceiver}
+ */
+function takeRecycledTransceiver(pcv2, kind) {
+  const preferredCodecs = {
+    audio: pcv2._preferredAudioCodecs.map(codec => codec.toLowerCase()),
+    video: pcv2._preferredVideoCodecs.map(({ codec }) => codec.toLowerCase())
+  }[kind];
+
+  const recycledTransceivers = pcv2._recycledTransceivers[kind];
+  const localCodec = preferredCodecs.find(codec => pcv2._localCodecs.has(codec));
+  if (!localCodec) {
+    return recycledTransceivers.shift();
+  }
+
+  const transceiver = recycledTransceivers.find(transceiver => {
+    const remoteCodecMap = pcv2._remoteCodecMaps.get(transceiver.mid);
+    return remoteCodecMap && remoteCodecMap.has(localCodec);
+  });
+
+  if (transceiver) {
+    recycledTransceivers.splice(recycledTransceivers.indexOf(transceiver), 1);
+  }
+  return transceiver;
+}
+
+/**
+ * Update the set of locally supported {@link Codec}s.
+ * @param pcv2
+ * @returns {void}
+ */
+function updateLocalCodecs(pcv2) {
+  const description = pcv2._peerConnection.localDescription;
+  if (!description) {
+    return;
+  }
+  getMediaSections(description.sdp).forEach(section => {
+    const codecMap = createCodecMapForMediaSection(section);
+    codecMap.forEach((pts, codec) => pcv2._localCodecs.add(codec));
+  });
+}
+
+/**
+ * Update the {@link Codec} maps for all m= sections in the remote {@link RTCSessionDescription}s.
+ * @param {PeerConnectionV2} pcv2
+ * @returns {void}
+ */
+function updateRemoteCodecMaps(pcv2) {
+  const description = pcv2._peerConnection.remoteDescription;
+  if (!description) {
+    return;
+  }
+  getMediaSections(description.sdp).forEach(section => {
+    const mid = section.match(/^a=mid:(.+)$/m)[1];
+    const codecMap = createCodecMapForMediaSection(section);
+    pcv2._remoteCodecMaps.set(mid, codecMap);
+  });
 }
 
 /**


### PR DESCRIPTION
@syerrapragada 

This PR fixes [JSDK-2330](https://issues.corp.twilio.com/browse/JSDK-2330). We now maintain a set of locally supported codecs and a map of MIDs and their remotely supported codecs. Now, when we add a new MediaStreamTrack, we choose the RTCRtpTransceiver as follows:

* If no preferred codecs are specified, just use the first re-useable RTCRtpTransceiver if present.
* Find the first preferred codec that is locally supported, and if present, choose an RTCRtpTransceiver which supports this codec remotely.
* If there are no locally supported preferred codecs, then this is equivalent to no preferred codecs, so just use the first re-useable RTCRtpTransceiver, if present.