### PR TITLE
JSDK-2408 add room and participant sid in connect message.

### DIFF
--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -94,7 +94,7 @@ class RoomV2 extends RoomSignaling {
     handleLocalParticipantEvents(this, localParticipant);
     handlePeerConnectionEvents(this, peerConnectionManager);
     handleTransportEvents(this, transport);
-    periodicallyPublishStats(this, localParticipant, transport, options.statsPublishIntervalMs);
+    periodicallyPublishStats(this, transport, options.statsPublishIntervalMs);
 
     this._update(initialState);
   }
@@ -563,11 +563,10 @@ function handleTransportEvents(roomV2, transport) {
  * Periodically publish {@link StatsReport}s.
  * @private
  * @param {RoomV2} roomV2
- * @param {LocalParticipantV2} localParticipant
  * @param {Transport} transport
  * @param {Number} intervalMs
  */
-function periodicallyPublishStats(roomV2, localParticipant, transport, intervalMs) {
+function periodicallyPublishStats(roomV2, transport, intervalMs) {
   const interval = setInterval(() => {
     roomV2.getStats().then(stats => {
       stats.forEach((response, id) => {
@@ -580,9 +579,7 @@ function periodicallyPublishStats(roomV2, localParticipant, transport, intervalM
           audioTrackStats: report.remoteAudioTrackStats,
           localAudioTrackStats: report.localAudioTrackStats,
           localVideoTrackStats: report.localVideoTrackStats,
-          participantSid: localParticipant.sid,
           peerConnectionId: report.peerConnectionId,
-          roomSid: roomV2.sid,
           videoTrackStats: report.remoteVideoTrackStats
         });
 

--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -172,6 +172,10 @@ class TwilioConnectionTransport extends StateMachine {
       }
     });
     setupEventListeners(this);
+
+    this.once('connected', (initialState) => {
+      this._eventPublisher.update(initialState.sid, initialState.participant.sid);
+    });
   }
 
   /**
@@ -449,6 +453,8 @@ function setupEventListeners(transport) {
           case 'connected':
             transport._session = message.session;
             transport.emit('connected', message);
+            // update eventPublisher with participant sid, and room
+            // transport.updateEventPublisher(message.sid, message.participant.sid);
             transport.preempt('connected');
             return;
           case 'synced':

--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -174,7 +174,7 @@ class TwilioConnectionTransport extends StateMachine {
     setupEventListeners(this);
 
     this.once('connected', (initialState) => {
-      this._eventPublisher.update(initialState.sid, initialState.participant.sid);
+      this._eventPublisher.connect(initialState.sid, initialState.participant.sid);
     });
   }
 
@@ -453,8 +453,6 @@ function setupEventListeners(transport) {
           case 'connected':
             transport._session = message.session;
             transport.emit('connected', message);
-            // update eventPublisher with participant sid, and room
-            // transport.updateEventPublisher(message.sid, message.participant.sid);
             transport.preempt('connected');
             return;
           case 'synced':

--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -173,8 +173,8 @@ class TwilioConnectionTransport extends StateMachine {
     });
     setupEventListeners(this);
 
-    this.once('connected', (initialState) => {
-      this._eventPublisher.connect(initialState.sid, initialState.participant.sid);
+    this.once('connected', ({ sid, participant }) => {
+      this._eventPublisher.connect(sid, participant.sid);
     });
   }
 

--- a/lib/util/insightspublisher/index.js
+++ b/lib/util/insightspublisher/index.js
@@ -47,7 +47,7 @@ class InsightsPublisher extends EventEmitter {
       _eventQueue: {
         value: []
       },
-      _readyToPublish: {
+      _readyToConnect: {
         value: util.defer()
       },
       _reconnectAttemptsLeft: {
@@ -63,30 +63,31 @@ class InsightsPublisher extends EventEmitter {
       }
     });
 
-    const self = this;
-
-    this.on('disconnected', function maybeReconnect(error) {
-      self._session = null;
-      if (error && self._reconnectAttemptsLeft > 0) {
-        self.emit('reconnecting');
-        reconnect(self, token, sdkName, sdkVersion, options);
-        return;
-      }
-      self.removeListener('disconnected', maybeReconnect);
-    });
-
-    this._readyToPublish.promise.then(({ roomSid, participantSid }) => {
+    this._readyToConnect.promise.then(({ roomSid, participantSid }) => {
+      const self = this;
+      this.on('disconnected', function maybeReconnect(error) {
+        self._session = null;
+        if (error && self._reconnectAttemptsLeft > 0) {
+          self.emit('reconnecting');
+          reconnect(self, token, sdkName, sdkVersion, roomSid, participantSid, options);
+          return;
+        }
+        self.removeListener('disconnected', maybeReconnect);
+      });
       connect(this, token, sdkName, sdkVersion, roomSid, participantSid, options);
+    }).catch(() => {
+      // ignore failures to connect
     });
   }
 
   /**
-   * setup room sid and participant sid to use by the events published.
+   * Start connecting to the Insights gateway.
    * @param {string} roomSid
    * @param {string} participantSid
+   * @returns {void}
    */
-  update(roomSid, participantSid) {
-    this._readyToPublish.resolve({ roomSid, participantSid });
+  connect(roomSid, participantSid) {
+    this._readyToConnect.resolve({ roomSid, participantSid });
   }
 
   /**
@@ -104,7 +105,10 @@ class InsightsPublisher extends EventEmitter {
    * @returns {boolean} true if called when connecting/open, false if not
    */
   disconnect() {
-    if (this._ws.readyState === this._WebSocket.CLOSING || this._ws.readyState === this._WebSocket.CLOSED) {
+    if (
+      this._ws === null ||
+      this._ws.readyState === this._WebSocket.CLOSING ||
+      this._ws.readyState === this._WebSocket.CLOSED) {
       return false;
     }
 
@@ -126,7 +130,10 @@ class InsightsPublisher extends EventEmitter {
    * @returns {boolean} true if queued or published, false if disconnect() called
    */
   publish(groupName, eventName, payload) {
-    if (this._ws.readyState === this._WebSocket.CLOSING || this._ws.readyState === this._WebSocket.CLOSED) {
+    if (
+      this._ws !== null &&
+      (this._ws.readyState === this._WebSocket.CLOSING ||
+      this._ws.readyState === this._WebSocket.CLOSED)) {
       return false;
     }
 
@@ -236,20 +243,22 @@ function handleConnectResponse(publisher, response, options) {
  * @param {string} token
  * @param {string} sdkName
  * @param {string} sdkVersion
+ * @param {string} roomSid
+ * @param {string} participantSid
  * @param {InsightsPublisherOptions} options
  */
-function reconnect(publisher, token, sdkName, sdkVersion, options) {
+function reconnect(publisher, token, sdkName, sdkVersion, roomSid, participantSid, options) {
   const connectInterval = Date.now() - publisher._connectTimestamp;
   const timeToWait = options.reconnectIntervalMs - connectInterval;
 
   if (timeToWait > 0) {
     setTimeout(() => {
-      connect(publisher, token, sdkName, sdkVersion, options);
+      connect(publisher, token, sdkName, sdkVersion, roomSid, participantSid, options);
     }, timeToWait);
     return;
   }
 
-  connect(publisher, token, sdkName, sdkVersion, options);
+  connect(publisher, token, sdkName, sdkVersion, roomSid, participantSid, options);
 }
 
 /**

--- a/lib/util/insightspublisher/index.js
+++ b/lib/util/insightspublisher/index.js
@@ -10,6 +10,7 @@ const WS_CLOSE_NORMAL = 1000;
 
 const toplevel = global.window || global;
 const WebSocket = toplevel.WebSocket ? toplevel.WebSocket : require('ws');
+const util = require('../../util');
 
 /**
  * Publish events to the Insights gateway.
@@ -46,6 +47,9 @@ class InsightsPublisher extends EventEmitter {
       _eventQueue: {
         value: []
       },
+      _readyToPublish: {
+        value: util.defer()
+      },
       _reconnectAttemptsLeft: {
         value: options.maxReconnectAttempts,
         writable: true
@@ -71,11 +75,9 @@ class InsightsPublisher extends EventEmitter {
       self.removeListener('disconnected', maybeReconnect);
     });
 
-    this.once('readytoconnect', (roomSid, participantSid) => {
-      console.log("makarand: Eventpublisher connecting: ", roomSid, participantSid);
+    this._readyToPublish.promise.then(({ roomSid, participantSid }) => {
       connect(this, token, sdkName, sdkVersion, roomSid, participantSid, options);
     });
-
   }
 
   /**
@@ -84,8 +86,7 @@ class InsightsPublisher extends EventEmitter {
    * @param {string} participantSid
    */
   update(roomSid, participantSid) {
-    console.log("makarand: Eventpublisher got update: ", roomSid, participantSid);
-    this.emit('readytoconnect', roomSid, participantSid);
+    this._readyToPublish.resolve({ roomSid, participantSid });
   }
 
   /**
@@ -159,7 +160,6 @@ class InsightsPublisher extends EventEmitter {
  * @param {InsightsPublisherOptions} options
  */
 function connect(publisher, token, sdkName, sdkVersion, roomSid, participantSid, options) {
-  console.log("makarand: inside connect");
   publisher._connectTimestamp = Date.now();
   publisher._reconnectAttemptsLeft--;
   publisher._ws = new options.WebSocket(options.gateway);

--- a/lib/util/insightspublisher/index.js
+++ b/lib/util/insightspublisher/index.js
@@ -71,7 +71,21 @@ class InsightsPublisher extends EventEmitter {
       self.removeListener('disconnected', maybeReconnect);
     });
 
-    connect(this, token, sdkName, sdkVersion, options);
+    this.once('readytoconnect', (roomSid, participantSid) => {
+      console.log("makarand: Eventpublisher connecting: ", roomSid, participantSid);
+      connect(this, token, sdkName, sdkVersion, roomSid, participantSid, options);
+    });
+
+  }
+
+  /**
+   * setup room sid and participant sid to use by the events published.
+   * @param {string} roomSid
+   * @param {string} participantSid
+   */
+  update(roomSid, participantSid) {
+    console.log("makarand: Eventpublisher got update: ", roomSid, participantSid);
+    this.emit('readytoconnect', roomSid, participantSid);
   }
 
   /**
@@ -140,9 +154,12 @@ class InsightsPublisher extends EventEmitter {
  * @param {string} token
  * @param {string} sdkName
  * @param {string} sdkVersion
+ * @param {string} roomSid
+ * @param {string} participantSid
  * @param {InsightsPublisherOptions} options
  */
-function connect(publisher, token, sdkName, sdkVersion, options) {
+function connect(publisher, token, sdkName, sdkVersion, roomSid, participantSid, options) {
+  console.log("makarand: inside connect");
   publisher._connectTimestamp = Date.now();
   publisher._reconnectAttemptsLeft--;
   publisher._ws = new options.WebSocket(options.gateway);
@@ -170,7 +187,9 @@ function connect(publisher, token, sdkName, sdkVersion, options) {
     connectRequest.publisher = {
       name: sdkName,
       sdkVersion,
-      userAgent: options.userAgent
+      userAgent: options.userAgent,
+      participantSid: participantSid,
+      roomSid: roomSid,
     };
 
     ws.send(JSON.stringify(connectRequest));

--- a/lib/util/insightspublisher/index.js
+++ b/lib/util/insightspublisher/index.js
@@ -105,10 +105,9 @@ class InsightsPublisher extends EventEmitter {
    * @returns {boolean} true if called when connecting/open, false if not
    */
   disconnect() {
-    if (
-      this._ws === null ||
-      this._ws.readyState === this._WebSocket.CLOSING ||
-      this._ws.readyState === this._WebSocket.CLOSED) {
+    if (this._ws === null
+      || this._ws.readyState === this._WebSocket.CLOSING
+      || this._ws.readyState === this._WebSocket.CLOSED) {
       return false;
     }
 
@@ -130,10 +129,9 @@ class InsightsPublisher extends EventEmitter {
    * @returns {boolean} true if queued or published, false if disconnect() called
    */
   publish(groupName, eventName, payload) {
-    if (
-      this._ws !== null &&
-      (this._ws.readyState === this._WebSocket.CLOSING ||
-      this._ws.readyState === this._WebSocket.CLOSED)) {
+    if (this._ws !== null
+      && (this._ws.readyState === this._WebSocket.CLOSING
+        || this._ws.readyState === this._WebSocket.CLOSED)) {
       return false;
     }
 

--- a/lib/util/insightspublisher/null.js
+++ b/lib/util/insightspublisher/null.js
@@ -16,6 +16,13 @@ class InsightsPublisher {
   }
 
   /**
+   * Connect
+   * @returns {void}
+   */
+  connect() {
+  }
+
+  /**
    * Disconnect.
    * @returns {boolean}
    */

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -1,11 +1,11 @@
 'use strict';
 
 require('./spec/connect');
-require('./spec/localparticipant');
-require('./spec/localtracks');
-require('./spec/localtrackpublication');
-require('./spec/rest');
-require('./spec/room');
-require('./spec/util/insightspublisher');
-require('./spec/util/support');
-require('./spec/util/simulcast');
+// require('./spec/localparticipant');
+// require('./spec/localtracks');
+// require('./spec/localtrackpublication');
+// require('./spec/rest');
+// require('./spec/room');
+// require('./spec/util/insightspublisher');
+// require('./spec/util/support');
+// require('./spec/util/simulcast');

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -1,11 +1,11 @@
 'use strict';
 
 require('./spec/connect');
-// require('./spec/localparticipant');
-// require('./spec/localtracks');
-// require('./spec/localtrackpublication');
-// require('./spec/rest');
-// require('./spec/room');
-// require('./spec/util/insightspublisher');
-// require('./spec/util/support');
-// require('./spec/util/simulcast');
+require('./spec/localparticipant');
+require('./spec/localtracks');
+require('./spec/localtrackpublication');
+require('./spec/rest');
+require('./spec/room');
+require('./spec/util/insightspublisher');
+require('./spec/util/support');
+require('./spec/util/simulcast');

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -145,7 +145,7 @@ describe('connect', function() {
     });
   });
 
-  describe.only('insights option', () => {
+  describe('insights option', () => {
     let sid = null;
     let token = null;
     let error = null;

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -145,6 +145,43 @@ describe('connect', function() {
     });
   });
 
+  describe.only('insights option', () => {
+    let sid = null;
+    let token = null;
+    let error = null;
+
+    beforeEach(async () => {
+      const identity = randomName();
+      token = getToken(identity);
+      sid = await createRoom(randomName(), defaults.topology);
+    });
+
+    [true, false].forEach((insights) => {
+      it(`when set to  ${insights}`, async () => {
+        let cancelablePromise = null;
+        let room = null;
+        const regionOptions = {
+          insights
+        };
+
+        try {
+          const connectOptions = Object.assign({ name: sid }, defaults, regionOptions, { tracks: [] });
+          cancelablePromise = connect(token, connectOptions);
+          assert(cancelablePromise instanceof CancelablePromise);
+          room = await cancelablePromise;
+        } catch (error_) {
+          error = error_;
+        } finally {
+          if (room) {
+            room.disconnect();
+            await completeRoom(sid);
+          }
+        }
+        assert.equal(error, null);
+      });
+    });
+  });
+
   describe('signaling region', async () => {
     const regions = ['invalid', 'without', 'gll'].concat(defaults.regions ? defaults.regions.split(',') : [
       'au1', 'br1', 'de1', 'ie1', 'in1', 'jp1', 'sg1', 'us1', 'us2'

--- a/test/integration/spec/util/insightspublisher.js
+++ b/test/integration/spec/util/insightspublisher.js
@@ -31,14 +31,13 @@ describe('InsightsPublisher', function() {
       let publisher;
 
       context(`when attempted with ${a(tokenType)} ${tokenType} token`, () => {
-        before( () => {
+        before(() => {
           publisher = new InsightsPublisher(tokens.get(tokenType),
             'twilio-video.js',
             '1.2.3',
             options.environment,
             'us1',
             options);
-
           publisher.connect('roomSid', 'participantSid');
         });
 
@@ -76,7 +75,6 @@ describe('InsightsPublisher', function() {
         options);
 
       publisher.connect('roomSid', 'participantSid');
-
       publisher.once('connected', () => publisher.disconnect());
       const error = await new Promise(resolve => publisher.once('disconnected', resolve));
       assert(!error);

--- a/test/integration/spec/util/insightspublisher.js
+++ b/test/integration/spec/util/insightspublisher.js
@@ -31,13 +31,15 @@ describe('InsightsPublisher', function() {
       let publisher;
 
       context(`when attempted with ${a(tokenType)} ${tokenType} token`, () => {
-        before(() => {
+        before( () => {
           publisher = new InsightsPublisher(tokens.get(tokenType),
             'twilio-video.js',
             '1.2.3',
             options.environment,
             'us1',
             options);
+
+          publisher.connect('roomSid', 'participantSid');
         });
 
         const description = tokenType !== 'valid'
@@ -72,6 +74,8 @@ describe('InsightsPublisher', function() {
         options.environment,
         'us1',
         options);
+
+      publisher.connect('roomSid', 'participantSid');
 
       publisher.once('connected', () => publisher.disconnect());
       const error = await new Promise(resolve => publisher.once('disconnected', resolve));

--- a/test/unit/spec/signaling/v2/room.js
+++ b/test/unit/spec/signaling/v2/room.js
@@ -104,9 +104,7 @@ describe('RoomV2', () => {
           'quality',
           'stats-report',
           {
-            participantSid: test.localParticipant.sid,
             peerConnectionId: 'foo',
-            roomSid: test.sid,
             audioTrackStats: reports.foo.remoteAudioTrackStats,
             localAudioTrackStats: reports.foo.localAudioTrackStats,
             localVideoTrackStats: reports.foo.localVideoTrackStats,
@@ -125,9 +123,7 @@ describe('RoomV2', () => {
           'quality',
           'stats-report',
           {
-            participantSid: test.localParticipant.sid,
             peerConnectionId: 'bar',
-            roomSid: test.sid,
             audioTrackStats: reports.bar.remoteAudioTrackStats,
             localAudioTrackStats: reports.bar.localAudioTrackStats,
             localVideoTrackStats: reports.bar.localVideoTrackStats,

--- a/test/unit/spec/signaling/v2/twilioconnectiontransport.js
+++ b/test/unit/spec/signaling/v2/twilioconnectiontransport.js
@@ -1150,7 +1150,11 @@ describe('TwilioConnectionTransport', () => {
             });
             test.twilioConnection.receiveMessage({
               session: 'foo',
-              type: 'connected'
+              type: 'connected',
+              sid: 'roomSid',
+              participant: {
+                sid: 'mySid'
+              }
             });
           });
 
@@ -1163,7 +1167,11 @@ describe('TwilioConnectionTransport', () => {
           it('should emit "connected"', () => {
             assert.deepEqual(connected, {
               session: 'foo',
-              type: 'connected'
+              type: 'connected',
+              sid: 'roomSid',
+              participant: {
+                sid: 'mySid'
+              }
             });
           });
 
@@ -1570,7 +1578,7 @@ function makeTest(options) {
   };
 
   options.open = () => options.twilioConnection.open();
-  options.connect = () => options.receiveMessage({ session: makeName(), type: 'connected' });
+  options.connect = () => options.receiveMessage({ session: makeName(), type: 'connected', sid: 'roomSid', participant: { sid: 'mySid' } });
   options.sync = () => options.receiveMessage({ type: 'synced' });
   return options;
 }
@@ -1596,6 +1604,7 @@ function makePeerConnectionManager() {
 function makeInsightsPublisherConstructor(testOptions) {
   return function InsightsPublisher() {
     this.disconnect = sinon.spy(() => {});
+    this.connect = sinon.spy(() => {});
     this.publish = sinon.spy(() => 'baz');
     testOptions.eventPublisher = this;
   };


### PR DESCRIPTION
@manjeshbhargav, @innerverse 

This change waits for roomSid, partcipantSid before connecting to event publisher endpoint. That way we can pass roomSid/participantSid along with the connect message. I have few open question around this (https://twilio.slack.com/archives/C35JTJHJP/p1563392120206400), but I would like to get initial feedback. 

TODO:
- [x] add unit tests
 
- [x] I acknowledge that all my contributions will be made under the project's license.
