### PR TITLE
JSDK-2307 MSP objects do not recover on JSDK side after SFU Failover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ New Features
   Setting it to `false` will make sure that you will not subscribe to any RemoteTrack in a Group or
   Small Group Room. Setting it to `true`, or not setting it at all preserves the default behavior.
   This flag does not have any effect in a Peer-to-Peer Room. (JSDK-2395)
- 
+
   ```js
     const { connect } = require('twilio-video');
     const room = await connect(token, {
@@ -24,7 +24,8 @@ New Features
 
 Bug Fixes
 ---------
-
+- Fixed a bug where, Dominant Speaker and Network Quality events used to stop
+  emitting after VMS instance fails over (JSDK-2307)
 - Fixed a bug where, the local and remote AudioTracks' audioLevels returned by
   `Room.getStats()` were not in the range [0-32767]. (JSDK-2303)
 - Fixed a bug where Chrome and Safari Participants were enabling simulcast for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@ New Features
 
 Bug Fixes
 ---------
-- Fixed a bug where, Dominant Speaker and Network Quality events used to stop
-  emitting after VMS instance fails over (JSDK-2307)
+- Fixed a bug where Participants in a Group or Small Group Room stopped receiving
+  Dominant Speaker and Network Quality updates when the media server recovered
+  from a failover. (JSDK-2307)
 - Fixed a bug where, the local and remote AudioTracks' audioLevels returned by
   `Room.getStats()` were not in the range [0-32767]. (JSDK-2303)
 - Fixed a bug where Chrome and Safari Participants were enabling simulcast for

--- a/lib/data/receiver.js
+++ b/lib/data/receiver.js
@@ -60,8 +60,11 @@ class DataTrackReceiver extends DataTrackTransceiver {
 
 /**
  * @event DataTrackReceiver#message
- * @event DataTrackReceiver#close
  * @param {string|ArrayBuffer} data
+ */
+
+/**
+ * @event DataTrackReceiver#close
  */
 
 module.exports = DataTrackReceiver;

--- a/lib/data/receiver.js
+++ b/lib/data/receiver.js
@@ -9,6 +9,7 @@ const DataTransport = require('./transport');
  * receive data.
  * @extends DataTrackTransceiver
  * @emits DataTrackReceiver#message
+ * @emits DataTrackReceiver#close
  */
 class DataTrackReceiver extends DataTrackTransceiver {
   /**
@@ -59,6 +60,7 @@ class DataTrackReceiver extends DataTrackTransceiver {
 
 /**
  * @event DataTrackReceiver#message
+ * @event DataTrackReceiver#close
  * @param {string|ArrayBuffer} data
  */
 

--- a/lib/data/receiver.js
+++ b/lib/data/receiver.js
@@ -37,6 +37,10 @@ class DataTrackReceiver extends DataTrackTransceiver {
     dataChannel.addEventListener('message', event => {
       this.emit('message', event.data);
     });
+
+    dataChannel.addEventListener('close', () => {
+      this.emit('close');
+    });
   }
 
   stop() {

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -18,6 +18,7 @@ const STATS_PUBLISH_INTERVAL_MS = 1000;
 class RoomV2 extends RoomSignaling {
   constructor(localParticipant, initialState, transport, peerConnectionManager, options) {
     options = Object.assign({
+      DominantSpeakerSignaling,
       NetworkQualityMonitor,
       NetworkQualitySignaling,
       RecordingSignaling: RecordingV2,
@@ -31,6 +32,9 @@ class RoomV2 extends RoomSignaling {
       _dominantSpeakerSignaling: {
         value: null,
         writable: true
+      },
+      _DominantSpeakerSignaling: {
+        value: options.DominantSpeakerSignaling
       },
       _dominantSpeakerSignalingPromise: {
         value: null,
@@ -341,15 +345,11 @@ class RoomV2 extends RoomSignaling {
         return;
       }
 
-      receiver.on('close', () => {
-        // during SFU failover, old datachannel gets closed
-        // as new PC (and data channel) gets established.
-        // tear this instnace down, and let it get
-        // recreated as update is received.
-        this._teardownDominantSpeakerSignaling();
-      });
-
-      const dominantSpeakerSignaling = new DominantSpeakerSignaling(receiver.toDataTransport());
+      // NOTE(mpatwardhan): The underlying RTCDataChannel is closed whenever
+      // the VMS instance fails over, and a new RTCDataChannel is created in order
+      // to resume sending Dominant Speaker updates.
+      receiver.on('close', () => this._teardownDominantSpeakerSignaling());
+      const dominantSpeakerSignaling = new this._DominantSpeakerSignaling(receiver.toDataTransport());
       this._setDominantSpeakerSignaling(dominantSpeakerSignaling);
     });
     this._dominantSpeakerSignalingPromise = dominantSpeakerSignalingPromise;
@@ -373,13 +373,10 @@ class RoomV2 extends RoomSignaling {
         return;
       }
 
-      receiver.on('close', () => {
-        // during SFU failover, old datachannel gets closed
-        // as new PC (and data channel) gets established.
-        // tear this instnace down, and let it get
-        // recreated as update is received.
-        this._teardownNetworkQualityMonitor();
-      });
+      // NOTE(mpatwardhan): The underlying RTCDataChannel is closed whenever
+      // the VMS instance fails over, and new a RTCDataChannel is created in order
+      // to resume exchanging Network Quality messages.
+      receiver.once('close', () => this. _teardownNetworkQualityMonitor());
 
       const networkQualitySignaling = new this._NetworkQualitySignaling(
         receiver.toDataTransport(), self._networkQualityConfiguration);

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -340,6 +340,15 @@ class RoomV2 extends RoomSignaling {
         // NOTE(mroberts): _teardownDominantSpeakerSignaling was called.
         return;
       }
+
+      receiver.on('close', () => {
+        // during SFU failover, old datachannel gets closed
+        // as new PC (and data channel) gets established.
+        // tear this instnace down, and let it get
+        // recreated as update is received.
+        this._teardownDominantSpeakerSignaling();
+      });
+
       const dominantSpeakerSignaling = new DominantSpeakerSignaling(receiver.toDataTransport());
       this._setDominantSpeakerSignaling(dominantSpeakerSignaling);
     });
@@ -363,6 +372,15 @@ class RoomV2 extends RoomSignaling {
         // NOTE(mroberts): _teardownNetworkQualityMonitor was called.
         return;
       }
+
+      receiver.on('close', () => {
+        // during SFU failover, old datachannel gets closed
+        // as new PC (and data channel) gets established.
+        // tear this instnace down, and let it get
+        // recreated as update is received.
+        this._teardownNetworkQualityMonitor();
+      });
+
       const networkQualitySignaling = new this._NetworkQualitySignaling(
         receiver.toDataTransport(), self._networkQualityConfiguration);
       const networkQualityMonitor = new this._NetworkQualityMonitor(this._peerConnectionManager, networkQualitySignaling);

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -348,7 +348,8 @@ class RoomV2 extends RoomSignaling {
       // NOTE(mpatwardhan): The underlying RTCDataChannel is closed whenever
       // the VMS instance fails over, and a new RTCDataChannel is created in order
       // to resume sending Dominant Speaker updates.
-      receiver.on('close', () => this._teardownDominantSpeakerSignaling());
+      receiver.once('close', () => this._teardownDominantSpeakerSignaling());
+
       const dominantSpeakerSignaling = new this._DominantSpeakerSignaling(receiver.toDataTransport());
       this._setDominantSpeakerSignaling(dominantSpeakerSignaling);
     });

--- a/test/unit/spec/signaling/v2/room.js
+++ b/test/unit/spec/signaling/v2/room.js
@@ -1199,8 +1199,8 @@ describe('RoomV2', () => {
 
       beforeEach(() => {
         NetworkQualitySignaling = sinon.spy(function() {
-            networkQualitySignaling = {};
-            return networkQualitySignaling;
+          networkQualitySignaling = {};
+          return networkQualitySignaling;
         });
 
         NetworkQualityMonitor = sinon.spy(function() {
@@ -1342,8 +1342,7 @@ describe('RoomV2', () => {
             dataTrackTransport2 = new EventEmitter();
             dataTrackTransport2.stop = sinon.spy();
 
-
-            // emit old on old track
+            // emit close on old channel
             dataTrackReceiver.emit('close');
             await new Promise(resolve => setTimeout(resolve));
 


### PR DESCRIPTION
Note: This PR was originally opened as https://github.com/twilio/twilio-video.js/pull/665, 

For network quality and dominant speaker updates client  listen on a datachannel. The id for the channels is obtained from RSP field (roomState.media_signaling.network_quality.transport.label, roomState.media_signaling.network_quality.transport.label).

During the call in a group room if the VMS process gets killed, a new instance gets created - This results in an update message on signaling channel with a new peerconnection id. Client responds by creating a new peer connection.

The problem was we were not rehooking our NetoworkMonitor, Dominant Spekear dataChannels from the new peerconnection in such cases.

With this change, we fix this by tearing down the monitors after close event on datachannel. They get recreated when a new update message is received.
I have verified the changes by killing the VMS and ensuring that we continue to update networkQualityLevelChanged, and Dominant Speaker changes.

- [x] I acknowledge that all my contributions will be made under the project's license.
