### PR TITLE
JSDK-2410 - Make sure we don't rewrite the dummy audio MediaStreamTrack's appdata field.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ New Features
 
 Bug Fixes
 ---------
+
 - Fixed a bug where Participants in a Group or Small Group Room stopped receiving
   Dominant Speaker and Network Quality updates when the media server recovered
   from a failover. (JSDK-2307)
@@ -31,6 +32,20 @@ Bug Fixes
   `Room.getStats()` were not in the range [0-32767]. (JSDK-2303)
 - Fixed a bug where Chrome and Safari Participants were enabling simulcast for
   H264 LocalVideoTracks when VP8 simulcast was enabled. (JSDK-2321)
+
+Developer Notes
+---------------
+
+- On October 12, 2018, the specification for the JavaScript Session Establishment
+  Protocol (JSEP) was [updated](https://github.com/rtcweb-wg/jsep/pull/850) to remove
+  MediaStreamTrack IDs from Unified Plan SDPs (Media Session Descriptions). twilio-video.js
+  depends on MediaStreamTrack IDs to map WebRTC MediaStreamTracks to the corresponding
+  RemoteAudioTracks and RemoteVideoTracks. With this release of twilio-video.js, we have
+  added support for the updated JSEP specification for Firefox and Safari (twilio-video.js
+  uses Plan B SDPs on Chrome). We highly recommend that you upgrade to this version so your
+  application continues to work on Firefox and Safari even after they support the updated
+  JSEP specification. We will provide a detailed advisory once we have more information
+  about when they are planning to support the updated JSEP specification. (JSDK-2385)
 
 2.0.0-beta11 (June 12, 2019)
 ============================

--- a/COMMON_ISSUES.md
+++ b/COMMON_ISSUES.md
@@ -88,11 +88,6 @@ once a Participant unpublishes a MediaTrack of any kind (audio or video), it wil
 not be able to publish another MediaTrack of the same kind. DataTracks are not affected.
 We have escalated this bug to the Safari Team and are keeping track of related developments.
 
-### Network Quality API not working
-
-We are working to fix a bug in twilio-video.js where Safari clients do not
-receive Network Quality Score updates in a Group Room. (JSDK-2133)
-
 ### Experimental support
 
 twilio-video.js 1.2.1 introduces experimental support for Safari 11 and newer.

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -753,7 +753,7 @@ class PeerConnectionV2 extends StateMachine {
       kind,
       unassignedTransceivers.filter(({ sender }) => sender.track.kind === kind).map(({ sender }) => sender.track.id)
     ]));
-    const sdp2 = unifiedPlanAddOrRewriteNewTrackIds(sdp1, newTrackIdsByKind);
+    const sdp2 = unifiedPlanAddOrRewriteNewTrackIds(sdp1, midsToTrackIds, newTrackIdsByKind);
 
     return new this._RTCSessionDescription({
       sdp: sdp2,

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -442,16 +442,17 @@ function revertSimulcastForNonVP8MediaSections(localSdp, localSdpWithoutSimulcas
  * removed MediaStreamTracks are added back (or Track IDs may not be present in the
  * SDPs at all once browsers implement the latest WebRTC spec).
  * @param {string} sdp
+ * @param {Map<string, Track.ID>} activeMidsToTrackIds
  * @param {Map<Track.Kind, Array<Track.ID>>} trackIdsByKind
  * @returns {string}
  */
-function unifiedPlanAddOrRewriteNewTrackIds(sdp, trackIdsByKind) {
+function unifiedPlanAddOrRewriteNewTrackIds(sdp, activeMidsToTrackIds, trackIdsByKind) {
   // NOTE(mmalavalli): The m= sections for the new MediaStreamTracks are usually
   // present after the m= sections for the existing MediaStreamTracks, in order
   // of addition.
   const newMidsToTrackIds = Array.from(trackIdsByKind).reduce((midsToTrackIds, [kind, trackIds]) => {
     const mediaSections = getMediaSections(sdp, kind);
-    const newMids = mediaSections.slice(mediaSections.length - trackIds.length).map(getMidForMediaSection);
+    const newMids = mediaSections.map(getMidForMediaSection).filter(mid => !activeMidsToTrackIds.has(mid));
     newMids.forEach((mid, i) => midsToTrackIds.set(mid, trackIds[i]));
     return midsToTrackIds;
   }, new Map());
@@ -463,7 +464,7 @@ function unifiedPlanAddOrRewriteNewTrackIds(sdp, trackIdsByKind) {
  * MediaStreamTrack IDs. These IDs need not be the same (or Track IDs may not be
  * present in the SDPs at all once browsers implement the latest WebRTC spec).
  * @param {string} sdp
- * @param {Map<string, string>} midsToTrackIds
+ * @param {Map<string, Track.ID>} midsToTrackIds
  * @returns {string}
  */
 function unifiedPlanAddOrRewriteTrackIds(sdp, midsToTrackIds) {

--- a/test/unit/spec/util/sdp/index.js
+++ b/test/unit/spec/util/sdp/index.js
@@ -855,8 +855,9 @@ describe('unifiedPlanAddOrRewriteNewTrackIds', () => {
           audio: ['foo', 'bar'],
           video: ['baz', 'zee']
         }, null, null, withAppData);
+        const activeMidsToTrackIds = new Map([['mid_baz', 'baz']]);
         const newTrackIdsByKind = new Map([['audio', ['xxx', 'yyy']], ['video', ['zzz']]]);
-        const newSdp = unifiedPlanAddOrRewriteNewTrackIds(sdp, newTrackIdsByKind);
+        const newSdp = unifiedPlanAddOrRewriteNewTrackIds(sdp, activeMidsToTrackIds, newTrackIdsByKind);
         const msAttrsAndKinds = getMediaSections(newSdp).map(section => [
           section.match(/^a=msid:(.+)/m)[1],
           section.match(/^m=(audio|video)/)[1]


### PR DESCRIPTION
@syerrapragada 

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
