### PR TITLE
JSDK-2307 MSP objects do not recover on JSDK side after SFU Failover …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ package-lock.json
 test.json
 yarn.lock
 .idea
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 For 2.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/master/CHANGELOG.md).
 
+1.18.2 (in progress)
+=====================
+
+Bug Fixes
+---------
+- Fixed a bug where Participants in a Group or Small Group Room stopped receiving
+  Dominant Speaker and Network Quality updates when the media server recovered
+  from a failover. (JSDK-2307)
+
 1.18.1 (June 7, 2019)
 =====================
 
@@ -43,7 +52,7 @@ New Features
   room.on('participantConnected', setupNetworkQualityStats);
 
   function logNetworkQualityStats(participant, networkQualityLevel, networkQualityStats) {
-    console.log(`Network quality level for ${participant.identity}:`, networkQualityLevel);  
+    console.log(`Network quality level for ${participant.identity}:`, networkQualityLevel);
     if (networkQualityStats) {
       // Verbosity is in the range [2 - 3].
       console.log('Network quality statistics used to compute the level:', networkQualityStats);
@@ -80,7 +89,7 @@ New Features
   with H264. You will now be able to play back VP8 VideoTracks from Chrome and Firefox
   Participants in a Group Room. For more details, refer to these guides:
   [Developing for Safari](https://www.twilio.com/docs/video/developing-safari-11)
-  and [Working with VP8 Simulcast](https://www.twilio.com/docs/video/tutorials/working-with-vp8-simulcast). (JSDK-2314) 
+  and [Working with VP8 Simulcast](https://www.twilio.com/docs/video/tutorials/working-with-vp8-simulcast). (JSDK-2314)
 
 1.16.0 (March 18, 2019)
 =======================
@@ -412,7 +421,7 @@ New Features
   event is emitted on the RemoteParticipant (and subsequently on the Room) whenever
   a Track is published. A "trackUnpublished" event is emitted on the RemoteParticipant
   whenever a Track is unpublished. (JSDK-1438)
-  
+
   ```js
   participant.on('trackPublished', publication => {
     console.log('A new Track was published!', publication);
@@ -1094,13 +1103,13 @@ New Features
   LocalTacks should be stopped. If `stop` is not specified, then the removed
   LocalTracks will be stopped. This mirrors the behavior of the LocalParticicipant's
   `removeTrack` method.
-  
+
   ```js
   // Stops the removed LocalTracks
   localParticipant.removeTracks(tracks);
   localParticipant.removeTracks(tracks, true);
   ```
-  
+
   ```js
   // Does not stop the removed LocalTracks
   localParticipant.removeTracks(tracks, false);
@@ -1120,9 +1129,9 @@ Bug Fixes
 1.0.0 (April 25, 2017)
 ======================
 
-1.0.0-beta7 has been promoted to 1.0.0! 
+1.0.0-beta7 has been promoted to 1.0.0!
 
-This library uses [Semantic Versioning](http://semver.org/): We've removed the 
+This library uses [Semantic Versioning](http://semver.org/): We've removed the
 pre-release identifier, and we're proud to share the first generally available
 release of twilio-video.js.
 

--- a/lib/data/receiver.js
+++ b/lib/data/receiver.js
@@ -9,6 +9,7 @@ const DataTransport = require('./transport');
  * receive data.
  * @extends DataTrackTransceiver
  * @emits DataTrackReceiver#message
+ * @emits DataTrackReceiver#close
  */
 class DataTrackReceiver extends DataTrackTransceiver {
   /**
@@ -37,6 +38,10 @@ class DataTrackReceiver extends DataTrackTransceiver {
     dataChannel.addEventListener('message', event => {
       this.emit('message', event.data);
     });
+
+    dataChannel.addEventListener('close', () => {
+      this.emit('close');
+    });
   }
 
   /**
@@ -51,6 +56,10 @@ class DataTrackReceiver extends DataTrackTransceiver {
 /**
  * @event DataTrackReceiver#message
  * @param {string|ArrayBuffer} data
+ */
+
+/**
+ * @event DataTrackReceiver#close
  */
 
 module.exports = DataTrackReceiver;

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -18,6 +18,7 @@ const STATS_PUBLISH_INTERVAL_MS = 1000;
 class RoomV2 extends RoomSignaling {
   constructor(localParticipant, initialState, transport, peerConnectionManager, options) {
     options = Object.assign({
+      DominantSpeakerSignaling,
       NetworkQualityMonitor,
       NetworkQualitySignaling,
       RecordingSignaling: RecordingV2,
@@ -31,6 +32,9 @@ class RoomV2 extends RoomSignaling {
       _dominantSpeakerSignaling: {
         value: null,
         writable: true
+      },
+      _DominantSpeakerSignaling: {
+        value: options.DominantSpeakerSignaling
       },
       _dominantSpeakerSignalingPromise: {
         value: null,
@@ -332,7 +336,13 @@ class RoomV2 extends RoomSignaling {
         // NOTE(mroberts): _teardownDominantSpeakerSignaling was called.
         return;
       }
-      const dominantSpeakerSignaling = new DominantSpeakerSignaling(receiver.toDataTransport());
+
+      // NOTE(mpatwardhan): The underlying RTCDataChannel is closed whenever
+      // the VMS instance fails over, and a new RTCDataChannel is created in order
+      // to resume sending Dominant Speaker updates.
+      receiver.once('close', () => this._teardownDominantSpeakerSignaling());
+
+      const dominantSpeakerSignaling = new this._DominantSpeakerSignaling(receiver.toDataTransport());
       this._setDominantSpeakerSignaling(dominantSpeakerSignaling);
     });
     this._dominantSpeakerSignalingPromise = dominantSpeakerSignalingPromise;
@@ -355,6 +365,12 @@ class RoomV2 extends RoomSignaling {
         // NOTE(mroberts): _teardownNetworkQualityMonitor was called.
         return;
       }
+
+      // NOTE(mpatwardhan): The underlying RTCDataChannel is closed whenever
+      // the VMS instance fails over, and new a RTCDataChannel is created in order
+      // to resume exchanging Network Quality messages.
+      receiver.once('close', () => this. _teardownNetworkQualityMonitor());
+
       const networkQualitySignaling = new this._NetworkQualitySignaling(
         receiver.toDataTransport(), self._networkQualityConfiguration);
       const networkQualityMonitor = new this._NetworkQualityMonitor(this._peerConnectionManager, networkQualitySignaling);

--- a/test/unit/spec/signaling/v2/room.js
+++ b/test/unit/spec/signaling/v2/room.js
@@ -1171,7 +1171,7 @@ describe('RoomV2', () => {
     });
   });
 
-  describe('Dominant Speaker', () => {
+  describe('Dominant Speaker Signaling', () => {
     describe('when update is called with an RSP message that determines Active Speaker over RTCDataChannel', () => {
       let DominantSpeakerSignaling;
       let dominantSpeakerSignaling;

--- a/test/unit/spec/signaling/v2/room.js
+++ b/test/unit/spec/signaling/v2/room.js
@@ -9,6 +9,7 @@ const { flatMap } = require('../../../../../lib/util');
 
 const StatsReport = require('../../../../../lib/stats/statsreport');
 const RoomV2 = require('../../../../../lib/signaling/v2/room');
+const RealDominantSpeakerSignaling = require('../../../../../lib/signaling/v2/dominantspeakersignaling');
 
 describe('RoomV2', () => {
   // RoomV2
@@ -1170,8 +1171,115 @@ describe('RoomV2', () => {
     });
   });
 
-  // Network Quality Signaling
-  // -------------------------
+  describe('Dominant Speaker', () => {
+    describe('when update is called with an RSP message that determines Active Speaker over RTCDataChannel', () => {
+      let DominantSpeakerSignaling;
+      let dominantSpeakerSignaling;
+      let dominantSpeaker;
+      let test;
+      beforeEach(() => {
+        DominantSpeakerSignaling = sinon.spy(function(param) {
+          dominantSpeakerSignaling = new RealDominantSpeakerSignaling(param);
+          return dominantSpeakerSignaling;
+        });
+
+        test = makeTest({
+          DominantSpeakerSignaling
+        });
+
+        test.room.on('dominantSpeakerChanged', () => {
+          dominantSpeaker = test.room.dominantSpeakerSid;
+        });
+
+        test.transport.emit('message', {
+          // eslint-disable-next-line
+          media_signaling: {
+            // eslint-disable-next-line
+            active_speaker: {
+              transport: { type: 'data-channel', label: 'foo' }
+            }
+          }
+        });
+      });
+
+      describe('waits for a DataTrackReceiver with the expected label, and', () => {
+        let dataTrackReceiver;
+        let dataTrackTransport;
+
+        beforeEach(async () => {
+          dataTrackTransport = new EventEmitter();
+          dataTrackTransport.stop = sinon.spy();
+
+          dataTrackReceiver = makeTrackReceiver({ id: 'foo', kind: 'data' });
+          dataTrackReceiver.toDataTransport = sinon.spy(() => dataTrackTransport);
+
+          test.peerConnectionManager.emit('trackAdded', dataTrackReceiver);
+
+          await new Promise(resolve => setTimeout(resolve));
+        });
+
+        it('converts the DataTrackReciever to a DataTrackTransport,', () => {
+          assert(dataTrackReceiver.toDataTransport.calledOnce);
+        });
+
+        it('constructs a DominantSpeakerSignaling with the DataTrackTransport,', () => {
+          assert(DominantSpeakerSignaling.calledWith(dataTrackTransport));
+        });
+
+        it('starts updating when the track emits "message"', () => {
+          dataTrackTransport.emit('message', { type: 'active_speaker', participant: 'bob' });
+          assert.equal(dominantSpeaker, 'bob');
+          dataTrackTransport.emit('message', { type: 'active_speaker', participant: 'alice' });
+          assert.equal(dominantSpeaker, 'alice');
+        });
+
+        describe('when the underlying DataTrackReceiver is closed, and new one is created', () => {
+          let dataTrackTransport2;
+          let dataTrackReceiver2;
+          beforeEach(async () => {
+            // emit close on old channel
+            dataTrackReceiver.emit('close');
+            await new Promise(resolve => setTimeout(resolve));
+            dataTrackTransport2 = new EventEmitter();
+            dataTrackTransport2.stop = sinon.spy();
+
+            // send update message.
+            test.transport.emit('message', {
+              // eslint-disable-next-line
+              media_signaling: {
+                // eslint-disable-next-line
+                active_speaker: {
+                  transport: { type: 'data-channel', label: 'foo' }
+                }
+              }
+            });
+
+            // create another track receiver
+            dataTrackReceiver2 = makeTrackReceiver({ id: 'foo', kind: 'data' });
+            dataTrackReceiver2.toDataTransport = sinon.spy(() => dataTrackReceiver2);
+            test.peerConnectionManager.emit('trackAdded', dataTrackReceiver2);
+            await new Promise(resolve => setTimeout(resolve));
+          });
+
+          it('converts DataTrackReciever2 to a DataTrackTransport,', () => {
+            assert(dataTrackReceiver2.toDataTransport.calledOnce);
+          });
+
+          it('constructs new NetworkQualitySignaling with the dataTrackReceiver2,', () => {
+            assert(DominantSpeakerSignaling.calledWith(dataTrackReceiver2));
+          });
+
+          it('starts updating when new track emits "message"', () => {
+            dataTrackReceiver2.emit('message', { type: 'active_speaker', participant: 'Charlie' });
+            assert.equal(dominantSpeaker, 'Charlie');
+
+            dataTrackReceiver2.emit('message', { type: 'active_speaker', participant: 'alice' });
+            assert.equal(dominantSpeaker, 'alice');
+          });
+        });
+      });
+    });
+  });
 
   describe('Network Quality Signaling', () => {
     describe('when update is called with an RSP message that negotiates Network Quality Signaling over RTCDataChannel', () => {
@@ -1189,8 +1297,10 @@ describe('RoomV2', () => {
           return networkQualitySignaling;
         });
 
+        let instanceNumber = 0;
         NetworkQualityMonitor = sinon.spy(function() {
           networkQualityMonitor = new EventEmitter();
+          networkQualityMonitor.instanceNumber = ++instanceNumber;
           networkQualityMonitor.setNetworkConfiguration = sinon.spy;
           networkQualityMonitor.start = sinon.spy();
           networkQualityMonitor.stop = sinon.spy();
@@ -1319,6 +1429,63 @@ describe('RoomV2', () => {
           test.peerConnectionManager.iceConnectionState = 'failed';
           test.peerConnectionManager.emit('iceConnectionStateChanged');
           assert(participant.setNetworkQualityLevel.calledWith(0));
+        });
+
+        describe('when the underlying DataTrackReceiver is closed', () => {
+          let dataTrackTransport2;
+          let dataTrackReceiver2;
+          beforeEach(async () => {
+            // emit close on old channel
+            dataTrackReceiver.emit('close');
+            await new Promise(resolve => setTimeout(resolve));
+          });
+
+          it('should tear down the networkQualityMonitor', () => {
+            assert(networkQualityMonitor.stop.calledOnce);
+            assert(networkQualityMonitor.instanceNumber === 1);
+          });
+
+          context('when a new DataTrackReceiver is created', () => {
+            beforeEach(async () => {
+              dataTrackTransport2 = new EventEmitter();
+              dataTrackTransport2.stop = sinon.spy();
+
+              // send update message.
+              test.transport.emit('message', {
+                // eslint-disable-next-line
+                media_signaling: {
+                  // eslint-disable-next-line
+                  network_quality: {
+                    transport: { type: 'data-channel', label: ':-)' }
+                  }
+                }
+              });
+
+              // create another track receiver
+              dataTrackReceiver2 = makeTrackReceiver({ id: ':-)', kind: 'data' });
+              dataTrackReceiver2.toDataTransport = sinon.spy(() => dataTrackReceiver2);
+              test.peerConnectionManager.emit('trackAdded', dataTrackReceiver2);
+              await new Promise(resolve => setTimeout(resolve));
+            });
+
+            it('converts DataTrackReciever2 to a DataTrackTransport,', () => {
+              assert(dataTrackReceiver2.toDataTransport.calledOnce);
+            });
+
+            it('constructs new NetworkQualitySignaling with the dataTrackReceiver2,', () => {
+              assert(NetworkQualitySignaling.calledWith(dataTrackReceiver2));
+            });
+
+            it('constructs a NetworkQualityMonitor with the NetworkQualitySignaling,', () => {
+              assert(NetworkQualityMonitor.calledWith(test.peerConnectionManager, networkQualitySignaling));
+              assert(networkQualityMonitor.instanceNumber === 2);
+            });
+
+            it('calls .start() on the another instance of NetworkQualityMonitor', () => {
+              assert(networkQualityMonitor.instanceNumber === 2);
+              assert(networkQualityMonitor.start.calledOnce);
+            });
+          });
         });
 
         describe('then, when the RoomV2 finally disconnects,', () => {
@@ -1607,11 +1774,11 @@ function makeTrack(options) {
 }
 
 function makeTrackReceiver(mediaStreamTrack) {
+  var trackReceiver = new EventEmitter();
   const { id, kind } = mediaStreamTrack;
-  return {
-    id,
-    kind,
-    readyState: 'foo',
-    track: mediaStreamTrack
-  };
+  trackReceiver.id = id;
+  trackReceiver.kind = kind;
+  trackReceiver.readyState = 'foo';
+  trackReceiver.track = mediaStreamTrack;
+  return trackReceiver;
 }


### PR DESCRIPTION
Poriting #669 into `support-1.x-chrome-planb` branch 

- [x] I acknowledge that all my contributions will be made under the project's license.
