### PR TITLE
Prep for 2.0.0-beta9.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/support-1.x/CHANGELOG.md).
 
-2.0.0-beta9 (in progress)
+2.0.0-beta9 (May 2, 2019)
 =========================
 
 New Features
 ------------
 
-- Network reconnection, which was introduced as an opt-in feature in `twilio-video.js@2.0.0-beta6`,
-  is now enabled by default. The temporary ConnectOptions flag `_useTwilioConnection` has been
-  removed. If this flag is present in ConnectOptions, it will be ignored. (JSDK-2335)
+- [Network reconnection](https://www.twilio.com/docs/video/reconnection-states-and-events),
+  which was introduced as an opt-in feature in `twilio-video.js@2.0.0-beta6`, is now
+  enabled by default. The temporary ConnectOptions flag `_useTwilioConnection` has
+  been removed. If this flag is present in ConnectOptions, it will be ignored. (JSDK-2335)
 
 2.0.0-beta8 (April 23, 2019)
 ============================

--- a/COMMON_ISSUES.md
+++ b/COMMON_ISSUES.md
@@ -47,9 +47,10 @@ to ensure playback:
 Firefox Participants are not able to recover media after network interruptions or handoffs
 ------------------------------------------------------------------------------------------
 
-Because of this [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1546562), Firefox
-is not able to recover media connections with other Participants in a Room after
-network interruptions or handoffs.
+Because of this [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1546562) and
+this [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1548318), Firefox is not
+able to recover media connections with other Participants in a Room after network
+interruptions or handoffs.
 
 Firefox 64/65 Participants may sometimes experience media loss in Group Rooms
 -----------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For 1.x, go [here](https://github.com/twilio/twilio-video.js/tree/support-1.x/).
 
 twilio-video.js allows you to add real-time voice and video to your web apps.
 
-* [API Docs](//media.twiliocdn.com/sdk/js/video/releases/2.0.0-beta8/docs)
+* [API Docs](//media.twiliocdn.com/sdk/js/video/releases/2.0.0-beta9/docs)
 * [Quickstart and Examples](//github.com/twilio/video-quickstart-js)
 * [Common Issues](https://github.com/twilio/twilio-video.js/blob/master/COMMON_ISSUES.md)
 
@@ -56,7 +56,7 @@ Releases of twilio-video.js are hosted on a CDN, and you can include these
 directly in your web app using a &lt;script&gt; tag.
 
 ```html
-<script src="//media.twiliocdn.com/sdk/js/video/releases/2.0.0-beta8/twilio-video.min.js"></script>
+<script src="//media.twiliocdn.com/sdk/js/video/releases/2.0.0-beta9/twilio-video.min.js"></script>
 ```
 
 Using this method, twilio-video.js will set a browser global:
@@ -69,7 +69,7 @@ Usage
 -----
 
 The following is a simple example for connecting to a Room. For more information, refer to the
-[API Docs](//media.twiliocdn.com/sdk/js/video/releases/2.0.0-beta8/docs).
+[API Docs](//media.twiliocdn.com/sdk/js/video/releases/2.0.0-beta9/docs).
 
 ```js
 const Video = require('twilio-video');


### PR DESCRIPTION
@makarandp0 

This PR updates the docs links to point to 2.0.0-beta9 and updates COMMON_ISSUES.md to note that Firefox fails to recover media connections during network interruptions or handoffs.