### PR TITLE
Enable simulcast only if VP8 is the preferred codec in answer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ Bug Fixes
   LocalDataTrack after joining a Group Room. (JSDK-2274)
 - Fixed a bug where Firefox Participants sometimes lost their media connections
   when they tried to publish a LocalDataTrack in a Group Room. (JSDK-2256)
+- Fixed a bug where LocalParticipant on Chrome and Safari failed to publish 
+  a VideoTrack when VP8 simulcast is enabled but H264 is the preferred codec. (JSDK-2321)
 
 2.0.0-beta9 (May 2, 2019)
 =========================

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -14,6 +14,7 @@ const oncePerTick = require('../../util').oncePerTick;
 const setBitrateParameters = require('../../util/sdp').setBitrateParameters;
 const setCodecPreferences = require('../../util/sdp').setCodecPreferences;
 const setSimulcast = require('../../util/sdp').setSimulcast;
+const revertSimulcastForNonVP8MediaSections = require('../../util/sdp').revertSimulcastForNonVP8MediaSections;
 const unifiedPlanRewriteTrackIds = require('../../util/sdp').unifiedPlanRewriteTrackIds;
 const IceBox = require('./icebox');
 const MediaClientLocalDescFailedError = require('../../util/twilio-video-errors').MediaClientLocalDescFailedError;
@@ -96,6 +97,7 @@ class PeerConnectionV2 extends StateMachine {
       iceServers: [],
       logLevel: DEFAULT_LOG_LEVEL,
       offerOptions: {},
+      revertSimulcastForNonVP8MediaSections,
       setBitrateParameters,
       setCodecPreferences,
       setSimulcast,
@@ -163,6 +165,10 @@ class PeerConnectionV2 extends StateMachine {
       _localCandidatesRevision: {
         writable: true,
         value: 1
+      },
+      _localDescriptionWithoutSimulcast: {
+        writable: true,
+        value: null
       },
       _localDescription: {
         writable: true,
@@ -235,6 +241,9 @@ class PeerConnectionV2 extends StateMachine {
       },
       _setSimulcast: {
         value: options.setSimulcast
+      },
+      _revertSimulcastForNonVP8MediaSections: {
+        value: options.revertSimulcastForNonVP8MediaSections
       },
       _RTCIceCandidate: {
         value: options.RTCIceCandidate
@@ -383,7 +392,17 @@ class PeerConnectionV2 extends StateMachine {
       if (!isFirefox) {
         answer = workaroundIssue8329(answer);
       }
-      return this._setLocalDescription(answer);
+      var description = {
+        type: answer.type,
+        sdp: (isChrome || isSafari) && this._isSimulcastRequested()
+          ? this._revertSimulcastForNonVP8MediaSections(
+              this._setSimulcast(answer.sdp, sdpFormat, this._trackIdsToAttributes),
+              answer.sdp,
+              offer.sdp)
+          : answer.sdp
+      };
+      description = new this._RTCSessionDescription(description);
+      return this._setLocalDescription(description);
     }).then(() => {
       return this._checkIceBox(offer);
     }).then(() => {
@@ -411,6 +430,16 @@ class PeerConnectionV2 extends StateMachine {
       return true;
     }
     return false;
+  }
+
+  /**
+   * Check if simulcast is requested.
+   * @private
+   * @returns {boolean}
+   */
+  _isSimulcastRequested() {
+    return this._preferredVideoCodecs.some(
+      codecSettings => codecSettings.codec.toLowerCase() === 'vp8' && codecSettings.simulcast);
   }
 
   /**
@@ -634,9 +663,17 @@ class PeerConnectionV2 extends StateMachine {
       if (!this._negotiationRole) {
         this._negotiationRole = 'offerer';
       }
+
+      // cache local description
+      this._localDescriptionWithoutSimulcast = {
+        type: offer.type,
+        sdp: updatedSdp
+      };
       return this._setLocalDescription({
         type: 'offer',
-        sdp: updatedSdp
+        sdp: (isChrome || isSafari) && this._isSimulcastRequested()
+          ? this._setSimulcast(updatedSdp, sdpFormat, this._trackIdsToAttributes)
+          : updatedSdp
       });
     });
   }
@@ -666,23 +703,7 @@ class PeerConnectionV2 extends StateMachine {
    * @returns {Promise<void>}
    */
   _setLocalDescription(description) {
-    const vp8SimulcastRequested = this._preferredVideoCodecs.some(codecSettings => codecSettings.codec.toLowerCase() === 'vp8' && codecSettings.simulcast);
-
-    return Promise.resolve().then(() => {
-      if (description.sdp) {
-        // NOTE(mmalavalli): We do not directly modify "description.sdp" here as
-        // "description" might be an RTCSessionDescription, in which case its
-        // properties are immutable.
-        description = {
-          type: description.type,
-          sdp: (isChrome || isSafari) && vp8SimulcastRequested
-            ? this._setSimulcast(description.sdp, sdpFormat, this._trackIdsToAttributes)
-            : description.sdp
-        };
-      }
-      description = new this._RTCSessionDescription(description);
-      return this._peerConnection.setLocalDescription(description);
-    }).catch(error => {
+    return this._peerConnection.setLocalDescription(description).catch(error => {
       this._log.warn(`Calling setLocalDescription with an RTCSessionDescription of type "${description.type}" failed with the error "${error.message}".`);
       if (description.sdp) {
         this._log.warn(`The SDP was ${description.sdp}`);
@@ -737,7 +758,21 @@ class PeerConnectionV2 extends StateMachine {
       }
     }
     description = new this._RTCSessionDescription(description);
-    return this._peerConnection.setRemoteDescription(description).then(() => {
+    return Promise.resolve().then(() => {
+      // NOTE(syerrapragada): VMS does not support simulcast for H264. So,
+      // Unset simulcast for sections in local offer where corresponding
+      // sections in answer doesn't have vp8 as preferred codec and reapply offer.
+      if (description.type === 'answer' && (isChrome || isSafari)) {
+        var localDescription = {
+          type: this._localDescription.type,
+          sdp: this._revertSimulcastForNonVP8MediaSections(
+            this._localDescription.sdp,
+            this._localDescriptionWithoutSimulcast.sdp,
+            description.sdp)
+        };
+        return this._setLocalDescription(localDescription);
+      }
+    }).then(() => this._peerConnection.setRemoteDescription(description)).then(() => {
       if (description.type === 'answer' && this._isRestartingIce) {
         this._log.debug('An ICE restart was in-progress and is now completed');
         this._isRestartingIce = false;

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -216,6 +216,10 @@ class PeerConnectionV2 extends StateMachine {
       _preferredVideoCodecs: {
         value: preferredCodecs.video
       },
+      _shouldApplySimulcast: {
+        value: (isChrome || isSafari) && preferredCodecs.video.some(
+          codecSettings => codecSettings.codec.toLowerCase() === 'vp8' && codecSettings.simulcast)
+      },
       _queuedDescription: {
         writable: true,
         value: null
@@ -392,16 +396,19 @@ class PeerConnectionV2 extends StateMachine {
       if (!isFirefox) {
         answer = workaroundIssue8329(answer);
       }
-      var description = {
-        type: answer.type,
-        sdp: (isChrome || isSafari) && this._isSimulcastRequested()
-          ? this._revertSimulcastForNonVP8MediaSections(
-              this._setSimulcast(answer.sdp, sdpFormat, this._trackIdsToAttributes),
-              answer.sdp,
-              offer.sdp)
-          : answer.sdp
-      };
-      description = new this._RTCSessionDescription(description);
+
+      var description = answer;
+      if (this._shouldApplySimulcast) {
+        var updatedSdp = this._setSimulcast(answer.sdp, sdpFormat, this._trackIdsToAttributes);
+        // NOTE(syerrapragada): VMS does not support H264 simulcast. So,
+        // unset simulcast for sections in local offer where corresponding
+        // sections in answer doesn't have vp8 as preferred codec and reapply offer.
+        updatedSdp = this._revertSimulcastForNonVP8MediaSections(updatedSdp, answer.sdp, offer.sdp);
+        description = {
+          type: description.type,
+          sdp: updatedSdp
+        };
+      }
       return this._setLocalDescription(description);
     }).then(() => {
       return this._checkIceBox(offer);
@@ -430,16 +437,6 @@ class PeerConnectionV2 extends StateMachine {
       return true;
     }
     return false;
-  }
-
-  /**
-   * Check if simulcast is requested.
-   * @private
-   * @returns {boolean}
-   */
-  _isSimulcastRequested() {
-    return this._preferredVideoCodecs.some(
-      codecSettings => codecSettings.codec.toLowerCase() === 'vp8' && codecSettings.simulcast);
   }
 
   /**
@@ -654,7 +651,7 @@ class PeerConnectionV2 extends StateMachine {
         offer = workaroundIssue8329(offer);
       }
 
-      const updatedSdp = this._setCodecPreferences(
+      var updatedSdp = this._setCodecPreferences(
         offer.sdp,
         this._preferredAudioCodecs,
         this._preferredVideoCodecs);
@@ -664,16 +661,18 @@ class PeerConnectionV2 extends StateMachine {
         this._negotiationRole = 'offerer';
       }
 
-      // cache local description
-      this._localDescriptionWithoutSimulcast = {
-        type: offer.type,
-        sdp: updatedSdp
-      };
+      if (this._shouldApplySimulcast) {
+        // cache local description before applying simulcast
+        this._localDescriptionWithoutSimulcast = {
+          type: 'offer',
+          sdp: updatedSdp
+        };
+        updatedSdp = this._setSimulcast(updatedSdp, sdpFormat, this._trackIdsToAttributes);
+      }
+
       return this._setLocalDescription({
         type: 'offer',
-        sdp: (isChrome || isSafari) && this._isSimulcastRequested()
-          ? this._setSimulcast(updatedSdp, sdpFormat, this._trackIdsToAttributes)
-          : updatedSdp
+        sdp: updatedSdp
       });
     });
   }
@@ -694,6 +693,16 @@ class PeerConnectionV2 extends StateMachine {
       sdp: unifiedPlanRewriteTrackIds(description.sdp, midsToTrackIds),
       type: description.type
     });
+  }
+
+  /**
+   * Rollback and apply the given offer.
+   * @private
+   * @param {RTCSessionDescriptionInit} offer
+   * @returns {Promise<void>}
+   */
+  _rollbackAndApplyOffer(offer) {
+    return this._setLocalDescription({ type: 'rollback' }).then(() => this._setLocalDescription(offer));
   }
 
   /**
@@ -759,18 +768,15 @@ class PeerConnectionV2 extends StateMachine {
     }
     description = new this._RTCSessionDescription(description);
     return Promise.resolve().then(() => {
-      // NOTE(syerrapragada): VMS does not support simulcast for H264. So,
-      // Unset simulcast for sections in local offer where corresponding
+      // NOTE(syerrapragada): VMS does not support H264 simulcast. So,
+      // unset simulcast for sections in local offer where corresponding
       // sections in answer doesn't have vp8 as preferred codec and reapply offer.
-      if (description.type === 'answer' && (isChrome || isSafari)) {
-        var localDescription = {
+      if (description.type === 'answer' && this._shouldApplySimulcast) {
+        return this._rollbackAndApplyOffer({
           type: this._localDescription.type,
           sdp: this._revertSimulcastForNonVP8MediaSections(
-            this._localDescription.sdp,
-            this._localDescriptionWithoutSimulcast.sdp,
-            description.sdp)
-        };
-        return this._setLocalDescription(localDescription);
+            this._localDescription.sdp, this._localDescriptionWithoutSimulcast.sdp, description.sdp)
+        });
       }
     }).then(() => this._peerConnection.setRemoteDescription(description)).then(() => {
       if (description.type === 'answer' && this._isRestartingIce) {

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -397,7 +397,7 @@ class PeerConnectionV2 extends StateMachine {
         answer = workaroundIssue8329(answer);
       }
 
-      var description = answer;
+      let description = answer;
       if (this._shouldApplySimulcast) {
         var updatedSdp = this._setSimulcast(answer.sdp, sdpFormat, this._trackIdsToAttributes);
         // NOTE(syerrapragada): VMS does not support H264 simulcast. So,
@@ -651,7 +651,7 @@ class PeerConnectionV2 extends StateMachine {
         offer = workaroundIssue8329(offer);
       }
 
-      var updatedSdp = this._setCodecPreferences(
+      let updatedSdp = this._setCodecPreferences(
         offer.sdp,
         this._preferredAudioCodecs,
         this._preferredVideoCodecs);
@@ -662,7 +662,6 @@ class PeerConnectionV2 extends StateMachine {
       }
 
       if (this._shouldApplySimulcast) {
-        // cache local description before applying simulcast
         this._localDescriptionWithoutSimulcast = {
           type: 'offer',
           sdp: updatedSdp

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -266,16 +266,16 @@ function setSimulcast(sdp, sdpFormat, trackIdsToAttributes) {
 
 /**
  * Return a new SDP string after reverting simulcast for non vp8 sections in remote sdp.
- * @param sdp - simulcast enabled local sdp
- * @param sdpWithoutSimulcast - local sdp before simulcast was set
+ * @param localSdp - simulcast enabled local sdp
+ * @param localSdpWithoutSimulcast - local sdp before simulcast was set
  * @param remoteSdp - remote sdp
  * @return {string} Updated SDP string
  */
-function revertSimulcastForNonVP8MediaSections(sdp, sdpWithoutSimulcast, remoteSdp) {
-  const remoteMidToMediaSectionMap = createMidMapForSdp(remoteSdp);
-  const noSimMidToMediaSectionMap = createMidMapForSdp(sdpWithoutSimulcast);
-  const mediaSections = getMediaSections(sdp);
-  const session = sdp.split('\r\nm=')[0];
+function revertSimulcastForNonVP8MediaSections(localSdp, localSdpWithoutSimulcast, remoteSdp) {
+  const remoteMidToMediaSections = createMidMapForSdp(remoteSdp);
+  const localMidToMediaSectionsWithoutSimulcast = createMidMapForSdp(localSdpWithoutSimulcast);
+  const mediaSections = getMediaSections(localSdp);
+  const session = localSdp.split('\r\nm=')[0];
   return [session].concat(mediaSections.map(section => {
     section = section.replace(/\r\n$/, '');
     if (!/^m=video/.test(section)) {
@@ -283,14 +283,16 @@ function revertSimulcastForNonVP8MediaSections(sdp, sdpWithoutSimulcast, remoteS
     }
     const midMatches = section.match(/^a=mid:(.+)$/m);
     const mid = midMatches && midMatches[1];
+    if (!mid) {
+      return section;
+    }
 
-    const remoteSection = remoteMidToMediaSectionMap.get(mid);
-    const remotePtToCodecMap = createPtToCodecName(remoteSection);
-    const remotePayloadTypes = getPayloadTypesInMediaSection(section);
+    const remoteSection = remoteMidToMediaSections.get(mid);
+    const remotePtToCodecs = createPtToCodecName(remoteSection);
+    const remotePayloadTypes = getPayloadTypesInMediaSection(remoteSection);
 
-    const isVP8ThePreferredCodec = remotePayloadTypes.length
-      && remotePtToCodecMap.get(remotePayloadTypes[0]) === 'vp8';
-    return isVP8ThePreferredCodec ? section : noSimMidToMediaSectionMap.get(mid).replace(/\r\n$/, '');
+    const isVP8ThePreferredCodec = remotePayloadTypes.length && remotePtToCodecs.get(remotePayloadTypes[0]) === 'vp8';
+    return isVP8ThePreferredCodec ? section : localMidToMediaSectionsWithoutSimulcast.get(mid).replace(/\r\n$/, '');
   })).concat('').join('\r\n');
 }
 

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -58,6 +58,19 @@ function createCodecMapForMediaSection(section) {
 }
 
 /**
+ * Create a mid map for the given sdp.
+ * @param {string} sdp
+ * @returns {Map<string, string>}
+ */
+function createMidMapForSdp(sdp) {
+  return getMediaSections(sdp).reduce((midMap, section) => {
+    const midMatches = section.match(/^a=mid:(.+)$/m);
+    const mid = midMatches && midMatches[1];
+    return midMap.set(mid, section);
+  }, new Map());
+}
+
+/**
  * Create a Map from PTs to codec names for the given m= section.
  * @param {string} mediaSection - The given m= section.
  * @returns {Map<PT, Codec>} ptToCodecName
@@ -252,6 +265,36 @@ function setSimulcast(sdp, sdpFormat, trackIdsToAttributes) {
 }
 
 /**
+ * Return a new SDP string after reverting simulcast for non vp8 sections in remote sdp.
+ * @param sdp - simulcast enabled local sdp
+ * @param sdpWithoutSimulcast - local sdp before simulcast was set
+ * @param remoteSdp - remote sdp
+ * @return {string} Updated SDP string
+ */
+function revertSimulcastForNonVP8MediaSections(sdp, sdpWithoutSimulcast, remoteSdp) {
+  const remoteMidToMediaSectionMap = createMidMapForSdp(remoteSdp);
+  const noSimMidToMediaSectionMap = createMidMapForSdp(sdpWithoutSimulcast);
+  const mediaSections = getMediaSections(sdp);
+  const session = sdp.split('\r\nm=')[0];
+  return [session].concat(mediaSections.map(section => {
+    section = section.replace(/\r\n$/, '');
+    if (!/^m=video/.test(section)) {
+      return section;
+    }
+    const midMatches = section.match(/^a=mid:(.+)$/m);
+    const mid = midMatches && midMatches[1];
+
+    const remoteSection = remoteMidToMediaSectionMap.get(mid);
+    const remotePtToCodecMap = createPtToCodecName(remoteSection);
+    const remotePayloadTypes = getPayloadTypesInMediaSection(section);
+
+    const isVP8ThePreferredCodec = remotePayloadTypes.length
+      && remotePtToCodecMap.get(remotePayloadTypes[0]) === 'vp8';
+    return isVP8ThePreferredCodec ? section : noSimMidToMediaSectionMap.get(mid).replace(/\r\n$/, '');
+  })).concat('').join('\r\n');
+}
+
+/**
  * Rewrite MSIDs in the given Unified Plan SDP with their corresponding local
  * MediaStreamTrack IDs. These can be different when MediaStreamTracks are added
  * using RTCRtpSender.replaceTrack().
@@ -282,6 +325,7 @@ function unifiedPlanRewriteTrackIds(sdp, midsToTrackIds) {
 exports.createCodecMapForMediaSection = createCodecMapForMediaSection;
 exports.createPtToCodecName = createPtToCodecName;
 exports.getMediaSections = getMediaSections;
+exports.revertSimulcastForNonVP8MediaSections = revertSimulcastForNonVP8MediaSections;
 exports.setBitrateParameters = setBitrateParameters;
 exports.setCodecPreferences = setCodecPreferences;
 exports.setSimulcast = setSimulcast;

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -813,49 +813,64 @@ describe('connect', function() {
   });
 
   (isChrome || safariVersion >= 12.1 ? describe : describe.skip)('VP8 simulcast', () => {
-    let peerConnections;
-    let sid;
-    let thisRoom;
-    let thoseRooms;
+    [
+      ['VP8', true],
+      ['H264', false]
+    ].forEach(([roomCodec, shouldAddSSRCs]) => {
+      describe(`in ${roomCodec} only room`, () => {
+        let peerConnections;
+        let sid;
+        let thisRoom;
+        let thoseRooms;
 
-    before(async () => {
-      [sid, thisRoom, thoseRooms, peerConnections] = await setup(randomName(), {
-        preferredVideoCodecs: [{ codec: 'VP8', simulcast: true }]
+        before(async () => {
+          [sid, thisRoom, thoseRooms, peerConnections] = await setup(randomName(), {
+            preferredVideoCodecs: [{ codec: 'VP8', simulcast: true }]
+          }, null, null, null, {
+            VideoCodecs: [roomCodec]
+          });
+
+          // NOTE(mmalavalli): Ensuring that the local RTCSessionDescription is set
+          // before verifying that simulcast has been enabled. This was added to remove
+          // flakiness of this test in Travis.
+          await Promise.all(peerConnections.map(pc => pc.localDescription ? Promise.resolve() : new Promise(resolve => {
+            pc.addEventListener('signalingstatechange', () => pc.localDescription && resolve());
+          })));
+        });
+
+        it(`should ${shouldAddSSRCs ? '' : 'not '}add Simulcast SSRCs to the video m= section of all local descriptions`, () => {
+          flatMap(peerConnections, pc => {
+            assert(pc.localDescription.sdp);
+            return getMediaSections(pc.localDescription.sdp, 'video', '(sendonly|sendrecv)');
+          }).forEach(section => {
+            const flowSSRCs = new Set(flatMap(section.match(/^a=ssrc-group:FID .+$/gm), line => {
+              return line.split(' ').slice(1);
+            }));
+            if (shouldAddSSRCs) {
+              const simSSRCs = new Set(flatMap(section.match(/^a=ssrc-group:SIM .+$/gm), line => {
+                return line.split(' ').slice(1);
+              }));
+              const trackSSRCs = new Set(section.match(/^a=ssrc:.+ msid:.+$/gm).map(line => {
+                return line.match(/a=ssrc:([0-9]+)/)[1];
+              }));
+              assert.equal(flowSSRCs.size, 6);
+              assert.equal(simSSRCs.size, 3);
+              assert.equal(trackSSRCs.size, 6);
+              simSSRCs.forEach(ssrc => assert(trackSSRCs.has(ssrc)));
+              flowSSRCs.forEach(ssrc => assert(trackSSRCs.has(ssrc)));
+            } else {
+              assert.equal(flowSSRCs.size, 2);
+              assert.equal(section.match(/^a=ssrc-group:SIM .+$/gm), null);
+              assert.equal(section.match(/^a=ssrc:.+ msid:.+$/gm), null);
+            }
+          });
+        });
+
+        after(() => {
+          [thisRoom, ...thoseRooms].forEach(room => room && room.disconnect());
+          return completeRoom(sid);
+        });
       });
-
-      // NOTE(mmalavalli): Ensuring that the local RTCSessionDescription is set
-      // before verifying that simulcast has been enabled. This was added to remove
-      // flakiness of this test in Travis.
-      await Promise.all(peerConnections.map(pc => pc.localDescription ? Promise.resolve() : new Promise(resolve => {
-        pc.addEventListener('signalingstatechange', () => pc.localDescription && resolve());
-      })));
-    });
-
-    it('should add Simulcast SSRCs to the video m= section of all local descriptions', () => {
-      flatMap(peerConnections, pc => {
-        assert(pc.localDescription.sdp);
-        return getMediaSections(pc.localDescription.sdp, 'video', '(sendonly|sendrecv)');
-      }).forEach(section => {
-        const flowSSRCs = new Set(flatMap(section.match(/^a=ssrc-group:FID .+$/gm), line => {
-          return line.split(' ').slice(1);
-        }));
-        const simSSRCs = new Set(flatMap(section.match(/^a=ssrc-group:SIM .+$/gm), line => {
-          return line.split(' ').slice(1);
-        }));
-        const trackSSRCs = new Set(section.match(/^a=ssrc:.+ msid:.+$/gm).map(line => {
-          return line.match(/a=ssrc:([0-9]+)/)[1];
-        }));
-        assert.equal(flowSSRCs.size, 6);
-        assert.equal(simSSRCs.size, 3);
-        assert.equal(trackSSRCs.size, 6);
-        simSSRCs.forEach(ssrc => assert(trackSSRCs.has(ssrc)));
-        flowSSRCs.forEach(ssrc => assert(trackSSRCs.has(ssrc)));
-      });
-    });
-
-    after(() => {
-      [thisRoom, ...thoseRooms].forEach(room => room && room.disconnect());
-      return completeRoom(sid);
     });
   });
 });
@@ -864,13 +879,13 @@ function getPayloadTypes(mediaSection) {
   return [...createPtToCodecName(mediaSection).keys()];
 }
 
-async function setup(name, testOptions, otherOptions, nTracks, alone) {
+async function setup(name, testOptions, otherOptions, nTracks, alone, roomOptions) {
   const options = Object.assign({
     audio: true,
     video: smallVideoConstraints
   }, testOptions, defaults);
   const token = getToken(randomName());
-  options.name = await createRoom(name, options.topology);
+  options.name = await createRoom(name, options.topology, roomOptions);
   const thisRoom = await connect(token, options);
   if (alone) {
     return [options.name, thisRoom];

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -846,7 +846,7 @@ describe('connect', function() {
             const flowSSRCs = new Set(flatMap(section.match(/^a=ssrc-group:FID .+$/gm), line => {
               return line.split(' ').slice(1);
             }));
-            if (shouldAddSSRCs) {
+            if (shouldAddSSRCs || defaults.topology === 'peer-to-peer') {
               const simSSRCs = new Set(flatMap(section.match(/^a=ssrc-group:SIM .+$/gm), line => {
                 return line.split(' ').slice(1);
               }));

--- a/test/lib/mocksdp.js
+++ b/test/lib/mocksdp.js
@@ -68,12 +68,13 @@ a=rtcp-mux\r
       const { id, ssrc } = typeof trackAndSSRC === 'string'
         ? { id: trackAndSSRC, ssrc: 1 }
         : trackAndSSRC;
-      return sdp + `a=mid:mid_${id}\r\n` + (type === 'planb' ? '' : media + `\
+      return sdp + (type === 'planb' ? '' : media + `\
 a=mid:mid_${id}\r
 a=msid:- ${id}\r
 `) + `\
 a=ssrc:${ssrc} cname:0\r
 a=ssrc:${ssrc} msid:${type === 'planb' ? 'stream' : '-'} ${id}\r
+a=mid:mid_${id}\r
 `;
     }, sdp + (type === 'planb' ? media : ''));
   }, session);

--- a/test/lib/mocksdp.js
+++ b/test/lib/mocksdp.js
@@ -68,7 +68,7 @@ a=rtcp-mux\r
       const { id, ssrc } = typeof trackAndSSRC === 'string'
         ? { id: trackAndSSRC, ssrc: 1 }
         : trackAndSSRC;
-      return sdp + (type === 'planb' ? '' : media + `\
+      return sdp + `a=mid:mid_${id}\r\n` + (type === 'planb' ? '' : media + `\
 a=mid:mid_${id}\r
 a=msid:- ${id}\r
 `) + `\

--- a/test/lib/mocksdp.js
+++ b/test/lib/mocksdp.js
@@ -69,7 +69,6 @@ a=rtcp-mux\r
         ? { id: trackAndSSRC, ssrc: 1 }
         : trackAndSSRC;
       return sdp + (type === 'planb' ? '' : media + `\
-a=mid:mid_${id}\r
 a=msid:- ${id}\r
 `) + `\
 a=ssrc:${ssrc} cname:0\r

--- a/test/lib/rest.js
+++ b/test/lib/rest.js
@@ -55,11 +55,11 @@ function completeRoom(nameOrSid) {
  * @param {'group' | 'group-small' | 'peer-to-peer'} type
  * @returns {Promise<Room.SID>}
  */
- async function createRoom(name, type) {
-  const { sid, status } = await post('/v1/Rooms', {
+ async function createRoom(name, type, roomOptions) {
+  const { sid, status } = await post('/v1/Rooms', Object.assign({
     Type: type,
     UniqueName: name
-  });
+  }, roomOptions));
   if (status === 'in-progress') {
     return sid;
   }

--- a/test/unit/spec/util/sdp/index.js
+++ b/test/unit/spec/util/sdp/index.js
@@ -9,6 +9,7 @@ const {
   setBitrateParameters,
   setCodecPreferences,
   setSimulcast,
+  revertSimulcastForNonVP8MediaSections,
   unifiedPlanRewriteTrackIds
 } = require('../../../../../lib/util/sdp');
 
@@ -487,6 +488,56 @@ a=ssrc:0000000000 label:d8b9a935-da54-4d21-a8de-522c87258244\r
       const ssrcs2 = new Set(simSdp2.match(/a=ssrc:[0-9]+/g).map(line => line.match(/a=ssrc:([0-9]+)/)[1]));
       assert.equal(ssrcs2.size, 3, 'RTX is disabled; therefore, there should be just 3 SSRCs in the SDP');
     });
+  });
+});
+
+describe.only('revertSimulcastForNonVP8MediaSections', () => {
+  combinationContext([
+    [
+      ['planb', 'unified'],
+      x => `when called with a ${x} sdp`
+    ],
+    [
+      [true, false],
+      x => `when the preferred payload type in answer is${x ? '' : ' not'} VP8`
+    ],
+    [
+      [new Set(['01234']), new Set(['01234', '56789'])],
+      x => `when retransmission is${x.size === 2 ? '' : ' not'} supported`
+    ]
+  ], ([sdpType, isVP8PreferredPayloadType, ssrcs]) => {
+    let sdp;
+    let simSdp;
+    let remoteSdp;
+    let revertedSdp;
+    let trackIdsToAttributes;
+
+    before(() => {
+      ssrcs = Array.from(ssrcs.values());
+      sdp = makeSdpForSimulcast(sdpType, ssrcs);
+      trackIdsToAttributes = new Map();
+      simSdp = setSimulcast(sdp, sdpType, trackIdsToAttributes);
+      remoteSdp = makeSdpWithTracks(sdpType, {
+        audio: ['audio-1'],
+        video: [{ id: 'video-1', ssrc: ssrcs[0] }]
+      });
+      if (isVP8PreferredPayloadType) {
+        remoteSdp = setCodecPreferences(sdp, ['PCMU'], [{ codec: 'VP8' }]);
+      } else {
+        remoteSdp = setCodecPreferences(sdp, ['PCMU'], [{ codec: 'H264' }]);
+      }
+      revertedSdp = revertSimulcastForNonVP8MediaSections(simSdp, sdp, remoteSdp);
+    });
+
+    if (isVP8PreferredPayloadType) {
+      it('should not revert simulcast SSRCs', () => {
+        assert.equal(revertedSdp, simSdp);
+      });
+    } else {
+      it('should revert simulcast SSRCs', () => {
+        assert.equal(revertedSdp, sdp);
+      });
+    }
   });
 });
 

--- a/test/unit/spec/util/sdp/index.js
+++ b/test/unit/spec/util/sdp/index.js
@@ -491,7 +491,7 @@ a=ssrc:0000000000 label:d8b9a935-da54-4d21-a8de-522c87258244\r
   });
 });
 
-describe.only('revertSimulcastForNonVP8MediaSections', () => {
+describe('revertSimulcastForNonVP8MediaSections', () => {
   combinationContext([
     [
       ['planb', 'unified'],


### PR DESCRIPTION
This PR attempts to fix the issue where the group room failed when simulcast is enabled for H264 media sections.

for chrome and safari browsers:

Offerer case:
- client creates offer
**- cache the created offer (offerWithoutSimulcast)**
- enable simulcast
- setLocalDescription
- starts negotiation
- upon receiving the answer:
  **- use the cached offer to reverts simulcast in the negotiated offer for sections where vp8 is not the preferred codec in the corresponding section of the remote answer**
 **- rollback** 
  **- call setLocalDescription with this new offer**
- setRemoteDescription to complete the negotiation

Answerer case:
- client receives offer
- setRemoteDescription
- createAnswer
- enable simulcast
**- revert simulcast for sections where vp8 is not the preferred codec in the corresponding section of the remote offer**
- setLocalDescription to complete negotiation

