### PR TITLE
JSDK-2385 Add or rewrite Track IDs in local SDPs even if "appdata" field is not present.

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -142,6 +142,8 @@ function connect(token, options) {
     preferredVideoCodecs: [],
     realm: constants.DEFAULT_REALM,
     region: constants.DEFAULT_REGION,
+    // TODO(mmalavalli): Remove once we decide to support Unified Plan on Chrome 72+
+    sdpSemantics: constants.DEFAULT_CHROME_SDP_SEMANTICS,
     signaling: SignalingV2
   }, util.filterObject(options));
 

--- a/lib/data/sender.js
+++ b/lib/data/sender.js
@@ -98,7 +98,11 @@ class DataTrackSender extends DataTrackTransceiver {
       }
     });
     this._clones.forEach(clone => {
-      clone.send(data);
+      try {
+        clone.send(data);
+      } catch (error) {
+        // Do nothing.
+      }
     });
     return this;
   }

--- a/lib/data/transport.js
+++ b/lib/data/transport.js
@@ -48,7 +48,11 @@ class DataTransport extends EventEmitter {
    */
   _publish(message) {
     const data = JSON.stringify(message);
-    this._dataChannel.send(data);
+    try {
+      this._dataChannel.send(data);
+    } catch (error) {
+      // Do nothing.
+    }
   }
 
   /**

--- a/lib/signaling/v2/cancelableroomsignalingpromise.js
+++ b/lib/signaling/v2/cancelableroomsignalingpromise.js
@@ -62,7 +62,8 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
           networkQuality: options.networkQuality,
           iceServerSourceStatus: iceServerSource.status,
           insights: options.insights,
-          realm: options.realm
+          realm: options.realm,
+          sdpSemantics: options.sdpSemantics
         }, transportOptions);
 
         const Transport = options.Transport;

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -36,12 +36,13 @@ const guess = guessBrowser();
 const isChrome = guess === 'chrome';
 const isFirefox = guess === 'firefox';
 const isSafari = guess === 'safari';
-const sdpFormat = getSdpFormat();
-const isUnifiedPlan = sdpFormat === 'unified';
 
 const firefoxMajorVersion = isFirefox
   ? parseInt(navigator.userAgent.match(/Firefox\/(\d+)/)[1], 10)
   : null;
+
+let isUnifiedPlan;
+let sdpFormat;
 
 /*
 PeerConnectionV2 States
@@ -109,10 +110,13 @@ class PeerConnectionV2 extends StateMachine {
       RTCSessionDescription: DefaultRTCSessionDescription
     }, options);
 
-    const RTCPeerConnection = options.RTCPeerConnection;
     const configuration = getConfiguration(options);
+    sdpFormat = sdpFormat || getSdpFormat(configuration.sdpSemantics);
+    isUnifiedPlan = typeof isUnifiedPlan === 'boolean' ? isUnifiedPlan : sdpFormat === 'unified';
+
     const localMediaStream = isUnifiedPlan ? null : new options.MediaStream();
     const logLevels = buildLogLevels(options.logLevel);
+    const RTCPeerConnection = options.RTCPeerConnection;
     const peerConnection = new RTCPeerConnection(configuration, options.chromeSpecificConstraints);
 
     if (options.dummyAudioMediaStreamTrack) {

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1,31 +1,44 @@
 'use strict';
 
-const WebRTC = require('@twilio/webrtc');
+const {
+  MediaStream: DefaultMediaStream,
+  RTCIceCandidate: DefaultRTCIceCandidate,
+  RTCPeerConnection: DefaultRTCPeerConnection,
+  RTCSessionDescription: DefaultRTCSessionDescription,
+  getStats: getStatistics
+} = require('@twilio/webrtc');
+
 const { guessBrowser } = require('@twilio/webrtc/lib/util');
 const { getSdpFormat } = require('@twilio/webrtc/lib/util/sdp');
-const DefaultMediaStream = WebRTC.MediaStream;
-const DefaultRTCIceCandidate = WebRTC.RTCIceCandidate;
-const DefaultRTCPeerConnection = WebRTC.RTCPeerConnection;
-const DefaultRTCSessionDescription = WebRTC.RTCSessionDescription;
-const getStatistics = WebRTC.getStats;
-const createCodecMapForMediaSection = require('../../util/sdp').createCodecMapForMediaSection;
-const unifiedPlanFilterLocalCodecs = require('../../util/sdp').unifiedPlanFilterLocalCodecs;
-const getMediaSections = require('../../util/sdp').getMediaSections;
-const oncePerTick = require('../../util').oncePerTick;
-const setBitrateParameters = require('../../util/sdp').setBitrateParameters;
-const setCodecPreferences = require('../../util/sdp').setCodecPreferences;
-const setSimulcast = require('../../util/sdp').setSimulcast;
-const revertSimulcastForNonVP8MediaSections = require('../../util/sdp').revertSimulcastForNonVP8MediaSections;
-const unifiedPlanAddOrRewriteNewTrackIds = require('../../util/sdp').unifiedPlanAddOrRewriteNewTrackIds;
-const unifiedPlanAddOrRewriteTrackIds = require('../../util/sdp').unifiedPlanAddOrRewriteTrackIds;
+const { DEFAULT_LOG_LEVEL } = require('../../util/constants');
+
+const {
+  createCodecMapForMediaSection,
+  getMediaSections,
+  revertSimulcastForNonVP8MediaSections,
+  setBitrateParameters,
+  setCodecPreferences,
+  setSimulcast,
+  unifiedPlanAddOrRewriteNewTrackIds,
+  unifiedPlanAddOrRewriteTrackIds,
+  unifiedPlanFilterLocalCodecs
+} = require('../../util/sdp');
+
+const {
+  MediaClientLocalDescFailedError,
+  MediaClientRemoteDescFailedError
+} = require('../../util/twilio-video-errors');
+
+const {
+  buildLogLevels,
+  makeUUID,
+  oncePerTick
+} = require('../../util');
+
 const IceBox = require('./icebox');
-const MediaClientLocalDescFailedError = require('../../util/twilio-video-errors').MediaClientLocalDescFailedError;
-const MediaClientRemoteDescFailedError = require('../../util/twilio-video-errors').MediaClientRemoteDescFailedError;
 const DataTrackReceiver = require('../../data/receiver');
 const MediaTrackReceiver = require('../../media/track/receiver');
 const StateMachine = require('../../statemachine');
-const { buildLogLevels, makeUUID } = require('../../util');
-const { DEFAULT_LOG_LEVEL } = require('../../util/constants');
 const Log = require('../../util/log');
 const IdentityTrackMatcher = require('../../util/sdp/trackmatcher/identity');
 const OrderedTrackMatcher = require('../../util/sdp/trackmatcher/ordered');
@@ -690,7 +703,7 @@ class PeerConnectionV2 extends StateMachine {
   }
 
   /**
-   * Add or rewrite Rewrite local MediaStreamTrack IDs in the given Unified Plan RTCSessionDescription.
+   * Add or rewrite local MediaStreamTrack IDs in the given Unified Plan RTCSessionDescription.
    * @private
    * @param {RTCSessionDescription} description
    * @return {RTCSessionDescription}

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -16,7 +16,8 @@ const setBitrateParameters = require('../../util/sdp').setBitrateParameters;
 const setCodecPreferences = require('../../util/sdp').setCodecPreferences;
 const setSimulcast = require('../../util/sdp').setSimulcast;
 const revertSimulcastForNonVP8MediaSections = require('../../util/sdp').revertSimulcastForNonVP8MediaSections;
-const unifiedPlanRewriteTrackIds = require('../../util/sdp').unifiedPlanRewriteTrackIds;
+const unifiedPlanAddOrRewriteNewTrackIds = require('../../util/sdp').unifiedPlanAddOrRewriteNewTrackIds;
+const unifiedPlanAddOrRewriteTrackIds = require('../../util/sdp').unifiedPlanAddOrRewriteTrackIds;
 const IceBox = require('./icebox');
 const MediaClientLocalDescFailedError = require('../../util/twilio-video-errors').MediaClientLocalDescFailedError;
 const MediaClientRemoteDescFailedError = require('../../util/twilio-video-errors').MediaClientRemoteDescFailedError;
@@ -682,19 +683,34 @@ class PeerConnectionV2 extends StateMachine {
   }
 
   /**
-   * Rewrite local MediaStreamTrack IDs in the given Unified Plan RTCSessionDescription.
+   * Add or rewrite Rewrite local MediaStreamTrack IDs in the given Unified Plan RTCSessionDescription.
    * @private
    * @param {RTCSessionDescription} description
    * @return {RTCSessionDescription}
    */
-  _rewriteLocalTrackIds(description) {
-    const midsToTrackIds = new Map(this._peerConnection.getTransceivers().filter(({ mid, sender, stopped }) => {
-      return !stopped && mid && sender && sender.track;
-    }).map(({ mid, sender }) => {
-      return [mid, sender.track.id];
-    }));
+  _addOrRewriteLocalTrackIds(description) {
+    const transceivers = this._peerConnection.getTransceivers();
+    const activeTransceivers = transceivers.filter(({ sender, stopped }) => !stopped && sender && sender.track);
+
+    // NOTE(mmalavalli): There is no guarantee that MediaStreamTrack IDs will be present in
+    // SDPs, and even if they are, there is no guarantee that they will be the same as the
+    // actual MediaStreamTrack IDs. So, we add or re-write the actual MediaStreamTrack IDs
+    // to the assigned m= sections here.
+    const assignedTransceivers = activeTransceivers.filter(({ mid }) => mid);
+    const midsToTrackIds = new Map(assignedTransceivers.map(({ mid, sender }) => [mid, sender.track.id]));
+    const sdp1 = unifiedPlanAddOrRewriteTrackIds(description.sdp, midsToTrackIds);
+
+    // NOTE(mmalavalli): Chrome and Safari do not apply the offer until they get an answer.
+    // So, we add or re-write the actual MediaStreamTrack IDs to the unassigned m= sections here.
+    const unassignedTransceivers = activeTransceivers.filter(({ mid }) => !mid);
+    const newTrackIdsByKind = new Map(['audio', 'video'].map(kind => [
+      kind,
+      unassignedTransceivers.filter(({ sender }) => sender.track.kind === kind).map(({ sender }) => sender.track.id)
+    ]));
+    const sdp2 = unifiedPlanAddOrRewriteNewTrackIds(sdp1, newTrackIdsByKind);
+
     return new this._RTCSessionDescription({
-      sdp: unifiedPlanRewriteTrackIds(description.sdp, midsToTrackIds),
+      sdp: sdp2,
       type: description.type
     });
   }
@@ -724,7 +740,7 @@ class PeerConnectionV2 extends StateMachine {
       throw new MediaClientLocalDescFailedError();
     }).then(() => {
       if (description.type !== 'rollback') {
-        this._localDescription = isUnifiedPlan ? this._rewriteLocalTrackIds(description) : description;
+        this._localDescription = isUnifiedPlan ? this._addOrRewriteLocalTrackIds(description) : description;
         this._localCandidates = [];
         if (description.type === 'offer') {
           this._descriptionRevision++;

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -41,9 +41,6 @@ const firefoxMajorVersion = isFirefox
   ? parseInt(navigator.userAgent.match(/Firefox\/(\d+)/)[1], 10)
   : null;
 
-let isUnifiedPlan;
-let sdpFormat;
-
 /*
 PeerConnectionV2 States
 -----------------------
@@ -111,8 +108,8 @@ class PeerConnectionV2 extends StateMachine {
     }, options);
 
     const configuration = getConfiguration(options);
-    sdpFormat = sdpFormat || getSdpFormat(configuration.sdpSemantics);
-    isUnifiedPlan = typeof isUnifiedPlan === 'boolean' ? isUnifiedPlan : sdpFormat === 'unified';
+    const sdpFormat = getSdpFormat(configuration.sdpSemantics);
+    const isUnifiedPlan = sdpFormat === 'unified';
 
     const localMediaStream = isUnifiedPlan ? null : new options.MediaStream();
     const logLevels = buildLogLevels(options.logLevel);
@@ -152,6 +149,9 @@ class PeerConnectionV2 extends StateMachine {
       _isRestartingIce: {
         writable: true,
         value: false
+      },
+      _isUnifiedPlan: {
+        value: isUnifiedPlan
       },
       _lastIceConnectionState: {
         writable: true,
@@ -242,6 +242,9 @@ class PeerConnectionV2 extends StateMachine {
       _remoteCandidates: {
         writable: true,
         value: new IceBox()
+      },
+      _sdpFormat: {
+        value: sdpFormat
       },
       _setBitrateParameters: {
         value: options.setBitrateParameters
@@ -405,7 +408,7 @@ class PeerConnectionV2 extends StateMachine {
 
       let description = answer;
       if (this._shouldApplySimulcast) {
-        var updatedSdp = this._setSimulcast(answer.sdp, sdpFormat, this._trackIdsToAttributes);
+        let updatedSdp = this._setSimulcast(answer.sdp, this._sdpFormat, this._trackIdsToAttributes);
         // NOTE(syerrapragada): VMS does not support H264 simulcast. So,
         // unset simulcast for sections in local offer where corresponding
         // sections in answer doesn't have vp8 as preferred codec and reapply offer.
@@ -567,7 +570,7 @@ class PeerConnectionV2 extends StateMachine {
         // support, we have to use the same hacky solution as Safari. Revisit
         // this when RTCRtpTransceivers and MIDs land. We should be able to use
         // the same technique as Firefox.
-        : isSafari || isUnifiedPlan ? new OrderedTrackMatcher() : new IdentityTrackMatcher();
+        : isSafari || this._isUnifiedPlan ? new OrderedTrackMatcher() : new IdentityTrackMatcher();
     }
     this._trackMatcher.update(sdp);
 
@@ -614,7 +617,7 @@ class PeerConnectionV2 extends StateMachine {
       // We can reduce the number of cases where renegotiation is needed by
       // re-introducing 'offerToReceiveAudio' to the default RTCOfferOptions with a
       // value > 1.
-      if (isUnifiedPlan && localDescription.type === 'answer') {
+      if (this._isUnifiedPlan && localDescription.type === 'answer') {
         const senders = this._peerConnection.getSenders().filter(sender => sender.track);
         shouldReoffer = ['audio', 'video'].reduce((shouldOffer, kind) => {
           const mediaSections = getMediaSections(localDescription.sdp, kind, '(sendrecv|sendonly)');
@@ -657,7 +660,7 @@ class PeerConnectionV2 extends StateMachine {
         offer = workaroundIssue8329(offer);
       }
 
-      const sdp = isUnifiedPlan && this._peerConnection.remoteDescription
+      const sdp = this._isUnifiedPlan && this._peerConnection.remoteDescription
         ? unifiedPlanFilterLocalCodecs(offer.sdp, this._peerConnection.remoteDescription.sdp)
         : offer.sdp;
 
@@ -676,7 +679,7 @@ class PeerConnectionV2 extends StateMachine {
           type: 'offer',
           sdp: updatedSdp
         };
-        updatedSdp = this._setSimulcast(updatedSdp, sdpFormat, this._trackIdsToAttributes);
+        updatedSdp = this._setSimulcast(updatedSdp, this._sdpFormat, this._trackIdsToAttributes);
       }
 
       return this._setLocalDescription({
@@ -744,13 +747,13 @@ class PeerConnectionV2 extends StateMachine {
       throw new MediaClientLocalDescFailedError();
     }).then(() => {
       if (description.type !== 'rollback') {
-        this._localDescription = isUnifiedPlan ? this._addOrRewriteLocalTrackIds(description) : description;
+        this._localDescription = this._isUnifiedPlan ? this._addOrRewriteLocalTrackIds(description) : description;
         this._localCandidates = [];
         if (description.type === 'offer') {
           this._descriptionRevision++;
         } else if (description.type === 'answer') {
           this._lastStableDescriptionRevision = this._descriptionRevision;
-          if (isUnifiedPlan) {
+          if (this._isUnifiedPlan) {
             updateRecycledTransceivers(this);
             updateLocalCodecs(this);
             updateRemoteCodecMaps(this);
@@ -807,7 +810,7 @@ class PeerConnectionV2 extends StateMachine {
         this._log.debug('An ICE restart was in-progress and is now completed');
         this._isRestartingIce = false;
       }
-      if (description.type === 'answer' && isUnifiedPlan) {
+      if (description.type === 'answer' && this._isUnifiedPlan) {
         updateRecycledTransceivers(this);
         updateLocalCodecs(this);
         updateRemoteCodecMaps(this);

--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -91,7 +91,7 @@ class TwilioConnectionTransport extends StateMachine {
       maxReconnectAttempts: MAX_RECONNECT_ATTEMPTS,
       reconnectBackOffJitter: RECONNECT_BACKOFF_JITTER,
       reconnectBackOffMs: RECONNECT_BACKOFF_MS,
-      sdpFormat: getSdpFormat(),
+      sdpFormat: getSdpFormat(options.sdpSemantics),
       userAgent: getUserAgent()
     }, options);
     super('connecting', states);

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -71,3 +71,7 @@ module.exports.typeErrors = {
 module.exports.DEFAULT_NQ_LEVEL_LOCAL = 1;
 module.exports.DEFAULT_NQ_LEVEL_REMOTE = 0;
 module.exports.MAX_NQ_LEVEL = 3;
+
+// TODO(mmalavalli): Once we decide to support Unified Plan on Chrome 72+,
+// we need to remove this constant and its references.
+module.exports.DEFAULT_CHROME_SDP_SEMANTICS = 'plan-b';

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -437,25 +437,64 @@ function revertSimulcastForNonVP8MediaSections(localSdp, localSdpWithoutSimulcas
 }
 
 /**
- * Rewrite MSIDs in the given Unified Plan SDP with their corresponding local
- * MediaStreamTrack IDs. These IDs need not be the same.
+ * Add or rewrite MSIDs for new m= sections in the given Unified Plan SDP with their
+ * corresponding local MediaStreamTrack IDs. These can be different when previously
+ * removed MediaStreamTracks are added back (or Track IDs may not be present in the
+ * SDPs at all once browsers implement the latest WebRTC spec).
+ * @param {string} sdp
+ * @param {Map<Track.Kind, Array<Track.ID>>} trackIdsByKind
+ * @returns {string}
+ */
+function unifiedPlanAddOrRewriteNewTrackIds(sdp, trackIdsByKind) {
+  // NOTE(mmalavalli): The m= sections for the new MediaStreamTracks are usually
+  // present after the m= sections for the existing MediaStreamTracks, in order
+  // of addition.
+  const newMidsToTrackIds = Array.from(trackIdsByKind).reduce((midsToTrackIds, [kind, trackIds]) => {
+    const mediaSections = getMediaSections(sdp, kind);
+    const newMids = mediaSections.slice(mediaSections.length - trackIds.length).map(getMidForMediaSection);
+    newMids.forEach((mid, i) => midsToTrackIds.set(mid, trackIds[i]));
+    return midsToTrackIds;
+  }, new Map());
+  return unifiedPlanAddOrRewriteTrackIds(sdp, newMidsToTrackIds);
+}
+
+/**
+ * Add or rewrite MSIDs in the given Unified Plan SDP with their corresponding local
+ * MediaStreamTrack IDs. These IDs need not be the same (or Track IDs may not be
+ * present in the SDPs at all once browsers implement the latest WebRTC spec).
  * @param {string} sdp
  * @param {Map<string, string>} midsToTrackIds
  * @returns {string}
  */
-function unifiedPlanRewriteTrackIds(sdp, midsToTrackIds) {
-  return Array.from(midsToTrackIds).reduce((sdp, [mid, trackId]) => {
-    const midRegex = new RegExp(`a=mid:${mid}`);
-    const section = getMediaSections(sdp).find(section => midRegex.test(section));
-    if (section) {
-      const trackIdToRewrite = (section.match(/^a=msid:.+ (.+)$/m) || [])[1];
-      if (trackIdToRewrite) {
-        const msidRegex = new RegExp(`msid:(.+) ${trackIdToRewrite}$`, 'gm');
-        sdp = sdp.replace(msidRegex, `msid:$1 ${trackId}`);
-      }
+function unifiedPlanAddOrRewriteTrackIds(sdp, midsToTrackIds) {
+  const mediaSections = getMediaSections(sdp);
+  const session = sdp.split('\r\nm=')[0];
+  return [session].concat(mediaSections.map(mediaSection => {
+    // Do nothing if the m= section represents neither audio nor video.
+    if (!/^m=(audio|video)/.test(mediaSection)) {
+      return mediaSection;
     }
-    return sdp;
-  }, sdp);
+    // This shouldn't happen, but in case there is no MID for the m= section, do nothing.
+    const mid = getMidForMediaSection(mediaSection);
+    if (!mid) {
+      return mediaSection;
+    }
+    // In case there is no Track ID for the given MID in the map, do nothing.
+    const trackId = midsToTrackIds.get(mid);
+    if (!trackId) {
+      return mediaSection;
+    }
+    // This shouldn't happen, but in case there is no a=msid: line, do nothing.
+    const attributes = (mediaSection.match(/^a=msid:(.+)$/m) || [])[1];
+    if (!attributes) {
+      return mediaSection;
+    }
+    // If the a=msid: line contains the "appdata" field, then replace it with the Track ID,
+    // otherwise append the Track ID.
+    const [msid, trackIdToRewrite] = attributes.split(' ');
+    const msidRegex = new RegExp(`msid:${msid}${trackIdToRewrite ? ` ${trackIdToRewrite}` : ''}$`, 'gm');
+    return mediaSection.replace(msidRegex, `msid:${msid} ${trackId}`);
+  })).join('\r\n');
 }
 
 exports.createCodecMapForMediaSection = createCodecMapForMediaSection;
@@ -466,4 +505,5 @@ exports.setBitrateParameters = setBitrateParameters;
 exports.setCodecPreferences = setCodecPreferences;
 exports.setSimulcast = setSimulcast;
 exports.unifiedPlanFilterLocalCodecs = unifiedPlanFilterLocalCodecs;
-exports.unifiedPlanRewriteTrackIds = unifiedPlanRewriteTrackIds;
+exports.unifiedPlanAddOrRewriteNewTrackIds = unifiedPlanAddOrRewriteNewTrackIds;
+exports.unifiedPlanAddOrRewriteTrackIds = unifiedPlanAddOrRewriteTrackIds;

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- ./test/unit/index.js"
   },
   "dependencies": {
-    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#add-sdpSemantics-flag",
+    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#87f7e61106f58e29364999d8753c773e5602536f",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- ./test/unit/index.js"
   },
   "dependencies": {
-    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#4.1.0-rc1",
+    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#add-sdpSemantics-flag",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- ./test/unit/index.js"
   },
   "dependencies": {
-    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#87f7e61106f58e29364999d8753c773e5602536f",
+    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#479469971944f88a3ea6a9ca78a3e41630287a31",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -862,7 +862,7 @@ describe('connect', function() {
               const simSSRCs = new Set(flatMap(section.match(/^a=ssrc-group:SIM .+$/gm), line => {
                 return line.split(' ').slice(1);
               }));
-              const trackSSRCs = new Set(section.match(/^a=ssrc:.+ msid:.+$/gm).map(line => {
+              const trackSSRCs = new Set(section.match(/^a=ssrc:.+$/gm).map(line => {
                 return line.match(/a=ssrc:([0-9]+)/)[1];
               }));
               assert.equal(flowSSRCs.size, 6);
@@ -873,7 +873,10 @@ describe('connect', function() {
             } else {
               assert.equal(flowSSRCs.size, 2);
               assert.equal(section.match(/^a=ssrc-group:SIM .+$/gm), null);
-              assert.equal(section.match(/^a=ssrc:.+ msid:.+$/gm), null);
+              const ssrcsWithAttributes = new Set(flatMap(section.match(/^a=ssrc:.+$/gm), line => {
+                return line.match(/a=ssrc:([0-9]+)/)[1];
+              }));
+              assert.deepEqual(Array.from(flowSSRCs), Array.from(ssrcsWithAttributes));
             }
           });
         });

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const assert = require('assert');
-const sdpFormat = require('@twilio/webrtc/lib/util/sdp').getSdpFormat();
+const { DEFAULT_CHROME_SDP_SEMANTICS } = require('../../../lib/util/constants');
+const sdpFormat = require('@twilio/webrtc/lib/util/sdp').getSdpFormat(DEFAULT_CHROME_SDP_SEMANTICS);
 
 const {
   connect,

--- a/test/integration/spec/util/simulcast.js
+++ b/test/integration/spec/util/simulcast.js
@@ -5,9 +5,10 @@ const { guessBrowser } = require('@twilio/webrtc/lib/util');
 const { getSdpFormat } = require('@twilio/webrtc/lib/util/sdp');
 const { getMediaSections, setSimulcast } = require('../../../../lib/util/sdp');
 const { RTCPeerConnection, RTCSessionDescription } = require('@twilio/webrtc');
+const { DEFAULT_CHROME_SDP_SEMANTICS } = require('../../../../lib/util/constants');
 
 const isChrome = guessBrowser() === 'chrome';
-const sdpFormat = getSdpFormat();
+const sdpFormat = getSdpFormat(DEFAULT_CHROME_SDP_SEMANTICS);
 
 describe('setSimulcast', () => {
   let answer1;

--- a/test/lib/mocksdp.js
+++ b/test/lib/mocksdp.js
@@ -22,9 +22,10 @@
  * @param {TracksByKind} kinds
  * @param {number} [maxAudioBitrate]
  * @param {number} [maxVideoBitrate]
+ * @param {boolean} [withAppData = true]
  * @returns {string} sdp
  */
-function makeSdpWithTracks(type, kinds, maxAudioBitrate, maxVideoBitrate) {
+function makeSdpWithTracks(type, kinds, maxAudioBitrate, maxVideoBitrate, withAppData = true) {
   const session = `\
 v=0\r
 o=- 0 1 IN IP4 0.0.0.0\r
@@ -69,10 +70,10 @@ a=rtcp-mux\r
         ? { id: trackAndSSRC, ssrc: 1 }
         : trackAndSSRC;
       return sdp + (type === 'planb' ? '' : media + `\
-a=msid:- ${id}\r
+a=msid:-${type === 'planb' || withAppData ? ` ${id}` : ''}\r
 `) + `\
 a=ssrc:${ssrc} cname:0\r
-a=ssrc:${ssrc} msid:${type === 'planb' ? 'stream' : '-'} ${id}\r
+a=ssrc:${ssrc} msid:${type === 'planb' ? 'stream' : '-'}${type === 'planb' || withAppData ? ` ${id}` : ''}\r
 a=mid:mid_${id}\r
 `;
     }, sdp + (type === 'planb' ? media : ''));

--- a/test/unit/spec/util/sdp/index.js
+++ b/test/unit/spec/util/sdp/index.js
@@ -855,14 +855,14 @@ describe('unifiedPlanAddOrRewriteNewTrackIds', () => {
           audio: ['foo', 'bar'],
           video: ['baz', 'zee']
         }, null, null, withAppData);
-        const newTrackIdsByKind = new Map([['audio', ['yyy']], ['video', ['zzz']]]);
+        const newTrackIdsByKind = new Map([['audio', ['xxx', 'yyy']], ['video', ['zzz']]]);
         const newSdp = unifiedPlanAddOrRewriteNewTrackIds(sdp, newTrackIdsByKind);
         const msAttrsAndKinds = getMediaSections(newSdp).map(section => [
           section.match(/^a=msid:(.+)/m)[1],
           section.match(/^m=(audio|video)/)[1]
         ]);
         assert.deepEqual(msAttrsAndKinds, [
-          [withAppData ? '- foo' : '-', 'audio'],
+          ['- xxx', 'audio'],
           ['- yyy', 'audio'],
           [withAppData ? '- baz' : '-', 'video'],
           ['- zzz', 'video']


### PR DESCRIPTION
@makarandp0 @syerrapragada 

This PR has two sections:

1. As of now, each m= section has this line `a=msid:<streamId> <appdata>`. The `appdata` field represents the Track ID associated with the m= section. This need not be the same as the ID of the actual MediaStreamTrack that is assigned to this m= section. So we have been rewriting the `appdata` field with the actual MediaStreamTrack ID. In this PR, we make sure that we write the MediaStreamTrack ID even if `appdata` is not present in the m= section, because WebRTC spec has been updated to remove `appdata`.

2. A new (or rather a previously available) `sdpSemantics` ConnectOptions flag is (re)introduced to switch easily between `plan-b` and `unified-plan`. Now, we don't need to maintain a separate branch for the Plan B implementation.

NOTE: Because we now calculate the SDP format after connect() is called in Chrome, JSDK-2392 is fixed.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
