### PR TITLE
JSDK-2346 Track priority for publishing a LocalTrack.

### DIFF
--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -604,7 +604,9 @@ class LocalParticipant extends Participant {
  * Options for publishing a {@link LocalTrack}.
  * @typedef {object} LocalTrackPublishOptions
  * @property {Track.Priority} [priority='medium'] - The priority with which the {@link LocalTrack}
- *   is to be published; Defaults to "medium" when not provided
+ *   is to be published; In Group or Small Group Rooms, the appropriate bandwidth is
+ *   allocated to the {@link LocalTrack} based on its {@link Track.Priority}; It has no
+ *   effect in Peer-to-Peer Rooms; It defaults to "medium" when not provided
  */
 
 /**

--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -1,11 +1,11 @@
 'use strict';
 
+const { MediaStreamTrack } = require('@twilio/webrtc');
 const util = require('./util');
-const E = require('./util/constants').typeErrors;
+const { typeErrors: E, trackPriority: { STANDARD } } = require('./util/constants');
 const LocalAudioTrack = require('./media/track/es5/localaudiotrack');
 const LocalDataTrack = require('./media/track/es5/localdatatrack');
 const LocalVideoTrack = require('./media/track/es5/localvideotrack');
-const MediaStreamTrack = require('@twilio/webrtc').MediaStreamTrack;
 const Participant = require('./participant');
 const LocalAudioTrackPublication = require('./media/track/localaudiotrackpublication');
 const LocalDataTrackPublication = require('./media/track/localdatatrackpublication');
@@ -189,9 +189,10 @@ class LocalParticipant extends Participant {
     this.on('trackStopped', localTrackStopped);
 
     this._tracks.forEach(track => {
-      this._addLocalTrack(track, 'medium');
-      this._getOrCreateLocalTrackPublication(track).catch(() => {
-        // Do nothing for now.
+      this._addLocalTrack(track, STANDARD);
+      this._getOrCreateLocalTrackPublication(track).catch(error => {
+        // Just log a warning for now.
+        log.warn(`Failed to get or create LocalTrackPublication for ${track}:`, error);
       });
     });
 
@@ -312,7 +313,9 @@ class LocalParticipant extends Participant {
    *     });
    *   });
    * }).then(function(publication) {
-   *   console.log('The LocalTrack "' + publication.trackName + '" was successfully published');
+   *   console.log('The LocalTrack "' + publication.trackName
+   *     + '" was successfully published with priority "'
+   *     * publication.priority + '"');
    * });
   *//**
    * Publishes a MediaStreamTrack to the {@link Room}.
@@ -320,11 +323,8 @@ class LocalParticipant extends Participant {
    *   to publish; if a corresponding {@link LocalAudioTrack} or
    *   {@link LocalVideoTrack} has not yet been published, this method will
    *   construct one
-   * @param {LocalTrackOptions} [options] - The {@link LocalTrackOptions} for
-   *   constructing the  MediaStreamTrack's corresponding {@link LocalAudioTrack}
-   *   or {@link LocalVideoTrack}
-   * @param {LocalTrackPublishOptions} [publishOptions] - The {@link LocalTrackPublishOptions}
-   *   for publishing the {@link LocalTrack}
+   * @param {MediaStreamTrackPublishOptions} [options] - The options for publishing
+   *   the MediaStreamTrack
    * @returns {Promise<LocalTrackPublication>} - Resolves with the corresponding
    *   {@link LocalTrackPublication} if successful
    * @example
@@ -339,16 +339,17 @@ class LocalParticipant extends Participant {
    *   }).then(function(mediaStream) {
    *     var mediaStreamTrack = mediaStream.getTracks()[0];
    *     return room.localParticipant.publishTrack(mediaStreamTrack, {
-   *       name: 'camera'
-   *     }, {
+   *       name: 'camera',
    *       priority: 'high'
    *     });
    *   });
    * }).then(function(publication) {
-   *   console.log('The LocalTrack "' + publication.trackName + '" was successfully published');
+   *   console.log('The LocalTrack "' + publication.trackName
+   *     + '" was successfully published with priority "'
+   *     * publication.priority + '"');
    * });
    */
-  publishTrack(localTrackOrMediaStreamTrack, options, publishOptions) {
+  publishTrack(localTrackOrMediaStreamTrack, options) {
     const trackPublication = getTrackPublication(this.tracks, localTrackOrMediaStreamTrack);
     if (trackPublication) {
       return Promise.resolve(trackPublication);
@@ -356,6 +357,7 @@ class LocalParticipant extends Participant {
 
     options = Object.assign({
       log: this._log,
+      priority: STANDARD,
       LocalAudioTrack: this._LocalAudioTrack,
       LocalDataTrack: this._LocalDataTrack,
       LocalVideoTrack: this._LocalVideoTrack,
@@ -369,15 +371,7 @@ class LocalParticipant extends Participant {
       return Promise.reject(error);
     }
 
-    publishOptions = Object.assign({
-      priority: 'medium'
-    }, publishOptions);
-
-    if (localTrack === localTrackOrMediaStreamTrack && 'priority' in options) {
-      publishOptions.priority = options.priority;
-    }
-
-    let addedLocalTrack = this._addTrack(localTrack, localTrack.id, publishOptions.priority)
+    let addedLocalTrack = this._addTrack(localTrack, localTrack.id, options.priority)
       || this._tracks.get(localTrack.id);
 
     return this._getOrCreateLocalTrackPublication(addedLocalTrack);
@@ -603,6 +597,15 @@ class LocalParticipant extends Participant {
 /**
  * Options for publishing a {@link LocalTrack}.
  * @typedef {object} LocalTrackPublishOptions
+ * @property {Track.Priority} [priority='medium'] - The priority with which the {@link LocalTrack}
+ *   is to be published; In Group or Small Group Rooms, the appropriate bandwidth is
+ *   allocated to the {@link LocalTrack} based on its {@link Track.Priority}; It has no
+ *   effect in Peer-to-Peer Rooms; It defaults to "medium" when not provided
+ */
+
+/**
+ * Options for publishing a {@link MediaStreamTrack}.
+ * @typedef {LocalTrackOptions} MediaStreamTrackPublishOptions
  * @property {Track.Priority} [priority='medium'] - The priority with which the {@link LocalTrack}
  *   is to be published; In Group or Small Group Rooms, the appropriate bandwidth is
  *   allocated to the {@link LocalTrack} based on its {@link Track.Priority}; It has no

--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -91,12 +91,13 @@ class LocalParticipant extends Participant {
    * @private
    * @param {LocalTrack} track
    * @param {Track.ID} id
+   * @param {Track.Priority} priority
    * @returns {?LocalTrack}
    */
-  _addTrack(track, id) {
+  _addTrack(track, id, priority) {
     const addedTrack = super._addTrack(track, id);
     if (addedTrack && this.state !== 'disconnected') {
-      this._addLocalTrack(track);
+      this._addLocalTrack(track, priority);
     }
     return addedTrack;
   }
@@ -104,10 +105,11 @@ class LocalParticipant extends Participant {
   /**
    * @private
    * @param {LocalTrack} track
+   * @param {Track.Priority} priority
    * @returns {void}
    */
-  _addLocalTrack(track) {
-    this._signaling.addTrack(track._trackSender, track.name);
+  _addLocalTrack(track, priority) {
+    this._signaling.addTrack(track._trackSender, track.name, priority);
     this._log.info(`Added a new ${util.trackClass(track, true)}:`, track.id);
     this._log.debug(`${util.trackClass(track, true)}:`, track);
   }
@@ -187,7 +189,7 @@ class LocalParticipant extends Participant {
     this.on('trackStopped', localTrackStopped);
 
     this._tracks.forEach(track => {
-      this._addLocalTrack(track);
+      this._addLocalTrack(track, 'medium');
       this._getOrCreateLocalTrackPublication(track).catch(() => {
         // Do nothing for now.
       });
@@ -272,7 +274,7 @@ class LocalParticipant extends Participant {
         localTrackPublication = getTrackPublication(self.tracks, localTrack);
 
         if (!localTrackPublication) {
-          localTrackPublication = util.asLocalTrackPublication(localTrack, sid, unpublish, options);
+          localTrackPublication = util.asLocalTrackPublication(localTrack, trackSignaling, unpublish, options);
           self._addTrackPublication(localTrackPublication);
         }
 
@@ -291,17 +293,8 @@ class LocalParticipant extends Participant {
   /**
    * Publishes a {@link LocalTrack} to the {@link Room}.
    * @param {LocalTrack} localTrack - The {@link LocalTrack} to publish
-   * @returns {Promise<LocalTrackPublication>} - Resolves with the corresponding
-   *   {@link LocalTrackPublication} if successful
-  *//**
-   * Publishes a MediaStreamTrack to the {@link Room}.
-   * @param {MediaStreamTrack} mediaStreamTrack - The MediaStreamTrack
-   *   to publish; if a corresponding {@link LocalAudioTrack} or
-   *   {@link LocalVideoTrack} has not yet been published, this method will
-   *   construct one
-   * @param {LocalTrackOptions} [options] - The {@link LocalTrackOptions} for
-   *   constructing the  MediaStreamTrack's corresponding {@link LocalAudioTrack}
-   *   or {@link LocalVideoTrack}
+   * @param {LocalTrackPublishOptions} [options] - The {@link LocalTrackPublishOptions}
+   *   for publishing the {@link LocalTrack}
    * @returns {Promise<LocalTrackPublication>} - Resolves with the corresponding
    *   {@link LocalTrackPublication} if successful
    * @example
@@ -311,15 +304,51 @@ class LocalParticipant extends Participant {
    *   name: 'my-cool-room',
    *   audio: true
    * }).then(function(room) {
-   *   // Publish a video MediaStreamTrack with a custom name
-   *   return room.localParticipant.publishTrack(mediaStreamTrack, {
+   *   return Video.createLocalVideoTrack({
    *     name: 'camera'
+   *   }).then(function(localVideoTrack) {
+   *     return room.localParticipant.publishTrack(localVideoTrack, {
+   *       priority: 'high'
+   *     });
+   *   });
+   * }).then(function(publication) {
+   *   console.log('The LocalTrack "' + publication.trackName + '" was successfully published');
+   * });
+  *//**
+   * Publishes a MediaStreamTrack to the {@link Room}.
+   * @param {MediaStreamTrack} mediaStreamTrack - The MediaStreamTrack
+   *   to publish; if a corresponding {@link LocalAudioTrack} or
+   *   {@link LocalVideoTrack} has not yet been published, this method will
+   *   construct one
+   * @param {LocalTrackOptions} [options] - The {@link LocalTrackOptions} for
+   *   constructing the  MediaStreamTrack's corresponding {@link LocalAudioTrack}
+   *   or {@link LocalVideoTrack}
+   * @param {LocalTrackPublishOptions} [publishOptions] - The {@link LocalTrackPublishOptions}
+   *   for publishing the {@link LocalTrack}
+   * @returns {Promise<LocalTrackPublication>} - Resolves with the corresponding
+   *   {@link LocalTrackPublication} if successful
+   * @example
+   * var Video = require('twilio-video');
+   *
+   * Video.connect(token, {
+   *   name: 'my-cool-room',
+   *   audio: true
+   * }).then(function(room) {
+   *   return navigator.mediaDevices.getUserMedia({
+   *     video: true
+   *   }).then(function(mediaStream) {
+   *     var mediaStreamTrack = mediaStream.getTracks()[0];
+   *     return room.localParticipant.publishTrack(mediaStreamTrack, {
+   *       name: 'camera'
+   *     }, {
+   *       priority: 'high'
+   *     });
    *   });
    * }).then(function(publication) {
    *   console.log('The LocalTrack "' + publication.trackName + '" was successfully published');
    * });
    */
-  publishTrack(localTrackOrMediaStreamTrack, options) {
+  publishTrack(localTrackOrMediaStreamTrack, options, publishOptions) {
     const trackPublication = getTrackPublication(this.tracks, localTrackOrMediaStreamTrack);
     if (trackPublication) {
       return Promise.resolve(trackPublication);
@@ -340,7 +369,15 @@ class LocalParticipant extends Participant {
       return Promise.reject(error);
     }
 
-    let addedLocalTrack = this._addTrack(localTrack, localTrack.id)
+    publishOptions = Object.assign({
+      priority: 'medium'
+    }, publishOptions);
+
+    if (localTrack === localTrackOrMediaStreamTrack && 'priority' in options) {
+      publishOptions.priority = options.priority;
+    }
+
+    let addedLocalTrack = this._addTrack(localTrack, localTrack.id, publishOptions.priority)
       || this._tracks.get(localTrack.id);
 
     return this._getOrCreateLocalTrackPublication(addedLocalTrack);
@@ -561,6 +598,13 @@ class LocalParticipant extends Participant {
  * @property {?number} [maxVideoBitrate] - Max outgoing video bitrate (bps);
  *   If not specified, retains the existing bitrate limit; A <code>null</code>
  *   value removes any previously set bitrate limit
+ */
+
+/**
+ * Options for publishing a {@link LocalTrack}.
+ * @typedef {object} LocalTrackPublishOptions
+ * @property {Track.Priority} [priority='medium'] - The priority with which the {@link LocalTrack}
+ *   is to be published; Defaults to "medium" when not provided
  */
 
 /**

--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -2,7 +2,7 @@
 
 const { MediaStreamTrack } = require('@twilio/webrtc');
 const util = require('./util');
-const { typeErrors: E, trackPriority: { STANDARD } } = require('./util/constants');
+const { typeErrors: E, trackPriority: { PRIORITY_STANDARD } } = require('./util/constants');
 const LocalAudioTrack = require('./media/track/es5/localaudiotrack');
 const LocalDataTrack = require('./media/track/es5/localdatatrack');
 const LocalVideoTrack = require('./media/track/es5/localvideotrack');
@@ -189,7 +189,7 @@ class LocalParticipant extends Participant {
     this.on('trackStopped', localTrackStopped);
 
     this._tracks.forEach(track => {
-      this._addLocalTrack(track, STANDARD);
+      this._addLocalTrack(track, PRIORITY_STANDARD);
       this._getOrCreateLocalTrackPublication(track).catch(error => {
         // Just log a warning for now.
         log.warn(`Failed to get or create LocalTrackPublication for ${track}:`, error);
@@ -357,7 +357,7 @@ class LocalParticipant extends Participant {
 
     options = Object.assign({
       log: this._log,
-      priority: STANDARD,
+      priority: PRIORITY_STANDARD,
       LocalAudioTrack: this._LocalAudioTrack,
       LocalDataTrack: this._LocalDataTrack,
       LocalVideoTrack: this._LocalVideoTrack,

--- a/lib/media/track/index.js
+++ b/lib/media/track/index.js
@@ -70,6 +70,11 @@ class Track extends EventEmitter {
  */
 
 /**
+ * The {@link Track}'s priority can be "low", "medium", or "high".
+ * @typedef {string} Track.Priority
+ */
+
+/**
  * The {@link Track} SID is a unique string identifier for the {@link Track}
  * that is published to a {@link Room}.
  * @typedef {string} Track.SID

--- a/lib/media/track/localaudiotrackpublication.js
+++ b/lib/media/track/localaudiotrackpublication.js
@@ -12,14 +12,15 @@ const LocalTrackPublication = require('./localtrackpublication');
 class LocalAudioTrackPublication extends LocalTrackPublication {
   /**
    * Construct a {@link LocalAudioTrackPublication}.
-   * @param {Track.SID} trackSid - SID assigned to the published {@link LocalAudioTrack}
+   * @param {LocalTrackPublicationSignaling} signaling - The corresponding
+   *   {@link LocalTrackPublicationSignaling}
    * @param {LocalAudioTrack} track - the {@link LocalAudioTrack}
    * @param {function(LocalTrackPublication): void} unpublish - The callback
    *    that unpublishes the {@link LocalTrackPublication}
    * @param {TrackPublicationOptions} options - {@link LocalTrackPublication} options
    */
-  constructor(trackSid, track, unpublish, options) {
-    super(trackSid, track, unpublish, options);
+  constructor(signaling, track, unpublish, options) {
+    super(signaling, track, unpublish, options);
   }
 
   toString() {

--- a/lib/media/track/localdatatrackpublication.js
+++ b/lib/media/track/localdatatrackpublication.js
@@ -12,14 +12,15 @@ const LocalTrackPublication = require('./localtrackpublication');
 class LocalDataTrackPublication extends LocalTrackPublication {
   /**
    * Construct a {@link LocalDataTrackPublication}.
-   * @param {Track.SID} trackSid - SID assigned to the published {@link LocalDataTrack}
+   * @param {LocalTrackPublicationSignaling} signaling - The corresponding
+   *   {@link LocalTrackPublicationSignaling}
    * @param {LocalDataTrack} track - the {@link LocalDataTrack}
    * @param {function(LocalTrackPublication): void} unpublish - The callback
    *    that unpublishes the {@link LocalTrackPublication}
    * @param {TrackPublicationOptions} options - {@link LocalTrackPublication} options
    */
-  constructor(trackSid, track, unpublish, options) {
-    super(trackSid, track, unpublish, options);
+  constructor(signaling, track, unpublish, options) {
+    super(signaling, track, unpublish, options);
   }
 
   toString() {

--- a/lib/media/track/localtrackpublication.js
+++ b/lib/media/track/localtrackpublication.js
@@ -8,26 +8,31 @@ const TrackPublication = require('./trackpublication');
  * @property {boolean} isTrackEnabled - whether the published {@link LocalTrack}
  *   is enabled
  * @property {Track.Kind} kind - kind of the published {@link LocalTrack}
+ * @property {Track.Priority} priority - the publish priority of the {@link LocalTrack}
  * @property {LocalTrack} track - the {@link LocalTrack}
  */
 class LocalTrackPublication extends TrackPublication {
   /**
    * Construct a {@link LocalTrackPublication}.
-   * @param {Track.SID} trackSid - SID assigned to the published {@link LocalTrack}
-   * @param {LocalTrack} track - the {@link LocalTrack}
+   * @param {LocalTrackPublicationSignaling} signaling - The corresponding
+   *   {@link LocalTrackPublicationSignaling}
+   * @param {LocalTrack} track - The {@link LocalTrack}
    * @param {function(LocalTrackPublication): void} unpublish - The callback
    *   that unpublishes the {@link LocalTrackPublication}
    * @param {TrackPublicationOptions} options - {@link LocalTrackPublication}
    *   options
    */
-  constructor(trackSid, track, unpublish, options) {
-    super(track.name, trackSid, options);
+  constructor(signaling, track, unpublish, options) {
+    super(track.name, signaling.sid, options);
 
     Object.defineProperties(this, {
       _reemitTrackEvent: {
         value: () => this.emit(this.isTrackEnabled
           ? 'trackEnabled'
           : 'trackDisabled')
+      },
+      _signaling: {
+        value: signaling
       },
       _unpublish: {
         value: unpublish
@@ -41,6 +46,12 @@ class LocalTrackPublication extends TrackPublication {
       kind: {
         enumerable: true,
         value: track.kind
+      },
+      priority: {
+        enumerable: true,
+        get() {
+          return signaling.priority;
+        }
       },
       track: {
         enumerable: true,

--- a/lib/media/track/localvideotrackpublication.js
+++ b/lib/media/track/localvideotrackpublication.js
@@ -12,14 +12,15 @@ const LocalTrackPublication = require('./localtrackpublication');
 class LocalVideoTrackPublication extends LocalTrackPublication {
   /**
    * Construct a {@link LocalVideoTrackPublication}.
-   * @param {Track.SID} trackSid - SID assigned to the published {@link LocalVideoTrack}
+   * @param {LocalTrackPublicationSignaling} signaling - The corresponding
+   *   {@link LocalTrackPublicationSignaling}
    * @param {LocalVideoTrack} track - the {@link LocalVideoTrack}
    * @param {function(LocalTrackPublication): void} unpublish - The callback
    *    that unpublishes the {@link LocalTrackPublication}
    * @param {TrackPublicationOptions} options - {@link LocalTrackPublication} options
    */
-  constructor(trackSid, track, unpublish, options) {
-    super(trackSid, track, unpublish, options);
+  constructor(signaling, track, unpublish, options) {
+    super(signaling, track, unpublish, options);
   }
 
   toString() {

--- a/lib/media/track/remotetrackpublication.js
+++ b/lib/media/track/remotetrackpublication.js
@@ -10,6 +10,8 @@ const TrackPublication = require('./trackpublication');
  * @property {boolean} isTrackEnabled - whether the published
  *   {@link RemoteTrack} is enabled
  * @property {Track.Kind} kind - kind of the published {@link RemoteTrack}
+ * @property {Track.Priority} publishPriority - the priority of the published
+ *   {@link RemoteTrack} set by the {@link RemoteParticipant}
  * @property {?RemoteTrack} track - Unless you have subscribed to the
  *   {@link RemoteTrack}, this property is null
  * @emits RemoteTrackPublication#subscribed
@@ -51,6 +53,10 @@ class RemoteTrackPublication extends TrackPublication {
       kind: {
         enumerable: true,
         value: signaling.kind
+      },
+      publishPriority: {
+        enumerable: true,
+        value: signaling.priority
       },
       track: {
         enumerable: true,

--- a/lib/signaling/localparticipant.js
+++ b/lib/signaling/localparticipant.js
@@ -17,10 +17,12 @@ class LocalParticipantSignaling extends ParticipantSignaling {
 
   /**
    * @param {DataTrackSender|MediaTrackSender} trackSender
+   * @param {string} name
+   * @param {Track.Priority} priority
    * @returns {LocalTrackPublicationSignaling} publication
    */
-  addTrack(trackSender, name) {
-    const publication = this._createLocalTrackPublicationSignaling(trackSender, name);
+  addTrack(trackSender, name, priority) {
+    const publication = this._createLocalTrackPublicationSignaling(trackSender, name, priority);
     this._trackSendersToPublications.set(trackSender, publication);
     this._publicationsToTrackSenders.set(publication, trackSender);
     super.addTrack(publication);

--- a/lib/signaling/localtrackpublication.js
+++ b/lib/signaling/localtrackpublication.js
@@ -5,7 +5,6 @@ const TrackSignaling = require('./track');
 /**
  * A {@link LocalTrackPublication} implementation
  * @extends TrackSignaling
- * @property {?Error} error - non-null if publication failed
  * @property {Track.ID} id
  */
 class LocalTrackPublicationSignaling extends TrackSignaling {
@@ -22,16 +21,6 @@ class LocalTrackPublicationSignaling extends TrackSignaling {
     super(name, trackSender.kind, enabled, priority);
     this.setTrackTransceiver(trackSender);
     Object.defineProperties(this, {
-      _error: {
-        value: null,
-        writable: true
-      },
-      error: {
-        enumerable: true,
-        get() {
-          return this._error;
-        }
-      },
       id: {
         enumerable: true,
         value: trackSender.id

--- a/lib/signaling/localtrackpublication.js
+++ b/lib/signaling/localtrackpublication.js
@@ -7,7 +7,6 @@ const TrackSignaling = require('./track');
  * @extends TrackSignaling
  * @property {?Error} error - non-null if publication failed
  * @property {Track.ID} id
- * @property {Track.Priority} priority
  */
 class LocalTrackPublicationSignaling extends TrackSignaling {
   /**
@@ -20,7 +19,7 @@ class LocalTrackPublicationSignaling extends TrackSignaling {
   constructor(trackSender, name, priority) {
     trackSender = trackSender.clone();
     const enabled = trackSender.kind === 'data' ? true : trackSender.track.enabled;
-    super(name, trackSender.kind, enabled);
+    super(name, trackSender.kind, enabled, priority);
     this.setTrackTransceiver(trackSender);
     Object.defineProperties(this, {
       _error: {
@@ -36,10 +35,6 @@ class LocalTrackPublicationSignaling extends TrackSignaling {
       id: {
         enumerable: true,
         value: trackSender.id
-      },
-      priority: {
-        enumerable: true,
-        value: priority
       }
     });
   }

--- a/lib/signaling/localtrackpublication.js
+++ b/lib/signaling/localtrackpublication.js
@@ -7,6 +7,7 @@ const TrackSignaling = require('./track');
  * @extends TrackSignaling
  * @property {?Error} error - non-null if publication failed
  * @property {Track.ID} id
+ * @property {Track.Priority} priority
  */
 class LocalTrackPublicationSignaling extends TrackSignaling {
   /**
@@ -14,8 +15,9 @@ class LocalTrackPublicationSignaling extends TrackSignaling {
    * are always cloned.
    * @param {DataTrackSender|MediaTrackSender} trackSender
    * @param {string} name
+   * @param {Track.Priority} priority
    */
-  constructor(trackSender, name) {
+  constructor(trackSender, name, priority) {
     trackSender = trackSender.clone();
     const enabled = trackSender.kind === 'data' ? true : trackSender.track.enabled;
     super(name, trackSender.kind, enabled);
@@ -34,6 +36,10 @@ class LocalTrackPublicationSignaling extends TrackSignaling {
       id: {
         enumerable: true,
         value: trackSender.id
+      },
+      priority: {
+        enumerable: true,
+        value: priority
       }
     });
   }

--- a/lib/signaling/remotetrackpublication.js
+++ b/lib/signaling/remotetrackpublication.js
@@ -5,6 +5,7 @@ const TrackSignaling = require('./track');
 /**
  * A {@link RemoteTrackPublication} implementation
  * @extends TrackSignaling
+ * @property {Track.Priority} priority
  */
 class RemoteTrackPublicationSignaling extends TrackSignaling {
   /**
@@ -13,13 +14,18 @@ class RemoteTrackPublicationSignaling extends TrackSignaling {
    * @param {string} name
    * @param {Track.Kind} kind
    * @param {boolean} isEnabled
+   * @param {Track.Priority} priority
    */
-  constructor(sid, name, kind, isEnabled) {
+  constructor(sid, name, kind, isEnabled, priority) {
     super(name, kind, isEnabled);
     Object.defineProperties(this, {
       _error: {
         value: null,
         writable: true
+      },
+      priority: {
+        enumerable: true,
+        value: priority
       }
     });
     this.setSid(sid);

--- a/lib/signaling/remotetrackpublication.js
+++ b/lib/signaling/remotetrackpublication.js
@@ -5,7 +5,6 @@ const TrackSignaling = require('./track');
 /**
  * A {@link RemoteTrackPublication} implementation
  * @extends TrackSignaling
- * @property {Track.Priority} priority
  */
 class RemoteTrackPublicationSignaling extends TrackSignaling {
   /**
@@ -17,7 +16,7 @@ class RemoteTrackPublicationSignaling extends TrackSignaling {
    * @param {Track.Priority} priority
    */
   constructor(sid, name, kind, isEnabled, priority) {
-    super(name, kind, isEnabled);
+    super(name, kind, isEnabled, priority);
     Object.defineProperties(this, {
       _error: {
         value: null,

--- a/lib/signaling/remotetrackpublication.js
+++ b/lib/signaling/remotetrackpublication.js
@@ -17,25 +17,7 @@ class RemoteTrackPublicationSignaling extends TrackSignaling {
    */
   constructor(sid, name, kind, isEnabled, priority) {
     super(name, kind, isEnabled, priority);
-    Object.defineProperties(this, {
-      _error: {
-        value: null,
-        writable: true
-      },
-      priority: {
-        enumerable: true,
-        value: priority
-      }
-    });
     this.setSid(sid);
-  }
-
-  /**
-   * Non-null if subscription failed.
-   * @property {?Error}
-   */
-  get error() {
-    return this._error;
   }
 
   /**

--- a/lib/signaling/track.js
+++ b/lib/signaling/track.js
@@ -20,6 +20,10 @@ class TrackSignaling extends EventEmitter {
     super();
     let sid = null;
     Object.defineProperties(this, {
+      _error: {
+        value: null,
+        writable: true
+      },
       _isEnabled: {
         value: isEnabled,
         writable: true
@@ -51,6 +55,14 @@ class TrackSignaling extends EventEmitter {
         value: name
       }
     });
+  }
+
+  /**
+   * Non-null if publication or subscription failed.
+   * @property {?Error} error
+   */
+  get error() {
+    return this._error;
   }
 
   /**

--- a/lib/signaling/track.js
+++ b/lib/signaling/track.js
@@ -14,13 +14,18 @@ class TrackSignaling extends EventEmitter {
    * @param {string} name
    * @param {Track.Kind} kind
    * @param {boolean} isEnabled
+   * @param {Track.Priority} priority
    */
-  constructor(name, kind, isEnabled) {
+  constructor(name, kind, isEnabled, priority) {
     super();
     let sid = null;
     Object.defineProperties(this, {
       _isEnabled: {
         value: isEnabled,
+        writable: true
+      },
+      _priority: {
+        value: priority,
         writable: true
       },
       _trackTransceiver: {
@@ -54,6 +59,14 @@ class TrackSignaling extends EventEmitter {
    */
   get isEnabled() {
     return this._isEnabled;
+  }
+
+  /**
+   * The {@link TrackSignaling}'s priority.
+   * @property {Track.Priority}
+   */
+  get priority() {
+    return this._priority;
   }
 
   /**

--- a/lib/signaling/v2/localparticipant.js
+++ b/lib/signaling/v2/localparticipant.js
@@ -89,10 +89,11 @@ class LocalParticipantV2 extends LocalParticipantSignaling {
    * @protected
    * @param {DataTrackSender|MediaTrackSender} trackSender
    * @param {string} name
+   * @param {Track.Priority} priority
    * @returns {LocalTrackPublicationV2}
    */
-  _createLocalTrackPublicationSignaling(trackSender, name) {
-    return new this._LocalTrackPublicationV2(trackSender, name);
+  _createLocalTrackPublicationSignaling(trackSender, name, priority) {
+    return new this._LocalTrackPublicationV2(trackSender, name, priority);
   }
 
   /**
@@ -100,10 +101,11 @@ class LocalParticipantV2 extends LocalParticipantSignaling {
    * or {@link MediaTrackSender} to the {@link LocalParticipantV2}.
    * @param {DataTrackSender|MediaTrackSender} trackSender
    * @param {string} name
+   * @param {Track.Priority} priority
    * @returns {this}
    */
-  addTrack(trackSender, name) {
-    super.addTrack(trackSender, name);
+  addTrack(trackSender, name, priority) {
+    super.addTrack(trackSender, name, priority);
     const publication = this.getPublication(trackSender);
 
     let { sid } = publication;

--- a/lib/signaling/v2/localtrackpublication.js
+++ b/lib/signaling/v2/localtrackpublication.js
@@ -11,9 +11,10 @@ class LocalTrackPublicationV2 extends LocalTrackPublicationSignaling {
    * Construct a {@link LocalTrackPublicationV2}.
    * @param {DataTrackSender|MediaTrackSender} trackSender
    * @param {string} name
+   * @param {Track.Priority} priority
    */
-  constructor(trackSender, name) {
-    super(trackSender, name);
+  constructor(trackSender, name, priority) {
+    super(trackSender, name, priority);
   }
 
   /**
@@ -25,7 +26,8 @@ class LocalTrackPublicationV2 extends LocalTrackPublicationSignaling {
       enabled: this.isEnabled,
       id: this.id,
       kind: this.kind,
-      name: this.name
+      name: this.name,
+      priority: this.priority
     };
   }
 
@@ -60,6 +62,7 @@ class LocalTrackPublicationV2 extends LocalTrackPublicationSignaling {
  * @property {Track.ID} id
  * @property {Track.Kind} kind
  * @property {string} name
+ * @priority {Track.Priority} priority
  * @property {Track.SID} sid
  */
 

--- a/lib/signaling/v2/peerconnectionmanager.js
+++ b/lib/signaling/v2/peerconnectionmanager.js
@@ -158,7 +158,6 @@ class PeerConnectionManager extends QueueingEventEmitter {
       try {
         peerConnection = new PeerConnectionV2(id, this._encodingParameters, this._preferredCodecs, options);
       } catch (e) {
-        console.log(e.message);
         throw new MediaConnectionError();
       }
 

--- a/lib/signaling/v2/peerconnectionmanager.js
+++ b/lib/signaling/v2/peerconnectionmanager.js
@@ -158,6 +158,7 @@ class PeerConnectionManager extends QueueingEventEmitter {
       try {
         peerConnection = new PeerConnectionV2(id, this._encodingParameters, this._preferredCodecs, options);
       } catch (e) {
+        console.log(e.message);
         throw new MediaConnectionError();
       }
 

--- a/lib/signaling/v2/remotetrackpublication.js
+++ b/lib/signaling/v2/remotetrackpublication.js
@@ -11,7 +11,7 @@ class RemoteTrackPublicationV2 extends RemoteTrackPublicationSignaling {
    * @param {RemoteTrackPublicationV2#Representation} track
    */
   constructor(track) {
-    super(track.sid, track.name, track.kind, track.enabled);
+    super(track.sid, track.name, track.kind, track.enabled, track.priority);
   }
 
   /**
@@ -31,7 +31,7 @@ class RemoteTrackPublicationV2 extends RemoteTrackPublicationSignaling {
 /**
  * The Room Signaling Protocol (RSP) representation of a {@link RemoteTrackPublicationV2}.
  * @typedef {LocalTrackPublicationV2#Representation} RemoteTrackPublicationV2#Representation
- * @property (boolean} subscribed
+ * @property {boolean} subscribed
  */
 
 module.exports = RemoteTrackPublicationV2;

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -78,3 +78,9 @@ module.exports.DEFAULT_CHROME_SDP_SEMANTICS = 'plan-b';
 
 module.exports.ICE_ACTIVITY_CHECK_PERIOD_MS = 1000;
 module.exports.ICE_INACTIVITY_THRESHOLD_MS = 3000;
+
+module.exports.trackPriority = {
+  HIGH: 'high',
+  LOW: 'low',
+  STANDARD: 'medium'
+};

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -80,7 +80,7 @@ module.exports.ICE_ACTIVITY_CHECK_PERIOD_MS = 1000;
 module.exports.ICE_INACTIVITY_THRESHOLD_MS = 3000;
 
 module.exports.trackPriority = {
-  HIGH: 'high',
-  LOW: 'low',
-  STANDARD: 'medium'
+  PRIORITY_HIGH: 'high',
+  PRIORITY_LOW: 'low',
+  PRIORITY_STANDARD: 'medium'
 };

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -28,17 +28,17 @@ function asLocalTrack(track, options) {
 /**
  * Create a new {@link LocalTrackPublication} for the given {@link LocalTrack}.
  * @param {LocalTrack} track
- * @param {string} sid
+ * @param {LocalTrackPublicationSignaling} signaling
  * @param {function(track: LocalTrackPublication): void} unpublish
  * @param {object} options
  */
-function asLocalTrackPublication(track, sid, unpublish, options) {
+function asLocalTrackPublication(track, signaling, unpublish, options) {
   const LocalTrackPublication = {
     audio: options.LocalAudioTrackPublication,
     video: options.LocalVideoTrackPublication,
     data: options.LocalDataTrackPublication
   }[track.kind];
-  return new LocalTrackPublication(sid, track, unpublish, options);
+  return new LocalTrackPublication(signaling, track, unpublish, options);
 }
 
 /**

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -394,8 +394,10 @@ describe('connect', function() {
               assert(participant);
               const trackSids = [...participant.tracks.values()].map(publication => publication.trackSid).sort();
               const localTrackPublicationSids = [...localParticipant.tracks.values()].map(publication => publication.trackSid).sort();
+              const publishPriorities = [...participant.tracks.values()].map(publication => publication.publishPriority);
               assert.equal(trackSids.length, localTrackPublicationSids.length);
               assert.deepEqual(trackSids, localTrackPublicationSids);
+              publishPriorities.forEach(priority => assert.equal(priority, 'medium'));
             });
           });
         });

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -343,9 +343,8 @@ describe('LocalParticipant', function() {
 
       // TODO(mmalavalli): Until we find out why Travis is failing tests due
       // to not being able to create enough RTCPeerConnections, we will enable
-      // testing for only 2 cases: specifying no priority and specifying "high"
-      // priority.
-      if (priority === 'low' || priority === 'medium') {
+      // testing for only when priority is set to "high".
+      if (priority !== 'high') {
         return;
       }
 

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -21,7 +21,7 @@ const RemoteDataTrackPublication = require('../../../lib/media/track/remotedatat
 const RemoteVideoTrack = require('../../../lib/media/track/remotevideotrack');
 const RemoteVideoTrackPublication = require('../../../lib/media/track/remotevideotrackpublication');
 const { flatMap } = require('../../../lib/util');
-const { trackPriority: { HIGH, LOW, STANDARD } } = require('../../../lib/util/constants');
+const { trackPriority: { PRIORITY_HIGH, PRIORITY_LOW, PRIORITY_STANDARD } } = require('../../../lib/util/constants');
 const { getMediaSections } = require('../../../lib/util/sdp');
 const { TrackNameIsDuplicatedError, TrackNameTooLongError } = require('../../../lib/util/twilio-video-errors');
 
@@ -246,8 +246,8 @@ describe('LocalParticipant', function() {
         ]);
 
         trackPublications = await Promise.all([
-          room.localParticipant.publishTrack(tracks[0], { priority: LOW }),
-          anotherRoom.localParticipant.publishTrack(tracks[0], { priority: HIGH })
+          room.localParticipant.publishTrack(tracks[0], { priority: PRIORITY_LOW }),
+          anotherRoom.localParticipant.publishTrack(tracks[0], { priority: PRIORITY_HIGH })
         ]);
       });
 
@@ -280,8 +280,8 @@ describe('LocalParticipant', function() {
           localTrackPublication => localTrackPublication.track === tracks[0]);
         const localTrackPublication2 = [...anotherRoom.localParticipant.tracks.values()].find(
           localTrackPublication => localTrackPublication.track === tracks[0]);
-        assert.equal(localTrackPublication1.priority, LOW);
-        assert.equal(localTrackPublication2.priority, HIGH);
+        assert.equal(localTrackPublication1.priority, PRIORITY_LOW);
+        assert.equal(localTrackPublication2.priority, PRIORITY_HIGH);
       });
 
       after(() => {
@@ -328,7 +328,7 @@ describe('LocalParticipant', function() {
         x => `with${x ? '' : 'out'} a name for the LocalTrack`
       ],
       [
-        [undefined, HIGH, LOW, STANDARD],
+        [undefined, PRIORITY_HIGH, PRIORITY_LOW, PRIORITY_STANDARD],
         x => `with${x ? ` priority "${x}"` : 'out specifying a priority'}`
       ],
       [
@@ -344,8 +344,8 @@ describe('LocalParticipant', function() {
 
       // TODO(mmalavalli): Until we find out why Travis is failing tests due
       // to not being able to create enough RTCPeerConnections, we will enable
-      // testing for only when priority is set to "high".
-      if (priority !== HIGH) {
+      // testing for only when priority is set to "high". (JSDK-2417)
+      if (priority !== PRIORITY_HIGH) {
         return;
       }
 

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -245,8 +245,8 @@ describe('LocalParticipant', function() {
         ]);
 
         trackPublications = await Promise.all([
-          room.localParticipant.publishTrack(tracks[0]),
-          anotherRoom.localParticipant.publishTrack(tracks[0])
+          room.localParticipant.publishTrack(tracks[0], { priority: 'low' }),
+          anotherRoom.localParticipant.publishTrack(tracks[0], { priority: 'high' })
         ]);
       });
 
@@ -272,6 +272,15 @@ describe('LocalParticipant', function() {
 
       it('should assign different SIDs to the two LocalTrackPublications', () => {
         assert.notEqual(trackPublications[0].trackSid, trackPublications[1].trackSid);
+      });
+
+      it('should set the appropriate priority values to the two LocalTrackPublications', () => {
+        const localTrackPublication1 = [...room.localParticipant.tracks.values()].find(
+          localTrackPublication => localTrackPublication.track === tracks[0]);
+        const localTrackPublication2 = [...anotherRoom.localParticipant.tracks.values()].find(
+          localTrackPublication => localTrackPublication.track === tracks[0]);
+        assert.equal(localTrackPublication1.priority, 'low');
+        assert.equal(localTrackPublication2.priority, 'high');
       });
 
       after(() => {
@@ -318,10 +327,14 @@ describe('LocalParticipant', function() {
         x => `with${x ? '' : 'out'} a name for the LocalTrack`
       ],
       [
+        [undefined, 'low', 'medium', 'high'],
+        x => `with${x ? ` priority "${x}"` : 'out specifying a priority'}`
+      ],
+      [
         ['never', 'previously'],
         x => `that has ${x} been published`
       ]
-    ], ([isEnabled, kind, withName, when]) => {
+    ], ([isEnabled, kind, withName, priority, when]) => {
       // TODO(mmalavalli): Enable this scenario for Firefox when the following
       // bug is fixed: https://bugzilla.mozilla.org/show_bug.cgi?id=1526253
       if (isFirefox && kind === 'data' && when === 'previously') {
@@ -409,7 +422,7 @@ describe('LocalParticipant', function() {
         }
 
         [thisLocalTrackPublication, thoseTracksPublished, thoseTracksSubscribed] = await Promise.all([
-          thisParticipant.publishTrack(thisTrack),
+          thisParticipant.publishTrack.apply(thisParticipant, priority ? [thisTrack, { priority }] : [thisTrack]),
           ...['trackPublished', 'trackSubscribed'].map(event => {
             return Promise.all(thoseParticipants.map(async thatParticipant => {
               const [trackOrPublication] = await waitForTracks(event, thatParticipant, 1);
@@ -441,10 +454,11 @@ describe('LocalParticipant', function() {
         }[kind]));
       });
 
-      ['isTrackEnabled', 'trackName', 'trackSid'].forEach(prop => {
-        it(`should set the RemoteTrackPublication's .${prop} to the LocalTrackPublication's .${prop}`, () => {
+      ['isTrackEnabled', ['publishPriority', 'priority'], 'trackName', 'trackSid'].forEach(propOrPropPair => {
+        const [remoteProp, localProp] = Array.isArray(propOrPropPair) ? propOrPropPair : [propOrPropPair, propOrPropPair];
+        it(`should set the RemoteTrackPublication's .${remoteProp} to the LocalTrackPublication's .${localProp}`, () => {
           const thoseTrackPublications = thoseTracksMap.trackPublished;
-          thoseTrackPublications.forEach(thatPublication => assert.equal(thatPublication[prop], thisLocalTrackPublication[prop]));
+          thoseTrackPublications.forEach(thatPublication => assert.equal(thatPublication[remoteProp], thisLocalTrackPublication[localProp]));
         });
       });
 

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -21,6 +21,7 @@ const RemoteDataTrackPublication = require('../../../lib/media/track/remotedatat
 const RemoteVideoTrack = require('../../../lib/media/track/remotevideotrack');
 const RemoteVideoTrackPublication = require('../../../lib/media/track/remotevideotrackpublication');
 const { flatMap } = require('../../../lib/util');
+const { trackPriority: { HIGH, LOW, STANDARD } } = require('../../../lib/util/constants');
 const { getMediaSections } = require('../../../lib/util/sdp');
 const { TrackNameIsDuplicatedError, TrackNameTooLongError } = require('../../../lib/util/twilio-video-errors');
 
@@ -245,8 +246,8 @@ describe('LocalParticipant', function() {
         ]);
 
         trackPublications = await Promise.all([
-          room.localParticipant.publishTrack(tracks[0], { priority: 'low' }),
-          anotherRoom.localParticipant.publishTrack(tracks[0], { priority: 'high' })
+          room.localParticipant.publishTrack(tracks[0], { priority: LOW }),
+          anotherRoom.localParticipant.publishTrack(tracks[0], { priority: HIGH })
         ]);
       });
 
@@ -279,8 +280,8 @@ describe('LocalParticipant', function() {
           localTrackPublication => localTrackPublication.track === tracks[0]);
         const localTrackPublication2 = [...anotherRoom.localParticipant.tracks.values()].find(
           localTrackPublication => localTrackPublication.track === tracks[0]);
-        assert.equal(localTrackPublication1.priority, 'low');
-        assert.equal(localTrackPublication2.priority, 'high');
+        assert.equal(localTrackPublication1.priority, LOW);
+        assert.equal(localTrackPublication2.priority, HIGH);
       });
 
       after(() => {
@@ -327,7 +328,7 @@ describe('LocalParticipant', function() {
         x => `with${x ? '' : 'out'} a name for the LocalTrack`
       ],
       [
-        [undefined, 'low', 'medium', 'high'],
+        [undefined, HIGH, LOW, STANDARD],
         x => `with${x ? ` priority "${x}"` : 'out specifying a priority'}`
       ],
       [
@@ -344,7 +345,7 @@ describe('LocalParticipant', function() {
       // TODO(mmalavalli): Until we find out why Travis is failing tests due
       // to not being able to create enough RTCPeerConnections, we will enable
       // testing for only when priority is set to "high".
-      if (priority !== 'high') {
+      if (priority !== HIGH) {
         return;
       }
 

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -341,6 +341,14 @@ describe('LocalParticipant', function() {
         return;
       }
 
+      // TODO(mmalavalli): Until we find out why Travis is failing tests due
+      // to not being able to create enough RTCPeerConnections, we will enable
+      // testing for only 2 cases: specifying no priority and specifying "high"
+      // priority.
+      if (priority === 'low' || priority === 'medium') {
+        return;
+      }
+
       let thisRoom;
       let thisParticipant;
       let thisLocalTrackPublication;

--- a/test/unit/spec/localparticipant.js
+++ b/test/unit/spec/localparticipant.js
@@ -12,7 +12,7 @@ const MediaTrackSender = require('../../../lib/media/track/sender');
 
 const log = require('../../lib/fakelog');
 const { FakeMediaStreamTrack } = require('../../lib/fakemediastream');
-const { a, capitalize } = require('../../lib/util');
+const { capitalize, combinationContext } = require('../../lib/util');
 
 const LocalAudioTrack = sinon.spy(function LocalAudioTrack(mediaStreamTrack, options) {
   mediaStreamTrack = mediaStreamTrack || new FakeMediaStreamTrack('audio');
@@ -246,27 +246,30 @@ describe('LocalParticipant', () => {
 
     beforeEach(() => {
       options = {
-        LocalAudioTrackPublication: function(sid, track) {
+        LocalAudioTrackPublication: function(signaling, track) {
           this.trackName = track.name;
-          this.trackSid = sid;
+          this.trackSid = signaling.sid;
           this.track = track;
           this.kind = track.kind;
+          this.priority = signaling.priority;
           this.on = () => {};
           this.removeListener = () => {};
         },
-        LocalVideoTrackPublication: function(sid, track) {
+        LocalVideoTrackPublication: function(signaling, track) {
           this.trackName = track.name;
-          this.trackSid = sid;
+          this.trackSid = signaling.sid;
           this.track = track;
           this.kind = track.kind;
+          this.priority = signaling.priority;
           this.on = () => {};
           this.removeListener = () => {};
         },
-        LocalDataTrackPublication: function(sid, track) {
+        LocalDataTrackPublication: function(signaling, track) {
           this.trackName = track.name;
-          this.trackSid = sid;
+          this.trackSid = signaling.sid;
           this.track = track;
           this.kind = track.kind;
+          this.priority = signaling.priority;
           this.on = () => {};
           this.removeListener = () => {};
         }
@@ -297,169 +300,191 @@ describe('LocalParticipant', () => {
       });
     });
 
-    [
+    combinationContext([
       [
-        'LocalTrack',
-        ['audio', 'video', 'data'],
-        kind => ({
-          audio: new LocalAudioTrack(new FakeMediaStreamTrack(kind)),
-          video: new LocalVideoTrack(new FakeMediaStreamTrack(kind)),
-          data: new LocalDataTrack(new DataTrackSender(null, null, true))
-        }[kind])
+        ['LocalTrack', 'MediaStreamTrack'],
+        x => `when called with a ${x}`
       ],
       [
-        'MediaStreamTrack',
-        ['audio', 'video'],
-        kind => ({
-          audio: new FakeMediaStreamTrack(kind),
-          video: new FakeMediaStreamTrack(kind)
-        }[kind])
+        ['audio', 'data', 'video'],
+        x => `of kind ${x}`
+      ],
+      [
+        [undefined, 'low', 'medium', 'high'],
+        x => `with priority ${x ? `"${x}"` : 'not specified'}`
       ]
-    ].forEach(([trackType, kinds, createTrack]) => {
-      kinds.forEach(kind => {
-        context(`when called with ${a(kind)} ${kind} ${trackType}`, () => {
-          [true, false].forEach(isConnected => {
-            context(`and the LocalParticipant's ParticipantSignaling is in the "${isConnected ? 'connected' : 'connecting'}" state`, () => {
-              context(`when the .tracks collection already has an entry for the ${trackType}`, () => {
-                let localTrack;
+    ], ([trackType, kind, priority]) => {
+      if (trackType === 'MediaStreamTrack' && kind === 'data') {
+        return;
+      }
 
-                beforeEach(async () => {
-                  localTrack = createTrack(kind);
-                  const promise = test.participant.publishTrack(localTrack);
-                  const trackSignaling = test.participant._signaling.tracks.get(localTrack.id);
-                  trackSignaling.setSid('foo');
-                  await promise;
-                  await new Promise(resolve => test.participant.on('trackPublished', resolve));
+      function createTrack() {
+        return {
+          LocalTrack: {
+            audio: () => new LocalAudioTrack(new FakeMediaStreamTrack(kind)),
+            data: () => new LocalDataTrack(new DataTrackSender(null, null, true)),
+            video: () => new LocalVideoTrack(new FakeMediaStreamTrack(kind))
+          },
+          MediaStreamTrack: {
+            audio: () => new FakeMediaStreamTrack(kind),
+            video: () => new FakeMediaStreamTrack(kind)
+          }
+        }[trackType][kind]();
+      }
+
+      function publishTrack(track, options = {}) {
+        return {
+          LocalTrack: priority
+            ? () => test.participant.publishTrack(track, { priority })
+            : () => test.participant.publishTrack(track),
+          MediaStreamTrack: priority
+            ? () => test.participant.publishTrack(track, options, { priority })
+            : () => test.participant.publishTrack(track, options)
+        }[trackType]();
+      }
+
+      [true, false].forEach(isConnected => {
+        context(`and the LocalParticipant's ParticipantSignaling is in the "${isConnected ? 'connected' : 'connecting'}" state`, () => {
+          context(`when the .tracks collection already has an entry for the ${trackType}`, () => {
+            let localTrack;
+
+            beforeEach(async () => {
+              localTrack = createTrack();
+              const promise = publishTrack(localTrack);
+              const trackSignaling = test.participant._signaling.tracks.get(localTrack.id);
+              trackSignaling.setSid('foo');
+              await promise;
+              await new Promise(resolve => test.participant.on('trackPublished', resolve));
+            });
+
+            it('should return a Promise that is resolved with the entry from the .tracks', async () => {
+              const localTrackPublication = await publishTrack(localTrack);
+              assert.equal(localTrackPublication, test.participant.tracks.get('foo'));
+            });
+
+            it('should not raise a "trackPublished" event', async () => {
+              let trackPublishedEvent;
+              test.participant.on('trackPublished', () => { trackPublishedEvent = true; });
+              await publishTrack(localTrack);
+              await new Promise(resolve => setTimeout(resolve));
+              assert(!trackPublishedEvent);
+            });
+          });
+
+          [true, false].forEach(hasLocalTrack => {
+            context(`when the .tracks collection ${hasLocalTrack ? 'already has' : 'doesn\'t have'} an entry for the ${trackType}'s .id`, () => {
+              let localTrack;
+              let localTrackPublication;
+              let trackPublishedEvent;
+
+              beforeEach(async () => {
+                test.signaling.state = isConnected ? 'connected' : 'connecting';
+                localTrack = createTrack();
+                if (hasLocalTrack) {
+                  publishTrack(localTrack);
+                  test.signaling.addTrack.resetHistory();
+                }
+                const promise = trackType === 'LocalTrack'
+                  ? publishTrack(localTrack)
+                  : publishTrack(localTrack, { name: 'bar' });
+                test.participant._signaling.tracks.get(localTrack.id).setSid('foo');
+                localTrackPublication = await promise;
+                trackPublishedEvent = null;
+                test.participant.on('trackPublished', publication => { trackPublishedEvent = publication; });
+                await new Promise(resolve => setTimeout(resolve));
+              });
+
+              it(`should ${hasLocalTrack ? 'not ' : ''}call .addTrack on the underlying ParticipantSignaling with the corresponding MediaStreamTrack and LocalTrack name`, () => {
+                if (hasLocalTrack) {
+                  sinon.assert.notCalled(test.signaling.addTrack);
+                  return;
+                }
+                sinon.assert.calledOnce(test.signaling.addTrack);
+                assert(test.signaling.addTrack.args[0][0] instanceof MediaTrackSender
+                  || test.signaling.addTrack.args[0][0] instanceof DataTrackSender);
+                assert.equal(test.signaling.addTrack.args[0][1], (hasLocalTrack || trackType === 'LocalTrack') ? localTrack.id : 'bar');
+                assert.equal(test.signaling.addTrack.args[0][2], priority || 'medium');
+              });
+
+              context('when the SID is set for the underlying LocalTrackPublicationSignaling', () => {
+                const otherKinds = {
+                  audio: ['video', 'data'],
+                  video: ['audio', 'data'],
+                  data: ['audio', 'video']
+                }[kind];
+
+                it(`should resolve the returned Promise with a ${capitalize(kind)}TrackPublication`, () => {
+                  const LocalTrackPublication = options[`Local${capitalize(kind)}TrackPublication`];
+                  assert(localTrackPublication instanceof LocalTrackPublication);
+                  assert.equal(localTrackPublication.trackName, (hasLocalTrack || trackType === 'LocalTrack') ? localTrack.id : 'bar');
+                  assert.equal(localTrackPublication.trackSid, 'foo');
+                  assert.equal(localTrackPublication.track.id, localTrack.id);
+                  assert.equal(localTrackPublication.priority, priority || 'medium');
                 });
 
-                it('should return a Promise that is resolved with the entry from the .tracks', async () => {
-                  const localTrackPublication = await test.participant.publishTrack(localTrack);
-                  assert.equal(localTrackPublication, test.participant.tracks.get('foo'));
+                if (isConnected) {
+                  it('should raise a "trackPublished" event with the LocalTrackPublication after the Promise resolves', () => {
+                    assert.equal(trackPublishedEvent, localTrackPublication);
+                  });
+                } else {
+                  it('should not raise a "trackPublished" event', () => {
+                    assert(!trackPublishedEvent);
+                  });
+                }
+
+                it(`should add the ${capitalize(kind)}TrackPublication to the .tracks and .${kind}Tracks collections`, () => {
+                  assert.equal(localTrackPublication, test.participant.tracks.get(localTrackPublication.trackSid));
+                  assert.equal(localTrackPublication, test.participant[`${kind}Tracks`].get(localTrackPublication.trackSid));
                 });
 
-                it('should not raise a "trackPublished" event', async () => {
-                  let trackPublishedEvent;
-                  test.participant.on('trackPublished', () => { trackPublishedEvent = true; });
-                  await test.participant.publishTrack(localTrack);
-                  await new Promise(resolve => setTimeout(resolve));
-                  assert(!trackPublishedEvent);
+                otherKinds.forEach(otherKind => {
+                  it(`should not add the ${capitalize(kind)}TrackPublication to the .${otherKind}Tracks collection`, () => {
+                    assert(!test.participant[`${otherKind}Tracks`].has(localTrack.id));
+                  });
                 });
               });
 
-              [true, false].forEach(hasLocalTrack => {
-                context(`when the .tracks collection ${hasLocalTrack ? 'already has' : 'doesn\'t have'} an entry for the ${trackType}'s .id`, () => {
-                  let localTrack;
-                  let localTrackPublication;
-                  let trackPublishedEvent;
+              context('when there is an error while setting the SID for the underlying LocalTrackPublicationSignaling', () => {
+                let actualError;
+                let expectedError;
+                let localTrack2;
+                let trackPublicationFailedEvent;
 
-                  beforeEach(async () => {
-                    test.signaling.state = isConnected ? 'connected' : 'connecting';
-                    localTrack = createTrack(kind);
-                    if (hasLocalTrack) {
-                      test.participant.publishTrack(localTrack);
-                      test.signaling.addTrack.reset();
-                    }
-                    const promise = trackType === 'LocalTrack'
-                      ? test.participant.publishTrack(localTrack)
-                      : test.participant.publishTrack(localTrack, { name: 'bar' });
-                    test.participant._signaling.tracks.get(localTrack.id).setSid('foo');
-                    localTrackPublication = await promise;
-                    trackPublishedEvent = null;
-                    test.participant.on('trackPublished', publication => { trackPublishedEvent = publication; });
-                    await new Promise(resolve => setTimeout(resolve));
-                  });
-
-                  it(`should ${hasLocalTrack ? 'not ' : ''}call .addTrack on the underlying ParticipantSignaling with the corresponding MediaStreamTrack and LocalTrack name`, () => {
-                    if (hasLocalTrack) {
-                      sinon.assert.notCalled(test.signaling.addTrack);
-                      return;
-                    }
-                    sinon.assert.calledOnce(test.signaling.addTrack);
-                    assert(test.signaling.addTrack.args[0][0] instanceof MediaTrackSender
-                      || test.signaling.addTrack.args[0][0] instanceof DataTrackSender);
-                    assert.equal(test.signaling.addTrack.args[0][1], (hasLocalTrack || trackType === 'LocalTrack') ? localTrack.id : 'bar');
-                  });
-
-                  context('when the SID is set for the underlying LocalTrackPublicationSignaling', () => {
-                    const otherKinds = {
-                      audio: ['video', 'data'],
-                      video: ['audio', 'data'],
-                      data: ['audio', 'video']
-                    }[kind];
-
-                    it(`should resolve the returned Promise with a ${capitalize(kind)}TrackPublication`, () => {
-                      const LocalTrackPublication = options[`Local${capitalize(kind)}TrackPublication`];
-                      assert(localTrackPublication instanceof LocalTrackPublication);
-                      assert.equal(localTrackPublication.trackName, (hasLocalTrack || trackType === 'LocalTrack') ? localTrack.id : 'bar');
-                      assert.equal(localTrackPublication.trackSid, 'foo');
-                      assert.equal(localTrackPublication.track.id, localTrack.id);
-                    });
-
-                    if (isConnected) {
-                      it('should raise a "trackPublished" event with the LocalTrackPublication after the Promise resolves', () => {
-                        assert.equal(trackPublishedEvent, localTrackPublication);
-                      });
-                    } else {
-                      it('should not raise a "trackPublished" event', () => {
-                        assert(!trackPublishedEvent);
-                      });
-                    }
-
-                    it(`should add the ${capitalize(kind)}TrackPublication to the .tracks and .${kind}Tracks collections`, () => {
-                      assert.equal(localTrackPublication, test.participant.tracks.get(localTrackPublication.trackSid));
-                      assert.equal(localTrackPublication, test.participant[`${kind}Tracks`].get(localTrackPublication.trackSid));
-                    });
-
-                    otherKinds.forEach(otherKind => {
-                      it(`should not add the ${capitalize(kind)}TrackPublication to the .${otherKind}Tracks collection`, () => {
-                        assert(!test.participant[`${otherKind}Tracks`].has(localTrack.id));
-                      });
-                    });
-                  });
-
-                  context('when there is an error while setting the SID for the underlying LocalTrackPublicationSignaling', () => {
-                    let actualError;
-                    let expectedError;
-                    let localTrack2;
-                    let trackPublicationFailedEvent;
-
-                    beforeEach(async () => {
-                      actualError = null;
-                      expectedError = new Error();
-                      localTrack2 = createTrack(kind);
-                      const promise = test.participant.publishTrack(localTrack2);
-                      const localTrackSignaling = test.participant._signaling.tracks.get(localTrack2.id);
-                      localTrackSignaling.publishFailed(expectedError);
-                      try {
-                        await promise;
-                      } catch (error) {
-                        actualError = error;
-                        trackPublicationFailedEvent = null;
-                        test.participant.on('trackPublicationFailed', (error, localTrack) => {
-                          if (trackType === 'LocalTrack') {
-                            trackPublicationFailedEvent = [error, localTrack];
-                          } else {
-                            trackPublicationFailedEvent = [error, localTrack.mediaStreamTrack];
-                          }
-                        });
-                        await new Promise(resolve => setTimeout(resolve));
-                        return;
+                beforeEach(async () => {
+                  actualError = null;
+                  expectedError = new Error();
+                  localTrack2 = createTrack();
+                  const promise = publishTrack(localTrack2);
+                  const localTrackSignaling = test.participant._signaling.tracks.get(localTrack2.id);
+                  localTrackSignaling.publishFailed(expectedError);
+                  try {
+                    await promise;
+                  } catch (error) {
+                    actualError = error;
+                    trackPublicationFailedEvent = null;
+                    test.participant.on('trackPublicationFailed', (error, localTrack) => {
+                      if (trackType === 'LocalTrack') {
+                        trackPublicationFailedEvent = [error, localTrack];
+                      } else {
+                        trackPublicationFailedEvent = [error, localTrack.mediaStreamTrack];
                       }
-                      throw new Error('Unexpectedly resolved');
                     });
+                    await new Promise(resolve => setTimeout(resolve));
+                    return;
+                  }
+                  throw new Error('Unexpectedly resolved');
+                });
 
-                    it('should reject the returned Promise with the given error', () => {
-                      assert.equal(actualError, expectedError);
-                    });
+                it('should reject the returned Promise with the given error', () => {
+                  assert.equal(actualError, expectedError);
+                });
 
-                    it('should raise a "trackPublicationFailed" event with the error and failed LocalTrack after the Promise rejects', () => {
-                      assert.deepEqual(trackPublicationFailedEvent, [expectedError, localTrack2]);
-                    });
+                it('should raise a "trackPublicationFailed" event with the error and failed LocalTrack after the Promise rejects', () => {
+                  assert.deepEqual(trackPublicationFailedEvent, [expectedError, localTrack2]);
+                });
 
-                    it(`should not add the Local${capitalize(kind)}Track to the ._tracks collection`, () => {
-                      assert(!test.participant._tracks.has(localTrack2.id));
-                    });
-                  });
+                it(`should not add the Local${capitalize(kind)}Track to the ._tracks collection`, () => {
+                  assert(!test.participant._tracks.has(localTrack2.id));
                 });
               });
             });
@@ -1048,8 +1073,8 @@ function makeSignaling(options) {
   signaling.sid = options.sid || null;
   signaling.state = options.state;
   signaling.tracks = new Map();
-  signaling.addTrack = sinon.spy(track => {
-    const trackSignaling = new LocalTrackPublicationSignaling(track);
+  signaling.addTrack = sinon.spy((track, name, priority) => {
+    const trackSignaling = new LocalTrackPublicationSignaling(track, name, priority);
     signaling.tracks.set(track.id, trackSignaling);
     return signaling;
   });

--- a/test/unit/spec/localparticipant.js
+++ b/test/unit/spec/localparticipant.js
@@ -9,6 +9,7 @@ const DataTrackSender = require('../../../lib/data/sender');
 const LocalParticipant = require('../../../lib/localparticipant');
 const LocalTrackPublicationSignaling = require('../../../lib/signaling/localtrackpublication');
 const MediaTrackSender = require('../../../lib/media/track/sender');
+const { trackPriority: { HIGH, LOW, STANDARD } } = require('../../../lib/util/constants');
 
 const log = require('../../lib/fakelog');
 const { FakeMediaStreamTrack } = require('../../lib/fakemediastream');
@@ -310,7 +311,7 @@ describe('LocalParticipant', () => {
         x => `of kind ${x}`
       ],
       [
-        [undefined, 'low', 'medium', 'high'],
+        [undefined, HIGH, LOW, STANDARD],
         x => `with priority ${x ? `"${x}"` : 'not specified'}`
       ]
     ], ([trackType, kind, priority]) => {
@@ -338,7 +339,7 @@ describe('LocalParticipant', () => {
             ? () => test.participant.publishTrack(track, { priority })
             : () => test.participant.publishTrack(track),
           MediaStreamTrack: priority
-            ? () => test.participant.publishTrack(track, options, { priority })
+            ? () => test.participant.publishTrack(track, Object.assign({ priority }, options))
             : () => test.participant.publishTrack(track, options)
         }[trackType]();
       }

--- a/test/unit/spec/localparticipant.js
+++ b/test/unit/spec/localparticipant.js
@@ -9,7 +9,7 @@ const DataTrackSender = require('../../../lib/data/sender');
 const LocalParticipant = require('../../../lib/localparticipant');
 const LocalTrackPublicationSignaling = require('../../../lib/signaling/localtrackpublication');
 const MediaTrackSender = require('../../../lib/media/track/sender');
-const { trackPriority: { HIGH, LOW, STANDARD } } = require('../../../lib/util/constants');
+const { trackPriority: { PRIORITY_HIGH, PRIORITY_LOW, PRIORITY_STANDARD } } = require('../../../lib/util/constants');
 
 const log = require('../../lib/fakelog');
 const { FakeMediaStreamTrack } = require('../../lib/fakemediastream');
@@ -311,7 +311,7 @@ describe('LocalParticipant', () => {
         x => `of kind ${x}`
       ],
       [
-        [undefined, HIGH, LOW, STANDARD],
+        [undefined, PRIORITY_HIGH, PRIORITY_LOW, PRIORITY_STANDARD],
         x => `with priority ${x ? `"${x}"` : 'not specified'}`
       ]
     ], ([trackType, kind, priority]) => {

--- a/test/unit/spec/media/track/remotetrackpublication.js
+++ b/test/unit/spec/media/track/remotetrackpublication.js
@@ -26,6 +26,7 @@ const RemoteVideoTrackPublication = require('../../../../../lib/media/track/remo
         ['isSubscribed', false],
         ['isTrackEnabled', signaling.isEnabled],
         ['kind', kind],
+        ['publishPriority', signaling.priority],
         ['track', null],
         ['trackName', signaling.name],
         ['trackSid', signaling.sid]
@@ -217,6 +218,7 @@ const RemoteVideoTrackPublication = require('../../../../../lib/media/track/remo
           'isSubscribed',
           'isTrackEnabled',
           'kind',
+          'publishPriority',
           'track'
         ]);
       });
@@ -234,6 +236,7 @@ const RemoteVideoTrackPublication = require('../../../../../lib/media/track/remo
           isSubscribed: publication.isSubscribed,
           isTrackEnabled: publication.isTrackEnabled,
           kind: publication.kind,
+          publishPriority: publication.publishPriority,
           track: null,
           trackName: publication.trackName,
           trackSid: publication.trackSid
@@ -249,6 +252,7 @@ function makeSignaling(isEnabled, kind, sid) {
   signaling.isEnabled = isEnabled;
   signaling.kind = kind;
   signaling.name = randomName();
+  signaling.priority = randomName();
   signaling.sid = sid;
 
   signaling.update = options => {

--- a/test/unit/spec/signaling/v2/localparticipant.js
+++ b/test/unit/spec/signaling/v2/localparticipant.js
@@ -8,13 +8,15 @@ const DataTrackSender = require('../../../../../lib/data/sender');
 const EncodingParametersImpl = require('../../../../../lib/encodingparameters');
 const LocalParticipantV2 = require('../../../../../lib/signaling/v2/localparticipant');
 const NetworkQualityConfigurationImpl = require('../../../../../lib/networkqualityconfiguration');
+const { makeUUID } = require('../../../../../lib/util');
 
 class MockLocalTrackPublicationV2 extends EventEmitter {
-  constructor(trackSender, name) {
+  constructor(trackSender, name, priority) {
     super();
     this.trackTransceiver = trackSender.clone();
     this.id = trackSender.id;
     this.name = name;
+    this.priority = priority;
     this.sid = null;
     this.stop = () => this.trackTransceiver.stop();
   }
@@ -27,6 +29,7 @@ describe('LocalParticipantV2', () => {
   let encodingParameters;
   let name;
   let networkQualityConfiguration;
+  let priority;
   let publication;
 
   beforeEach(() => {
@@ -42,8 +45,8 @@ describe('LocalParticipantV2', () => {
     });
 
     trackSender = new DataTrackSender();
-
-    name = `track-${Math.random() * 1000}`;
+    name = makeUUID();
+    priority = makeUUID();
   });
 
   describe('constructor', () => {
@@ -61,18 +64,18 @@ describe('LocalParticipantV2', () => {
   });
 
   describe('#addTrack', () => {
-    describe('called with a TrackSender and a name', () => {
+    describe('called with a TrackSender, name and priority', () => {
       it('returns the LocalParticipantV2 instance', () => {
-        assert.equal(localParticipant.addTrack(trackSender, name), localParticipant);
+        assert.equal(localParticipant.addTrack(trackSender, name, priority), localParticipant);
       });
 
-      it('constructs a LocalTrackPublicationV2 with the TrackSender and name', () => {
-        localParticipant.addTrack(trackSender, name);
-        sinon.assert.calledWith(LocalTrackPublicationV2Constructor, trackSender, name);
+      it('constructs a LocalTrackPublicationV2 with the TrackSender, name and priority', () => {
+        localParticipant.addTrack(trackSender, name, priority);
+        sinon.assert.calledWith(LocalTrackPublicationV2Constructor, trackSender, name, priority);
       });
 
       it('adds the LocalTrackPublicationV2 to the LocalParticipantV2\'s .tracks Map', () => {
-        localParticipant.addTrack(trackSender, name);
+        localParticipant.addTrack(trackSender, name, priority);
         assert.equal(localParticipant.tracks.get(trackSender.id), publication);
       });
 
@@ -80,13 +83,13 @@ describe('LocalParticipantV2', () => {
         const events = [];
         ['trackAdded', 'updated'].forEach(event =>
           localParticipant.once(event, () => events.push(event)));
-        localParticipant.addTrack(trackSender, name);
+        localParticipant.addTrack(trackSender, name, priority);
         assert.deepEqual(events, ['trackAdded', 'updated']);
       });
 
       describe('starts listening to the resulting LocalTrackPublicationV2\'s "updated" event and,', () => {
         beforeEach(() => {
-          localParticipant.addTrack(trackSender, name);
+          localParticipant.addTrack(trackSender, name, priority);
         });
 
         describe('when the LocalTrackPublicationV2\'s SID is set,', () => {
@@ -118,7 +121,7 @@ describe('LocalParticipantV2', () => {
   describe('#removeTrack, called with a DataTrackSedner or MediaTrackSender that is', () => {
     describe('currently added', () => {
       beforeEach(() => {
-        localParticipant.addTrack(trackSender, name);
+        localParticipant.addTrack(trackSender, name, priority);
         publication.sid = 'MT123';
         publication.emit('updated');
       });

--- a/test/unit/spec/signaling/v2/localtrackpublication.js
+++ b/test/unit/spec/signaling/v2/localtrackpublication.js
@@ -17,13 +17,15 @@ describe('LocalTrackPublicationV2', () => {
     let mediaStreamTrack;
     let mediaTrackSender;
     let name;
+    let priority;
 
     before(() => {
       mediaStreamTrack = new FakeMediaStreamTrack(makeKind());
       mediaStreamTrack.enabled = makeEnabled();
       mediaTrackSender = makeTrackSender(mediaStreamTrack);
       name = makeUUID();
-      localTrackPublicationV2 = new LocalTrackPublicationV2(mediaTrackSender, name);
+      priority = makePriority();
+      localTrackPublicationV2 = new LocalTrackPublicationV2(mediaTrackSender, name, priority);
     });
 
     it('should return a LocalTrackPublicationV2', () => {
@@ -42,6 +44,10 @@ describe('LocalTrackPublicationV2', () => {
       assert.equal(localTrackPublicationV2.name, name);
     });
 
+    it('should set the .priority property', () => {
+      assert.equal(localTrackPublicationV2.priority, priority);
+    });
+
     [
       ['kind', 'kind'],
       ['isEnabled', 'enabled']
@@ -54,12 +60,14 @@ describe('LocalTrackPublicationV2', () => {
     describe('#getState', () => {
       let localTrackPublicationV2;
       let mediaStreamTrack;
+      let priority;
       let state;
 
       before(() => {
         mediaStreamTrack = new FakeMediaStreamTrack(makeKind());
         mediaStreamTrack.enabled = makeEnabled();
-        localTrackPublicationV2 = new LocalTrackPublicationV2(makeTrackSender(mediaStreamTrack), makeUUID());
+        priority = makePriority();
+        localTrackPublicationV2 = new LocalTrackPublicationV2(makeTrackSender(mediaStreamTrack), makeUUID(), priority);
         state = localTrackPublicationV2.getState();
       });
 
@@ -68,7 +76,8 @@ describe('LocalTrackPublicationV2', () => {
           ['id', 'id'],
           ['kind', 'kind'],
           ['enabled', 'isEnabled'],
-          ['name', 'name']
+          ['name', 'name'],
+          ['priority', 'priority']
         ].forEach(([stateProp, ltProp]) => {
           it(`.${stateProp} is equal to the LocalTrackPublicationV2's ${ltProp}`, () => {
             assert.equal(state[stateProp], localTrackPublicationV2[ltProp]);
@@ -88,7 +97,7 @@ describe('LocalTrackPublicationV2', () => {
 
         beforeEach(() => {
           payload = { state: 'ready', sid: makeSid() };
-          localTrackPublicationV2 = new LocalTrackPublicationV2(makeTrackSender(new FakeMediaStreamTrack()));
+          localTrackPublicationV2 = new LocalTrackPublicationV2(makeTrackSender(new FakeMediaStreamTrack()), makeUUID(), makePriority());
           updated = false;
           localTrackPublicationV2.once('updated', () => { updated = true; });
           ret = localTrackPublicationV2.update(payload);
@@ -121,7 +130,7 @@ describe('LocalTrackPublicationV2', () => {
 
         beforeEach(() => {
           payload = { state: 'failed', error: { code: 1, message: 'foo' } };
-          localTrackPublicationV2 = new LocalTrackPublicationV2(makeTrackSender(new FakeMediaStreamTrack()));
+          localTrackPublicationV2 = new LocalTrackPublicationV2(makeTrackSender(new FakeMediaStreamTrack()), makeUUID(), makePriority());
           updated = false;
           localTrackPublicationV2.once('updated', () => { updated = true; });
           ret = localTrackPublicationV2.update(payload);
@@ -159,7 +168,7 @@ describe('LocalTrackPublicationV2', () => {
     beforeEach(() => {
       const mediaStreamTrack = new FakeMediaStreamTrack(makeKind());
       sid = makeSid();
-      localTrackPublicationV2 = new LocalTrackPublicationV2(makeTrackSender(mediaStreamTrack), makeUUID());
+      localTrackPublicationV2 = new LocalTrackPublicationV2(makeTrackSender(mediaStreamTrack), makeUUID(), makePriority());
       updated = false;
     });
 
@@ -248,7 +257,7 @@ describe('LocalTrackPublicationV2', () => {
       describe(`called with \`${enabled}\``, () => {
         it(`sets the cloned MediaTrackSender's MediaStreamTrack's .enabled state to \`${enabled}\``, () => {
           const mediaTrackSender = makeTrackSender(new FakeMediaStreamTrack(makeKind()));
-          const localTrackPublicationV2 = new LocalTrackPublicationV2(mediaTrackSender, makeUUID());
+          const localTrackPublicationV2 = new LocalTrackPublicationV2(mediaTrackSender, makeUUID(), makePriority());
           const mediaStreamTrack = localTrackPublicationV2.trackTransceiver.track;
           mediaStreamTrack.enabled = !enabled;
           localTrackPublicationV2.enable(enabled);
@@ -267,7 +276,7 @@ describe('LocalTrackPublicationV2', () => {
     beforeEach(() => {
       const mediaStreamTrack = new FakeMediaStreamTrack(makeKind());
       error = new Error('Track publication failed');
-      localTrackPublicationV2 = new LocalTrackPublicationV2(makeTrackSender(mediaStreamTrack));
+      localTrackPublicationV2 = new LocalTrackPublicationV2(makeTrackSender(mediaStreamTrack), makeUUID(), makePriority());
       updated = false;
     });
 
@@ -351,7 +360,7 @@ describe('LocalTrackPublicationV2', () => {
   describe('#stop', () => {
     it('calls stop on the cloned MediaTrackSender\'s MediaStreamTrack', () => {
       const mediaTrackSender = makeTrackSender(new FakeMediaStreamTrack(makeKind()));
-      const localTrackPublicationV2 = new LocalTrackPublicationV2(mediaTrackSender, makeUUID());
+      const localTrackPublicationV2 = new LocalTrackPublicationV2(mediaTrackSender, makeUUID(), makePriority());
       const mediaStreamTrack = localTrackPublicationV2.trackTransceiver.track;
       mediaStreamTrack.stop = sinon.spy();
       localTrackPublicationV2.stop();
@@ -366,6 +375,10 @@ function makeEnabled() {
 
 function makeKind() {
   return ['audio', 'video'][Number(Math.random() > 0.5)];
+}
+
+function makePriority() {
+  return makeUUID();
 }
 
 function makeSid() {

--- a/test/unit/spec/signaling/v2/remotetrackpublication.js
+++ b/test/unit/spec/signaling/v2/remotetrackpublication.js
@@ -6,71 +6,31 @@ const RemoteTrackPublicationV2 = require('../../../../../lib/signaling/v2/remote
 const { makeUUID } = require('../../../../../lib/util');
 
 describe('RemoteTrackPublicationV2', () => {
-  // RemoteTrackPublicationV2
-  // -------
-
   describe('constructor', () => {
-    it('sets .name', () => {
-      const name = makeUUID();
-      assert.equal(name, (new RemoteTrackPublicationV2({
-        enabled: makeEnabled(),
-        kind: makeKind(),
-        name: name,
-        sid: makeSid()
-      })).name);
-    });
-
-    it('sets .sid', () => {
-      const sid = makeSid();
-      assert.equal(sid, (new RemoteTrackPublicationV2({
-        enabled: makeEnabled(),
-        kind: makeKind(),
-        name: makeUUID(),
-        sid: sid
-      })).sid);
-    });
-
-    context('when trackState.enabled is true', () => {
-      it('sets .isEnabled to true', () => {
-        assert((new RemoteTrackPublicationV2({
-          enabled: true,
+    ['kind', 'name', 'priority', 'sid'].forEach(prop => {
+      it(`sets .${prop}`, () => {
+        const trackState = {
+          enabled: makeEnabled(),
           kind: makeKind(),
           name: makeUUID(),
+          priority: makeUUID(),
           sid: makeSid()
-        })).isEnabled);
+        };
+        assert.equal((new RemoteTrackPublicationV2(trackState))[prop], trackState[prop]);
       });
     });
 
-    context('when trackState.enabled is false', () => {
-      it('sets .isEnabled to false', () => {
-        assert(!(new RemoteTrackPublicationV2({
-          enabled: false,
-          kind: makeKind(),
-          name: makeUUID(),
-          sid: makeSid()
-        })).isEnabled);
-      });
-    });
-
-    context('when trackState.kind is "audio"', () => {
-      it('sets .kind to "audio"', () => {
-        assert.equal('audio', (new RemoteTrackPublicationV2({
-          enabled: makeEnabled(),
-          kind: 'audio',
-          name: makeUUID(),
-          sid: makeSid()
-        })).kind);
-      });
-    });
-
-    context('when trackState.kind is "video"', () => {
-      it('sets .kind to "video"', () => {
-        assert.equal('video', (new RemoteTrackPublicationV2({
-          enabled: makeEnabled(),
-          kind: 'video',
-          name: makeUUID(),
-          sid: makeSid()
-        })).kind);
+    [true, false].forEach(enabled => {
+      context(`when trackState.enabled is ${enabled}`, () => {
+        it(`sets .isEnabled to ${enabled}`, () => {
+          assert.equal((new RemoteTrackPublicationV2({
+            enabled,
+            kind: makeKind(),
+            name: makeUUID(),
+            priority: makeUUID(),
+            sid: makeSid()
+          })).isEnabled, enabled);
+        });
       });
     });
   });
@@ -83,6 +43,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           };
           const track = new RemoteTrackPublicationV2(trackState);
@@ -95,6 +56,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           };
           const track = new RemoteTrackPublicationV2(trackState);
@@ -108,6 +70,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           };
           const track = new RemoteTrackPublicationV2(trackState);
@@ -125,6 +88,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           };
           const track = new RemoteTrackPublicationV2(trackState);
@@ -137,6 +101,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           };
           const track = new RemoteTrackPublicationV2(trackState);
@@ -150,6 +115,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           };
           const track = new RemoteTrackPublicationV2(trackState);
@@ -169,6 +135,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           };
           const track = new RemoteTrackPublicationV2(trackState);
@@ -181,6 +148,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           };
           const track = new RemoteTrackPublicationV2(trackState);
@@ -194,6 +162,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           };
           const track = new RemoteTrackPublicationV2(trackState);
@@ -211,6 +180,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           };
           const track = new RemoteTrackPublicationV2(trackState);
@@ -223,6 +193,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           };
           const track = new RemoteTrackPublicationV2(trackState);
@@ -236,6 +207,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           };
           const track = new RemoteTrackPublicationV2(trackState);
@@ -259,6 +231,7 @@ describe('RemoteTrackPublicationV2', () => {
           enabled: true,
           kind: makeKind(),
           name: makeUUID(),
+          priority: makeUUID(),
           sid: makeSid()
         });
         assert.equal(track, track.disable());
@@ -269,6 +242,7 @@ describe('RemoteTrackPublicationV2', () => {
           enabled: true,
           kind: makeKind(),
           name: makeUUID(),
+          priority: makeUUID(),
           sid: makeSid()
         });
         track.disable();
@@ -280,6 +254,7 @@ describe('RemoteTrackPublicationV2', () => {
           enabled: true,
           kind: makeKind(),
           name: makeUUID(),
+          priority: makeUUID(),
           sid: makeSid()
         });
         let isEnabled;
@@ -295,6 +270,7 @@ describe('RemoteTrackPublicationV2', () => {
           enabled: false,
           kind: makeKind(),
           name: makeUUID(),
+          priority: makeUUID(),
           sid: makeSid()
         });
         assert.equal(track, track.disable());
@@ -305,6 +281,7 @@ describe('RemoteTrackPublicationV2', () => {
           enabled: false,
           kind: makeKind(),
           name: makeUUID(),
+          priority: makeUUID(),
           sid: makeSid()
         });
         track.disable();
@@ -316,6 +293,7 @@ describe('RemoteTrackPublicationV2', () => {
           enabled: false,
           kind: makeKind(),
           name: makeUUID(),
+          priority: makeUUID(),
           sid: makeSid()
         });
         let updated;
@@ -334,6 +312,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           });
           assert.equal(track, track.enable(false));
@@ -344,6 +323,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           });
           track.enable(false);
@@ -355,6 +335,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           });
           let isEnabled;
@@ -370,6 +351,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           });
           assert.equal(track, track.enable(false));
@@ -380,6 +362,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           });
           track.enable(false);
@@ -391,6 +374,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           });
           let updated;
@@ -408,6 +392,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           });
           assert.equal(track, track.enable(true));
@@ -418,6 +403,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           });
           track.enable(true);
@@ -429,6 +415,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           });
           let updated;
@@ -444,6 +431,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           });
           assert.equal(track, track.enable(true));
@@ -454,6 +442,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           });
           track.enable(true);
@@ -465,6 +454,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           });
           let isEnabled;
@@ -482,6 +472,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           });
           assert.equal(track, track.enable());
@@ -492,6 +483,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           });
           track.enable();
@@ -503,6 +495,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: true,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           });
           let updated;
@@ -518,6 +511,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           });
           assert.equal(track, track.enable());
@@ -528,6 +522,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           });
           track.enable();
@@ -539,6 +534,7 @@ describe('RemoteTrackPublicationV2', () => {
             enabled: false,
             kind: makeKind(),
             name: makeUUID(),
+            priority: makeUUID(),
             sid: makeSid()
           });
           let isEnabled;
@@ -556,6 +552,7 @@ describe('RemoteTrackPublicationV2', () => {
         enabled: makeEnabled(),
         kind: makeKind(),
         name: makeUUID(),
+        priority: makeUUID(),
         sid: makeSid()
       });
       const mediaTrackReceiver = {};
@@ -567,6 +564,7 @@ describe('RemoteTrackPublicationV2', () => {
         enabled: makeEnabled(),
         kind: makeKind(),
         name: makeUUID(),
+        priority: makeUUID(),
         sid: makeSid()
       });
       const mediaTrackReceiver = {};


### PR DESCRIPTION
@makarandp0 

This PR implements the publisher side Track Priority API. Please take a look when you can.

## TODO
- [x] Add `publishPriority` to RemoteTrackPublication.
- [x] Integration tests.
- [x] Update JSDoc comments to say that priority works only with Group Rooms.
- [x] ~~Change "medium" to "standard" once this is available in RSP.~~ (Will be addressed in a separate PR).

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
