### PR TITLE
JSDK-2343 Modify Content Security Policy to replace SIP.js endpoint with TCMP global endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Want to enable [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) in a
 way that's compatible with twilio-video.js? Use the following policy directives:
 
 ```
-connect-src https://ecs.us1.twilio.com wss://endpoint.twilio.com wss://sdkgw.us1.twilio.com
+connect-src https://ecs.us1.twilio.com wss://global.vss.twilio.com wss://sdkgw.us1.twilio.com
 media-src mediastream:
 ```
 


### PR DESCRIPTION
@innerverse 

CSP now contains the TCMP endpoint and no longer has the SIP.js endpoint.