### PR TITLE
JSDK-2400 invalid characters in region parameter should return correct errorcode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/support-1.x/CHANGELOG.md).
 
+2.0.0-beta13 (in progress)
+============================
+
+Bug Fixes
+---------
+
+- Instead of using region specified directly, we now `encodeURIComponent` the region,
+This ensures that if `region` contains invalid characters for URI, it will fail with
+correct error code.
+
 2.0.0-beta12 (July 12, 2019)
 ============================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/support-1.x/CHANGELOG.md).
 
 2.0.0-beta13 (in progress)
-============================
+==========================
 
 Bug Fixes
 ---------
 
-- Instead of using region specified directly, we now `encodeURIComponent` the region,
-This ensures that if `region` contains invalid characters for URI, it will fail with
-correct error code.
+- Fixed a bug where connecting to a Room with a `region` containing special
+  characters in ConnectOptions failed with an Error other than
+  [SignalingConnectionError](https://www.twilio.com/docs/api/errors/53000). (JSDK-2400)
 
 2.0.0-beta12 (July 12, 2019)
 ============================

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -5,7 +5,7 @@ module.exports.DEFAULT_REALM = 'us1';
 module.exports.DEFAULT_REGION = 'gll';
 module.exports.DEFAULT_LOG_LEVEL = 'warn';
 module.exports.WS_SERVER = (environment, region) => {
-  region = region === 'gll' ? 'global' : region;
+  region = region === 'gll' ? 'global' : encodeURIComponent(region);
   return environment === 'prod'
     ? `wss://${region}.vss.twilio.com/signaling`
     : `wss://${region}.vss.${environment}.twilio.com/signaling`;


### PR DESCRIPTION
Instead of using region specified directly, we now `encodeURIComponent` the region, This ensures that if `region` contains invalid characters for URI, it will fail with correct error code.   