### PR TITLE
JSDK-2381 [1.x] Rewriting Track IDs in local SDPs with the Track IDs signaled via RSP.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ addons:
     packages:
       - pulseaudio
 
+# https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-directly
+dist: trusty
+
 env:
   global:
     - DBUS_SESSION_BUS_ADDRESS=/dev/null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 For 2.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/master/CHANGELOG.md).
 
+1.18.1 (in progress)
+====================
+
+Bug Fixes
+---------
+
+- Fixed a bug where Participants on Firefox 68 or above were unable to publish
+  LocalAudioTracks or LocalVideoTracks. (JSDK-2381)
+
 1.18.0 (April 23, 2019)
 =======================
 

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -13,6 +13,8 @@ const oncePerTick = require('../../util').oncePerTick;
 const setBitrateParameters = require('../../util/sdp').setBitrateParameters;
 const setCodecPreferences = require('../../util/sdp').setCodecPreferences;
 const setSimulcast = require('../../util/sdp').setSimulcast;
+const unifiedPlanRewriteNewTrackIds = require('../../util/sdp').unifiedPlanRewriteNewTrackIds;
+const unifiedPlanRewriteTrackIds = require('../../util/sdp').unifiedPlanRewriteTrackIds;
 const IceBox = require('./icebox');
 const MediaClientLocalDescFailedError = require('../../util/twilio-video-errors').MediaClientLocalDescFailedError;
 const MediaClientRemoteDescFailedError = require('../../util/twilio-video-errors').MediaClientRemoteDescFailedError;
@@ -597,6 +599,41 @@ class PeerConnectionV2 extends StateMachine {
   }
 
   /**
+   * Rewrite local MediaStreamTrack IDs in the given Unified Plan RTCSessionDescription.
+   * @private
+   * @param {RTCSessionDescription} description
+   * @return {RTCSessionDescription}
+   */
+  _rewriteLocalTrackIds(description) {
+    const transceivers = this._peerConnection.getTransceivers();
+    const activeTransceivers = transceivers.filter(({ sender, stopped }) => !stopped && sender && sender.track);
+
+    // NOTE(mmalavalli): MediaStreamTracks that are added to a recycled RTCRtpTransceiver
+    // using RTCRtpSender.replaceTrack() will result in a different MSID in the
+    // corresponding m= section. We re-write them here so that the m= sections
+    // contain the actual MediaStreamTrack IDs.
+    const assignedTransceivers = activeTransceivers.filter(({ mid }) => mid);
+    const midsToTrackIds = new Map(assignedTransceivers.map(({ mid, sender }) => [mid, sender.track.id]));
+    const sdp1 = unifiedPlanRewriteTrackIds(description.sdp, midsToTrackIds);
+
+    // NOTE(mmalavalli): In Chrome and Safari, since we do not apply the offer
+    // until we get an answer, any re-added MediaStreamTracks will result in a
+    // different MSID in their corresponding m= sections. We re-write them
+    // here so that the m= sections contain the actual MediaStreamTrack IDs.
+    const unassignedTransceivers = activeTransceivers.filter(({ mid }) => !mid);
+    const newTrackIdsByKind = new Map(['audio', 'video'].map(kind => [
+      kind,
+      unassignedTransceivers.filter(({ sender }) => sender.track.kind === kind).map(({ sender }) => sender.track.id)
+    ]));
+    const sdp2 = unifiedPlanRewriteNewTrackIds(sdp1, newTrackIdsByKind);
+
+    return new this._RTCSessionDescription({
+      sdp: sdp2,
+      type: description.type
+    });
+  }
+
+  /**
    * Set a local description on the {@link PeerConnectionV2}.
    * @private
    * @param {RTCSessionDescription|RTCSessionDescriptionInit} description
@@ -627,7 +664,7 @@ class PeerConnectionV2 extends StateMachine {
       throw new MediaClientLocalDescFailedError();
     }).then(() => {
       if (description.type !== 'rollback') {
-        this._localDescription = description;
+        this._localDescription = isUnifiedPlan ? this._rewriteLocalTrackIds(description) : description;
         this._localCandidates = [];
         if (description.type === 'offer') {
           this._descriptionRevision++;

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -252,6 +252,58 @@ function setSimulcast(sdp, sdpFormat, trackIdsToAttributes) {
 }
 
 /**
+ * Rewrite MSIDs for new m= sections in the given Unified Plan SDP with their
+ * corresponding local MediaStreamTrack IDs. These can be different when previously
+ * removed MediaStreamTracks are added back.
+ * @param {string} sdp
+ * @param {Map<Track.Kind, Array<Track.ID>>} trackIdsByKind
+ * @returns {string}
+ */
+function unifiedPlanRewriteNewTrackIds(sdp, trackIdsByKind) {
+  return Array.from(trackIdsByKind).reduce((sdp, [kind, trackIds]) => {
+    const sections = getMediaSections(sdp, kind);
+    // NOTE(mmalavalli): The m= sections for the new MediaStreamTracks are usually
+    // present after the m= sections for the existing MediaStreamTracks, in order
+    // of addition.
+    const sdpTrackIds = sections.slice(sections.length - trackIds.length).map(section => {
+      return (section.match(/^a=msid:.+ (.+)$/m) || [])[1];
+    });
+
+    return sdpTrackIds.reduce((sdp, sdpTrackId, i) => {
+      if (sdpTrackId) {
+        const msidRegex = new RegExp(`msid:(.+) ${sdpTrackId}$`, 'gm');
+        sdp = sdp.replace(msidRegex, `msid:$1 ${trackIds[i]}`);
+      }
+      return sdp;
+    }, sdp);
+  }, sdp);
+}
+
+/**
+ * Rewrite MSIDs in the given Unified Plan SDP with their corresponding local
+ * MediaStreamTrack IDs. These can be different when MediaStreamTracks are added
+ * using RTCRtpSender.replaceTrack(), or in the case of Firefox 68+, also when the
+ * MediaStreamTracks are added for the first time using RTCPeerConnection.addTransceiver().
+ * @param {string} sdp
+ * @param {Map<string, Track.ID>} midsToTrackIds
+ * @returns {string}
+ */
+function unifiedPlanRewriteTrackIds(sdp, midsToTrackIds) {
+  return Array.from(midsToTrackIds).reduce((sdp, [mid, trackId]) => {
+    const midRegex = new RegExp(`a=mid:${mid}`);
+    const section = getMediaSections(sdp).find(section => midRegex.test(section));
+    if (section) {
+      const trackIdToRewrite = (section.match(/^a=msid:.+ (.+)$/m) || [])[1];
+      if (trackIdToRewrite) {
+        const msidRegex = new RegExp(`msid:(.+) ${trackIdToRewrite}$`, 'gm');
+        sdp = sdp.replace(msidRegex, `msid:$1 ${trackId}`);
+      }
+    }
+    return sdp;
+  }, sdp);
+}
+
+/**
  * Codec Payload Type.
  * @typedef {number} PayloadType
  */
@@ -262,3 +314,5 @@ exports.getMediaSections = getMediaSections;
 exports.setBitrateParameters = setBitrateParameters;
 exports.setCodecPreferences = setCodecPreferences;
 exports.setSimulcast = setSimulcast;
+exports.unifiedPlanRewriteNewTrackIds = unifiedPlanRewriteNewTrackIds;
+exports.unifiedPlanRewriteTrackIds = unifiedPlanRewriteTrackIds;

--- a/test/unit/spec/util/sdp/index.js
+++ b/test/unit/spec/util/sdp/index.js
@@ -3,7 +3,15 @@
 const assert = require('assert');
 
 const { flatMap } = require('../../../../../lib/util');
-const { setBitrateParameters, setCodecPreferences, setSimulcast } = require('../../../../../lib/util/sdp');
+
+const {
+  getMediaSections,
+  setBitrateParameters,
+  setCodecPreferences,
+  setSimulcast,
+  unifiedPlanRewriteNewTrackIds,
+  unifiedPlanRewriteTrackIds
+} = require('../../../../../lib/util/sdp');
 
 const { makeSdpForSimulcast, makeSdpWithTracks } = require('../../../../lib/mocksdp');
 const { combinationContext } = require('../../../../lib/util');
@@ -475,6 +483,38 @@ a=ssrc:0000000000 label:d8b9a935-da54-4d21-a8de-522c87258244\r
 
       const ssrcs2 = new Set(simSdp2.match(/a=ssrc:[0-9]+/g).map(line => line.match(/a=ssrc:([0-9]+)/)[1]));
       assert.equal(ssrcs2.size, 3, 'RTX is disabled; therefore, there should be just 3 SSRCs in the SDP');
+    });
+  });
+});
+
+describe('unifiedPlanRewriteNewTrackIds', () => {
+  it('should rewrite Track IDs with the IDs of MediaStreamTracks associated with unassigned RTCRtpTransceivers', () => {
+    const sdp = makeSdpWithTracks('unified', { audio: ['foo', 'bar'], video: ['baz', 'zee'] });
+    const newTrackIdsByKind = new Map([['audio', ['yyy']], ['video', ['zzz']]]);
+    const newSdp = unifiedPlanRewriteNewTrackIds(sdp, newTrackIdsByKind);
+    const trackIdAndKinds = getMediaSections(newSdp).map(section => [
+      section.match(/^a=msid:.+ (.+)/m)[1],
+      section.match(/^m=(audio|video)/)[1]
+    ]);
+    assert.deepEqual(trackIdAndKinds, [
+      ['foo', 'audio'],
+      ['yyy', 'audio'],
+      ['baz', 'video'],
+      ['zzz', 'video']
+    ]);
+  });
+});
+
+describe('unifiedPlanRewriteTrackIds', () => {
+  it('should rewrite Track IDs with the IDs of MediaStreamTracks associated with recycled RTCRtpTransceivers', () => {
+    const sdp = makeSdpWithTracks('unified', { audio: ['foo'], video: ['bar'] });
+    const midsToTrackIds = new Map([['mid_foo', 'baz'], ['mid_bar', 'zee']]);
+    const newSdp = unifiedPlanRewriteTrackIds(sdp, midsToTrackIds);
+    const sections = getMediaSections(newSdp);
+    midsToTrackIds.forEach((trackId, mid) => {
+      const section = sections.find(section => new RegExp(`^a=mid:${mid}$`, 'm').test(section));
+      assert.equal(section.match(/^a=msid:.+ (.+)$/m)[1], trackId);
+      assert.equal(section.match(/^a=ssrc:.+ msid:.+ (.+)$/m)[1], trackId);
     });
   });
 });


### PR DESCRIPTION
@syerrapragada 

This PR fixes JSDK-2381 for 1.x.