### PR TITLE
JSDK-2381 Rewriting Track IDs in local SDPs with the Track IDs signaled via RSP.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ addons:
     packages:
       - pulseaudio
 
+# https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-directly
+dist: trusty
+
 env:
   global:
     - DBUS_SESSION_BUS_ADDRESS=/dev/null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/support-1.x/CHANGELOG.md).
 
+2.0.0-beta10 (in progress)
+==========================
+
+Bug Fixes
+---------
+
+- Fixed a bug where Participants on Firefox 68 or above were unable to publish
+  LocalAudioTracks or LocalVideoTracks. (JSDK-2381)
+
 2.0.0-beta9 (May 2, 2019)
 =========================
 

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -13,6 +13,7 @@ const oncePerTick = require('../../util').oncePerTick;
 const setBitrateParameters = require('../../util/sdp').setBitrateParameters;
 const setCodecPreferences = require('../../util/sdp').setCodecPreferences;
 const setSimulcast = require('../../util/sdp').setSimulcast;
+const unifiedPlanRewriteTrackIds = require('../../util/sdp').unifiedPlanRewriteTrackIds;
 const IceBox = require('./icebox');
 const MediaClientLocalDescFailedError = require('../../util/twilio-video-errors').MediaClientLocalDescFailedError;
 const MediaClientRemoteDescFailedError = require('../../util/twilio-video-errors').MediaClientRemoteDescFailedError;
@@ -583,6 +584,24 @@ class PeerConnectionV2 extends StateMachine {
   }
 
   /**
+   * Rewrite local MediaStreamTrack IDs in the given Unified Plan RTCSessionDescription.
+   * @private
+   * @param {RTCSessionDescription} description
+   * @return {RTCSessionDescription}
+   */
+  _rewriteLocalTrackIds(description) {
+    const midsToTrackIds = new Map(this._peerConnection.getTransceivers().filter(({ mid, sender, stopped }) => {
+      return !stopped && mid && sender && sender.track;
+    }).map(({ mid, sender }) => {
+      return [mid, sender.track.id];
+    }));
+    return new this._RTCSessionDescription({
+      sdp: unifiedPlanRewriteTrackIds(description.sdp, midsToTrackIds),
+      type: description.type
+    });
+  }
+
+  /**
    * Set a local description on the {@link PeerConnectionV2}.
    * @private
    * @param {RTCSessionDescription|RTCSessionDescriptionInit} description
@@ -613,7 +632,7 @@ class PeerConnectionV2 extends StateMachine {
       throw new MediaClientLocalDescFailedError();
     }).then(() => {
       if (description.type !== 'rollback') {
-        this._localDescription = description;
+        this._localDescription = isUnifiedPlan ? this._rewriteLocalTrackIds(description) : description;
         this._localCandidates = [];
         if (description.type === 'offer') {
           this._descriptionRevision++;

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -252,6 +252,28 @@ function setSimulcast(sdp, sdpFormat, trackIdsToAttributes) {
 }
 
 /**
+ * Rewrite MSIDs in the given Unified Plan SDP with their corresponding local
+ * MediaStreamTrack IDs. These IDs need not be the same.
+ * @param {string} sdp
+ * @param {Map<string, string>} midsToTrackIds
+ * @returns {string}
+ */
+function unifiedPlanRewriteTrackIds(sdp, midsToTrackIds) {
+  return Array.from(midsToTrackIds).reduce((sdp, [mid, trackId]) => {
+    const midRegex = new RegExp(`a=mid:${mid}`);
+    const section = getMediaSections(sdp).find(section => midRegex.test(section));
+    if (section) {
+      const trackIdToRewrite = (section.match(/^a=msid:.+ (.+)$/m) || [])[1];
+      if (trackIdToRewrite) {
+        const msidRegex = new RegExp(`msid:(.+) ${trackIdToRewrite}$`, 'gm');
+        sdp = sdp.replace(msidRegex, `msid:$1 ${trackId}`);
+      }
+    }
+    return sdp;
+  }, sdp);
+}
+
+/**
  * Codec Payload Type.
  * @typedef {number} PayloadType
  */
@@ -262,3 +284,4 @@ exports.getMediaSections = getMediaSections;
 exports.setBitrateParameters = setBitrateParameters;
 exports.setCodecPreferences = setCodecPreferences;
 exports.setSimulcast = setSimulcast;
+exports.unifiedPlanRewriteTrackIds = unifiedPlanRewriteTrackIds;

--- a/test/unit/spec/util/sdp/index.js
+++ b/test/unit/spec/util/sdp/index.js
@@ -3,7 +3,14 @@
 const assert = require('assert');
 
 const { flatMap } = require('../../../../../lib/util');
-const { setBitrateParameters, setCodecPreferences, setSimulcast } = require('../../../../../lib/util/sdp');
+
+const {
+  getMediaSections,
+  setBitrateParameters,
+  setCodecPreferences,
+  setSimulcast,
+  unifiedPlanRewriteTrackIds
+} = require('../../../../../lib/util/sdp');
 
 const { makeSdpForSimulcast, makeSdpWithTracks } = require('../../../../lib/mocksdp');
 const { combinationContext } = require('../../../../lib/util');
@@ -479,6 +486,20 @@ a=ssrc:0000000000 label:d8b9a935-da54-4d21-a8de-522c87258244\r
 
       const ssrcs2 = new Set(simSdp2.match(/a=ssrc:[0-9]+/g).map(line => line.match(/a=ssrc:([0-9]+)/)[1]));
       assert.equal(ssrcs2.size, 3, 'RTX is disabled; therefore, there should be just 3 SSRCs in the SDP');
+    });
+  });
+});
+
+describe('unifiedPlanRewriteTrackIds', () => {
+  it('should rewrite Track IDs with the IDs of MediaStreamTracks associated with RTCRtpTransceivers', () => {
+    const sdp = makeSdpWithTracks('unified', { audio: ['foo'], video: ['bar'] });
+    const midsToTrackIds = new Map([['mid_foo', 'baz'], ['mid_bar', 'zee']]);
+    const newSdp = unifiedPlanRewriteTrackIds(sdp, midsToTrackIds);
+    const sections = getMediaSections(newSdp);
+    midsToTrackIds.forEach((trackId, mid) => {
+      const section = sections.find(section => new RegExp(`^a=mid:${mid}$`, 'm').test(section));
+      assert.equal(section.match(/^a=msid:.+ (.+)$/m)[1], trackId);
+      assert.equal(section.match(/^a=ssrc:.+ msid:.+ (.+)$/m)[1], trackId);
     });
   });
 });


### PR DESCRIPTION
@syerrapragada 

This PR fixes JSDK-2381. Firefox 68 onwards no longer generates local SDPs with the same Track IDs as the added MediaStreamTracks, even if they are added the first time. This is I think an intermediate step to removing Track IDs from SDPs altogether.

So, this PR rewrites the generated Track IDs with the Track IDs signaled via RSP, so that the RemoteParticipant can match a remote MediaStreamTrack to a given signaled Track ID.