### PR TITLE
JSDK-2368 Consider only non-rtx payload types in the remote RTCSessionDescription while filtering local codecs.

### DIFF
--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -354,13 +354,15 @@ function unifiedPlanFilterCodecsInLocalMediaSection(localSection, remoteMidsToMe
   const remotePtToCodecs = createPtToCodecName(remoteSection);
   // Construct a Map of the local codec names to their Payload Types.
   const localCodecsToPts = createCodecMapForMediaSection(localSection);
-  // Maintain a list of local Payload Types to retain.
-  let localPts = flatMap(Array.from(remotePtToCodecs), ([remotePt, remoteCodec]) => unifiedPlanGetMatchingLocalPayloadTypes(
-    remoteCodec,
-    remotePt,
-    localCodecsToPts,
-    localSection,
-    remoteSection));
+  // Maintain a list of local non-rtx Payload Types to retain.
+  let localPts = flatMap(Array.from(remotePtToCodecs), ([remotePt, remoteCodec]) => remoteCodec !== 'rtx'
+    ? unifiedPlanGetMatchingLocalPayloadTypes(
+        remoteCodec,
+        remotePt,
+        localCodecsToPts,
+        localSection,
+        remoteSection)
+    : []);
 
   // For each local Payload Type that will be retained, retain their
   // corresponding rtx Payload Type if present.

--- a/test/unit/spec/util/sdp/index.js
+++ b/test/unit/spec/util/sdp/index.js
@@ -721,7 +721,7 @@ a=rtpmap:111 opus/48000/2\r
 a=rtcp-fb:111 transport-cc\r
 a=fmtp:111 minptime=10;useinbandfec=1\r
 a=rtpmap:0 PCMU/8000\r
-m=video 9 UDP/TLS/RTP/SAVPF 102 22\r
+m=video 9 UDP/TLS/RTP/SAVPF 99 22\r
 c=IN IP4 0.0.0.0\r
 a=rtcp:9 IN IP4 0.0.0.0\r
 a=ice-ufrag:Cmuk\r
@@ -740,15 +740,15 @@ a=extmap:8 http://www.webrtc.org/experiments/rtp-hdrext/video-timing\r
 a=recvonly\r
 a=rtcp-mux\r
 a=rtcp-rsize\r
-a=rtpmap:102 H264/90000\r
-a=rtcp-fb:102 goog-remb\r
-a=rtcp-fb:102 transport-cc\r
-a=rtcp-fb:102 ccm fir\r
-a=rtcp-fb:102 nack\r
-a=rtcp-fb:102 nack pli\r
-a=fmtp:102 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f\r
+a=rtpmap:99 H264/90000\r
+a=rtcp-fb:99 goog-remb\r
+a=rtcp-fb:99 transport-cc\r
+a=rtcp-fb:99 ccm fir\r
+a=rtcp-fb:99 nack\r
+a=rtcp-fb:99 nack pli\r
+a=fmtp:99 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f\r
 a=rtpmap:22 rtx/90000\r
-a=fmtp:22 apt=102\r
+a=fmtp:22 apt=99\r
 a=ssrc-group:FID 0000000000 1111111111\r
 a=ssrc:0000000000 cname:s9hDwDQNjISOxWtK\r
 a=ssrc:0000000000 msid:7a9d401b-3cf6-4216-b260-78f93ba4c32e d8b9a935-da54-4d21-a8de-522c87258244\r

--- a/test/unit/spec/util/sdp/index.js
+++ b/test/unit/spec/util/sdp/index.js
@@ -721,7 +721,7 @@ a=rtpmap:111 opus/48000/2\r
 a=rtcp-fb:111 transport-cc\r
 a=fmtp:111 minptime=10;useinbandfec=1\r
 a=rtpmap:0 PCMU/8000\r
-m=video 9 UDP/TLS/RTP/SAVPF 102\r
+m=video 9 UDP/TLS/RTP/SAVPF 102 22\r
 c=IN IP4 0.0.0.0\r
 a=rtcp:9 IN IP4 0.0.0.0\r
 a=ice-ufrag:Cmuk\r
@@ -747,6 +747,8 @@ a=rtcp-fb:102 ccm fir\r
 a=rtcp-fb:102 nack\r
 a=rtcp-fb:102 nack pli\r
 a=fmtp:102 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f\r
+a=rtpmap:22 rtx/90000\r
+a=fmtp:22 apt=102\r
 a=ssrc-group:FID 0000000000 1111111111\r
 a=ssrc:0000000000 cname:s9hDwDQNjISOxWtK\r
 a=ssrc:0000000000 msid:7a9d401b-3cf6-4216-b260-78f93ba4c32e d8b9a935-da54-4d21-a8de-522c87258244\r


### PR DESCRIPTION
@syerrapragada @makarandp0 

This PR fixes [JSDK-2368](https://issues.corp.twilio.com/browse/JSDK-2368), which was being caused due to a bug in the filtering logic where rtx payload types for filtered codecs were being retained. For ex, if the codec payload type 50 was removed, we would still retain the rtx payload type with `apt=50`.

The solution is to not consider rtx payload types in the remote RTCSessionDescription while constructing a list of local codecs to retain.