### PR TITLE
Handle Firefox 68+'s empty ice candidate in Chrome and Safari.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/suppor
 Bug Fixes
 ---------
 
+- Worked around a minor interop issue between Chrome/Safari Participants and Firefox 68+
+  Participants in a Peer-to-Peer Room. Although this issue does no affect the normal
+  functioning of the Room, it resulted in the Chrome/Safari Participants logging cryptic
+  Error messages to the JavaScript console. Now, twilio-video.js will log warning messages
+  until Chrome ([bug](https://bugs.chromium.org/p/chromium/issues/detail?id=978582)) and Safari
+  fix this issue. (JSDK-2412)
 - Fixed a bug where connecting to a Room with a `region` containing special
   characters in ConnectOptions failed with an Error other than
   [SignalingConnectionError](https://www.twilio.com/docs/api/errors/53000). (JSDK-2400)

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -55,6 +55,8 @@ const firefoxMajorVersion = isFirefox
   ? parseInt(navigator.userAgent.match(/Firefox\/(\d+)/)[1], 10)
   : null;
 
+let nInstances = 0;
+
 /*
 PeerConnectionV2 States
 -----------------------
@@ -156,6 +158,9 @@ class PeerConnectionV2 extends StateMachine {
       },
       _encodingParameters: {
         value: encodingParameters
+      },
+      _instanceId: {
+        value: ++nInstances
       },
       _isIceConnectionInactive: {
         writable: true,
@@ -329,6 +334,10 @@ class PeerConnectionV2 extends StateMachine {
     });
   }
 
+  toString() {
+    return `[PeerConnectionV2 #${this._instanceId}: ${this.id}]`;
+  }
+
   /**
    * The {@link PeerConnectionV2}'s underlying RTCPeerConnection's
    * RTCIceConnectionState.
@@ -360,6 +369,17 @@ class PeerConnectionV2 extends StateMachine {
     return Promise.resolve().then(() => {
       candidate = new this._RTCIceCandidate(candidate);
       return this._peerConnection.addIceCandidate(candidate);
+    }).catch(error => {
+      // NOTE(mmalavalli): Firefox 68+ now generates an RTCIceCandidate with an
+      // empty candidate string to signal end-of-candidates, followed by a null
+      // candidate. As of now, Chrome and Safari reject this RTCIceCandidate. Since
+      // this does not affect the media connection between Firefox 68+ and Chrome/Safari
+      // in Peer-to-Peer Rooms, we suppress the Error and log a warning message.
+      //
+      // Chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=978582
+      //
+      this._log.warn(`Failed to add RTCIceCandidate ${candidate ? `"${candidate.candidate}"` : 'null'}: `
+        + error.message);
     });
   }
 


### PR DESCRIPTION
@makarandp0 

This PR fixes JSDK-2412 and JSDK-2415. The reason for these bugs is that Firefox 68+ generates an RTCIceCandidate with an empty candidate string to signal the end of candidate gathering. It also generates a null candidate (legacy way of signaling end of candidate gathering). But Chrome and Safari do not yet accept the empty candidate. So, we now just log warnings and suppress the error since it does not affect media connection in any way.

The reason I wanted to log warnings is that we should be able to make out when Chrome and Safari start accepting the empty candidate. When they do, we should no longer see these console warnings.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
