### PR TITLE
JSDK-2440 dscp tagging option experiment

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -126,6 +126,7 @@ function connect(token, options) {
     automaticSubscription: true,
     createLocalTracks,
     dominantSpeaker: false,
+    dscpTagging: false,
     environment: constants.DEFAULT_ENVIRONMENT,
     iceServersTimeout: constants.ICE_SERVERS_TIMEOUT_MS,
     insights: true,
@@ -287,8 +288,13 @@ function connect(token, options) {
  *   not subscribe to any RemoteTrack in a Group or Small Group Room. Setting it to
  *   <code>true</code>, or not setting it at all preserves the default behavior. This
  *   flag does not have any effect in a Peer-to-Peer Room.
+ *
  * @property {boolean} [dominantSpeaker=false] - Whether to enable the Dominant
  *   Speaker API or not. This only takes effect in Group Rooms.
+ * @property {boolean} [dscpTagging=false] - DSCP tagging allows you to request enhanced
+ *   QoS treatment for RTP media packets from any firewall that the client may be behind.
+ *   Setting this option to <code>true</code>, will request DSCP tagging if the browser
+ *   supports it. Right now this is available only in Google Chrome..
  * @property {Array<RTCIceServer>} iceServers - Override the STUN and TURN
  *   servers used when connecting to {@link Room}s
  * @property {number} [iceServersTimeout=3000] - Override the amount of time, in

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -153,6 +153,11 @@ function connect(token, options) {
   const wsServer = constants.WS_SERVER(options.environment, options.region);
 
   options = Object.assign({ wsServer }, options);
+  if (options.dscpTagging === true) {
+    options.chromeSpecificConstraints = options.chromeSpecificConstraints || {};
+    options.chromeSpecificConstraints.optional = options.chromeSpecificConstraints.optional || [];
+    options.chromeSpecificConstraints.optional.push({ googDscp: true });
+  }
 
   const logLevels = util.buildLogLevels(options.logLevel);
   const logComponentName = `[connect #${++connectCalls}]`;

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -126,7 +126,7 @@ function connect(token, options) {
     automaticSubscription: true,
     createLocalTracks,
     dominantSpeaker: false,
-    dscpTagging: false,
+    dscpTagging: true, // false,
     environment: constants.DEFAULT_ENVIRONMENT,
     iceServersTimeout: constants.ICE_SERVERS_TIMEOUT_MS,
     insights: true,

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 'use strict';
 
 const {
@@ -979,6 +980,17 @@ class PeerConnectionV2 extends StateMachine {
     if (this._localMediaStream) {
       this._localMediaStream.addTrack(mediaTrackSender.track);
       sender = this._peerConnection.addTrack(mediaTrackSender.track, this._localMediaStream);
+      console.log("makarand: setting parameters for sender");
+      var params = sender.getParameters();
+      // eslint-disable-next-line quotes
+      console.log("makarand: setting parameters for sender", params);
+      params.networkPriority = 'high';
+      params.priority = 'high';
+      sender.setParameters(params).then(() => {
+        console.log("makarand: done setting parameters for sender", sender.getParameters());
+      }).catch((e) => {
+        console.log("makarand: error setting parameters for sender", e);
+      });
     } else {
       const transceiver = this._addOrUpdateTransceiver(mediaTrackSender.track);
       sender = transceiver.sender;

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -967,6 +967,20 @@ class PeerConnectionV2 extends StateMachine {
     }
   }
 
+  updateRTCRTPSenderWithPriority(sender) {
+    console.log("makarand: setting parameters for sender");
+    var params = sender.getParameters();
+    // eslint-disable-next-line quotes
+    console.log("makarand: setting parameters for sender", params);
+    params.networkPriority = 'high';
+    params.priority = 'high';
+    sender.setParameters(params).then(() => {
+      console.log("makarand: done setting parameters for sender", sender.getParameters());
+    }).catch((e) => {
+      console.log("makarand: error setting parameters for sender", e);
+    });
+  }
+
   /**
    * Add the {@link MediaTrackSender} to the {@link PeerConnectionV2}.
    * @param {MediaTrackSender} mediaTrackSender
@@ -980,20 +994,11 @@ class PeerConnectionV2 extends StateMachine {
     if (this._localMediaStream) {
       this._localMediaStream.addTrack(mediaTrackSender.track);
       sender = this._peerConnection.addTrack(mediaTrackSender.track, this._localMediaStream);
-      console.log("makarand: setting parameters for sender");
-      var params = sender.getParameters();
-      // eslint-disable-next-line quotes
-      console.log("makarand: setting parameters for sender", params);
-      params.networkPriority = 'high';
-      params.priority = 'high';
-      sender.setParameters(params).then(() => {
-        console.log("makarand: done setting parameters for sender", sender.getParameters());
-      }).catch((e) => {
-        console.log("makarand: error setting parameters for sender", e);
-      });
+      this.updateRTCRTPSenderWithPriority(sender);
     } else {
       const transceiver = this._addOrUpdateTransceiver(mediaTrackSender.track);
       sender = transceiver.sender;
+      this.updateRTCRTPSenderWithPriority(sender);
     }
     mediaTrackSender.addSender(sender);
     this._rtpSenders.set(mediaTrackSender, sender);


### PR DESCRIPTION
This change is only for demonstration purpose. It sets `chromeSpecificConstraints` to `{"optional":[{"googDscp":true}]}` 

I was hoping to DSCP field set with this change. Although I do see that chrome understands this parameter (as seen from chrome://webrtc-internals, I do not see any difference in DSCP header as reported by wireshark.
