### PR TITLE
JSDK-2357 Filter codecs in unified plan local SDPs based on remote SDPs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ addons:
     packages:
       - pulseaudio
 
+# https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-directly
+dist: trusty
+
 env:
   global:
     - DBUS_SESSION_BUS_ADDRESS=/dev/null
@@ -93,6 +96,7 @@ before_script:
     if [ "${TRAVIS_OS_NAME}" == 'linux' ]; then
       sh -e /etc/init.d/xvfb start
       pulseaudio --start
+      sleep 3
     fi
     if [ "${TOPOLOGY}" != 'peer-to-peer' ]; then
       export ENABLE_REST_API_TESTS=1

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -9,7 +9,7 @@ const DefaultRTCPeerConnection = WebRTC.RTCPeerConnection;
 const DefaultRTCSessionDescription = WebRTC.RTCSessionDescription;
 const getStatistics = WebRTC.getStats;
 const createCodecMapForMediaSection = require('../../util/sdp').createCodecMapForMediaSection;
-const unifiedPlanfilterLocalCodecs = require('../../util/sdp').unifiedPlanFilterLocalCodecs;
+const unifiedPlanFilterLocalCodecs = require('../../util/sdp').unifiedPlanFilterLocalCodecs;
 const getMediaSections = require('../../util/sdp').getMediaSections;
 const oncePerTick = require('../../util').oncePerTick;
 const setBitrateParameters = require('../../util/sdp').setBitrateParameters;
@@ -613,7 +613,7 @@ class PeerConnectionV2 extends StateMachine {
       }
 
       const sdp = isUnifiedPlan && this._peerConnection.remoteDescription
-        ? unifiedPlanfilterLocalCodecs(offer.sdp, this._peerConnection.remoteDescription.sdp)
+        ? unifiedPlanFilterLocalCodecs(offer.sdp, this._peerConnection.remoteDescription.sdp)
         : offer.sdp;
 
       const updatedSdp = this._setCodecPreferences(

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -9,6 +9,7 @@ const DefaultRTCPeerConnection = WebRTC.RTCPeerConnection;
 const DefaultRTCSessionDescription = WebRTC.RTCSessionDescription;
 const getStatistics = WebRTC.getStats;
 const createCodecMapForMediaSection = require('../../util/sdp').createCodecMapForMediaSection;
+const filterLocalCodecs = require('../../util/sdp').filterLocalCodecs;
 const getMediaSections = require('../../util/sdp').getMediaSections;
 const oncePerTick = require('../../util').oncePerTick;
 const setBitrateParameters = require('../../util/sdp').setBitrateParameters;
@@ -622,7 +623,9 @@ class PeerConnectionV2 extends StateMachine {
       }
       return this._setLocalDescription({
         type: 'offer',
-        sdp: updatedSdp
+        sdp: this._peerConnection.remoteDescription ?
+          filterLocalCodecs(updatedSdp, this._peerConnection.remoteDescription.sdp)
+          : updatedSdp
       });
     });
   }

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -9,7 +9,7 @@ const DefaultRTCPeerConnection = WebRTC.RTCPeerConnection;
 const DefaultRTCSessionDescription = WebRTC.RTCSessionDescription;
 const getStatistics = WebRTC.getStats;
 const createCodecMapForMediaSection = require('../../util/sdp').createCodecMapForMediaSection;
-const filterLocalCodecs = require('../../util/sdp').filterLocalCodecs;
+const unifiedPlanfilterLocalCodecs = require('../../util/sdp').unifiedPlanFilterLocalCodecs;
 const getMediaSections = require('../../util/sdp').getMediaSections;
 const oncePerTick = require('../../util').oncePerTick;
 const setBitrateParameters = require('../../util/sdp').setBitrateParameters;
@@ -612,8 +612,12 @@ class PeerConnectionV2 extends StateMachine {
         offer = workaroundIssue8329(offer);
       }
 
+      const sdp = isUnifiedPlan && this._peerConnection.remoteDescription
+        ? unifiedPlanfilterLocalCodecs(offer.sdp, this._peerConnection.remoteDescription.sdp)
+        : offer.sdp;
+
       const updatedSdp = this._setCodecPreferences(
-        offer.sdp,
+        sdp,
         this._preferredAudioCodecs,
         this._preferredVideoCodecs);
 
@@ -623,9 +627,7 @@ class PeerConnectionV2 extends StateMachine {
       }
       return this._setLocalDescription({
         type: 'offer',
-        sdp: this._peerConnection.remoteDescription ?
-          filterLocalCodecs(updatedSdp, this._peerConnection.remoteDescription.sdp)
-          : updatedSdp
+        sdp: updatedSdp
       });
     });
   }

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -290,6 +290,97 @@ function setSimulcast(sdp, sdpFormat, trackIdsToAttributes) {
 }
 
 /**
+ * Get the matching Payload Types in a unified plan local m= section for a particular remote codec.
+ * @param {string} remoteCodec
+ * @param {PayloadType} remotePt
+ * @param {Map<string, PayloadType>} localCodecsToPts
+ * @param {string} localSection
+ * @param {string} remoteSection
+ * @returns {Array<PayloadType>}
+ */
+function unifiedPlanGetMatchingLocalPayloadTypes(remoteCodec, remotePt, localCodecsToPts, localSection, remoteSection) {
+  // If there is at most one local Payload Type that matches the remote codec, retain it.
+  const matchingLocalPts = localCodecsToPts.get(remoteCodec) || [];
+  if (matchingLocalPts.length <= 1) {
+    return matchingLocalPts;
+  }
+
+  // If there are no fmtp attributes for the codec in the remote m= section,
+  // then we cannot get a match in the local m= section. In that case, retain
+  // all matching local Payload Types.
+  const remoteFmtpAttrs = getFmtpAttributesForPt(remotePt, remoteSection);
+  if (!remoteFmtpAttrs) {
+    return matchingLocalPts;
+  }
+
+  // Among the matched local Payload Types, find the one that matches the remote
+  // fmtp attributes.
+  const matchinglocalPt = matchingLocalPts.find(localPt => {
+    const localFmtpAttrs = getFmtpAttributesForPt(localPt, localSection);
+    return localFmtpAttrs && Object.keys(remoteFmtpAttrs).every(attr => {
+      return remoteFmtpAttrs[attr] === localFmtpAttrs[attr];
+    });
+  });
+
+  // If none of the matched local Payload Types also have matching fmtp attributes,
+  // then retain all of them, otherwise retain only the local Payload Type that
+  // matches the remote fmtp attributes.
+  return typeof matchinglocalPt === 'number' ? [matchinglocalPt] : matchingLocalPts;
+}
+
+/**
+ * Filter codecs in a local unified plan m= section based on its equivalent remote m= section.
+ * @param {string} localSection
+ * @param {Map<string, string>} remoteMidsToMediaSections
+ * @returns {string}
+ */
+function unifiedPlanFilterCodecsInLocalMediaSection(localSection, remoteMidsToMediaSections) {
+  // Do nothing if the local m= section represents neither audio nor video.
+  if (!/^m=(audio|video)/.test(localSection)) {
+    return localSection;
+  }
+
+  // Do nothing if the local m= section does not have an equivalent remote m= section.
+  const localMid = getMidForMediaSection(localSection);
+  const remoteSection = localMid && remoteMidsToMediaSections.get(localMid);
+  if (!remoteSection) {
+    return localSection;
+  }
+
+  // Construct a Map of the remote Payload Types to their codec names.
+  const remotePtToCodecs = createPtToCodecName(remoteSection);
+  // Construct a Map of the local codec names to their Payload Types.
+  const localCodecsToPts = createCodecMapForMediaSection(localSection);
+  // Maintain a list of local Payload Types to retain.
+  let localPts = flatMap(Array.from(remotePtToCodecs), ([remotePt, remoteCodec]) => unifiedPlanGetMatchingLocalPayloadTypes(
+    remoteCodec,
+    remotePt,
+    localCodecsToPts,
+    localSection,
+    remoteSection));
+
+  // For each local Payload Type that will be retained, retain their
+  // corresponding rtx Payload Type if present.
+  const localRtxPts = localCodecsToPts.get('rtx') || [];
+  localPts = localPts.concat(localRtxPts.filter(rtxPt => {
+    const fmtpAttrs = getFmtpAttributesForPt(rtxPt, localSection);
+    return fmtpAttrs && localPts.includes(fmtpAttrs.apt);
+  }));
+
+  // Filter out all rtpmap/fmtp/rtcp-fb lines in the local m= section that do
+  // not belong to one of the local Payload Types that are to be retained.
+  const lines = localSection.split('\r\n').filter(line => {
+    const ptMatches = line.match(/^a=(rtpmap|fmtp|rtcp-fb):(.+) .+$/);
+    const pt = ptMatches && ptMatches[2];
+    return !ptMatches || (pt && localPts.includes(parseInt(pt, 10)));
+  });
+
+  // Filter the list of Payload Types in the first line of the m= section.
+  const orderedLocalPts = getPayloadTypesInMediaSection(localSection).filter(pt => localPts.includes(pt));
+  return setPayloadTypesInMediaSection(orderedLocalPts, lines.join('\r\n'));
+}
+
+/**
  * Filter local codecs based on the remote unified plan SDP.
  * @param {string} localSdp
  * @param {string} remoteSdp
@@ -300,70 +391,7 @@ function unifiedPlanFilterLocalCodecs(localSdp, remoteSdp) {
   const localSession = localSdp.split('\r\nm=')[0];
   const remoteMidsToMediaSections = createMidToMediaSectionMap(remoteSdp);
   return [localSession].concat(localMediaSections.map(localSection => {
-    const localMid = getMidForMediaSection(localSection);
-    const remoteSection = localMid && remoteMidsToMediaSections.get(localMid);
-    // Do nothing if either the local m= section does not have an equivalent
-    // remote m= section or if it is neither an audio nor a video m= section.
-    if (!(remoteSection && /^m=(audio|video)/.test(localSection))) {
-      return localSection;
-    }
-    // Construct a Map of the remote Payload Types to their codec names.
-    const remotePtToCodecs = createPtToCodecName(remoteSection);
-    // Construct a Map of the local codec names to their Payload Types.
-    const localCodecToPts = createCodecMapForMediaSection(localSection);
-    // Maintain a list of local Payload Types to retain.
-    let localPts = [];
-
-    remotePtToCodecs.forEach((remoteCodec, remotePt) => {
-      const matchingLocalPts = localCodecToPts.get(remoteCodec) || [];
-      // If there is only one local Payload Type that matches the remote codec,
-      // retain it.
-      if (matchingLocalPts.length === 1) {
-        localPts.push(matchingLocalPts[0]);
-        return;
-      }
-
-      // If there are more than one matching local Payload Types, then retain the
-      // one with matching fmtp attributes.
-      if (matchingLocalPts.length > 1) {
-        const remoteFmtpAttrs = getFmtpAttributesForPt(remotePt, remoteSection);
-        if (!remoteFmtpAttrs) {
-          localPts = localPts.concat(matchingLocalPts);
-          return;
-        }
-
-        const matchinglocalPt = matchingLocalPts.find(localPt => {
-          const localFmtpAttrs = getFmtpAttributesForPt(localPt, localSection);
-          return localFmtpAttrs && Object.keys(remoteFmtpAttrs).every(attr => {
-            return remoteFmtpAttrs[attr] === localFmtpAttrs[attr];
-          });
-        });
-
-        localPts = localPts.concat(typeof matchinglocalPt === 'number'
-          ? [matchinglocalPt]
-          : matchingLocalPts);
-      }
-    });
-
-    // For each local Payload Type that will be retained, retain their
-    // corresponding rtx Payload Type if present.
-    const localRtxPts = localCodecToPts.get('rtx') || [];
-    localPts = localPts.concat(localRtxPts.filter(rtxPt => {
-      const fmtpAttrs = getFmtpAttributesForPt(rtxPt, localSection);
-      return fmtpAttrs && localPts.includes(fmtpAttrs.apt);
-    }));
-
-    // Filter out all rtpmap/fmtp/rtcp-fb lines in the local m= section that do
-    // not belong to one of the local Payload Types that are to be retained.
-    const lines = localSection.split('\r\n').filter(line => {
-      const ptMatches = line.match(/^a=(rtpmap|fmtp|rtcp-fb):(.+) .+$/);
-      const pt = ptMatches && ptMatches[2];
-      return !ptMatches || (pt && localPts.includes(parseInt(pt, 10)));
-    });
-
-    // Filter the list of Payload Types in the first line of the m= section.
-    const orderedLocalPts = getPayloadTypesInMediaSection(localSection).filter(pt => localPts.includes(pt));
-    return setPayloadTypesInMediaSection(orderedLocalPts, lines.join('\r\n'));
+    return unifiedPlanFilterCodecsInLocalMediaSection(localSection, remoteMidsToMediaSections);
   })).join('\r\n');
 }
 

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -76,6 +76,22 @@ function createPtToCodecName(mediaSection) {
 }
 
 /**
+ * Get the associated fmtp attributes for the given Payload Type in an m= section.
+ * @param {PT} pt
+ * @param {string} mediaSection
+ * @returns {?object}
+ */
+function getFmtpAttributesForPt(pt, mediaSection) {
+  const fmtpRegex = new RegExp(`^a=fmtp:${pt} (.+)$`, 'm');
+  const matches = mediaSection.match(fmtpRegex);
+  return matches && matches[1].split(';').reduce((attrs, nvPair) => {
+    const [name, value] = nvPair.split('=');
+    attrs[name] = isNaN(value) ? value : parseInt(value, 10);
+    return attrs;
+  }, {});
+}
+
+/**
  * Get the m= sections of a particular kind and direction from an sdp.
  * @param {string} sdp - SDP string
  * @param {string} [kind] - Pattern for matching kind
@@ -191,6 +207,84 @@ function setPayloadTypesInMediaSection(payloadTypes, section) {
 }
 
 /**
+ * Filter local codecs based on the remote SDP.
+ * @param {string} localSdp
+ * @param {string} remoteSdp
+ * @returns {string} - Updated local SDP
+ */
+function filterLocalCodecs(localSdp, remoteSdp) {
+  const localMediaSections = getMediaSections(localSdp);
+  const localSession = localSdp.split('\r\nm=')[0];
+  const remoteMediaSections = getMediaSections(remoteSdp);
+  return [localSession].concat(localMediaSections.map((localSection, i) => {
+    // Do nothing if either the local m= section does not have an equivalent
+    // remote m= section or if it is not a video m= section.
+    if (i >= remoteMediaSections.length || !/^m=video/.test(localSection)) {
+      return localSection;
+    }
+
+    // Construct a map of the remote Payload Types to their codec names.
+    const remotePtToCodecs = createPtToCodecName(remoteMediaSections[i]);
+    // Construct a Map of the local codec names to their Payload Types.
+    const localCodecToPts = createCodecMapForMediaSection(localSection);
+    // Maintain a list of local Payload Types to retain.
+    let localPts = [];
+
+    // For each remote Payload Type, find its corresponding local Payload Type.
+    // If more than one local Payload Types are found, then find the one that has
+    // matching fmtp attributes in the local SDP.
+    remotePtToCodecs.forEach((remoteCodec, remotePt) => {
+      const matchingLocalPts = localCodecToPts.get(remoteCodec) || [];
+      if (matchingLocalPts.length === 1) {
+        localPts.push(matchingLocalPts[0]);
+        return;
+      }
+
+      if (matchingLocalPts.length > 1) {
+        const remoteFmtpAttrs = getFmtpAttributesForPt(remotePt, remoteMediaSections[i]);
+        if (!remoteFmtpAttrs) {
+          localPts = localPts.concat(matchingLocalPts);
+          return;
+        }
+
+        const matchinglocalPt = matchingLocalPts.find(localPt => {
+          const localFmtpAttrs = getFmtpAttributesForPt(localPt, localSection);
+          return localFmtpAttrs && Object.keys(remoteFmtpAttrs).every(attr => {
+            return remoteFmtpAttrs[attr] === localFmtpAttrs[attr];
+          });
+        });
+
+        localPts = localPts.concat(typeof matchinglocalPt === 'number'
+          ? [matchinglocalPt]
+          : matchingLocalPts);
+      }
+    });
+
+    // For each local Payload Type that will be retained, retain their
+    // corresponding rtx Payload Type if present.
+    const localRtxPts = localCodecToPts.get('rtx') || [];
+    localPts = localPts.concat(localRtxPts.filter(rtxPt => {
+      const fmtpAttrs = getFmtpAttributesForPt(rtxPt, localSection);
+      return fmtpAttrs && localPts.includes(fmtpAttrs.apt);
+    }));
+
+    // Filter out all rtpmap/fmtp/rtcp-fb lines in the local m= section that do
+    // not belong to one of the local Payload Types that are to be retained.
+    const lines = localSection.split('\r\n').filter(line => {
+      if (/^a=(rtpmap|fmtp|rtcp-fb):/.test(line)) {
+        const pt = (line.match(/^a=(rtpmap|fmtp|rtcp-fb):(.+) .+$/) || [])[2];
+        return pt && localPts.includes(parseInt(pt, 10));
+      }
+      return true;
+    });
+
+    // Also filter the list of Payload Types in the first line of the m= section.
+    const orderedLocalPts = getPayloadTypesInMediaSection(localSection).filter(pt => localPts.includes(pt));
+    return setPayloadTypesInMediaSection(orderedLocalPts, lines.join('\r\n'));
+  })).join('\r\n');
+}
+
+/**
  * Return a new SDP string with the re-ordered codec preferences.
  * @param {string} sdp
  * @param {Array<AudioCodec>} preferredAudioCodecs - If empty, the existing order
@@ -281,6 +375,7 @@ function unifiedPlanRewriteTrackIds(sdp, midsToTrackIds) {
 
 exports.createCodecMapForMediaSection = createCodecMapForMediaSection;
 exports.createPtToCodecName = createPtToCodecName;
+exports.filterLocalCodecs = filterLocalCodecs;
 exports.getMediaSections = getMediaSections;
 exports.setBitrateParameters = setBitrateParameters;
 exports.setCodecPreferences = setCodecPreferences;

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -94,6 +94,8 @@ function createPtToCodecName(mediaSection) {
  * @returns {?object}
  */
 function getFmtpAttributesForPt(pt, mediaSection) {
+  // In "a=fmtp:<pt> <name>=<value>[;<name>=<value>]*", the regex matches the codec
+  // profile parameters expressed as name/value pairs separated by ";".
   const fmtpRegex = new RegExp(`^a=fmtp:${pt} (.+)$`, 'm');
   const matches = mediaSection.match(fmtpRegex);
   return matches && matches[1].split(';').reduce((attrs, nvPair) => {
@@ -109,6 +111,7 @@ function getFmtpAttributesForPt(pt, mediaSection) {
  * @return {?string}
  */
 function getMidForMediaSection(mediaSection) {
+  // In "a=mid:<mid>", the regex matches <mid>.
   const midMatches = mediaSection.match(/^a=mid:(.+)$/m);
   return midMatches && midMatches[1];
 }
@@ -362,13 +365,17 @@ function unifiedPlanFilterCodecsInLocalMediaSection(localSection, remoteMidsToMe
   // For each local Payload Type that will be retained, retain their
   // corresponding rtx Payload Type if present.
   const localRtxPts = localCodecsToPts.get('rtx') || [];
+  // In "a=fmtp:<rtxPt> apt=<apt>", extract the codec PT <apt> associated with rtxPt.
   localPts = localPts.concat(localRtxPts.filter(rtxPt => {
     const fmtpAttrs = getFmtpAttributesForPt(rtxPt, localSection);
     return fmtpAttrs && localPts.includes(fmtpAttrs.apt);
   }));
 
-  // Filter out all rtpmap/fmtp/rtcp-fb lines in the local m= section that do
-  // not belong to one of the local Payload Types that are to be retained.
+  // Filter out the below mentioned attribute lines in the local m= section that
+  // do not belong to one of the local Payload Types that are to be retained.
+  // 1. "a=rtpmap:<pt> <codec>"
+  // 2. "a=rtcp-fb:<pt> <attr>[ <attr>]*"
+  // 3. "a=fmtp:<pt> <name>=<value>[;<name>=<value>]*"
   const lines = localSection.split('\r\n').filter(line => {
     const ptMatches = line.match(/^a=(rtpmap|fmtp|rtcp-fb):(.+) .+$/);
     const pt = ptMatches && ptMatches[2];

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -137,16 +137,16 @@ function getPayloadTypesInMediaSection(section) {
   const mLine = section.split('\r\n')[0];
 
   // In "m=<kind> <port> <proto> <payload_type_1> <payload_type_2> ... <payload_type_n>",
-  // the regex matches <port> and the PayloadTypes.
+  // the regex matches <port> and the Payload Types.
   const matches = mLine.match(/([0-9]+)/g);
 
-  // This should not happen, but in case there are no PayloadTypes in
+  // This should not happen, but in case there are no Payload Types in
   // the m= line, return an empty array.
   if (!matches) {
     return [];
   }
 
-  // Since only the PayloadTypes are needed, we discard the <port>.
+  // Since only the Payload Types are needed, we discard the <port>.
   return matches.slice(1).map(match => parseInt(match, 10));
 }
 
@@ -291,12 +291,12 @@ function setSimulcast(sdp, sdpFormat, trackIdsToAttributes) {
 
 /**
  * Get the matching Payload Types in a unified plan local m= section for a particular remote codec.
- * @param {string} remoteCodec
- * @param {PayloadType} remotePt
- * @param {Map<string, PayloadType>} localCodecsToPts
+ * @param {Codec} remoteCodec
+ * @param {PT} remotePt
+ * @param {Map<Codec, PT>} localCodecsToPts
  * @param {string} localSection
  * @param {string} remoteSection
- * @returns {Array<PayloadType>}
+ * @returns {Array<PT>}
  */
 function unifiedPlanGetMatchingLocalPayloadTypes(remoteCodec, remotePt, localCodecsToPts, localSection, remoteSection) {
   // If there is at most one local Payload Type that matches the remote codec, retain it.
@@ -417,11 +417,6 @@ function unifiedPlanRewriteTrackIds(sdp, midsToTrackIds) {
     return sdp;
   }, sdp);
 }
-
-/**
- * Codec Payload Type.
- * @typedef {number} PayloadType
- */
 
 exports.createCodecMapForMediaSection = createCodecMapForMediaSection;
 exports.createPtToCodecName = createPtToCodecName;

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -58,6 +58,18 @@ function createCodecMapForMediaSection(section) {
 }
 
 /**
+ * Create a Map of MIDs to m= sections for the given SDP.
+ * @param {string} sdp
+ * @returns {Map<string, string>}
+ */
+function createMidToMediaSectionMap(sdp) {
+  return getMediaSections(sdp).reduce((midsToMediaSections, mediaSection) => {
+    const mid = getMidForMediaSection(mediaSection);
+    return mid ? midsToMediaSections.set(mid, mediaSection) : midsToMediaSections;
+  }, new Map());
+}
+
+/**
  * Create a Map from PTs to codec names for the given m= section.
  * @param {string} mediaSection - The given m= section.
  * @returns {Map<PT, Codec>} ptToCodecName
@@ -89,6 +101,16 @@ function getFmtpAttributesForPt(pt, mediaSection) {
     attrs[name] = isNaN(value) ? value : parseInt(value, 10);
     return attrs;
   }, {});
+}
+
+/**
+ * Get the MID for the given m= section.
+ * @param {string} mediaSection
+ * @return {?string}
+ */
+function getMidForMediaSection(mediaSection) {
+  const midMatches = mediaSection.match(/^a=mid:(.+)$/m);
+  return midMatches && midMatches[1];
 }
 
 /**
@@ -207,84 +229,6 @@ function setPayloadTypesInMediaSection(payloadTypes, section) {
 }
 
 /**
- * Filter local codecs based on the remote SDP.
- * @param {string} localSdp
- * @param {string} remoteSdp
- * @returns {string} - Updated local SDP
- */
-function filterLocalCodecs(localSdp, remoteSdp) {
-  const localMediaSections = getMediaSections(localSdp);
-  const localSession = localSdp.split('\r\nm=')[0];
-  const remoteMediaSections = getMediaSections(remoteSdp);
-  return [localSession].concat(localMediaSections.map((localSection, i) => {
-    // Do nothing if either the local m= section does not have an equivalent
-    // remote m= section or if it is not a video m= section.
-    if (i >= remoteMediaSections.length || !/^m=video/.test(localSection)) {
-      return localSection;
-    }
-
-    // Construct a map of the remote Payload Types to their codec names.
-    const remotePtToCodecs = createPtToCodecName(remoteMediaSections[i]);
-    // Construct a Map of the local codec names to their Payload Types.
-    const localCodecToPts = createCodecMapForMediaSection(localSection);
-    // Maintain a list of local Payload Types to retain.
-    let localPts = [];
-
-    // For each remote Payload Type, find its corresponding local Payload Type.
-    // If more than one local Payload Types are found, then find the one that has
-    // matching fmtp attributes in the local SDP.
-    remotePtToCodecs.forEach((remoteCodec, remotePt) => {
-      const matchingLocalPts = localCodecToPts.get(remoteCodec) || [];
-      if (matchingLocalPts.length === 1) {
-        localPts.push(matchingLocalPts[0]);
-        return;
-      }
-
-      if (matchingLocalPts.length > 1) {
-        const remoteFmtpAttrs = getFmtpAttributesForPt(remotePt, remoteMediaSections[i]);
-        if (!remoteFmtpAttrs) {
-          localPts = localPts.concat(matchingLocalPts);
-          return;
-        }
-
-        const matchinglocalPt = matchingLocalPts.find(localPt => {
-          const localFmtpAttrs = getFmtpAttributesForPt(localPt, localSection);
-          return localFmtpAttrs && Object.keys(remoteFmtpAttrs).every(attr => {
-            return remoteFmtpAttrs[attr] === localFmtpAttrs[attr];
-          });
-        });
-
-        localPts = localPts.concat(typeof matchinglocalPt === 'number'
-          ? [matchinglocalPt]
-          : matchingLocalPts);
-      }
-    });
-
-    // For each local Payload Type that will be retained, retain their
-    // corresponding rtx Payload Type if present.
-    const localRtxPts = localCodecToPts.get('rtx') || [];
-    localPts = localPts.concat(localRtxPts.filter(rtxPt => {
-      const fmtpAttrs = getFmtpAttributesForPt(rtxPt, localSection);
-      return fmtpAttrs && localPts.includes(fmtpAttrs.apt);
-    }));
-
-    // Filter out all rtpmap/fmtp/rtcp-fb lines in the local m= section that do
-    // not belong to one of the local Payload Types that are to be retained.
-    const lines = localSection.split('\r\n').filter(line => {
-      if (/^a=(rtpmap|fmtp|rtcp-fb):/.test(line)) {
-        const pt = (line.match(/^a=(rtpmap|fmtp|rtcp-fb):(.+) .+$/) || [])[2];
-        return pt && localPts.includes(parseInt(pt, 10));
-      }
-      return true;
-    });
-
-    // Also filter the list of Payload Types in the first line of the m= section.
-    const orderedLocalPts = getPayloadTypesInMediaSection(localSection).filter(pt => localPts.includes(pt));
-    return setPayloadTypesInMediaSection(orderedLocalPts, lines.join('\r\n'));
-  })).join('\r\n');
-}
-
-/**
  * Return a new SDP string with the re-ordered codec preferences.
  * @param {string} sdp
  * @param {Array<AudioCodec>} preferredAudioCodecs - If empty, the existing order
@@ -346,6 +290,84 @@ function setSimulcast(sdp, sdpFormat, trackIdsToAttributes) {
 }
 
 /**
+ * Filter local codecs based on the remote unified plan SDP.
+ * @param {string} localSdp
+ * @param {string} remoteSdp
+ * @returns {string} - Updated local SDP
+ */
+function unifiedPlanFilterLocalCodecs(localSdp, remoteSdp) {
+  const localMediaSections = getMediaSections(localSdp);
+  const localSession = localSdp.split('\r\nm=')[0];
+  const remoteMidsToMediaSections = createMidToMediaSectionMap(remoteSdp);
+  return [localSession].concat(localMediaSections.map(localSection => {
+    const localMid = getMidForMediaSection(localSection);
+    const remoteSection = localMid && remoteMidsToMediaSections.get(localMid);
+    // Do nothing if either the local m= section does not have an equivalent
+    // remote m= section or if it is neither an audio nor a video m= section.
+    if (!(remoteSection && /^m=(audio|video)/.test(localSection))) {
+      return localSection;
+    }
+    // Construct a Map of the remote Payload Types to their codec names.
+    const remotePtToCodecs = createPtToCodecName(remoteSection);
+    // Construct a Map of the local codec names to their Payload Types.
+    const localCodecToPts = createCodecMapForMediaSection(localSection);
+    // Maintain a list of local Payload Types to retain.
+    let localPts = [];
+
+    remotePtToCodecs.forEach((remoteCodec, remotePt) => {
+      const matchingLocalPts = localCodecToPts.get(remoteCodec) || [];
+      // If there is only one local Payload Type that matches the remote codec,
+      // retain it.
+      if (matchingLocalPts.length === 1) {
+        localPts.push(matchingLocalPts[0]);
+        return;
+      }
+
+      // If there are more than one matching local Payload Types, then retain the
+      // one with matching fmtp attributes.
+      if (matchingLocalPts.length > 1) {
+        const remoteFmtpAttrs = getFmtpAttributesForPt(remotePt, remoteSection);
+        if (!remoteFmtpAttrs) {
+          localPts = localPts.concat(matchingLocalPts);
+          return;
+        }
+
+        const matchinglocalPt = matchingLocalPts.find(localPt => {
+          const localFmtpAttrs = getFmtpAttributesForPt(localPt, localSection);
+          return localFmtpAttrs && Object.keys(remoteFmtpAttrs).every(attr => {
+            return remoteFmtpAttrs[attr] === localFmtpAttrs[attr];
+          });
+        });
+
+        localPts = localPts.concat(typeof matchinglocalPt === 'number'
+          ? [matchinglocalPt]
+          : matchingLocalPts);
+      }
+    });
+
+    // For each local Payload Type that will be retained, retain their
+    // corresponding rtx Payload Type if present.
+    const localRtxPts = localCodecToPts.get('rtx') || [];
+    localPts = localPts.concat(localRtxPts.filter(rtxPt => {
+      const fmtpAttrs = getFmtpAttributesForPt(rtxPt, localSection);
+      return fmtpAttrs && localPts.includes(fmtpAttrs.apt);
+    }));
+
+    // Filter out all rtpmap/fmtp/rtcp-fb lines in the local m= section that do
+    // not belong to one of the local Payload Types that are to be retained.
+    const lines = localSection.split('\r\n').filter(line => {
+      const ptMatches = line.match(/^a=(rtpmap|fmtp|rtcp-fb):(.+) .+$/);
+      const pt = ptMatches && ptMatches[2];
+      return !ptMatches || (pt && localPts.includes(parseInt(pt, 10)));
+    });
+
+    // Filter the list of Payload Types in the first line of the m= section.
+    const orderedLocalPts = getPayloadTypesInMediaSection(localSection).filter(pt => localPts.includes(pt));
+    return setPayloadTypesInMediaSection(orderedLocalPts, lines.join('\r\n'));
+  })).join('\r\n');
+}
+
+/**
  * Rewrite MSIDs in the given Unified Plan SDP with their corresponding local
  * MediaStreamTrack IDs. These can be different when MediaStreamTracks are added
  * using RTCRtpSender.replaceTrack().
@@ -375,9 +397,9 @@ function unifiedPlanRewriteTrackIds(sdp, midsToTrackIds) {
 
 exports.createCodecMapForMediaSection = createCodecMapForMediaSection;
 exports.createPtToCodecName = createPtToCodecName;
-exports.filterLocalCodecs = filterLocalCodecs;
 exports.getMediaSections = getMediaSections;
 exports.setBitrateParameters = setBitrateParameters;
 exports.setCodecPreferences = setCodecPreferences;
 exports.setSimulcast = setSimulcast;
+exports.unifiedPlanFilterLocalCodecs = unifiedPlanFilterLocalCodecs;
 exports.unifiedPlanRewriteTrackIds = unifiedPlanRewriteTrackIds;

--- a/test/unit/spec/util/sdp/index.js
+++ b/test/unit/spec/util/sdp/index.js
@@ -498,7 +498,7 @@ v=0\r
 o=- 6385359508499371184 3 IN IP4 127.0.0.1\r
 s=-\r
 t=0 0\r
-a=group:BUNDLE 0 1\r
+a=group:BUNDLE 0 1 2\r
 a=msid-semantic: WMS 7a9d401b-3cf6-4216-b260-78f93ba4c32e\r
 m=audio 22602 UDP/TLS/RTP/SAVPF 111 103 104 9 0 8 106 105 13 110 112 113 126\r
 c=IN IP4 34.203.250.135\r
@@ -537,6 +537,90 @@ a=ice-options:trickle\r
 a=fingerprint:sha-256 BE:29:0C:60:05:B6:6E:E6:EA:A8:28:D5:89:41:F9:5B:22:11:CD:26:01:98:E0:55:9D:FE:C2:F8:EA:4C:17:91\r
 a=setup:actpass\r
 a=mid:1\r
+a=extmap:2 urn:ietf:params:rtp-hdrext:toffset\r
+a=extmap:3 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r
+a=extmap:4 urn:3gpp:video-orientation\r
+a=extmap:5 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01\r
+a=extmap:6 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay\r
+a=extmap:7 http://www.webrtc.org/experiments/rtp-hdrext/video-content-type\r
+a=extmap:8 http://www.webrtc.org/experiments/rtp-hdrext/video-timing\r
+a=sendrecv\r
+a=rtcp-mux\r
+a=rtcp-rsize\r
+a=rtpmap:96 VP8/90000\r
+a=rtcp-fb:96 goog-remb\r
+a=rtcp-fb:96 transport-cc\r
+a=rtcp-fb:96 ccm fir\r
+a=rtcp-fb:96 nack\r
+a=rtcp-fb:96 nack pli\r
+a=rtpmap:97 rtx/90000\r
+a=fmtp:97 apt=96\r
+a=rtpmap:99 rtx/90000\r
+a=fmtp:99 apt=98\r
+a=rtpmap:101 rtx/90000\r
+a=fmtp:101 apt=100\r
+a=rtpmap:123 rtx/90000\r
+a=fmtp:123 apt=102\r
+a=rtpmap:122 rtx/90000\r
+a=fmtp:122 apt=127\r
+a=rtpmap:107 rtx/90000\r
+a=fmtp:107 apt=125\r
+a=rtpmap:109 rtx/90000\r
+a=fmtp:109 apt=108\r
+a=rtpmap:98 VP9/90000\r
+a=rtcp-fb:98 goog-remb\r
+a=rtcp-fb:98 transport-cc\r
+a=rtcp-fb:98 ccm fir\r
+a=rtcp-fb:98 nack\r
+a=rtcp-fb:98 nack pli\r
+a=rtpmap:100 H264/90000\r
+a=rtcp-fb:100 goog-remb\r
+a=rtcp-fb:100 transport-cc\r
+a=rtcp-fb:100 ccm fir\r
+a=rtcp-fb:100 nack\r
+a=rtcp-fb:100 nack pli\r
+a=fmtp:100 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f\r
+a=rtpmap:102 H264/90000\r
+a=rtcp-fb:102 goog-remb\r
+a=rtcp-fb:102 transport-cc\r
+a=rtcp-fb:102 ccm fir\r
+a=rtcp-fb:102 nack\r
+a=rtcp-fb:102 nack pli\r
+a=fmtp:102 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f\r
+a=rtpmap:127 H264/90000\r
+a=rtcp-fb:127 goog-remb\r
+a=rtcp-fb:127 transport-cc\r
+a=rtcp-fb:127 ccm fir\r
+a=rtcp-fb:127 nack\r
+a=rtcp-fb:127 nack pli\r
+a=fmtp:127 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=4d0032\r
+a=rtpmap:125 H264/90000\r
+a=rtcp-fb:125 goog-remb\r
+a=rtcp-fb:125 transport-cc\r
+a=rtcp-fb:125 ccm fir\r
+a=rtcp-fb:125 nack\r
+a=rtcp-fb:125 nack pli\r
+a=fmtp:125 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640032\r
+a=rtpmap:108 red/90000\r
+a=rtpmap:124 ulpfec/90000\r
+a=ssrc-group:FID 0000000000 1111111111\r
+a=ssrc:0000000000 cname:s9hDwDQNjISOxWtK\r
+a=ssrc:0000000000 msid:7a9d401b-3cf6-4216-b260-78f93ba4c32e d8b9a935-da54-4d21-a8de-522c87258244\r
+a=ssrc:0000000000 mslabel:7a9d401b-3cf6-4216-b260-78f93ba4c32e\r
+a=ssrc:0000000000 label:d8b9a935-da54-4d21-a8de-522c87258244\r
+a=ssrc:1111111111 cname:s9hDwDQNjISOxWtK\r
+a=ssrc:1111111111 msid:7a9d401b-3cf6-4216-b260-78f93ba4c32e d8b9a935-da54-4d21-a8de-522c87258244\r
+a=ssrc:1111111111 mslabel:7a9d401b-3cf6-4216-b260-78f93ba4c32e\r
+a=ssrc:1111111111 label:d8b9a935-da54-4d21-a8de-522c87258244\r
+m=video 9 UDP/TLS/RTP/SAVPF 96 97 99 101 123 122 107 109 98 100 102 127 125 108 124\r
+c=IN IP4 0.0.0.0\r
+a=rtcp:9 IN IP4 0.0.0.0\r
+a=ice-ufrag:Cmuk\r
+a=ice-pwd:qjHlb5sxe0bozbwpRSYqil3v\r
+a=ice-options:trickle\r
+a=fingerprint:sha-256 BE:29:0C:60:05:B6:6E:E6:EA:A8:28:D5:89:41:F9:5B:22:11:CD:26:01:98:E0:55:9D:FE:C2:F8:EA:4C:17:91\r
+a=setup:actpass\r
+a=mid:2\r
 a=extmap:2 urn:ietf:params:rtp-hdrext:toffset\r
 a=extmap:3 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r
 a=extmap:4 urn:3gpp:video-orientation\r
@@ -675,24 +759,24 @@ a=ssrc:1111111111 label:d8b9a935-da54-4d21-a8de-522c87258244\r
 `;
 
     const filteredLocalSdp = unifiedPlanFilterLocalCodecs(localSdp, remoteSdp);
-    const audioSection = getMediaSections(filteredLocalSdp, 'audio')[0];
-    const videoSection = getMediaSections(filteredLocalSdp, 'video')[0];
+    const [audioSection, videoSection, newVideoSection] = getMediaSections(localSdp);
+    const [filteredAudioSection, filteredVideoSection, filteredNewVideoSection] = getMediaSections(filteredLocalSdp);
 
     [
-      ['audio', audioSection, [111, 0], [103, 104, 9, 8, 106, 105, 13, 110, 112, 113, 126]],
-      ['video', videoSection, [123, 102], [96, 97, 99, 101, 122, 107, 109, 98, 100, 127, 125, 108, 124]]
-    ].forEach(([kind, section, expectedPtsRetained, expectedPtsFiltered]) => {
+      ['audio', filteredAudioSection, audioSection, [111, 0], [103, 104, 9, 8, 106, 105, 13, 110, 112, 113, 126]],
+      ['video', filteredVideoSection, videoSection, [123, 102], [96, 97, 99, 101, 122, 107, 109, 98, 100, 127, 125, 108, 124]]
+    ].forEach(([kind, filteredSection, section, expectedPtsRetained, expectedPtsFiltered]) => {
       const mLineRegex = new RegExp(`^m=${kind} .+ ${expectedPtsRetained.join(' ')}$`, 'm');
-      assert(mLineRegex.test(section));
+      assert(mLineRegex.test(filteredSection));
 
       expectedPtsRetained.forEach(pt => {
         ['rtpmap', 'rtcp-fb', 'fmtp'].forEach(attr => {
           const attrRegex = new RegExp(`^a=${attr}:${pt} (.+)$`, 'm');
-          const localSdpMatch = localSdp.match(attrRegex);
-          const filteredLocalSdpMatch = filteredLocalSdp.match(attrRegex);
-          assert.equal(!!filteredLocalSdpMatch, !!localSdpMatch);
-          if (filteredLocalSdpMatch) {
-            assert.equal(filteredLocalSdpMatch[1], localSdpMatch[1]);
+          const match = section.match(attrRegex);
+          const filteredMatch = filteredSection.match(attrRegex);
+          assert.equal(!!filteredMatch, !!match);
+          if (filteredMatch) {
+            assert.equal(filteredMatch[1], match[1]);
           }
         });
       });
@@ -700,9 +784,11 @@ a=ssrc:1111111111 label:d8b9a935-da54-4d21-a8de-522c87258244\r
       expectedPtsFiltered.forEach(pt => {
         ['rtpmap', 'rtcp-fb', 'fmtp'].forEach(attr => {
           const attrRegex = new RegExp(`^a=${attr}:${pt} .+$`, 'm');
-          assert(!attrRegex.test(filteredLocalSdp));
+          assert(!attrRegex.test(filteredSection));
         });
       });
+
+      assert.equal(filteredNewVideoSection, newVideoSection);
     });
   });
 });

--- a/test/unit/spec/util/sdp/index.js
+++ b/test/unit/spec/util/sdp/index.js
@@ -9,6 +9,7 @@ const {
   setBitrateParameters,
   setCodecPreferences,
   setSimulcast,
+  unifiedPlanFilterLocalCodecs,
   unifiedPlanRewriteTrackIds
 } = require('../../../../../lib/util/sdp');
 
@@ -486,6 +487,222 @@ a=ssrc:0000000000 label:d8b9a935-da54-4d21-a8de-522c87258244\r
 
       const ssrcs2 = new Set(simSdp2.match(/a=ssrc:[0-9]+/g).map(line => line.match(/a=ssrc:([0-9]+)/)[1]));
       assert.equal(ssrcs2.size, 3, 'RTX is disabled; therefore, there should be just 3 SSRCs in the SDP');
+    });
+  });
+});
+
+describe('unifiedPlanFilterLocalCodecs', () => {
+  it('should filter codecs in a local SDP based on those advertised in the remote SDP', () => {
+    const localSdp = `\
+v=0\r
+o=- 6385359508499371184 3 IN IP4 127.0.0.1\r
+s=-\r
+t=0 0\r
+a=group:BUNDLE 0 1\r
+a=msid-semantic: WMS 7a9d401b-3cf6-4216-b260-78f93ba4c32e\r
+m=audio 22602 UDP/TLS/RTP/SAVPF 111 103 104 9 0 8 106 105 13 110 112 113 126\r
+c=IN IP4 34.203.250.135\r
+a=rtcp:9 IN IP4 0.0.0.0\r
+a=candidate:2235265311 1 udp 7935 34.203.250.135 22602 typ relay raddr 107.20.226.156 rport 51463 generation 0 network-cost 50\r
+a=ice-ufrag:Cmuk\r
+a=ice-pwd:qjHlb5sxe0bozbwpRSYqil3v\r
+a=ice-options:trickle\r
+a=fingerprint:sha-256 BE:29:0C:60:05:B6:6E:E6:EA:A8:28:D5:89:41:F9:5B:22:11:CD:26:01:98:E0:55:9D:FE:C2:F8:EA:4C:17:91\r
+a=setup:actpass\r
+a=mid:0\r
+a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r
+a=sendrecv\r
+a=rtcp-mux\r
+a=rtpmap:111 opus/48000/2\r
+a=rtcp-fb:111 transport-cc\r
+a=fmtp:111 minptime=10;useinbandfec=1\r
+a=rtpmap:103 ISAC/16000\r
+a=rtpmap:104 ISAC/32000\r
+a=rtpmap:9 G722/8000\r
+a=rtpmap:0 PCMU/8000\r
+a=rtpmap:8 PCMA/8000\r
+a=rtpmap:106 CN/32000\r
+a=rtpmap:105 CN/16000\r
+a=rtpmap:13 CN/8000\r
+a=rtpmap:110 telephone-event/48000\r
+a=rtpmap:112 telephone-event/32000\r
+a=rtpmap:113 telephone-event/16000\r
+a=rtpmap:126 telephone-event/8000\r
+m=video 9 UDP/TLS/RTP/SAVPF 96 97 99 101 123 122 107 109 98 100 102 127 125 108 124\r
+c=IN IP4 0.0.0.0\r
+a=rtcp:9 IN IP4 0.0.0.0\r
+a=ice-ufrag:Cmuk\r
+a=ice-pwd:qjHlb5sxe0bozbwpRSYqil3v\r
+a=ice-options:trickle\r
+a=fingerprint:sha-256 BE:29:0C:60:05:B6:6E:E6:EA:A8:28:D5:89:41:F9:5B:22:11:CD:26:01:98:E0:55:9D:FE:C2:F8:EA:4C:17:91\r
+a=setup:actpass\r
+a=mid:1\r
+a=extmap:2 urn:ietf:params:rtp-hdrext:toffset\r
+a=extmap:3 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r
+a=extmap:4 urn:3gpp:video-orientation\r
+a=extmap:5 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01\r
+a=extmap:6 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay\r
+a=extmap:7 http://www.webrtc.org/experiments/rtp-hdrext/video-content-type\r
+a=extmap:8 http://www.webrtc.org/experiments/rtp-hdrext/video-timing\r
+a=sendrecv\r
+a=rtcp-mux\r
+a=rtcp-rsize\r
+a=rtpmap:96 VP8/90000\r
+a=rtcp-fb:96 goog-remb\r
+a=rtcp-fb:96 transport-cc\r
+a=rtcp-fb:96 ccm fir\r
+a=rtcp-fb:96 nack\r
+a=rtcp-fb:96 nack pli\r
+a=rtpmap:97 rtx/90000\r
+a=fmtp:97 apt=96\r
+a=rtpmap:99 rtx/90000\r
+a=fmtp:99 apt=98\r
+a=rtpmap:101 rtx/90000\r
+a=fmtp:101 apt=100\r
+a=rtpmap:123 rtx/90000\r
+a=fmtp:123 apt=102\r
+a=rtpmap:122 rtx/90000\r
+a=fmtp:122 apt=127\r
+a=rtpmap:107 rtx/90000\r
+a=fmtp:107 apt=125\r
+a=rtpmap:109 rtx/90000\r
+a=fmtp:109 apt=108\r
+a=rtpmap:98 VP9/90000\r
+a=rtcp-fb:98 goog-remb\r
+a=rtcp-fb:98 transport-cc\r
+a=rtcp-fb:98 ccm fir\r
+a=rtcp-fb:98 nack\r
+a=rtcp-fb:98 nack pli\r
+a=rtpmap:100 H264/90000\r
+a=rtcp-fb:100 goog-remb\r
+a=rtcp-fb:100 transport-cc\r
+a=rtcp-fb:100 ccm fir\r
+a=rtcp-fb:100 nack\r
+a=rtcp-fb:100 nack pli\r
+a=fmtp:100 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f\r
+a=rtpmap:102 H264/90000\r
+a=rtcp-fb:102 goog-remb\r
+a=rtcp-fb:102 transport-cc\r
+a=rtcp-fb:102 ccm fir\r
+a=rtcp-fb:102 nack\r
+a=rtcp-fb:102 nack pli\r
+a=fmtp:102 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f\r
+a=rtpmap:127 H264/90000\r
+a=rtcp-fb:127 goog-remb\r
+a=rtcp-fb:127 transport-cc\r
+a=rtcp-fb:127 ccm fir\r
+a=rtcp-fb:127 nack\r
+a=rtcp-fb:127 nack pli\r
+a=fmtp:127 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=4d0032\r
+a=rtpmap:125 H264/90000\r
+a=rtcp-fb:125 goog-remb\r
+a=rtcp-fb:125 transport-cc\r
+a=rtcp-fb:125 ccm fir\r
+a=rtcp-fb:125 nack\r
+a=rtcp-fb:125 nack pli\r
+a=fmtp:125 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640032\r
+a=rtpmap:108 red/90000\r
+a=rtpmap:124 ulpfec/90000\r
+a=ssrc-group:FID 0000000000 1111111111\r
+a=ssrc:0000000000 cname:s9hDwDQNjISOxWtK\r
+a=ssrc:0000000000 msid:7a9d401b-3cf6-4216-b260-78f93ba4c32e d8b9a935-da54-4d21-a8de-522c87258244\r
+a=ssrc:0000000000 mslabel:7a9d401b-3cf6-4216-b260-78f93ba4c32e\r
+a=ssrc:0000000000 label:d8b9a935-da54-4d21-a8de-522c87258244\r
+a=ssrc:1111111111 cname:s9hDwDQNjISOxWtK\r
+a=ssrc:1111111111 msid:7a9d401b-3cf6-4216-b260-78f93ba4c32e d8b9a935-da54-4d21-a8de-522c87258244\r
+a=ssrc:1111111111 mslabel:7a9d401b-3cf6-4216-b260-78f93ba4c32e\r
+a=ssrc:1111111111 label:d8b9a935-da54-4d21-a8de-522c87258244\r
+`;
+    const remoteSdp = `\
+v=0\r
+o=- 6385359508499371184 3 IN IP4 127.0.0.1\r
+s=-\r
+t=0 0\r
+a=group:BUNDLE 0 1\r
+a=msid-semantic: WMS 7a9d401b-3cf6-4216-b260-78f93ba4c32e\r
+m=audio 22602 UDP/TLS/RTP/SAVPF 111 0\r
+c=IN IP4 34.203.250.135\r
+a=rtcp:9 IN IP4 0.0.0.0\r
+a=candidate:2235265311 1 udp 7935 34.203.250.135 22602 typ relay raddr 107.20.226.156 rport 51463 generation 0 network-cost 50\r
+a=ice-ufrag:Cmuk\r
+a=ice-pwd:qjHlb5sxe0bozbwpRSYqil3v\r
+a=ice-options:trickle\r
+a=fingerprint:sha-256 BE:29:0C:60:05:B6:6E:E6:EA:A8:28:D5:89:41:F9:5B:22:11:CD:26:01:98:E0:55:9D:FE:C2:F8:EA:4C:17:91\r
+a=setup:actpass\r
+a=mid:0\r
+a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r
+a=recvonly\r
+a=rtcp-mux\r
+a=rtpmap:111 opus/48000/2\r
+a=rtcp-fb:111 transport-cc\r
+a=fmtp:111 minptime=10;useinbandfec=1\r
+a=rtpmap:0 PCMU/8000\r
+m=video 9 UDP/TLS/RTP/SAVPF 102\r
+c=IN IP4 0.0.0.0\r
+a=rtcp:9 IN IP4 0.0.0.0\r
+a=ice-ufrag:Cmuk\r
+a=ice-pwd:qjHlb5sxe0bozbwpRSYqil3v\r
+a=ice-options:trickle\r
+a=fingerprint:sha-256 BE:29:0C:60:05:B6:6E:E6:EA:A8:28:D5:89:41:F9:5B:22:11:CD:26:01:98:E0:55:9D:FE:C2:F8:EA:4C:17:91\r
+a=setup:actpass\r
+a=mid:1\r
+a=extmap:2 urn:ietf:params:rtp-hdrext:toffset\r
+a=extmap:3 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r
+a=extmap:4 urn:3gpp:video-orientation\r
+a=extmap:5 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01\r
+a=extmap:6 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay\r
+a=extmap:7 http://www.webrtc.org/experiments/rtp-hdrext/video-content-type\r
+a=extmap:8 http://www.webrtc.org/experiments/rtp-hdrext/video-timing\r
+a=recvonly\r
+a=rtcp-mux\r
+a=rtcp-rsize\r
+a=rtpmap:102 H264/90000\r
+a=rtcp-fb:102 goog-remb\r
+a=rtcp-fb:102 transport-cc\r
+a=rtcp-fb:102 ccm fir\r
+a=rtcp-fb:102 nack\r
+a=rtcp-fb:102 nack pli\r
+a=fmtp:102 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f\r
+a=ssrc-group:FID 0000000000 1111111111\r
+a=ssrc:0000000000 cname:s9hDwDQNjISOxWtK\r
+a=ssrc:0000000000 msid:7a9d401b-3cf6-4216-b260-78f93ba4c32e d8b9a935-da54-4d21-a8de-522c87258244\r
+a=ssrc:0000000000 mslabel:7a9d401b-3cf6-4216-b260-78f93ba4c32e\r
+a=ssrc:0000000000 label:d8b9a935-da54-4d21-a8de-522c87258244\r
+a=ssrc:1111111111 cname:s9hDwDQNjISOxWtK\r
+a=ssrc:1111111111 msid:7a9d401b-3cf6-4216-b260-78f93ba4c32e d8b9a935-da54-4d21-a8de-522c87258244\r
+a=ssrc:1111111111 mslabel:7a9d401b-3cf6-4216-b260-78f93ba4c32e\r
+a=ssrc:1111111111 label:d8b9a935-da54-4d21-a8de-522c87258244\r
+`;
+
+    const filteredLocalSdp = unifiedPlanFilterLocalCodecs(localSdp, remoteSdp);
+    const audioSection = getMediaSections(filteredLocalSdp, 'audio')[0];
+    const videoSection = getMediaSections(filteredLocalSdp, 'video')[0];
+
+    [
+      ['audio', audioSection, [111, 0], [103, 104, 9, 8, 106, 105, 13, 110, 112, 113, 126]],
+      ['video', videoSection, [123, 102], [96, 97, 99, 101, 122, 107, 109, 98, 100, 127, 125, 108, 124]]
+    ].forEach(([kind, section, expectedPtsRetained, expectedPtsFiltered]) => {
+      const mLineRegex = new RegExp(`^m=${kind} .+ ${expectedPtsRetained.join(' ')}$`, 'm');
+      assert(mLineRegex.test(section));
+
+      expectedPtsRetained.forEach(pt => {
+        ['rtpmap', 'rtcp-fb', 'fmtp'].forEach(attr => {
+          const attrRegex = new RegExp(`^a=${attr}:${pt} (.+)$`, 'm');
+          const localSdpMatch = localSdp.match(attrRegex);
+          const filteredLocalSdpMatch = filteredLocalSdp.match(attrRegex);
+          assert.equal(!!filteredLocalSdpMatch, !!localSdpMatch);
+          if (filteredLocalSdpMatch) {
+            assert.equal(filteredLocalSdpMatch[1], localSdpMatch[1]);
+          }
+        });
+      });
+
+      expectedPtsFiltered.forEach(pt => {
+        ['rtpmap', 'rtcp-fb', 'fmtp'].forEach(attr => {
+          const attrRegex = new RegExp(`^a=${attr}:${pt} .+$`, 'm');
+          assert(!attrRegex.test(filteredLocalSdp));
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
@syerrapragada @makarandp0 

This PR attempts to mitigate the issues found in [JSDK-2357](https://issues.corp.twilio.com/browse/JSDK-2357), where the signaling transport closes due to large SDP sizes if more than 10-12 Participants are in a Group Room with 1 audio and 1 video Track.

The main reason why this happens is the browser supports more codecs than those supported by VMS, and each of these extra codecs/profiles add significantly to the size of each m= section. The function `unifiedPlanFilterLocalCodecs` in `lib/util/sdp/index.js` filters the codecs in the m=sections of the local SDP based on the codecs present in the corresponding m= sections in the remote SDP.

According to @syerrapragada 's initial tests, the signaling transport can handle about 23 Participants in a Group Room with this change. Your feedback is greatly appreciated.

## TODO

- [x] Unit tests for `unifiedPlanFilterLocalCodecs`
- [x] Smoke tests on Simpler Signaling