### PR TITLE
WIP: JSDK wire enableAutomaticSubscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/suppor
 New Features
 ------------
 
+- Added a new property `enableAutomaticSubscription` to control Track subscription behavior in Group Rooms.
+  - Selecting `true` (the default value) causes the Participant to be subscribed to all Tracks that are published in the Room
+  - Selecting `false` causes the Participant to be subscribed to none of the Tracks that are published in the Room
+  - Selecting `false` has no impact in a Peer-to-Peer Room
+
+```js
+  const { connect } = require('twilio-video');
+  const room = await connect(token, {
+    enableAutomaticSubscription: false
+  });
+```
+
+New Features
+------------
+
 - twilio-video.js will now support the Unified Plan SDP format for Google Chrome.
   Google Chrome enabled Unified Plan as the default SDP format starting from version 72.
   In December 2018, we published an [advisory](https://support.twilio.com/hc/en-us/articles/360012782494-Breaking-Changes-in-Twilio-Video-JavaScript-SDKs-December-2018-)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,18 @@ For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/suppor
 New Features
 ------------
 
-- Added a new property `enableAutomaticSubscription` to control Track subscription behavior in Group Rooms.
-  - Selecting `true` (the default value) causes the Participant to be subscribed to all Tracks that are published in the Room
-  - Selecting `false` causes the Participant to be subscribed to none of the Tracks that are published in the Room
-  - Selecting `false` has no impact in a Peer-to-Peer Room
+- By default, you will subscribe to all RemoteTracks shared by other Participants in a Room.
+  You can now override this behavior through a new ConnectOptions flag automaticSubscription.
+  Setting it to false will make sure that you will not subscribe to any RemoteTrack in a Group or
+  Small Group Room. Setting it to true, or not setting it at all preserves the default behavior.
+  This flag does not have any effect in a Peer-to-Peer Room. (JSDK-2395)
 
 ```js
   const { connect } = require('twilio-video');
   const room = await connect(token, {
-    enableAutomaticSubscription: false
+    automaticSubscription: false
   });
 ```
-
-New Features
-------------
 
 - twilio-video.js will now support the Unified Plan SDP format for Google Chrome.
   Google Chrome enabled Unified Plan as the default SDP format starting from version 72.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ New Features
 ------------
 
 - By default, you will subscribe to all RemoteTracks shared by other Participants in a Room.
-  You can now override this behavior through a new ConnectOptions flag automaticSubscription.
-  Setting it to false will make sure that you will not subscribe to any RemoteTrack in a Group or
-  Small Group Room. Setting it to true, or not setting it at all preserves the default behavior.
+  You can now override this behavior through a new ConnectOptions flag `automaticSubscription`.
+  Setting it to `false` will make sure that you will not subscribe to any RemoteTrack in a Group or
+  Small Group Room. Setting it to `true`, or not setting it at all preserves the default behavior.
   This flag does not have any effect in a Peer-to-Peer Room. (JSDK-2395)
 
 ```js

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -125,7 +125,7 @@ function connect(token, options) {
     abortOnIceServersTimeout: false,
     createLocalTracks,
     dominantSpeaker: false,
-    networkQuality: false,
+    enableAutomaticSubscription: true,
     environment: constants.DEFAULT_ENVIRONMENT,
     iceServersTimeout: constants.ICE_SERVERS_TIMEOUT_MS,
     insights: true,
@@ -138,6 +138,7 @@ function connect(token, options) {
     maxAudioBitrate: null,
     maxVideoBitrate: null,
     name: null,
+    networkQuality: false,
     preferredAudioCodecs: [],
     preferredVideoCodecs: [],
     realm: constants.DEFAULT_REALM,
@@ -248,7 +249,7 @@ function connect(token, options) {
     createRoomSignaling.bind(null, token, options, signaling, iceServerSource, encodingParameters, preferredCodecs),
     createRoom.bind(null, options));
 
-  cancelableRoomPromise.then(room => {
+  return cancelableRoomPromise.then(room => {
     log.info('Connected to Room:', room.toString());
     log.info('Room name:', room.name);
     log.debug('Room:', room);
@@ -262,9 +263,8 @@ function connect(token, options) {
     } else {
       log.info('Error while connecting to a Room:', error);
     }
+    throw error;
   });
-
-  return cancelableRoomPromise;
 }
 
 /**
@@ -280,6 +280,10 @@ function connect(token, options) {
  * @property {boolean|CreateLocalTrackOptions} [audio=true] - Whether or not to
  *   get local audio with <code>getUserMedia</code> when <code>tracks</code>
  *   are not provided.
+ * @property {boolean} [enableAutomaticSubscription=true] - By default,
+ *   your LocalParticipant will subscribe to every RemoteParticipant's Tracks.
+ *   You can disable this by setting this property to `false`. Note that this does not
+ *   take effect in Peer-to-peer (P2P) Rooms, where the setting is silently ignored.
  * @property {boolean} [dominantSpeaker=false] - Whether to enable the Dominant
  *   Speaker API or not. This only takes effect in Group Rooms.
  * @property {Array<RTCIceServer>} iceServers - Override the STUN and TURN

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -142,6 +142,8 @@ function connect(token, options) {
     preferredVideoCodecs: [],
     realm: constants.DEFAULT_REALM,
     region: constants.DEFAULT_REGION,
+    // TODO(mmalavalli): Remove once we decide to support Unified Plan on Chrome 72+
+    sdpSemantics: constants.DEFAULT_CHROME_SDP_SEMANTICS,
     signaling: SignalingV2
   }, util.filterObject(options));
 

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -125,7 +125,7 @@ function connect(token, options) {
     abortOnIceServersTimeout: false,
     createLocalTracks,
     dominantSpeaker: false,
-    enableAutomaticSubscription: true,
+    automaticSubscription: true,
     environment: constants.DEFAULT_ENVIRONMENT,
     iceServersTimeout: constants.ICE_SERVERS_TIMEOUT_MS,
     insights: true,
@@ -249,7 +249,7 @@ function connect(token, options) {
     createRoomSignaling.bind(null, token, options, signaling, iceServerSource, encodingParameters, preferredCodecs),
     createRoom.bind(null, options));
 
-  return cancelableRoomPromise.then(room => {
+  cancelableRoomPromise.then(room => {
     log.info('Connected to Room:', room.toString());
     log.info('Room name:', room.name);
     log.debug('Room:', room);
@@ -263,8 +263,9 @@ function connect(token, options) {
     } else {
       log.info('Error while connecting to a Room:', error);
     }
-    throw error;
   });
+
+  return cancelableRoomPromise;
 }
 
 /**
@@ -280,10 +281,12 @@ function connect(token, options) {
  * @property {boolean|CreateLocalTrackOptions} [audio=true] - Whether or not to
  *   get local audio with <code>getUserMedia</code> when <code>tracks</code>
  *   are not provided.
- * @property {boolean} [enableAutomaticSubscription=true] - By default,
- *   your LocalParticipant will subscribe to every RemoteParticipant's Tracks.
- *   You can disable this by setting this property to `false`. Note that this does not
- *   take effect in Peer-to-peer (P2P) Rooms, where the setting is silently ignored.
+ * @property {boolean} [automaticSubscription=true] - By default, you will subscribe
+ *   to all RemoteTracks shared by other Participants in a Room. You can now override this
+ *   behavior through a new ConnectOptions flag automaticSubscription. Setting it to false
+ *   will make sure that you will not subscribe to any RemoteTrack in a Group or Small Group Room.
+ *   Setting it to true, or not setting it at all preserves the default behavior. This flag
+ *   does not have any effect in a Peer-to-Peer Room.
  * @property {boolean} [dominantSpeaker=false] - Whether to enable the Dominant
  *   Speaker API or not. This only takes effect in Group Rooms.
  * @property {Array<RTCIceServer>} iceServers - Override the STUN and TURN

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -123,9 +123,9 @@ function connect(token, options) {
 
   options = Object.assign({
     abortOnIceServersTimeout: false,
+    automaticSubscription: true,
     createLocalTracks,
     dominantSpeaker: false,
-    automaticSubscription: true,
     environment: constants.DEFAULT_ENVIRONMENT,
     iceServersTimeout: constants.ICE_SERVERS_TIMEOUT_MS,
     insights: true,
@@ -283,8 +283,8 @@ function connect(token, options) {
  *   are not provided.
  * @property {boolean} [automaticSubscription=true] - By default, you will subscribe
  *   to all RemoteTracks shared by other Participants in a Room. You can now override this
- *   behavior through a new ConnectOptions flag automaticSubscription. Setting it to false
- *   will make sure that you will not subscribe to any RemoteTrack in a Group or Small Group Room.
+ *   behavior by Setting this flag to false. It will make sure that you will not subscribe
+ *   to any RemoteTrack in a Group or Small Group Room.
  *   Setting it to true, or not setting it at all preserves the default behavior. This flag
  *   does not have any effect in a Peer-to-Peer Room.
  * @property {boolean} [dominantSpeaker=false] - Whether to enable the Dominant

--- a/lib/data/sender.js
+++ b/lib/data/sender.js
@@ -98,7 +98,11 @@ class DataTrackSender extends DataTrackTransceiver {
       }
     });
     this._clones.forEach(clone => {
-      clone.send(data);
+      try {
+        clone.send(data);
+      } catch (error) {
+        // Do nothing.
+      }
     });
     return this;
   }

--- a/lib/data/transport.js
+++ b/lib/data/transport.js
@@ -48,7 +48,11 @@ class DataTransport extends EventEmitter {
    */
   _publish(message) {
     const data = JSON.stringify(message);
-    this._dataChannel.send(data);
+    try {
+      this._dataChannel.send(data);
+    } catch (error) {
+      // Do nothing.
+    }
   }
 
   /**

--- a/lib/signaling/v2/cancelableroomsignalingpromise.js
+++ b/lib/signaling/v2/cancelableroomsignalingpromise.js
@@ -58,7 +58,7 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
         transportOptions = Object.assign({
           dominantSpeaker: options.dominantSpeaker,
           environment: options.environment,
-          enableAutomaticSubscription: options.enableAutomaticSubscription,
+          automaticSubscription: options.automaticSubscription,
           logLevel: options.logLevel,
           networkQuality: options.networkQuality,
           iceServerSourceStatus: iceServerSource.status,

--- a/lib/signaling/v2/cancelableroomsignalingpromise.js
+++ b/lib/signaling/v2/cancelableroomsignalingpromise.js
@@ -62,7 +62,8 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
           networkQuality: options.networkQuality,
           iceServerSourceStatus: iceServerSource.status,
           insights: options.insights,
-          realm: options.realm
+          realm: options.realm,
+          sdpSemantics: options.sdpSemantics
         }, transportOptions);
 
         const Transport = options.Transport;

--- a/lib/signaling/v2/cancelableroomsignalingpromise.js
+++ b/lib/signaling/v2/cancelableroomsignalingpromise.js
@@ -58,6 +58,7 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
         transportOptions = Object.assign({
           dominantSpeaker: options.dominantSpeaker,
           environment: options.environment,
+          enableAutomaticSubscription: options.enableAutomaticSubscription,
           logLevel: options.logLevel,
           networkQuality: options.networkQuality,
           iceServerSourceStatus: iceServerSource.status,

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1,30 +1,44 @@
 'use strict';
 
-const WebRTC = require('@twilio/webrtc');
+const {
+  MediaStream: DefaultMediaStream,
+  RTCIceCandidate: DefaultRTCIceCandidate,
+  RTCPeerConnection: DefaultRTCPeerConnection,
+  RTCSessionDescription: DefaultRTCSessionDescription,
+  getStats: getStatistics
+} = require('@twilio/webrtc');
+
 const { guessBrowser } = require('@twilio/webrtc/lib/util');
 const { getSdpFormat } = require('@twilio/webrtc/lib/util/sdp');
-const DefaultMediaStream = WebRTC.MediaStream;
-const DefaultRTCIceCandidate = WebRTC.RTCIceCandidate;
-const DefaultRTCPeerConnection = WebRTC.RTCPeerConnection;
-const DefaultRTCSessionDescription = WebRTC.RTCSessionDescription;
-const getStatistics = WebRTC.getStats;
-const createCodecMapForMediaSection = require('../../util/sdp').createCodecMapForMediaSection;
-const unifiedPlanFilterLocalCodecs = require('../../util/sdp').unifiedPlanFilterLocalCodecs;
-const getMediaSections = require('../../util/sdp').getMediaSections;
-const oncePerTick = require('../../util').oncePerTick;
-const setBitrateParameters = require('../../util/sdp').setBitrateParameters;
-const setCodecPreferences = require('../../util/sdp').setCodecPreferences;
-const setSimulcast = require('../../util/sdp').setSimulcast;
-const revertSimulcastForNonVP8MediaSections = require('../../util/sdp').revertSimulcastForNonVP8MediaSections;
-const unifiedPlanRewriteTrackIds = require('../../util/sdp').unifiedPlanRewriteTrackIds;
+const { DEFAULT_LOG_LEVEL } = require('../../util/constants');
+
+const {
+  createCodecMapForMediaSection,
+  getMediaSections,
+  revertSimulcastForNonVP8MediaSections,
+  setBitrateParameters,
+  setCodecPreferences,
+  setSimulcast,
+  unifiedPlanAddOrRewriteNewTrackIds,
+  unifiedPlanAddOrRewriteTrackIds,
+  unifiedPlanFilterLocalCodecs
+} = require('../../util/sdp');
+
+const {
+  MediaClientLocalDescFailedError,
+  MediaClientRemoteDescFailedError
+} = require('../../util/twilio-video-errors');
+
+const {
+  buildLogLevels,
+  makeUUID,
+  oncePerTick
+} = require('../../util');
+
 const IceBox = require('./icebox');
-const MediaClientLocalDescFailedError = require('../../util/twilio-video-errors').MediaClientLocalDescFailedError;
-const MediaClientRemoteDescFailedError = require('../../util/twilio-video-errors').MediaClientRemoteDescFailedError;
 const DataTrackReceiver = require('../../data/receiver');
 const MediaTrackReceiver = require('../../media/track/receiver');
 const StateMachine = require('../../statemachine');
-const { buildLogLevels, makeUUID } = require('../../util');
-const { DEFAULT_LOG_LEVEL } = require('../../util/constants');
 const Log = require('../../util/log');
 const IdentityTrackMatcher = require('../../util/sdp/trackmatcher/identity');
 const OrderedTrackMatcher = require('../../util/sdp/trackmatcher/ordered');
@@ -35,8 +49,6 @@ const guess = guessBrowser();
 const isChrome = guess === 'chrome';
 const isFirefox = guess === 'firefox';
 const isSafari = guess === 'safari';
-const sdpFormat = getSdpFormat();
-const isUnifiedPlan = sdpFormat === 'unified';
 
 const firefoxMajorVersion = isFirefox
   ? parseInt(navigator.userAgent.match(/Firefox\/(\d+)/)[1], 10)
@@ -108,10 +120,13 @@ class PeerConnectionV2 extends StateMachine {
       RTCSessionDescription: DefaultRTCSessionDescription
     }, options);
 
-    const RTCPeerConnection = options.RTCPeerConnection;
     const configuration = getConfiguration(options);
+    const sdpFormat = getSdpFormat(configuration.sdpSemantics);
+    const isUnifiedPlan = sdpFormat === 'unified';
+
     const localMediaStream = isUnifiedPlan ? null : new options.MediaStream();
     const logLevels = buildLogLevels(options.logLevel);
+    const RTCPeerConnection = options.RTCPeerConnection;
     const peerConnection = new RTCPeerConnection(configuration, options.chromeSpecificConstraints);
 
     if (options.dummyAudioMediaStreamTrack) {
@@ -147,6 +162,9 @@ class PeerConnectionV2 extends StateMachine {
       _isRestartingIce: {
         writable: true,
         value: false
+      },
+      _isUnifiedPlan: {
+        value: isUnifiedPlan
       },
       _lastIceConnectionState: {
         writable: true,
@@ -237,6 +255,9 @@ class PeerConnectionV2 extends StateMachine {
       _remoteCandidates: {
         writable: true,
         value: new IceBox()
+      },
+      _sdpFormat: {
+        value: sdpFormat
       },
       _setBitrateParameters: {
         value: options.setBitrateParameters
@@ -400,7 +421,7 @@ class PeerConnectionV2 extends StateMachine {
 
       let description = answer;
       if (this._shouldApplySimulcast) {
-        var updatedSdp = this._setSimulcast(answer.sdp, sdpFormat, this._trackIdsToAttributes);
+        let updatedSdp = this._setSimulcast(answer.sdp, this._sdpFormat, this._trackIdsToAttributes);
         // NOTE(syerrapragada): VMS does not support H264 simulcast. So,
         // unset simulcast for sections in local offer where corresponding
         // sections in answer doesn't have vp8 as preferred codec and reapply offer.
@@ -562,7 +583,7 @@ class PeerConnectionV2 extends StateMachine {
         // support, we have to use the same hacky solution as Safari. Revisit
         // this when RTCRtpTransceivers and MIDs land. We should be able to use
         // the same technique as Firefox.
-        : isSafari || isUnifiedPlan ? new OrderedTrackMatcher() : new IdentityTrackMatcher();
+        : isSafari || this._isUnifiedPlan ? new OrderedTrackMatcher() : new IdentityTrackMatcher();
     }
     this._trackMatcher.update(sdp);
 
@@ -609,7 +630,7 @@ class PeerConnectionV2 extends StateMachine {
       // We can reduce the number of cases where renegotiation is needed by
       // re-introducing 'offerToReceiveAudio' to the default RTCOfferOptions with a
       // value > 1.
-      if (isUnifiedPlan && localDescription.type === 'answer') {
+      if (this._isUnifiedPlan && localDescription.type === 'answer') {
         const senders = this._peerConnection.getSenders().filter(sender => sender.track);
         shouldReoffer = ['audio', 'video'].reduce((shouldOffer, kind) => {
           const mediaSections = getMediaSections(localDescription.sdp, kind, '(sendrecv|sendonly)');
@@ -652,7 +673,7 @@ class PeerConnectionV2 extends StateMachine {
         offer = workaroundIssue8329(offer);
       }
 
-      const sdp = isUnifiedPlan && this._peerConnection.remoteDescription
+      const sdp = this._isUnifiedPlan && this._peerConnection.remoteDescription
         ? unifiedPlanFilterLocalCodecs(offer.sdp, this._peerConnection.remoteDescription.sdp)
         : offer.sdp;
 
@@ -671,7 +692,7 @@ class PeerConnectionV2 extends StateMachine {
           type: 'offer',
           sdp: updatedSdp
         };
-        updatedSdp = this._setSimulcast(updatedSdp, sdpFormat, this._trackIdsToAttributes);
+        updatedSdp = this._setSimulcast(updatedSdp, this._sdpFormat, this._trackIdsToAttributes);
       }
 
       return this._setLocalDescription({
@@ -682,19 +703,34 @@ class PeerConnectionV2 extends StateMachine {
   }
 
   /**
-   * Rewrite local MediaStreamTrack IDs in the given Unified Plan RTCSessionDescription.
+   * Add or rewrite local MediaStreamTrack IDs in the given Unified Plan RTCSessionDescription.
    * @private
    * @param {RTCSessionDescription} description
    * @return {RTCSessionDescription}
    */
-  _rewriteLocalTrackIds(description) {
-    const midsToTrackIds = new Map(this._peerConnection.getTransceivers().filter(({ mid, sender, stopped }) => {
-      return !stopped && mid && sender && sender.track;
-    }).map(({ mid, sender }) => {
-      return [mid, sender.track.id];
-    }));
+  _addOrRewriteLocalTrackIds(description) {
+    const transceivers = this._peerConnection.getTransceivers();
+    const activeTransceivers = transceivers.filter(({ sender, stopped }) => !stopped && sender && sender.track);
+
+    // NOTE(mmalavalli): There is no guarantee that MediaStreamTrack IDs will be present in
+    // SDPs, and even if they are, there is no guarantee that they will be the same as the
+    // actual MediaStreamTrack IDs. So, we add or re-write the actual MediaStreamTrack IDs
+    // to the assigned m= sections here.
+    const assignedTransceivers = activeTransceivers.filter(({ mid }) => mid);
+    const midsToTrackIds = new Map(assignedTransceivers.map(({ mid, sender }) => [mid, sender.track.id]));
+    const sdp1 = unifiedPlanAddOrRewriteTrackIds(description.sdp, midsToTrackIds);
+
+    // NOTE(mmalavalli): Chrome and Safari do not apply the offer until they get an answer.
+    // So, we add or re-write the actual MediaStreamTrack IDs to the unassigned m= sections here.
+    const unassignedTransceivers = activeTransceivers.filter(({ mid }) => !mid);
+    const newTrackIdsByKind = new Map(['audio', 'video'].map(kind => [
+      kind,
+      unassignedTransceivers.filter(({ sender }) => sender.track.kind === kind).map(({ sender }) => sender.track.id)
+    ]));
+    const sdp2 = unifiedPlanAddOrRewriteNewTrackIds(sdp1, newTrackIdsByKind);
+
     return new this._RTCSessionDescription({
-      sdp: unifiedPlanRewriteTrackIds(description.sdp, midsToTrackIds),
+      sdp: sdp2,
       type: description.type
     });
   }
@@ -724,13 +760,13 @@ class PeerConnectionV2 extends StateMachine {
       throw new MediaClientLocalDescFailedError();
     }).then(() => {
       if (description.type !== 'rollback') {
-        this._localDescription = isUnifiedPlan ? this._rewriteLocalTrackIds(description) : description;
+        this._localDescription = this._isUnifiedPlan ? this._addOrRewriteLocalTrackIds(description) : description;
         this._localCandidates = [];
         if (description.type === 'offer') {
           this._descriptionRevision++;
         } else if (description.type === 'answer') {
           this._lastStableDescriptionRevision = this._descriptionRevision;
-          if (isUnifiedPlan) {
+          if (this._isUnifiedPlan) {
             updateRecycledTransceivers(this);
             updateLocalCodecs(this);
             updateRemoteCodecMaps(this);
@@ -787,7 +823,7 @@ class PeerConnectionV2 extends StateMachine {
         this._log.debug('An ICE restart was in-progress and is now completed');
         this._isRestartingIce = false;
       }
-      if (description.type === 'answer' && isUnifiedPlan) {
+      if (description.type === 'answer' && this._isUnifiedPlan) {
         updateRecycledTransceivers(this);
         updateLocalCodecs(this);
         updateRemoteCodecMaps(this);

--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -9,6 +9,7 @@ const TwilioConnection = require('../../twilioconnection');
 
 const {
   createMediaSignalingPayload,
+  createSubscribePayload,
   getUserAgent,
   withJitter
 } = require('../../util');
@@ -118,6 +119,9 @@ class TwilioConnectionTransport extends StateMachine {
           options.realm,
           eventPublisherOptions)
       },
+      _enableAutomaticSubscription: {
+        value: options.enableAutomaticSubscription
+      },
       _iceServerSourceStatus: {
         value: options.iceServerSourceStatus
       },
@@ -214,6 +218,8 @@ class TwilioConnectionTransport extends StateMachine {
         this._dominantSpeaker,
         this._networkQuality);
 
+      message.subscribe = createSubscribePayload(this._enableAutomaticSubscription);
+
       const sdpFormat = this._options.sdpFormat;
       if (sdpFormat) {
         message.format = sdpFormat;
@@ -225,6 +231,7 @@ class TwilioConnectionTransport extends StateMachine {
     } else if (message.type === 'update') {
       message.session = this._session;
     }
+
     this._twilioConnection.sendMessage(message);
   }
 

--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -91,7 +91,7 @@ class TwilioConnectionTransport extends StateMachine {
       maxReconnectAttempts: MAX_RECONNECT_ATTEMPTS,
       reconnectBackOffJitter: RECONNECT_BACKOFF_JITTER,
       reconnectBackOffMs: RECONNECT_BACKOFF_MS,
-      sdpFormat: getSdpFormat(),
+      sdpFormat: getSdpFormat(options.sdpSemantics),
       userAgent: getUserAgent()
     }, options);
     super('connecting', states);

--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -119,8 +119,8 @@ class TwilioConnectionTransport extends StateMachine {
           options.realm,
           eventPublisherOptions)
       },
-      _enableAutomaticSubscription: {
-        value: options.enableAutomaticSubscription
+      _automaticSubscription: {
+        value: options.automaticSubscription
       },
       _iceServerSourceStatus: {
         value: options.iceServerSourceStatus
@@ -218,7 +218,7 @@ class TwilioConnectionTransport extends StateMachine {
         this._dominantSpeaker,
         this._networkQuality);
 
-      message.subscribe = createSubscribePayload(this._enableAutomaticSubscription);
+      message.subscribe = createSubscribePayload(this._automaticSubscription);
 
       const sdpFormat = this._options.sdpFormat;
       if (sdpFormat) {

--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -107,6 +107,9 @@ class TwilioConnectionTransport extends StateMachine {
       _accessToken: {
         value: accessToken
       },
+      _automaticSubscription: {
+        value: options.automaticSubscription
+      },
       _dominantSpeaker: {
         value: options.dominantSpeaker
       },
@@ -118,9 +121,6 @@ class TwilioConnectionTransport extends StateMachine {
           options.environment,
           options.realm,
           eventPublisherOptions)
-      },
-      _automaticSubscription: {
-        value: options.automaticSubscription
       },
       _iceServerSourceStatus: {
         value: options.iceServerSourceStatus

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -71,3 +71,7 @@ module.exports.typeErrors = {
 module.exports.DEFAULT_NQ_LEVEL_LOCAL = 1;
 module.exports.DEFAULT_NQ_LEVEL_REMOTE = 0;
 module.exports.MAX_NQ_LEVEL = 3;
+
+// TODO(mmalavalli): Once we decide to support Unified Plan on Chrome 72+,
+// we need to remove this constant and its references.
+module.exports.DEFAULT_CHROME_SDP_SEMANTICS = 'plan-b';

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -542,6 +542,21 @@ function createMediaSignalingPayload(dominantSpeaker, networkQuality) {
 }
 
 /**
+ * Create the Subscribe payload included in an RSP connect message.
+ * @param {boolean} enableAutomaticSubscription - whether to subscribe to all tracks
+ * @returns {object}
+ */
+function createSubscribePayload(enableAutomaticSubscription) {
+  return {
+    rules: [{
+      type: enableAutomaticSubscription ? 'include' : 'exclude',
+      all: true
+    }],
+    revision: 1
+  };
+}
+
+/**
  * Add random jitter to a given value in the range [-jitter, jitter].
  * @private
  * @param {number} value
@@ -567,6 +582,7 @@ function inRange(num, min, max) {
 
 exports.constants = constants;
 exports.createMediaSignalingPayload = createMediaSignalingPayload;
+exports.createSubscribePayload = createSubscribePayload;
 exports.asLocalTrack = asLocalTrack;
 exports.asLocalTrackPublication = asLocalTrackPublication;
 exports.capitalize = capitalize;

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -543,13 +543,13 @@ function createMediaSignalingPayload(dominantSpeaker, networkQuality) {
 
 /**
  * Create the Subscribe payload included in an RSP connect message.
- * @param {boolean} enableAutomaticSubscription - whether to subscribe to all tracks
+ * @param {boolean} automaticSubscription - whether to subscribe to all tracks
  * @returns {object}
  */
-function createSubscribePayload(enableAutomaticSubscription) {
+function createSubscribePayload(automaticSubscription) {
   return {
     rules: [{
-      type: enableAutomaticSubscription ? 'include' : 'exclude',
+      type: automaticSubscription ? 'include' : 'exclude',
       all: true
     }],
     revision: 1

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -542,7 +542,7 @@ function createMediaSignalingPayload(dominantSpeaker, networkQuality) {
 }
 
 /**
- * Create the Subscribe payload included in an RSP connect message.
+ * Create the Subscribe payload included in an RSP connect/update message.
  * @param {boolean} automaticSubscription - whether to subscribe to all tracks
  * @returns {object}
  */

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -437,25 +437,64 @@ function revertSimulcastForNonVP8MediaSections(localSdp, localSdpWithoutSimulcas
 }
 
 /**
- * Rewrite MSIDs in the given Unified Plan SDP with their corresponding local
- * MediaStreamTrack IDs. These IDs need not be the same.
+ * Add or rewrite MSIDs for new m= sections in the given Unified Plan SDP with their
+ * corresponding local MediaStreamTrack IDs. These can be different when previously
+ * removed MediaStreamTracks are added back (or Track IDs may not be present in the
+ * SDPs at all once browsers implement the latest WebRTC spec).
+ * @param {string} sdp
+ * @param {Map<Track.Kind, Array<Track.ID>>} trackIdsByKind
+ * @returns {string}
+ */
+function unifiedPlanAddOrRewriteNewTrackIds(sdp, trackIdsByKind) {
+  // NOTE(mmalavalli): The m= sections for the new MediaStreamTracks are usually
+  // present after the m= sections for the existing MediaStreamTracks, in order
+  // of addition.
+  const newMidsToTrackIds = Array.from(trackIdsByKind).reduce((midsToTrackIds, [kind, trackIds]) => {
+    const mediaSections = getMediaSections(sdp, kind);
+    const newMids = mediaSections.slice(mediaSections.length - trackIds.length).map(getMidForMediaSection);
+    newMids.forEach((mid, i) => midsToTrackIds.set(mid, trackIds[i]));
+    return midsToTrackIds;
+  }, new Map());
+  return unifiedPlanAddOrRewriteTrackIds(sdp, newMidsToTrackIds);
+}
+
+/**
+ * Add or rewrite MSIDs in the given Unified Plan SDP with their corresponding local
+ * MediaStreamTrack IDs. These IDs need not be the same (or Track IDs may not be
+ * present in the SDPs at all once browsers implement the latest WebRTC spec).
  * @param {string} sdp
  * @param {Map<string, string>} midsToTrackIds
  * @returns {string}
  */
-function unifiedPlanRewriteTrackIds(sdp, midsToTrackIds) {
-  return Array.from(midsToTrackIds).reduce((sdp, [mid, trackId]) => {
-    const midRegex = new RegExp(`a=mid:${mid}`);
-    const section = getMediaSections(sdp).find(section => midRegex.test(section));
-    if (section) {
-      const trackIdToRewrite = (section.match(/^a=msid:.+ (.+)$/m) || [])[1];
-      if (trackIdToRewrite) {
-        const msidRegex = new RegExp(`msid:(.+) ${trackIdToRewrite}$`, 'gm');
-        sdp = sdp.replace(msidRegex, `msid:$1 ${trackId}`);
-      }
+function unifiedPlanAddOrRewriteTrackIds(sdp, midsToTrackIds) {
+  const mediaSections = getMediaSections(sdp);
+  const session = sdp.split('\r\nm=')[0];
+  return [session].concat(mediaSections.map(mediaSection => {
+    // Do nothing if the m= section represents neither audio nor video.
+    if (!/^m=(audio|video)/.test(mediaSection)) {
+      return mediaSection;
     }
-    return sdp;
-  }, sdp);
+    // This shouldn't happen, but in case there is no MID for the m= section, do nothing.
+    const mid = getMidForMediaSection(mediaSection);
+    if (!mid) {
+      return mediaSection;
+    }
+    // In case there is no Track ID for the given MID in the map, do nothing.
+    const trackId = midsToTrackIds.get(mid);
+    if (!trackId) {
+      return mediaSection;
+    }
+    // This shouldn't happen, but in case there is no a=msid: line, do nothing.
+    const attributes = (mediaSection.match(/^a=msid:(.+)$/m) || [])[1];
+    if (!attributes) {
+      return mediaSection;
+    }
+    // If the a=msid: line contains the "appdata" field, then replace it with the Track ID,
+    // otherwise append the Track ID.
+    const [msid, trackIdToRewrite] = attributes.split(' ');
+    const msidRegex = new RegExp(`msid:${msid}${trackIdToRewrite ? ` ${trackIdToRewrite}` : ''}$`, 'gm');
+    return mediaSection.replace(msidRegex, `msid:${msid} ${trackId}`);
+  })).join('\r\n');
 }
 
 exports.createCodecMapForMediaSection = createCodecMapForMediaSection;
@@ -466,4 +505,5 @@ exports.setBitrateParameters = setBitrateParameters;
 exports.setCodecPreferences = setCodecPreferences;
 exports.setSimulcast = setSimulcast;
 exports.unifiedPlanFilterLocalCodecs = unifiedPlanFilterLocalCodecs;
-exports.unifiedPlanRewriteTrackIds = unifiedPlanRewriteTrackIds;
+exports.unifiedPlanAddOrRewriteNewTrackIds = unifiedPlanAddOrRewriteNewTrackIds;
+exports.unifiedPlanAddOrRewriteTrackIds = unifiedPlanAddOrRewriteTrackIds;

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- ./test/unit/index.js"
   },
   "dependencies": {
-    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#4.1.0-rc1",
+    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#479469971944f88a3ea6a9ca78a3e41630287a31",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -104,8 +104,8 @@ describe('connect', function() {
     });
   });
 
-  describe.only('automaticSubscription option', () => {
-    ['missing', 'enabled', 'disabled'].forEach((option) => {
+  describe('automaticSubscription', () => {
+    ['missing', 'enabled', 'disabled'].forEach(option => {
       const subscriptionOption = {
         missing: {},
         enabled: { automaticSubscription: true },
@@ -137,11 +137,11 @@ describe('connect', function() {
           }
         });
         if (expectSubscriptionsEnabled) {
-          assert.equal(subscribed, 4, 'subscribed should be 4, but were: ' + subscribed);
-          assert.equal(notsubscribed, 0, 'notsubscribed should be zero, but were: ' + notsubscribed);
+          assert.equal(subscribed, 4, `subscribed should be 4, but were: ${subscribed}`);
+          assert.equal(notsubscribed, 0, `notsubscribed should be 0, but were: ${notsubscribed}`);
         } else {
-          assert.equal(subscribed, 0, 'subscribed should be 4, but were: ' + subscribed);
-          assert.equal(notsubscribed, 4, 'notsubscribed should be zero, but were: ' + notsubscribed);
+          assert.equal(subscribed, 0, `subscribed should be 0, but were: ${subscribed}`);
+          assert.equal(notsubscribed, 4, `notsubscribed should be 4, but were: ${notsubscribed}`);
         }
       });
     });

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -862,7 +862,7 @@ describe('connect', function() {
               const simSSRCs = new Set(flatMap(section.match(/^a=ssrc-group:SIM .+$/gm), line => {
                 return line.split(' ').slice(1);
               }));
-              const trackSSRCs = new Set(section.match(/^a=ssrc:.+ msid:.+$/gm).map(line => {
+              const trackSSRCs = new Set(section.match(/^a=ssrc:.+$/gm).map(line => {
                 return line.match(/a=ssrc:([0-9]+)/)[1];
               }));
               assert.equal(flowSSRCs.size, 6);
@@ -873,7 +873,10 @@ describe('connect', function() {
             } else {
               assert.equal(flowSSRCs.size, 2);
               assert.equal(section.match(/^a=ssrc-group:SIM .+$/gm), null);
-              assert.equal(section.match(/^a=ssrc:.+ msid:.+$/gm), null);
+              const ssrcsWithAttributes = new Set(flatMap(section.match(/^a=ssrc:.+$/gm), line => {
+                return line.match(/a=ssrc:([0-9]+)/)[1];
+              }));
+              assert.deepEqual(Array.from(flowSSRCs), Array.from(ssrcsWithAttributes));
             }
           });
         });

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -137,10 +137,10 @@ describe('connect', function() {
           }
         });
         if (expectSubscriptionsEnabled) {
-          assert.equal(subscribed, 4, 'subscribed should be zero, but were: ' + subscribed);
+          assert.equal(subscribed, 4, 'subscribed should be 4, but were: ' + subscribed);
           assert.equal(notsubscribed, 0, 'notsubscribed should be zero, but were: ' + notsubscribed);
         } else {
-          assert.equal(subscribed, 0, 'subscribed should be zero, but were: ' + subscribed);
+          assert.equal(subscribed, 0, 'subscribed should be 4, but were: ' + subscribed);
           assert.equal(notsubscribed, 4, 'notsubscribed should be zero, but were: ' + notsubscribed);
         }
       });
@@ -957,7 +957,6 @@ function getPayloadTypes(mediaSection) {
 }
 
 async function setup(setupOptions) {
-
   setupOptions = Object.assign({
     name: randomName(),
     nTracks: 2,
@@ -966,7 +965,6 @@ async function setup(setupOptions) {
     waitForSubscriptions: true,
   }, setupOptions);
 
-  setupOptions.name = setupOptions.name || randomName();
   const options = Object.assign({
     audio: true,
     video: smallVideoConstraints

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const assert = require('assert');
-const sdpFormat = require('@twilio/webrtc/lib/util/sdp').getSdpFormat();
+const { DEFAULT_CHROME_SDP_SEMANTICS } = require('../../../lib/util/constants');
+const sdpFormat = require('@twilio/webrtc/lib/util/sdp').getSdpFormat(DEFAULT_CHROME_SDP_SEMANTICS);
 
 const {
   connect,

--- a/test/integration/spec/util/simulcast.js
+++ b/test/integration/spec/util/simulcast.js
@@ -5,9 +5,10 @@ const { guessBrowser } = require('@twilio/webrtc/lib/util');
 const { getSdpFormat } = require('@twilio/webrtc/lib/util/sdp');
 const { getMediaSections, setSimulcast } = require('../../../../lib/util/sdp');
 const { RTCPeerConnection, RTCSessionDescription } = require('@twilio/webrtc');
+const { DEFAULT_CHROME_SDP_SEMANTICS } = require('../../../../lib/util/constants');
 
 const isChrome = guessBrowser() === 'chrome';
-const sdpFormat = getSdpFormat();
+const sdpFormat = getSdpFormat(DEFAULT_CHROME_SDP_SEMANTICS);
 
 describe('setSimulcast', () => {
   let answer1;

--- a/test/lib/mocksdp.js
+++ b/test/lib/mocksdp.js
@@ -22,9 +22,10 @@
  * @param {TracksByKind} kinds
  * @param {number} [maxAudioBitrate]
  * @param {number} [maxVideoBitrate]
+ * @param {boolean} [withAppData = true]
  * @returns {string} sdp
  */
-function makeSdpWithTracks(type, kinds, maxAudioBitrate, maxVideoBitrate) {
+function makeSdpWithTracks(type, kinds, maxAudioBitrate, maxVideoBitrate, withAppData = true) {
   const session = `\
 v=0\r
 o=- 0 1 IN IP4 0.0.0.0\r
@@ -69,10 +70,10 @@ a=rtcp-mux\r
         ? { id: trackAndSSRC, ssrc: 1 }
         : trackAndSSRC;
       return sdp + (type === 'planb' ? '' : media + `\
-a=msid:- ${id}\r
+a=msid:-${type === 'planb' || withAppData ? ` ${id}` : ''}\r
 `) + `\
 a=ssrc:${ssrc} cname:0\r
-a=ssrc:${ssrc} msid:${type === 'planb' ? 'stream' : '-'} ${id}\r
+a=ssrc:${ssrc} msid:${type === 'planb' ? 'stream' : '-'}${type === 'planb' || withAppData ? ` ${id}` : ''}\r
 a=mid:mid_${id}\r
 `;
     }, sdp + (type === 'planb' ? media : ''));

--- a/test/unit/spec/util/sdp/index.js
+++ b/test/unit/spec/util/sdp/index.js
@@ -11,7 +11,8 @@ const {
   setSimulcast,
   unifiedPlanFilterLocalCodecs,
   revertSimulcastForNonVP8MediaSections,
-  unifiedPlanRewriteTrackIds
+  unifiedPlanAddOrRewriteNewTrackIds,
+  unifiedPlanAddOrRewriteTrackIds
 } = require('../../../../../lib/util/sdp');
 
 const { makeSdpForSimulcast, makeSdpWithTracks } = require('../../../../lib/mocksdp');
@@ -846,16 +847,46 @@ describe('revertSimulcastForNonVP8MediaSections', () => {
   });
 });
 
-describe('unifiedPlanRewriteTrackIds', () => {
-  it('should rewrite Track IDs with the IDs of MediaStreamTracks associated with RTCRtpTransceivers', () => {
-    const sdp = makeSdpWithTracks('unified', { audio: ['foo'], video: ['bar'] });
-    const midsToTrackIds = new Map([['mid_foo', 'baz'], ['mid_bar', 'zee']]);
-    const newSdp = unifiedPlanRewriteTrackIds(sdp, midsToTrackIds);
-    const sections = getMediaSections(newSdp);
-    midsToTrackIds.forEach((trackId, mid) => {
-      const section = sections.find(section => new RegExp(`^a=mid:${mid}$`, 'm').test(section));
-      assert.equal(section.match(/^a=msid:.+ (.+)$/m)[1], trackId);
-      assert.equal(section.match(/^a=ssrc:.+ msid:.+ (.+)$/m)[1], trackId);
+describe('unifiedPlanAddOrRewriteNewTrackIds', () => {
+  [true, false].forEach(withAppData => {
+    context(`when the Unified Plan SDP ${withAppData ? 'has' : 'does not have'} MediaStreamTrack IDs in a=msid: lines`, () => {
+      it('should rewrite Track IDs with the IDs of MediaStreamTracks associated with unassigned RTCRtpTransceivers', () => {
+        const sdp = makeSdpWithTracks('unified', {
+          audio: ['foo', 'bar'],
+          video: ['baz', 'zee']
+        }, null, null, withAppData);
+        const newTrackIdsByKind = new Map([['audio', ['xxx', 'yyy']], ['video', ['zzz']]]);
+        const newSdp = unifiedPlanAddOrRewriteNewTrackIds(sdp, newTrackIdsByKind);
+        const msAttrsAndKinds = getMediaSections(newSdp).map(section => [
+          section.match(/^a=msid:(.+)/m)[1],
+          section.match(/^m=(audio|video)/)[1]
+        ]);
+        assert.deepEqual(msAttrsAndKinds, [
+          ['- xxx', 'audio'],
+          ['- yyy', 'audio'],
+          [withAppData ? '- baz' : '-', 'video'],
+          ['- zzz', 'video']
+        ]);
+      });
+
+    });
+  });
+});
+
+describe('unifiedPlanAddOrRewriteTrackIds', () => {
+  [true, false].forEach(withAppData => {
+    context(`when the Unified Plan SDP ${withAppData ? 'has' : 'does not have'} MediaStreamTrack IDs in a=msid: lines`, () => {
+      it('should rewrite Track IDs with the IDs of MediaStreamTracks associated with RTCRtpTransceivers', () => {
+        const sdp = makeSdpWithTracks('unified', { audio: ['foo'], video: ['bar'] }, null, null, withAppData);
+        const midsToTrackIds = new Map([['mid_foo', 'baz'], ['mid_bar', 'zee']]);
+        const newSdp = unifiedPlanAddOrRewriteTrackIds(sdp, midsToTrackIds);
+        const sections = getMediaSections(newSdp);
+        midsToTrackIds.forEach((trackId, mid) => {
+          const section = sections.find(section => new RegExp(`^a=mid:${mid}$`, 'm').test(section));
+          assert.equal(section.match(/^a=msid:.+ (.+)$/m)[1], trackId);
+          assert.equal(section.match(/^a=ssrc:.+ msid:.+ (.+)$/m)[1], trackId);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
This is Work in Progress. This changes adds a new property `enableAutomaticSubscription` in ConnectOptions.  When set to `false` ( default is `true`), this will cause local participant to not subscribe to any of the remote tracks. 

~This PR also adds a small (unrelated) change where instead of returning a connect promise with rejection handler attached, it generates a new promise - This will ensure that user will get `unhandled rejection` if they forget to handle the rejection on the returned promise.~ 

TODO:
- [x] add integration tests 
