### PR TITLE
JSDK-2383, JSDK-2410

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,27 @@ For 2.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/master
 
 Bug Fixes
 ---------
+
+- Fixed a bug where, in a Peer-to-Peer Room, a Firefox Participant's AudioTrack was
+  silent if it was the first to join the Room. (JSDK-2410)
 - Fixed a bug where Participants in a Group or Small Group Room stopped receiving
   Dominant Speaker and Network Quality updates when the media server recovered
   from a failover. (JSDK-2307)
+
+Developer Notes
+---------------
+
+- On October 12, 2018, the specification for the JavaScript Session Establishment
+  Protocol (JSEP) was [updated](https://github.com/rtcweb-wg/jsep/pull/850) to remove
+  MediaStreamTrack IDs from Unified Plan SDPs (Media Session Descriptions). twilio-video.js
+  depends on MediaStreamTrack IDs to map WebRTC MediaStreamTracks to the corresponding
+  RemoteAudioTracks and RemoteVideoTracks. With this release of twilio-video.js, we have
+  added support for the updated JSEP specification for Firefox and Safari (twilio-video.js
+  uses Plan B SDPs on Chrome). We highly recommend that you upgrade to this version so your
+  application continues to work on Firefox and Safari even after they support the updated
+  JSEP specification. We will provide a detailed advisory once we have more information
+  about when they are planning to support the updated JSEP specification. (JSDK-2383)
+
 
 1.18.1 (June 7, 2019)
 =====================

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1,28 +1,41 @@
 'use strict';
 
-const WebRTC = require('@twilio/webrtc');
+const {
+  MediaStream: DefaultMediaStream,
+  RTCIceCandidate: DefaultRTCIceCandidate,
+  RTCPeerConnection: DefaultRTCPeerConnection,
+  RTCSessionDescription: DefaultRTCSessionDescription,
+  getStats: getStatistics
+} = require('@twilio/webrtc');
+
 const { guessBrowser } = require('@twilio/webrtc/lib/util');
 const { getSdpFormat } = require('@twilio/webrtc/lib/util/sdp');
-const DefaultMediaStream = WebRTC.MediaStream;
-const DefaultRTCIceCandidate = WebRTC.RTCIceCandidate;
-const DefaultRTCPeerConnection = WebRTC.RTCPeerConnection;
-const DefaultRTCSessionDescription = WebRTC.RTCSessionDescription;
-const getStatistics = WebRTC.getStats;
-const getMediaSections = require('../../util/sdp').getMediaSections;
-const oncePerTick = require('../../util').oncePerTick;
-const setBitrateParameters = require('../../util/sdp').setBitrateParameters;
-const setCodecPreferences = require('../../util/sdp').setCodecPreferences;
-const setSimulcast = require('../../util/sdp').setSimulcast;
-const unifiedPlanRewriteNewTrackIds = require('../../util/sdp').unifiedPlanRewriteNewTrackIds;
-const unifiedPlanRewriteTrackIds = require('../../util/sdp').unifiedPlanRewriteTrackIds;
+const { DEFAULT_LOG_LEVEL } = require('../../util/constants');
+
+const {
+  getMediaSections,
+  setBitrateParameters,
+  setCodecPreferences,
+  setSimulcast,
+  unifiedPlanAddOrRewriteNewTrackIds,
+  unifiedPlanAddOrRewriteTrackIds,
+} = require('../../util/sdp');
+
+const {
+  MediaClientLocalDescFailedError,
+  MediaClientRemoteDescFailedError
+} = require('../../util/twilio-video-errors');
+
+const {
+  buildLogLevels,
+  makeUUID,
+  oncePerTick
+} = require('../../util');
+
 const IceBox = require('./icebox');
-const MediaClientLocalDescFailedError = require('../../util/twilio-video-errors').MediaClientLocalDescFailedError;
-const MediaClientRemoteDescFailedError = require('../../util/twilio-video-errors').MediaClientRemoteDescFailedError;
 const DataTrackReceiver = require('../../data/receiver');
 const MediaTrackReceiver = require('../../media/track/receiver');
 const StateMachine = require('../../statemachine');
-const { buildLogLevels, makeUUID } = require('../../util');
-const { DEFAULT_LOG_LEVEL } = require('../../util/constants');
 const Log = require('../../util/log');
 const IdentityTrackMatcher = require('../../util/sdp/trackmatcher/identity');
 const OrderedTrackMatcher = require('../../util/sdp/trackmatcher/ordered');
@@ -599,33 +612,31 @@ class PeerConnectionV2 extends StateMachine {
   }
 
   /**
-   * Rewrite local MediaStreamTrack IDs in the given Unified Plan RTCSessionDescription.
+   * Add or rewrite local MediaStreamTrack IDs in the given Unified Plan RTCSessionDescription.
    * @private
    * @param {RTCSessionDescription} description
    * @return {RTCSessionDescription}
    */
-  _rewriteLocalTrackIds(description) {
+  _addOrRewriteLocalTrackIds(description) {
     const transceivers = this._peerConnection.getTransceivers();
     const activeTransceivers = transceivers.filter(({ sender, stopped }) => !stopped && sender && sender.track);
 
-    // NOTE(mmalavalli): MediaStreamTracks that are added to a recycled RTCRtpTransceiver
-    // using RTCRtpSender.replaceTrack() will result in a different MSID in the
-    // corresponding m= section. We re-write them here so that the m= sections
-    // contain the actual MediaStreamTrack IDs.
+    // NOTE(mmalavalli): There is no guarantee that MediaStreamTrack IDs will be present in
+    // SDPs, and even if they are, there is no guarantee that they will be the same as the
+    // actual MediaStreamTrack IDs. So, we add or re-write the actual MediaStreamTrack IDs
+    // to the assigned m= sections here.
     const assignedTransceivers = activeTransceivers.filter(({ mid }) => mid);
     const midsToTrackIds = new Map(assignedTransceivers.map(({ mid, sender }) => [mid, sender.track.id]));
-    const sdp1 = unifiedPlanRewriteTrackIds(description.sdp, midsToTrackIds);
+    const sdp1 = unifiedPlanAddOrRewriteTrackIds(description.sdp, midsToTrackIds);
 
-    // NOTE(mmalavalli): In Chrome and Safari, since we do not apply the offer
-    // until we get an answer, any re-added MediaStreamTracks will result in a
-    // different MSID in their corresponding m= sections. We re-write them
-    // here so that the m= sections contain the actual MediaStreamTrack IDs.
+    // NOTE(mmalavalli): Chrome and Safari do not apply the offer until they get an answer.
+    // So, we add or re-write the actual MediaStreamTrack IDs to the unassigned m= sections here.
     const unassignedTransceivers = activeTransceivers.filter(({ mid }) => !mid);
     const newTrackIdsByKind = new Map(['audio', 'video'].map(kind => [
       kind,
       unassignedTransceivers.filter(({ sender }) => sender.track.kind === kind).map(({ sender }) => sender.track.id)
     ]));
-    const sdp2 = unifiedPlanRewriteNewTrackIds(sdp1, newTrackIdsByKind);
+    const sdp2 = unifiedPlanAddOrRewriteNewTrackIds(sdp1, midsToTrackIds, newTrackIdsByKind);
 
     return new this._RTCSessionDescription({
       sdp: sdp2,
@@ -664,7 +675,7 @@ class PeerConnectionV2 extends StateMachine {
       throw new MediaClientLocalDescFailedError();
     }).then(() => {
       if (description.type !== 'rollback') {
-        this._localDescription = isUnifiedPlan ? this._rewriteLocalTrackIds(description) : description;
+        this._localDescription = isUnifiedPlan ? this._addOrRewriteLocalTrackIds(description) : description;
         this._localCandidates = [];
         if (description.type === 'offer') {
           this._descriptionRevision++;

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -76,6 +76,17 @@ function createPtToCodecName(mediaSection) {
 }
 
 /**
+ * Get the MID for the given m= section.
+ * @param {string} mediaSection
+ * @return {?string}
+ */
+function getMidForMediaSection(mediaSection) {
+  // In "a=mid:<mid>", the regex matches <mid>.
+  const midMatches = mediaSection.match(/^a=mid:(.+)$/m);
+  return midMatches && midMatches[1];
+}
+
+/**
  * Get the m= sections of a particular kind and direction from an sdp.
  * @param {string} sdp - SDP string
  * @param {string} [kind] - Pattern for matching kind
@@ -252,55 +263,62 @@ function setSimulcast(sdp, sdpFormat, trackIdsToAttributes) {
 }
 
 /**
- * Rewrite MSIDs for new m= sections in the given Unified Plan SDP with their
+ * Add or rewrite MSIDs for new m= sections in the given Unified Plan SDP with their
  * corresponding local MediaStreamTrack IDs. These can be different when previously
- * removed MediaStreamTracks are added back.
+ * removed MediaStreamTracks are added back (or Track IDs may not be present in the
+ * SDPs at all once browsers implement the latest WebRTC spec).
  * @param {string} sdp
+ * @param {Map<string, Track.ID>} activeMidsToTrackIds
  * @param {Map<Track.Kind, Array<Track.ID>>} trackIdsByKind
  * @returns {string}
  */
-function unifiedPlanRewriteNewTrackIds(sdp, trackIdsByKind) {
-  return Array.from(trackIdsByKind).reduce((sdp, [kind, trackIds]) => {
-    const sections = getMediaSections(sdp, kind);
-    // NOTE(mmalavalli): The m= sections for the new MediaStreamTracks are usually
-    // present after the m= sections for the existing MediaStreamTracks, in order
-    // of addition.
-    const sdpTrackIds = sections.slice(sections.length - trackIds.length).map(section => {
-      return (section.match(/^a=msid:.+ (.+)$/m) || [])[1];
-    });
-
-    return sdpTrackIds.reduce((sdp, sdpTrackId, i) => {
-      if (sdpTrackId) {
-        const msidRegex = new RegExp(`msid:(.+) ${sdpTrackId}$`, 'gm');
-        sdp = sdp.replace(msidRegex, `msid:$1 ${trackIds[i]}`);
-      }
-      return sdp;
-    }, sdp);
-  }, sdp);
+function unifiedPlanAddOrRewriteNewTrackIds(sdp, activeMidsToTrackIds, trackIdsByKind) {
+  const newMidsToTrackIds = Array.from(trackIdsByKind).reduce((midsToTrackIds, [kind, trackIds]) => {
+    const mediaSections = getMediaSections(sdp, kind);
+    const newMids = mediaSections.map(getMidForMediaSection).filter(mid => !activeMidsToTrackIds.has(mid));
+    newMids.forEach((mid, i) => midsToTrackIds.set(mid, trackIds[i]));
+    return midsToTrackIds;
+  }, new Map());
+  return unifiedPlanAddOrRewriteTrackIds(sdp, newMidsToTrackIds);
 }
 
 /**
- * Rewrite MSIDs in the given Unified Plan SDP with their corresponding local
- * MediaStreamTrack IDs. These can be different when MediaStreamTracks are added
- * using RTCRtpSender.replaceTrack(), or in the case of Firefox 68+, also when the
- * MediaStreamTracks are added for the first time using RTCPeerConnection.addTransceiver().
+ * Add or rewrite MSIDs in the given Unified Plan SDP with their corresponding local
+ * MediaStreamTrack IDs. These IDs need not be the same (or Track IDs may not be
+ * present in the SDPs at all once browsers implement the latest WebRTC spec).
  * @param {string} sdp
- * @param {Map<string, Track.ID>} midsToTrackIds
+ * @param {Map<string, string>} midsToTrackIds
  * @returns {string}
  */
-function unifiedPlanRewriteTrackIds(sdp, midsToTrackIds) {
-  return Array.from(midsToTrackIds).reduce((sdp, [mid, trackId]) => {
-    const midRegex = new RegExp(`a=mid:${mid}`);
-    const section = getMediaSections(sdp).find(section => midRegex.test(section));
-    if (section) {
-      const trackIdToRewrite = (section.match(/^a=msid:.+ (.+)$/m) || [])[1];
-      if (trackIdToRewrite) {
-        const msidRegex = new RegExp(`msid:(.+) ${trackIdToRewrite}$`, 'gm');
-        sdp = sdp.replace(msidRegex, `msid:$1 ${trackId}`);
-      }
+function unifiedPlanAddOrRewriteTrackIds(sdp, midsToTrackIds) {
+  const mediaSections = getMediaSections(sdp);
+  const session = sdp.split('\r\nm=')[0];
+  return [session].concat(mediaSections.map(mediaSection => {
+    // Do nothing if the m= section represents neither audio nor video.
+    if (!/^m=(audio|video)/.test(mediaSection)) {
+      return mediaSection;
     }
-    return sdp;
-  }, sdp);
+    // This shouldn't happen, but in case there is no MID for the m= section, do nothing.
+    const mid = getMidForMediaSection(mediaSection);
+    if (!mid) {
+      return mediaSection;
+    }
+    // In case there is no Track ID for the given MID in the map, do nothing.
+    const trackId = midsToTrackIds.get(mid);
+    if (!trackId) {
+      return mediaSection;
+    }
+    // This shouldn't happen, but in case there is no a=msid: line, do nothing.
+    const attributes = (mediaSection.match(/^a=msid:(.+)$/m) || [])[1];
+    if (!attributes) {
+      return mediaSection;
+    }
+    // If the a=msid: line contains the "appdata" field, then replace it with the Track ID,
+    // otherwise append the Track ID.
+    const [msid, trackIdToRewrite] = attributes.split(' ');
+    const msidRegex = new RegExp(`msid:${msid}${trackIdToRewrite ? ` ${trackIdToRewrite}` : ''}$`, 'gm');
+    return mediaSection.replace(msidRegex, `msid:${msid} ${trackId}`);
+  })).join('\r\n');
 }
 
 /**
@@ -314,5 +332,5 @@ exports.getMediaSections = getMediaSections;
 exports.setBitrateParameters = setBitrateParameters;
 exports.setCodecPreferences = setCodecPreferences;
 exports.setSimulcast = setSimulcast;
-exports.unifiedPlanRewriteNewTrackIds = unifiedPlanRewriteNewTrackIds;
-exports.unifiedPlanRewriteTrackIds = unifiedPlanRewriteTrackIds;
+exports.unifiedPlanAddOrRewriteNewTrackIds = unifiedPlanAddOrRewriteNewTrackIds;
+exports.unifiedPlanAddOrRewriteTrackIds = unifiedPlanAddOrRewriteTrackIds;

--- a/test/lib/mocksdp.js
+++ b/test/lib/mocksdp.js
@@ -22,9 +22,10 @@
  * @param {TracksByKind} kinds
  * @param {number} [maxAudioBitrate]
  * @param {number} [maxVideoBitrate]
+ * @param {boolean} [withAppData = true]
  * @returns {string} sdp
  */
-function makeSdpWithTracks(type, kinds, maxAudioBitrate, maxVideoBitrate) {
+function makeSdpWithTracks(type, kinds, maxAudioBitrate, maxVideoBitrate, withAppData = true) {
   const session = `\
 v=0\r
 o=- 0 1 IN IP4 0.0.0.0\r
@@ -70,10 +71,10 @@ a=rtcp-mux\r
         : trackAndSSRC;
       return sdp + (type === 'planb' ? '' : media + `\
 a=mid:mid_${id}\r
-a=msid:- ${id}\r
+a=msid:-${type === 'planb' || withAppData ? ` ${id}` : ''}\r
 `) + `\
 a=ssrc:${ssrc} cname:0\r
-a=ssrc:${ssrc} msid:${type === 'planb' ? 'stream' : '-'} ${id}\r
+a=ssrc:${ssrc} msid:${type === 'planb' ? 'stream' : '-'}${type === 'planb' || withAppData ? ` ${id}` : ''}\r
 `;
     }, sdp + (type === 'planb' ? media : ''));
   }, session);

--- a/test/unit/spec/util/sdp/index.js
+++ b/test/unit/spec/util/sdp/index.js
@@ -9,8 +9,8 @@ const {
   setBitrateParameters,
   setCodecPreferences,
   setSimulcast,
-  unifiedPlanRewriteNewTrackIds,
-  unifiedPlanRewriteTrackIds
+  unifiedPlanAddOrRewriteNewTrackIds,
+  unifiedPlanAddOrRewriteTrackIds
 } = require('../../../../../lib/util/sdp');
 
 const { makeSdpForSimulcast, makeSdpWithTracks } = require('../../../../lib/mocksdp');
@@ -487,34 +487,47 @@ a=ssrc:0000000000 label:d8b9a935-da54-4d21-a8de-522c87258244\r
   });
 });
 
-describe('unifiedPlanRewriteNewTrackIds', () => {
-  it('should rewrite Track IDs with the IDs of MediaStreamTracks associated with unassigned RTCRtpTransceivers', () => {
-    const sdp = makeSdpWithTracks('unified', { audio: ['foo', 'bar'], video: ['baz', 'zee'] });
-    const newTrackIdsByKind = new Map([['audio', ['yyy']], ['video', ['zzz']]]);
-    const newSdp = unifiedPlanRewriteNewTrackIds(sdp, newTrackIdsByKind);
-    const trackIdAndKinds = getMediaSections(newSdp).map(section => [
-      section.match(/^a=msid:.+ (.+)/m)[1],
-      section.match(/^m=(audio|video)/)[1]
-    ]);
-    assert.deepEqual(trackIdAndKinds, [
-      ['foo', 'audio'],
-      ['yyy', 'audio'],
-      ['baz', 'video'],
-      ['zzz', 'video']
-    ]);
+describe('unifiedPlanAddOrRewriteNewTrackIds', () => {
+  [true, false].forEach(withAppData => {
+    context(`when the Unified Plan SDP ${withAppData ? 'has' : 'does not have'} MediaStreamTrack IDs in a=msid: lines`, () => {
+      it('should rewrite Track IDs with the IDs of MediaStreamTracks associated with unassigned RTCRtpTransceivers', () => {
+        const sdp = makeSdpWithTracks('unified', {
+          audio: ['foo', 'bar'],
+          video: ['baz', 'zee']
+        }, null, null, withAppData);
+        const activeMidsToTrackIds = new Map([['mid_baz', 'baz']]);
+        const newTrackIdsByKind = new Map([['audio', ['xxx', 'yyy']], ['video', ['zzz']]]);
+        const newSdp = unifiedPlanAddOrRewriteNewTrackIds(sdp, activeMidsToTrackIds, newTrackIdsByKind);
+        const msAttrsAndKinds = getMediaSections(newSdp).map(section => [
+          section.match(/^a=msid:(.+)/m)[1],
+          section.match(/^m=(audio|video)/)[1]
+        ]);
+        assert.deepEqual(msAttrsAndKinds, [
+          ['- xxx', 'audio'],
+          ['- yyy', 'audio'],
+          [withAppData ? '- baz' : '-', 'video'],
+          ['- zzz', 'video']
+        ]);
+      });
+
+    });
   });
 });
 
-describe('unifiedPlanRewriteTrackIds', () => {
-  it('should rewrite Track IDs with the IDs of MediaStreamTracks associated with recycled RTCRtpTransceivers', () => {
-    const sdp = makeSdpWithTracks('unified', { audio: ['foo'], video: ['bar'] });
-    const midsToTrackIds = new Map([['mid_foo', 'baz'], ['mid_bar', 'zee']]);
-    const newSdp = unifiedPlanRewriteTrackIds(sdp, midsToTrackIds);
-    const sections = getMediaSections(newSdp);
-    midsToTrackIds.forEach((trackId, mid) => {
-      const section = sections.find(section => new RegExp(`^a=mid:${mid}$`, 'm').test(section));
-      assert.equal(section.match(/^a=msid:.+ (.+)$/m)[1], trackId);
-      assert.equal(section.match(/^a=ssrc:.+ msid:.+ (.+)$/m)[1], trackId);
+describe('unifiedPlanAddOrRewriteTrackIds', () => {
+  [true, false].forEach(withAppData => {
+    context(`when the Unified Plan SDP ${withAppData ? 'has' : 'does not have'} MediaStreamTrack IDs in a=msid: lines`, () => {
+      it('should rewrite Track IDs with the IDs of MediaStreamTracks associated with RTCRtpTransceivers', () => {
+        const sdp = makeSdpWithTracks('unified', { audio: ['foo'], video: ['bar'] }, null, null, withAppData);
+        const midsToTrackIds = new Map([['mid_foo', 'baz'], ['mid_bar', 'zee']]);
+        const newSdp = unifiedPlanAddOrRewriteTrackIds(sdp, midsToTrackIds);
+        const sections = getMediaSections(newSdp);
+        midsToTrackIds.forEach((trackId, mid) => {
+          const section = sections.find(section => new RegExp(`^a=mid:${mid}$`, 'm').test(section));
+          assert.equal(section.match(/^a=msid:.+ (.+)$/m)[1], trackId);
+          assert.equal(section.match(/^a=ssrc:.+ msid:.+ (.+)$/m)[1], trackId);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
@syerrapragada 

* JSDK-2383 - Make sure Track IDs are rewritten even when appdata field is absent in local SDPs.
* JSDK-2410 - Make sure we don't rewrite the dummy audio MediaStreamTrack's appdata field.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
