### PR TITLE
JSDK-2387 Consuming REGIONS environment variable in integration tests for signaling region.

### DIFF
--- a/test/env.js
+++ b/test/env.js
@@ -12,6 +12,7 @@ const processEnv = {
   WS_SERVER_INSIGHTS: process.env.WS_SERVER_INSIGHTS,
   LOG_LEVEL: process.env.LOG_LEVEL,
   ENABLE_REST_API_TESTS: process.env.ENABLE_REST_API_TESTS,
+  REGIONS: process.env.REGIONS,
   TOPOLOGY: process.env.TOPOLOGY
 };
 
@@ -26,6 +27,7 @@ const env = [
   ['WS_SERVER_INSIGHTS',        'wsServerInsights'],
   ['LOG_LEVEL',                 'logLevel'],
   ['ENABLE_REST_API_TESTS',     'enableRestApiTests'],
+  ['REGIONS',                   'regions'],
   ['TOPOLOGY',                  'topology']
 ].reduce((env, [processEnvKey, envKey]) => {
   if (processEnvKey in processEnv) {

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -132,8 +132,8 @@ describe('connect', function() {
         });
 
         it(`should return a CancelablePromise that ${region === 'invalid' ? 'rejects with a SignalingConnectionError' : 'resolves with a Room'}`, async () => {
-          let error;
-          let room;
+          let error = null;
+          let room = null;
           try {
             room = await cancelablePromise;
           } catch (error_) {
@@ -143,10 +143,10 @@ describe('connect', function() {
               room.disconnect();
             }
             if (region === 'invalid') {
-              assert(!room, `Connected to Room ${room && room.sid} with an invalid signaling region "${region}"`);
+              assert.equal(room, null, `Connected to Room ${room && room.sid} with an invalid signaling region "${region}"`);
               assert(error instanceof SignalingConnectionError);
             } else {
-              assert(!error);
+              assert.equal(error, null);
               assert(room instanceof Room);
             }
           }

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -104,18 +104,26 @@ describe('connect', function() {
     });
   });
 
-  describe('region selection', async () => {
-    ['without', 'global', 'specific', 'invalid'].forEach(regionType => {
-      const regionOptions = {
-        global: { region: 'gll' },
-        invalid: { region: 'foo' },
-        specific: { region: 'de1' },
-        without: {}
-      }[regionType];
+  describe('signaling region', async () => {
+    const regions = ['invalid', 'without', 'gll'].concat(defaults.regions ? defaults.regions.split(',') : [
+      'au1', 'br1', 'de1', 'ie1', 'in1', 'jp1', 'sg1', 'us1', 'us2'
+    ]);
 
-      context(`when called ${regionType === 'without' ? regionType : `with a(n) ${regionType}`} region`, () => {
+    regions.forEach(region => {
+      const regionOptions = {
+        invalid: { region: 'foo' },
+        without: {}
+      }[region] || { region };
+
+      const scenario = `when called ${{
+        invalid: 'with an invalid',
+        without: 'without a',
+      }[region] || `with "${region}" as the`} signaling region`;
+
+      context(scenario, () => {
         let token;
         let cancelablePromise;
+
         beforeEach(() => {
           const identity = randomName();
           token = getToken(identity);
@@ -123,22 +131,26 @@ describe('connect', function() {
           assert(cancelablePromise instanceof CancelablePromise);
         });
 
-        if (regionType === 'invalid') {
-          it('should return a CancelablePromise that rejects with a SignalingConnectionError', async () => {
-            try {
-              const room = await cancelablePromise;
+        it(`should return a CancelablePromise that ${region === 'invalid' ? 'rejects with a SignalingConnectionError' : 'resolves with a Room'}`, async () => {
+          let error;
+          let room;
+          try {
+            room = await cancelablePromise;
+          } catch (error_) {
+            error = error_;
+          } finally {
+            if (room) {
               room.disconnect();
-              throw new Error(`Connected to ${room.sid} with an invalid region`);
-            } catch (error) {
-              assert(error instanceof SignalingConnectionError);
             }
-          });
-        } else {
-          it('should return a CancelablePromise that resolves with a Room', async () => {
-            const room = await cancelablePromise;
-            room.disconnect();
-          });
-        }
+            if (region === 'invalid') {
+              assert(!room, `Connected to Room ${room && room.sid} with an invalid signaling region "${region}"`);
+              assert(error instanceof SignalingConnectionError);
+            } else {
+              assert(!error);
+              assert(room instanceof Room);
+            }
+          }
+        });
       });
     });
   });

--- a/test/lib/defaults.js
+++ b/test/lib/defaults.js
@@ -8,6 +8,7 @@ const defaults = [
   'ecsServer',
   'environment',
   'logLevel',
+  'regions',
   'topology',
   'wsServer',
   'wsServerInsights'


### PR DESCRIPTION
@makarandp0 @syerrapragada 

This PR adds a new environment variable `REGIONS` to the integration test suite. In `stage`, you can use this to pass only those signaling regions that are supported in this environment like this:

```
... ENVIRONMENT=stage REGIONS=au1,in1,us1 ... npm run test:integration 
```

If you don't specify `REGIONS`, then all the signaling regions will be tested.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
