### PR TITLE
JSDK-2307 MSP objects do not recover on JSDK side after SFU Failover	

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -142,6 +142,8 @@ function connect(token, options) {
     preferredVideoCodecs: [],
     realm: constants.DEFAULT_REALM,
     region: constants.DEFAULT_REGION,
+    // TODO(mmalavalli): Remove once we decide to support Unified Plan on Chrome 72+
+    sdpSemantics: constants.DEFAULT_CHROME_SDP_SEMANTICS,
     signaling: SignalingV2
   }, util.filterObject(options));
 

--- a/lib/data/sender.js
+++ b/lib/data/sender.js
@@ -98,7 +98,11 @@ class DataTrackSender extends DataTrackTransceiver {
       }
     });
     this._clones.forEach(clone => {
-      clone.send(data);
+      try {
+        clone.send(data);
+      } catch (error) {
+        // Do nothing.
+      }
     });
     return this;
   }

--- a/lib/data/transport.js
+++ b/lib/data/transport.js
@@ -48,7 +48,11 @@ class DataTransport extends EventEmitter {
    */
   _publish(message) {
     const data = JSON.stringify(message);
-    this._dataChannel.send(data);
+    try {
+      this._dataChannel.send(data);
+    } catch (error) {
+      // Do nothing.
+    }
   }
 
   /**

--- a/lib/signaling/v2/cancelableroomsignalingpromise.js
+++ b/lib/signaling/v2/cancelableroomsignalingpromise.js
@@ -62,7 +62,8 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
           networkQuality: options.networkQuality,
           iceServerSourceStatus: iceServerSource.status,
           insights: options.insights,
-          realm: options.realm
+          realm: options.realm,
+          sdpSemantics: options.sdpSemantics
         }, transportOptions);
 
         const Transport = options.Transport;

--- a/lib/signaling/v2/networkqualitymonitor.js
+++ b/lib/signaling/v2/networkqualitymonitor.js
@@ -14,7 +14,7 @@ class NetworkQualityMonitor extends EventEmitter {
    * @param {PeerConnectionManager} manager
    * @param {NetworkQualitySignaling} signaling
    */
-  constructor(manager, signaling)  {
+  constructor(manager, signaling) {
     super();
     Object.defineProperties(this, {
       _factories: {

--- a/lib/signaling/v2/networkqualitymonitor.js
+++ b/lib/signaling/v2/networkqualitymonitor.js
@@ -14,7 +14,7 @@ class NetworkQualityMonitor extends EventEmitter {
    * @param {PeerConnectionManager} manager
    * @param {NetworkQualitySignaling} signaling
    */
-  constructor(manager, signaling) {
+  constructor(manager, signaling)  {
     super();
     Object.defineProperties(this, {
       _factories: {

--- a/lib/signaling/v2/networkqualitymonitor.js
+++ b/lib/signaling/v2/networkqualitymonitor.js
@@ -12,9 +12,8 @@ class NetworkQualityMonitor extends EventEmitter {
   /**
    * Construct a {@link NetworkQualityMonitor}.
    * @param {PeerConnectionManager} manager
-   * @param {NetworkQualitySignaling} signaling
    */
-  constructor(manager, signaling) {
+  constructor(manager) {
     super();
     Object.defineProperties(this, {
       _factories: {
@@ -24,10 +23,23 @@ class NetworkQualityMonitor extends EventEmitter {
         value: manager
       },
       _signaling: {
-        value: signaling
-      }
+        writable: true,
+        value: null
+      },
+      _emitUpdate: {
+        value: this.emit.bind(this, 'updated')
+      },
     });
-    signaling.on('updated', () => this.emit('updated'));
+  }
+  /**
+   * @param {NetworkQualitySignaling} signaling
+   */
+  setupOrUpdateSignaling(signaling) {
+    if (this._signaling) {
+      this._signaling.removeListener('updated', this._emitUpdate);
+    }
+    this._signaling = signaling;
+    this._signaling.on('updated', this._emitUpdate);
   }
 
   /**

--- a/lib/signaling/v2/networkqualitymonitor.js
+++ b/lib/signaling/v2/networkqualitymonitor.js
@@ -12,8 +12,9 @@ class NetworkQualityMonitor extends EventEmitter {
   /**
    * Construct a {@link NetworkQualityMonitor}.
    * @param {PeerConnectionManager} manager
+   * @param {NetworkQualitySignaling} signaling
    */
-  constructor(manager) {
+  constructor(manager, signaling) {
     super();
     Object.defineProperties(this, {
       _factories: {
@@ -24,20 +25,21 @@ class NetworkQualityMonitor extends EventEmitter {
       },
       _signaling: {
         writable: true,
-        value: null
+        value: signaling
       },
       _emitUpdate: {
-        value: this.emit.bind(this, 'updated')
-      },
+        value: () => this.emit('updated')
+      }
     });
+
+    signaling.on('updated', this._emitUpdate);
   }
   /**
+   * Replace signaling
    * @param {NetworkQualitySignaling} signaling
    */
-  setupOrUpdateSignaling(signaling) {
-    if (this._signaling) {
-      this._signaling.removeListener('updated', this._emitUpdate);
-    }
+  updateSignaling(signaling) {
+    this._signaling.removeListener('updated', this._emitUpdate);
     this._signaling = signaling;
     this._signaling.on('updated', this._emitUpdate);
   }

--- a/lib/signaling/v2/networkqualitysignaling.js
+++ b/lib/signaling/v2/networkqualitysignaling.js
@@ -109,6 +109,7 @@ class NetworkQualitySignaling extends EventEmitter {
         }
       }
     });
+
     mediaSignalingTransport.on('message', message => {
       switch (message.type) {
         case 'network_quality':

--- a/lib/signaling/v2/networkqualitysignaling.js
+++ b/lib/signaling/v2/networkqualitysignaling.js
@@ -109,9 +109,7 @@ class NetworkQualitySignaling extends EventEmitter {
         }
       }
     });
-    let internal = 0;
     mediaSignalingTransport.on('message', message => {
-      console.log(internal++, "makarand: mediaSignalingTransport: ", message);
       switch (message.type) {
         case 'network_quality':
           this._handleNetworkQualityMessage(message);

--- a/lib/signaling/v2/networkqualitysignaling.js
+++ b/lib/signaling/v2/networkqualitysignaling.js
@@ -109,8 +109,9 @@ class NetworkQualitySignaling extends EventEmitter {
         }
       }
     });
-
+    let internal = 0;
     mediaSignalingTransport.on('message', message => {
+      console.log(internal++, "makarand: mediaSignalingTransport: ", message);
       switch (message.type) {
         case 'network_quality':
           this._handleNetworkQualityMessage(message);

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1,30 +1,44 @@
 'use strict';
 
-const WebRTC = require('@twilio/webrtc');
+const {
+  MediaStream: DefaultMediaStream,
+  RTCIceCandidate: DefaultRTCIceCandidate,
+  RTCPeerConnection: DefaultRTCPeerConnection,
+  RTCSessionDescription: DefaultRTCSessionDescription,
+  getStats: getStatistics
+} = require('@twilio/webrtc');
+
 const { guessBrowser } = require('@twilio/webrtc/lib/util');
 const { getSdpFormat } = require('@twilio/webrtc/lib/util/sdp');
-const DefaultMediaStream = WebRTC.MediaStream;
-const DefaultRTCIceCandidate = WebRTC.RTCIceCandidate;
-const DefaultRTCPeerConnection = WebRTC.RTCPeerConnection;
-const DefaultRTCSessionDescription = WebRTC.RTCSessionDescription;
-const getStatistics = WebRTC.getStats;
-const createCodecMapForMediaSection = require('../../util/sdp').createCodecMapForMediaSection;
-const unifiedPlanFilterLocalCodecs = require('../../util/sdp').unifiedPlanFilterLocalCodecs;
-const getMediaSections = require('../../util/sdp').getMediaSections;
-const oncePerTick = require('../../util').oncePerTick;
-const setBitrateParameters = require('../../util/sdp').setBitrateParameters;
-const setCodecPreferences = require('../../util/sdp').setCodecPreferences;
-const setSimulcast = require('../../util/sdp').setSimulcast;
-const revertSimulcastForNonVP8MediaSections = require('../../util/sdp').revertSimulcastForNonVP8MediaSections;
-const unifiedPlanRewriteTrackIds = require('../../util/sdp').unifiedPlanRewriteTrackIds;
+const { DEFAULT_LOG_LEVEL } = require('../../util/constants');
+
+const {
+  createCodecMapForMediaSection,
+  getMediaSections,
+  revertSimulcastForNonVP8MediaSections,
+  setBitrateParameters,
+  setCodecPreferences,
+  setSimulcast,
+  unifiedPlanAddOrRewriteNewTrackIds,
+  unifiedPlanAddOrRewriteTrackIds,
+  unifiedPlanFilterLocalCodecs
+} = require('../../util/sdp');
+
+const {
+  MediaClientLocalDescFailedError,
+  MediaClientRemoteDescFailedError
+} = require('../../util/twilio-video-errors');
+
+const {
+  buildLogLevels,
+  makeUUID,
+  oncePerTick
+} = require('../../util');
+
 const IceBox = require('./icebox');
-const MediaClientLocalDescFailedError = require('../../util/twilio-video-errors').MediaClientLocalDescFailedError;
-const MediaClientRemoteDescFailedError = require('../../util/twilio-video-errors').MediaClientRemoteDescFailedError;
 const DataTrackReceiver = require('../../data/receiver');
 const MediaTrackReceiver = require('../../media/track/receiver');
 const StateMachine = require('../../statemachine');
-const { buildLogLevels, makeUUID } = require('../../util');
-const { DEFAULT_LOG_LEVEL } = require('../../util/constants');
 const Log = require('../../util/log');
 const IdentityTrackMatcher = require('../../util/sdp/trackmatcher/identity');
 const OrderedTrackMatcher = require('../../util/sdp/trackmatcher/ordered');
@@ -35,8 +49,6 @@ const guess = guessBrowser();
 const isChrome = guess === 'chrome';
 const isFirefox = guess === 'firefox';
 const isSafari = guess === 'safari';
-const sdpFormat = getSdpFormat();
-const isUnifiedPlan = sdpFormat === 'unified';
 
 const firefoxMajorVersion = isFirefox
   ? parseInt(navigator.userAgent.match(/Firefox\/(\d+)/)[1], 10)
@@ -108,10 +120,13 @@ class PeerConnectionV2 extends StateMachine {
       RTCSessionDescription: DefaultRTCSessionDescription
     }, options);
 
-    const RTCPeerConnection = options.RTCPeerConnection;
     const configuration = getConfiguration(options);
+    const sdpFormat = getSdpFormat(configuration.sdpSemantics);
+    const isUnifiedPlan = sdpFormat === 'unified';
+
     const localMediaStream = isUnifiedPlan ? null : new options.MediaStream();
     const logLevels = buildLogLevels(options.logLevel);
+    const RTCPeerConnection = options.RTCPeerConnection;
     const peerConnection = new RTCPeerConnection(configuration, options.chromeSpecificConstraints);
 
     if (options.dummyAudioMediaStreamTrack) {
@@ -147,6 +162,9 @@ class PeerConnectionV2 extends StateMachine {
       _isRestartingIce: {
         writable: true,
         value: false
+      },
+      _isUnifiedPlan: {
+        value: isUnifiedPlan
       },
       _lastIceConnectionState: {
         writable: true,
@@ -237,6 +255,9 @@ class PeerConnectionV2 extends StateMachine {
       _remoteCandidates: {
         writable: true,
         value: new IceBox()
+      },
+      _sdpFormat: {
+        value: sdpFormat
       },
       _setBitrateParameters: {
         value: options.setBitrateParameters
@@ -400,7 +421,7 @@ class PeerConnectionV2 extends StateMachine {
 
       let description = answer;
       if (this._shouldApplySimulcast) {
-        var updatedSdp = this._setSimulcast(answer.sdp, sdpFormat, this._trackIdsToAttributes);
+        let updatedSdp = this._setSimulcast(answer.sdp, this._sdpFormat, this._trackIdsToAttributes);
         // NOTE(syerrapragada): VMS does not support H264 simulcast. So,
         // unset simulcast for sections in local offer where corresponding
         // sections in answer doesn't have vp8 as preferred codec and reapply offer.
@@ -562,7 +583,7 @@ class PeerConnectionV2 extends StateMachine {
         // support, we have to use the same hacky solution as Safari. Revisit
         // this when RTCRtpTransceivers and MIDs land. We should be able to use
         // the same technique as Firefox.
-        : isSafari || isUnifiedPlan ? new OrderedTrackMatcher() : new IdentityTrackMatcher();
+        : isSafari || this._isUnifiedPlan ? new OrderedTrackMatcher() : new IdentityTrackMatcher();
     }
     this._trackMatcher.update(sdp);
 
@@ -609,7 +630,7 @@ class PeerConnectionV2 extends StateMachine {
       // We can reduce the number of cases where renegotiation is needed by
       // re-introducing 'offerToReceiveAudio' to the default RTCOfferOptions with a
       // value > 1.
-      if (isUnifiedPlan && localDescription.type === 'answer') {
+      if (this._isUnifiedPlan && localDescription.type === 'answer') {
         const senders = this._peerConnection.getSenders().filter(sender => sender.track);
         shouldReoffer = ['audio', 'video'].reduce((shouldOffer, kind) => {
           const mediaSections = getMediaSections(localDescription.sdp, kind, '(sendrecv|sendonly)');
@@ -652,7 +673,7 @@ class PeerConnectionV2 extends StateMachine {
         offer = workaroundIssue8329(offer);
       }
 
-      const sdp = isUnifiedPlan && this._peerConnection.remoteDescription
+      const sdp = this._isUnifiedPlan && this._peerConnection.remoteDescription
         ? unifiedPlanFilterLocalCodecs(offer.sdp, this._peerConnection.remoteDescription.sdp)
         : offer.sdp;
 
@@ -671,7 +692,7 @@ class PeerConnectionV2 extends StateMachine {
           type: 'offer',
           sdp: updatedSdp
         };
-        updatedSdp = this._setSimulcast(updatedSdp, sdpFormat, this._trackIdsToAttributes);
+        updatedSdp = this._setSimulcast(updatedSdp, this._sdpFormat, this._trackIdsToAttributes);
       }
 
       return this._setLocalDescription({
@@ -682,19 +703,34 @@ class PeerConnectionV2 extends StateMachine {
   }
 
   /**
-   * Rewrite local MediaStreamTrack IDs in the given Unified Plan RTCSessionDescription.
+   * Add or rewrite local MediaStreamTrack IDs in the given Unified Plan RTCSessionDescription.
    * @private
    * @param {RTCSessionDescription} description
    * @return {RTCSessionDescription}
    */
-  _rewriteLocalTrackIds(description) {
-    const midsToTrackIds = new Map(this._peerConnection.getTransceivers().filter(({ mid, sender, stopped }) => {
-      return !stopped && mid && sender && sender.track;
-    }).map(({ mid, sender }) => {
-      return [mid, sender.track.id];
-    }));
+  _addOrRewriteLocalTrackIds(description) {
+    const transceivers = this._peerConnection.getTransceivers();
+    const activeTransceivers = transceivers.filter(({ sender, stopped }) => !stopped && sender && sender.track);
+
+    // NOTE(mmalavalli): There is no guarantee that MediaStreamTrack IDs will be present in
+    // SDPs, and even if they are, there is no guarantee that they will be the same as the
+    // actual MediaStreamTrack IDs. So, we add or re-write the actual MediaStreamTrack IDs
+    // to the assigned m= sections here.
+    const assignedTransceivers = activeTransceivers.filter(({ mid }) => mid);
+    const midsToTrackIds = new Map(assignedTransceivers.map(({ mid, sender }) => [mid, sender.track.id]));
+    const sdp1 = unifiedPlanAddOrRewriteTrackIds(description.sdp, midsToTrackIds);
+
+    // NOTE(mmalavalli): Chrome and Safari do not apply the offer until they get an answer.
+    // So, we add or re-write the actual MediaStreamTrack IDs to the unassigned m= sections here.
+    const unassignedTransceivers = activeTransceivers.filter(({ mid }) => !mid);
+    const newTrackIdsByKind = new Map(['audio', 'video'].map(kind => [
+      kind,
+      unassignedTransceivers.filter(({ sender }) => sender.track.kind === kind).map(({ sender }) => sender.track.id)
+    ]));
+    const sdp2 = unifiedPlanAddOrRewriteNewTrackIds(sdp1, newTrackIdsByKind);
+
     return new this._RTCSessionDescription({
-      sdp: unifiedPlanRewriteTrackIds(description.sdp, midsToTrackIds),
+      sdp: sdp2,
       type: description.type
     });
   }
@@ -724,13 +760,13 @@ class PeerConnectionV2 extends StateMachine {
       throw new MediaClientLocalDescFailedError();
     }).then(() => {
       if (description.type !== 'rollback') {
-        this._localDescription = isUnifiedPlan ? this._rewriteLocalTrackIds(description) : description;
+        this._localDescription = this._isUnifiedPlan ? this._addOrRewriteLocalTrackIds(description) : description;
         this._localCandidates = [];
         if (description.type === 'offer') {
           this._descriptionRevision++;
         } else if (description.type === 'answer') {
           this._lastStableDescriptionRevision = this._descriptionRevision;
-          if (isUnifiedPlan) {
+          if (this._isUnifiedPlan) {
             updateRecycledTransceivers(this);
             updateLocalCodecs(this);
             updateRemoteCodecMaps(this);
@@ -787,7 +823,7 @@ class PeerConnectionV2 extends StateMachine {
         this._log.debug('An ICE restart was in-progress and is now completed');
         this._isRestartingIce = false;
       }
-      if (description.type === 'answer' && isUnifiedPlan) {
+      if (description.type === 'answer' && this._isUnifiedPlan) {
         updateRecycledTransceivers(this);
         updateLocalCodecs(this);
         updateRemoteCodecMaps(this);

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -123,14 +123,21 @@ class RoomV2 extends RoomSignaling {
   /**
    * @private
    */
+  _getTrackReceiverSync(id) {
+    const trackReceivers = this._peerConnectionManager.getTrackReceivers();
+    return trackReceivers.find(trackReceiver => trackReceiver.id === id && trackReceiver.readyState !== 'ended');
+  }
+
+  /**
+   * @private
+   */
   _getOrCreateTrackReceiverDeferred(id) {
     const deferred = this._trackReceiverDeferreds.get(id) || util.defer();
-    const trackReceivers = this._peerConnectionManager.getTrackReceivers();
 
     // NOTE(mmalavalli): In Firefox, there can be instances where a MediaStreamTrack
     // for the given Track ID already exists, for example, when a Track is removed
     // and added back. If that is the case, then we should resolve 'deferred'.
-    const trackReceiver = trackReceivers.find(trackReceiver => trackReceiver.id === id && trackReceiver.readyState !== 'ended');
+    const trackReceiver = this._getTrackReceiverSync(id);
 
     if (trackReceiver) {
       deferred.resolve(trackReceiver);
@@ -345,28 +352,55 @@ class RoomV2 extends RoomSignaling {
     });
     this._dominantSpeakerSignalingPromise = dominantSpeakerSignalingPromise;
   }
+
+  _setupNetworkQualitySignaling(receiver) {
+    if (receiver.kind === 'data') {
+      const networkQualityMonitor =
+        this._networkQualityMonitor ||
+        new this._NetworkQualityMonitor(this._peerConnectionManager);
+      const networkQualitySignaling = new this._NetworkQualitySignaling(
+        receiver.toDataTransport(), this._networkQualityConfiguration);
+      networkQualityMonitor.setupOrUpdateSignaling(networkQualitySignaling);
+      if (!this._networkQualityMonitor) {
+        // resolve the promise, and setup setup monitor.
+        this._networkQualityMonitorPromise.resolve();
+        this._setNetworkQualityMonitor(networkQualityMonitor);
+      }
+    } else {
+      throw new Error('unexected receiver kind:' + receiver.kind);
+    }
+  }
   /**
    * Create a {@link DataTransport}-backed {@link NetworkQualityMonitor}.
    * @private
    * @param {ID} id - ID of the {@link DataTrackReceiver} that will ultimately
    *   be converted into a {@link DataTrackTransport} for use with
    *   {@link NetworkQualitySignaling}
-   * @returns {Promise<void>}
+   * @returns {void}
    */
   _setupDataTransportBackedNetworkQualityMonitor(id) {
     var self = this;
     this._teardownNetworkQualityMonitor();
-    const networkQualityMonitorPromise = this._getTrackReceiver(id).then(receiver => {
-      if (receiver.kind !== 'data') {
-        throw new Error('Expected a DataTrackReceiver');
-      } if (this._networkQualityMonitorPromise !== networkQualityMonitorPromise) {
-        // NOTE(mroberts): _teardownNetworkQualityMonitor was called.
+    const networkQualityMonitorPromise = util.defer();
+    const receiver = this._getTrackReceiverSync(id);
+    if (receiver) {
+      this._setupNetworkQualitySignaling(receiver);
+    }
+    // the receiver we are interested may get added later.
+    // and it may also  get updated multiple times
+    // (as peerConnections are recreated by the room)
+    // to listen for the any trackAdded events matching this id.
+    // so that we can rehook our network monitor signaling.
+    this._peerConnectionManager.on('trackAdded', function updateSignaling(receiver) {
+      if (self._networkQualityMonitorPromise !== networkQualityMonitorPromise) {
+        // _teardownNetworkQualityMonitor happened. stop listening
+        // for any udpates for this id
+        self.peerConnectionManager.removeListener('trackAdded', updateSignaling);
         return;
       }
-      const networkQualitySignaling = new this._NetworkQualitySignaling(
-        receiver.toDataTransport(), self._networkQualityConfiguration);
-      const networkQualityMonitor = new this._NetworkQualityMonitor(this._peerConnectionManager, networkQualitySignaling);
-      this._setNetworkQualityMonitor(networkQualityMonitor);
+      if (receiver.id === id) {
+        self._setupNetworkQualitySignaling(receiver);
+      }
     });
     this._networkQualityMonitorPromise = networkQualityMonitorPromise;
   }

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -32,6 +32,9 @@ class RoomV2 extends RoomSignaling {
         value: null,
         writable: true
       },
+      _dominantSpeakerUpdate: {
+        value: () => this.setDominantSpeaker(this._dominantSpeakerSignaling.loudestParticipantSid)
+      },
       _dominantSpeakerSignalingPromise: {
         value: null,
         writable: true
@@ -340,31 +343,43 @@ class RoomV2 extends RoomSignaling {
    */
   _setupDataTransportBackedDominantSpeakerSignaling(id) {
     this._teardownDominantSpeakerSignaling();
-    const dominantSpeakerSignalingPromise = this._getTrackReceiver(id).then(receiver => {
-      if (receiver.kind !== 'data') {
-        throw new Error('Expected a DataTrackReceiver');
-      } if (this._dominantSpeakerSignalingPromise !== dominantSpeakerSignalingPromise) {
-        // NOTE(mroberts): _teardownDominantSpeakerSignaling was called.
+    const dominantSpeakerSignalingPromise = util.defer();
+    const receiver = this._getTrackReceiverSync(id);
+    if (receiver) {
+      this._setDominantSpeakerSignaling(receiver);
+    }
+    // the receiver we are interested may get added later.
+    // and it may also  get updated multiple times
+    // (as peerConnections are recreated by the room)
+    // to listen for the any trackAdded events matching this id.
+    // so that we can rehook our network monitor signaling.
+    const self = this;
+    this._peerConnectionManager.on('trackAdded', function updateSignaling(receiver) {
+      if (self._dominantSpeakerSignalingPromise !== dominantSpeakerSignalingPromise) {
+        // _teardownDominantSpeakerSignaling happened. stop listening
+        // for any udpates for this id
+        self.peerConnectionManager.removeListener('trackAdded', updateSignaling);
         return;
       }
-      const dominantSpeakerSignaling = new DominantSpeakerSignaling(receiver.toDataTransport());
-      this._setDominantSpeakerSignaling(dominantSpeakerSignaling);
+      if (receiver.id === id && receiver.kind === 'data') {
+        self._setDominantSpeakerSignaling(receiver);
+      }
     });
     this._dominantSpeakerSignalingPromise = dominantSpeakerSignalingPromise;
   }
 
   _setupNetworkQualitySignaling(receiver) {
     if (receiver.kind === 'data') {
-      const networkQualityMonitor =
-        this._networkQualityMonitor ||
-        new this._NetworkQualityMonitor(this._peerConnectionManager);
       const networkQualitySignaling = new this._NetworkQualitySignaling(
         receiver.toDataTransport(), this._networkQualityConfiguration);
-      networkQualityMonitor.setupOrUpdateSignaling(networkQualitySignaling);
-      if (!this._networkQualityMonitor) {
-        // resolve the promise, and setup setup monitor.
+
+      if (this._networkQualityMonitor) {
+        this._networkQualityMonitor.updateSignaling(networkQualitySignaling);
+      } else {
+        // resolve the promise, and setup monitor.
         this._networkQualityMonitorPromise.resolve();
-        this._setNetworkQualityMonitor(networkQualityMonitor);
+        this._setNetworkQualityMonitor(
+          new this._NetworkQualityMonitor(this._peerConnectionManager, networkQualitySignaling));
       }
     } else {
       throw new Error('unexected receiver kind:' + receiver.kind);
@@ -405,9 +420,17 @@ class RoomV2 extends RoomSignaling {
     this._networkQualityMonitorPromise = networkQualityMonitorPromise;
   }
 
-  _setDominantSpeakerSignaling(dominantSpeakerSignaling) {
-    this._dominantSpeakerSignaling = dominantSpeakerSignaling;
-    dominantSpeakerSignaling.on('updated', () => this.setDominantSpeaker(dominantSpeakerSignaling.loudestParticipantSid));
+  _setDominantSpeakerSignaling(receiver) {
+    if (receiver.kind === 'data') {
+      if (this._dominantSpeakerSignaling) {
+        this._dominantSpeakerSignaling.removeListener('updated', this._dominantSpeakerUpdate);
+      } else {
+        this._dominantSpeakerSignalingPromise.resolve();
+      }
+
+      this._dominantSpeakerSignaling = new DominantSpeakerSignaling(receiver.toDataTransport());
+      this._dominantSpeakerSignaling.on('updated', this._dominantSpeakerUpdate);
+    }
   }
 
   _setNetworkQualityMonitor(networkQualityMonitor) {

--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -91,7 +91,7 @@ class TwilioConnectionTransport extends StateMachine {
       maxReconnectAttempts: MAX_RECONNECT_ATTEMPTS,
       reconnectBackOffJitter: RECONNECT_BACKOFF_JITTER,
       reconnectBackOffMs: RECONNECT_BACKOFF_MS,
-      sdpFormat: getSdpFormat(),
+      sdpFormat: getSdpFormat(options.sdpSemantics),
       userAgent: getUserAgent()
     }, options);
     super('connecting', states);

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -71,3 +71,7 @@ module.exports.typeErrors = {
 module.exports.DEFAULT_NQ_LEVEL_LOCAL = 1;
 module.exports.DEFAULT_NQ_LEVEL_REMOTE = 0;
 module.exports.MAX_NQ_LEVEL = 3;
+
+// TODO(mmalavalli): Once we decide to support Unified Plan on Chrome 72+,
+// we need to remove this constant and its references.
+module.exports.DEFAULT_CHROME_SDP_SEMANTICS = 'plan-b';

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -437,25 +437,64 @@ function revertSimulcastForNonVP8MediaSections(localSdp, localSdpWithoutSimulcas
 }
 
 /**
- * Rewrite MSIDs in the given Unified Plan SDP with their corresponding local
- * MediaStreamTrack IDs. These IDs need not be the same.
+ * Add or rewrite MSIDs for new m= sections in the given Unified Plan SDP with their
+ * corresponding local MediaStreamTrack IDs. These can be different when previously
+ * removed MediaStreamTracks are added back (or Track IDs may not be present in the
+ * SDPs at all once browsers implement the latest WebRTC spec).
+ * @param {string} sdp
+ * @param {Map<Track.Kind, Array<Track.ID>>} trackIdsByKind
+ * @returns {string}
+ */
+function unifiedPlanAddOrRewriteNewTrackIds(sdp, trackIdsByKind) {
+  // NOTE(mmalavalli): The m= sections for the new MediaStreamTracks are usually
+  // present after the m= sections for the existing MediaStreamTracks, in order
+  // of addition.
+  const newMidsToTrackIds = Array.from(trackIdsByKind).reduce((midsToTrackIds, [kind, trackIds]) => {
+    const mediaSections = getMediaSections(sdp, kind);
+    const newMids = mediaSections.slice(mediaSections.length - trackIds.length).map(getMidForMediaSection);
+    newMids.forEach((mid, i) => midsToTrackIds.set(mid, trackIds[i]));
+    return midsToTrackIds;
+  }, new Map());
+  return unifiedPlanAddOrRewriteTrackIds(sdp, newMidsToTrackIds);
+}
+
+/**
+ * Add or rewrite MSIDs in the given Unified Plan SDP with their corresponding local
+ * MediaStreamTrack IDs. These IDs need not be the same (or Track IDs may not be
+ * present in the SDPs at all once browsers implement the latest WebRTC spec).
  * @param {string} sdp
  * @param {Map<string, string>} midsToTrackIds
  * @returns {string}
  */
-function unifiedPlanRewriteTrackIds(sdp, midsToTrackIds) {
-  return Array.from(midsToTrackIds).reduce((sdp, [mid, trackId]) => {
-    const midRegex = new RegExp(`a=mid:${mid}`);
-    const section = getMediaSections(sdp).find(section => midRegex.test(section));
-    if (section) {
-      const trackIdToRewrite = (section.match(/^a=msid:.+ (.+)$/m) || [])[1];
-      if (trackIdToRewrite) {
-        const msidRegex = new RegExp(`msid:(.+) ${trackIdToRewrite}$`, 'gm');
-        sdp = sdp.replace(msidRegex, `msid:$1 ${trackId}`);
-      }
+function unifiedPlanAddOrRewriteTrackIds(sdp, midsToTrackIds) {
+  const mediaSections = getMediaSections(sdp);
+  const session = sdp.split('\r\nm=')[0];
+  return [session].concat(mediaSections.map(mediaSection => {
+    // Do nothing if the m= section represents neither audio nor video.
+    if (!/^m=(audio|video)/.test(mediaSection)) {
+      return mediaSection;
     }
-    return sdp;
-  }, sdp);
+    // This shouldn't happen, but in case there is no MID for the m= section, do nothing.
+    const mid = getMidForMediaSection(mediaSection);
+    if (!mid) {
+      return mediaSection;
+    }
+    // In case there is no Track ID for the given MID in the map, do nothing.
+    const trackId = midsToTrackIds.get(mid);
+    if (!trackId) {
+      return mediaSection;
+    }
+    // This shouldn't happen, but in case there is no a=msid: line, do nothing.
+    const attributes = (mediaSection.match(/^a=msid:(.+)$/m) || [])[1];
+    if (!attributes) {
+      return mediaSection;
+    }
+    // If the a=msid: line contains the "appdata" field, then replace it with the Track ID,
+    // otherwise append the Track ID.
+    const [msid, trackIdToRewrite] = attributes.split(' ');
+    const msidRegex = new RegExp(`msid:${msid}${trackIdToRewrite ? ` ${trackIdToRewrite}` : ''}$`, 'gm');
+    return mediaSection.replace(msidRegex, `msid:${msid} ${trackId}`);
+  })).join('\r\n');
 }
 
 exports.createCodecMapForMediaSection = createCodecMapForMediaSection;
@@ -466,4 +505,5 @@ exports.setBitrateParameters = setBitrateParameters;
 exports.setCodecPreferences = setCodecPreferences;
 exports.setSimulcast = setSimulcast;
 exports.unifiedPlanFilterLocalCodecs = unifiedPlanFilterLocalCodecs;
-exports.unifiedPlanRewriteTrackIds = unifiedPlanRewriteTrackIds;
+exports.unifiedPlanAddOrRewriteNewTrackIds = unifiedPlanAddOrRewriteNewTrackIds;
+exports.unifiedPlanAddOrRewriteTrackIds = unifiedPlanAddOrRewriteTrackIds;

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- ./test/unit/index.js"
   },
   "dependencies": {
-    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#4.1.0-rc1",
+    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#479469971944f88a3ea6a9ca78a3e41630287a31",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -862,7 +862,7 @@ describe('connect', function() {
               const simSSRCs = new Set(flatMap(section.match(/^a=ssrc-group:SIM .+$/gm), line => {
                 return line.split(' ').slice(1);
               }));
-              const trackSSRCs = new Set(section.match(/^a=ssrc:.+ msid:.+$/gm).map(line => {
+              const trackSSRCs = new Set(section.match(/^a=ssrc:.+$/gm).map(line => {
                 return line.match(/a=ssrc:([0-9]+)/)[1];
               }));
               assert.equal(flowSSRCs.size, 6);
@@ -873,7 +873,10 @@ describe('connect', function() {
             } else {
               assert.equal(flowSSRCs.size, 2);
               assert.equal(section.match(/^a=ssrc-group:SIM .+$/gm), null);
-              assert.equal(section.match(/^a=ssrc:.+ msid:.+$/gm), null);
+              const ssrcsWithAttributes = new Set(flatMap(section.match(/^a=ssrc:.+$/gm), line => {
+                return line.match(/a=ssrc:([0-9]+)/)[1];
+              }));
+              assert.deepEqual(Array.from(flowSSRCs), Array.from(ssrcsWithAttributes));
             }
           });
         });

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const assert = require('assert');
-const sdpFormat = require('@twilio/webrtc/lib/util/sdp').getSdpFormat();
+const { DEFAULT_CHROME_SDP_SEMANTICS } = require('../../../lib/util/constants');
+const sdpFormat = require('@twilio/webrtc/lib/util/sdp').getSdpFormat(DEFAULT_CHROME_SDP_SEMANTICS);
 
 const {
   connect,

--- a/test/integration/spec/util/simulcast.js
+++ b/test/integration/spec/util/simulcast.js
@@ -5,9 +5,10 @@ const { guessBrowser } = require('@twilio/webrtc/lib/util');
 const { getSdpFormat } = require('@twilio/webrtc/lib/util/sdp');
 const { getMediaSections, setSimulcast } = require('../../../../lib/util/sdp');
 const { RTCPeerConnection, RTCSessionDescription } = require('@twilio/webrtc');
+const { DEFAULT_CHROME_SDP_SEMANTICS } = require('../../../../lib/util/constants');
 
 const isChrome = guessBrowser() === 'chrome';
-const sdpFormat = getSdpFormat();
+const sdpFormat = getSdpFormat(DEFAULT_CHROME_SDP_SEMANTICS);
 
 describe('setSimulcast', () => {
   let answer1;

--- a/test/lib/mocksdp.js
+++ b/test/lib/mocksdp.js
@@ -22,9 +22,10 @@
  * @param {TracksByKind} kinds
  * @param {number} [maxAudioBitrate]
  * @param {number} [maxVideoBitrate]
+ * @param {boolean} [withAppData = true]
  * @returns {string} sdp
  */
-function makeSdpWithTracks(type, kinds, maxAudioBitrate, maxVideoBitrate) {
+function makeSdpWithTracks(type, kinds, maxAudioBitrate, maxVideoBitrate, withAppData = true) {
   const session = `\
 v=0\r
 o=- 0 1 IN IP4 0.0.0.0\r
@@ -69,10 +70,10 @@ a=rtcp-mux\r
         ? { id: trackAndSSRC, ssrc: 1 }
         : trackAndSSRC;
       return sdp + (type === 'planb' ? '' : media + `\
-a=msid:- ${id}\r
+a=msid:-${type === 'planb' || withAppData ? ` ${id}` : ''}\r
 `) + `\
 a=ssrc:${ssrc} cname:0\r
-a=ssrc:${ssrc} msid:${type === 'planb' ? 'stream' : '-'} ${id}\r
+a=ssrc:${ssrc} msid:${type === 'planb' ? 'stream' : '-'}${type === 'planb' || withAppData ? ` ${id}` : ''}\r
 a=mid:mid_${id}\r
 `;
     }, sdp + (type === 'planb' ? media : ''));

--- a/test/unit/spec/signaling/v2/networkqualitymonitor.js
+++ b/test/unit/spec/signaling/v2/networkqualitymonitor.js
@@ -45,6 +45,29 @@ describe('NetworkQualityMonitor', () => {
     });
   });
 
+  describe('.updateSignaling()', () => {
+    it('removes old signaling and uses new signaling for updates', () => {
+      const signaling1 = new EventEmitter();
+      const signaling2 = new EventEmitter();
+      const monitor = new NetworkQualityMonitor(null, signaling1);
+      let emitCount = 0;
+
+      monitor.once('updated', () => { emitCount++; });
+      assert.equal(signaling1.listenerCount('updated'), 1);
+      assert.equal(signaling2.listenerCount('updated'), 0);
+
+      monitor.updateSignaling(signaling2);
+      assert.equal(signaling1.listenerCount('updated'), 0);
+      assert.equal(signaling2.listenerCount('updated'), 1);
+
+      assert.equal(emitCount, 0);
+      signaling1.emit('updated');
+      assert.equal(emitCount, 0);
+      signaling2.emit('updated');
+      assert.equal(emitCount, 1);
+    });
+  });
+
   describe('.start()', () => {
     it('constructs a PeerConnectionReportFactory for each RTCPeerConnection contained within PeerConnectionManager', () => {
       // TODO(mroberts): ...

--- a/test/unit/spec/util/sdp/index.js
+++ b/test/unit/spec/util/sdp/index.js
@@ -11,7 +11,8 @@ const {
   setSimulcast,
   unifiedPlanFilterLocalCodecs,
   revertSimulcastForNonVP8MediaSections,
-  unifiedPlanRewriteTrackIds
+  unifiedPlanAddOrRewriteNewTrackIds,
+  unifiedPlanAddOrRewriteTrackIds
 } = require('../../../../../lib/util/sdp');
 
 const { makeSdpForSimulcast, makeSdpWithTracks } = require('../../../../lib/mocksdp');
@@ -846,16 +847,46 @@ describe('revertSimulcastForNonVP8MediaSections', () => {
   });
 });
 
-describe('unifiedPlanRewriteTrackIds', () => {
-  it('should rewrite Track IDs with the IDs of MediaStreamTracks associated with RTCRtpTransceivers', () => {
-    const sdp = makeSdpWithTracks('unified', { audio: ['foo'], video: ['bar'] });
-    const midsToTrackIds = new Map([['mid_foo', 'baz'], ['mid_bar', 'zee']]);
-    const newSdp = unifiedPlanRewriteTrackIds(sdp, midsToTrackIds);
-    const sections = getMediaSections(newSdp);
-    midsToTrackIds.forEach((trackId, mid) => {
-      const section = sections.find(section => new RegExp(`^a=mid:${mid}$`, 'm').test(section));
-      assert.equal(section.match(/^a=msid:.+ (.+)$/m)[1], trackId);
-      assert.equal(section.match(/^a=ssrc:.+ msid:.+ (.+)$/m)[1], trackId);
+describe('unifiedPlanAddOrRewriteNewTrackIds', () => {
+  [true, false].forEach(withAppData => {
+    context(`when the Unified Plan SDP ${withAppData ? 'has' : 'does not have'} MediaStreamTrack IDs in a=msid: lines`, () => {
+      it('should rewrite Track IDs with the IDs of MediaStreamTracks associated with unassigned RTCRtpTransceivers', () => {
+        const sdp = makeSdpWithTracks('unified', {
+          audio: ['foo', 'bar'],
+          video: ['baz', 'zee']
+        }, null, null, withAppData);
+        const newTrackIdsByKind = new Map([['audio', ['xxx', 'yyy']], ['video', ['zzz']]]);
+        const newSdp = unifiedPlanAddOrRewriteNewTrackIds(sdp, newTrackIdsByKind);
+        const msAttrsAndKinds = getMediaSections(newSdp).map(section => [
+          section.match(/^a=msid:(.+)/m)[1],
+          section.match(/^m=(audio|video)/)[1]
+        ]);
+        assert.deepEqual(msAttrsAndKinds, [
+          ['- xxx', 'audio'],
+          ['- yyy', 'audio'],
+          [withAppData ? '- baz' : '-', 'video'],
+          ['- zzz', 'video']
+        ]);
+      });
+
+    });
+  });
+});
+
+describe('unifiedPlanAddOrRewriteTrackIds', () => {
+  [true, false].forEach(withAppData => {
+    context(`when the Unified Plan SDP ${withAppData ? 'has' : 'does not have'} MediaStreamTrack IDs in a=msid: lines`, () => {
+      it('should rewrite Track IDs with the IDs of MediaStreamTracks associated with RTCRtpTransceivers', () => {
+        const sdp = makeSdpWithTracks('unified', { audio: ['foo'], video: ['bar'] }, null, null, withAppData);
+        const midsToTrackIds = new Map([['mid_foo', 'baz'], ['mid_bar', 'zee']]);
+        const newSdp = unifiedPlanAddOrRewriteTrackIds(sdp, midsToTrackIds);
+        const sections = getMediaSections(newSdp);
+        midsToTrackIds.forEach((trackId, mid) => {
+          const section = sections.find(section => new RegExp(`^a=mid:${mid}$`, 'm').test(section));
+          assert.equal(section.match(/^a=msid:.+ (.+)$/m)[1], trackId);
+          assert.equal(section.match(/^a=ssrc:.+ msid:.+ (.+)$/m)[1], trackId);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION

For network quality updates client creates a `NetworkQualityMonitor` object listen on a datachannel for network quality monitor. The id for the channel is obtained from RSP field (`roomState.media_signaling.network_quality.transport.label`). 

During the call in a group room if the VMS process gets killed, a new instance gets created - This results in an `update` message on signaling channel with a new peerconnection id. Client responds by creating a new peer connection.

The problem was we were not rehooking our NetoworkMonitor to the dataChannel from the new peerconnection in such cases. 

With this change, we fix this by updating the dataChannel that we listen on everytime a new dataChannel with desired id is detected. As part of NetoworkMonitor creation, client now listens for any `trackAdded` messages from peerConnectionManager. Whenever a  track with the id that we were interested in gets added, it will start listening on new track.

I have verified the changes by killing the VMS and ensuring that we continue to update networkQualityLevelChanged.

Still TODO:
- [ ] Add tests
- [x] Incorporate similar changes for DominantSpeaker channel.
