### PR TITLE
JSDK-2370 fix doc annotation error

### DIFF
--- a/lib/media/track/remoteaudiotrackpublication.js
+++ b/lib/media/track/remoteaudiotrackpublication.js
@@ -37,7 +37,7 @@ class RemoteAudioTrackPublication extends RemoteTrackPublication {
  */
 
 /**
- * Your {@link LocalParticipant failed to subscribe to the {@link RemoteAudioTrack}.
+ * Your {@link LocalParticipant} failed to subscribe to the {@link RemoteAudioTrack}.
  * @param {TwilioError} error - the reason the {@link RemoteAudioTrack} could not be
  *   subscribed to
  * @event RemoteAudioTrackPublication#subscriptionFailed

--- a/lib/media/track/remotedatatrackpublication.js
+++ b/lib/media/track/remotedatatrackpublication.js
@@ -35,7 +35,7 @@ class RemoteDataTrackPublication extends RemoteTrackPublication {
  */
 
 /**
- * Your {@link LocalParticipant failed to subscribe to the {@link RemoteDataTrack}.
+ * Your {@link LocalParticipant} failed to subscribe to the {@link RemoteDataTrack}.
  * @param {TwilioError} error - the reason the {@link RemoteDataTrack} could not be
  *   subscribed to
  * @event RemoteDataTrackPublication#subscriptionFailed

--- a/lib/media/track/remotetrackpublication.js
+++ b/lib/media/track/remotetrackpublication.js
@@ -106,7 +106,7 @@ class RemoteTrackPublication extends TrackPublication {
  */
 
 /**
- * Your {@link LocalParticipant failed to subscribe to the {@link RemoteTrack}.
+ * Your {@link LocalParticipant} failed to subscribe to the {@link RemoteTrack}.
  * @param {TwilioError} error - the reason the {@link RemoteTrack} could not be
  *   subscribed to
  * @event RemoteTrackPublication#subscriptionFailed

--- a/lib/media/track/remotevideotrackpublication.js
+++ b/lib/media/track/remotevideotrackpublication.js
@@ -37,7 +37,7 @@ class RemoteVideoTrackPublication extends RemoteTrackPublication {
  */
 
 /**
- * Your {@link LocalParticipant failed to subscribe to the {@link RemoteVideoTrack}.
+ * Your {@link LocalParticipant} failed to subscribe to the {@link RemoteVideoTrack}.
  * @param {TwilioError} error - the reason the {@link RemoteVideoTrack} could not be
  *   subscribed to
  * @event RemoteVideoTrackPublication#subscriptionFailed


### PR DESCRIPTION
This change fixes error in doc annotation.

after
```
~/work/twilio-video.js> npm run docs

> twilio-video@2.0.0-dev docs /Users/mpatwardhan/work/twilio-video.js
> node ./scripts/docs.js ./dist/docs

(node:72097) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
~/work/twilio-video.js> 
```

before:
```
~/work/twilio-video.js> npm run docs

> twilio-video@2.0.0-dev docs /Users/mpatwardhan/work/twilio-video.js
> node ./scripts/docs.js ./dist/docs

Error: unable to parse RemoteAudioTrack</a>.</p>: Expected "!", "$", "'", "(", "*", ".", "...", "0", "?", "@", "Function", "\"", "\\", "_", "break", "case", "catch", "class", "const", "continue", "debugger", "default", "delete", "do", "else", "enum", "export", "extends", "false", "finally", "for", "function", "if", "implements", "import", "in", "instanceof", "interface", "let", "new", "null", "package", "private", "protected", "public", "return", "static", "super", "switch", "this", "throw", "true", "try", "typeof", "undefined", "var", "void", "while", "with", "yield", "{", Unicode letter number, Unicode lowercase letter, Unicode modifier letter, Unicode other letter, Unicode titlecase letter, Unicode uppercase letter or [1-9] but "/" found.
    at parseType (/Users/mpatwardhan/work/twilio-video.js/node_modules/jsdoc/lib/jsdoc/util/templateHelper.js:255:15)
    at buildLink (/Users/mpatwardhan/work/twilio-video.js/node_modules/jsdoc/lib/jsdoc/util/templateHelper.js:332:22)
    at processLink (/Users/mpatwardhan/work/twilio-video.js/node_modules/jsdoc/lib/jsdoc/util/templateHelper.js:544:53)
    at replaceMatch (/Users/mpatwardhan/work/twilio-video.js/node_modules/jsdoc/lib/jsdoc/tag/inline.js:91:16)
    at /Users/mpatwardhan/work/twilio-video.js/node_modules/jsdoc/lib/jsdoc/tag/inline.js:106:26
    at Array.forEach (<anonymous>)
    at Object.exports.replaceInlineTags (/Users/mpatwardhan/work/twilio-video.js/node_modules/jsdoc/lib/jsdoc/tag/inline.js:96:28)
    at Object.exports.resolveLinks (/Users/mpatwardhan/work/twilio-video.js/node_modules/jsdoc/lib/jsdoc/util/templateHelper.js:565:19)
    at generate (/Users/mpatwardhan/work/twilio-video.js/node_modules/ink-docstrap/template/publish.js:272:19)
    at Object.exports.publish (/Users/mpatwardhan/work/twilio-video.js/node_modules/ink-docstrap/template/publish.js:729:5)
    at Object.module.exports.cli.generateDocs (/Users/mpatwardhan/work/twilio-video.js/node_modules/jsdoc/cli.js:448:35)
    at Object.module.exports.cli.processParseResults (/Users/mpatwardhan/work/twilio-video.js/node_modules/jsdoc/cli.js:399:20)
    at module.exports.cli.main (/Users/mpatwardhan/work/twilio-video.js/node_modules/jsdoc/cli.js:240:14)
    at Object.module.exports.cli.runCommand (/Users/mpatwardhan/work/twilio-video.js/node_modules/jsdoc/cli.js:189:5)
    at /Users/mpatwardhan/work/twilio-video.js/node_modules/jsdoc/jsdoc.js:105:9
    at Object.<anonymous> (/Users/mpatwardhan/work/twilio-video.js/node_modules/jsdoc/jsdoc.js:106:3)
```

