### PR TITLE
Fix issue where the 'trackUnpublished' event was not being fired

### DIFF
--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -28,6 +28,7 @@ const LocalVideoTrackPublication = require('./media/track/localvideotrackpublica
  * @emits LocalParticipant#trackEnabled
  * @emits LocalParticipant#trackPublicationFailed
  * @emits LocalParticipant#trackPublished
+ * @emits LocalParticipant#trackUnpublished
  * @emits LocalParticipant#trackStarted
  * @emits LocalParticipant#trackStopped
  */
@@ -474,7 +475,11 @@ class LocalParticipant extends Participant {
 
     const localTrackPublication = getTrackPublication(this.tracks, localTrack);
     if (localTrackPublication) {
-      this._removeTrackPublication(localTrackPublication);
+      const removedPublication = this._removeTrackPublication(localTrackPublication);
+
+      setTimeout(() => {
+        this.emit('trackUnpublished', removedPublication);
+      });
     }
     return localTrackPublication;
   }
@@ -537,6 +542,13 @@ class LocalParticipant extends Participant {
  *   {@link LocalTrackPublication} for the published {@link LocalTrack}
  * @event LocalParticipant#trackPublished
  */
+
+ /**
+  * A {@link LocalTrack} was successfully unpublished.
+  * @param {LocalTrackPublication} publication - The resulting
+  *   {@link LocalTrackPublication} for the unpublished {@link LocalTrack}
+  * @event LocalParticipant#trackUnpublished
+  */
 
 /**
  * One of the {@link LocalParticipant}'s {@link LocalTrack}s started.


### PR DESCRIPTION
Fix issue #656 where the `trackUnpublished` event was not being fired for the local participant's tracks when tracks publications were removed.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
