### PR TITLE
JSDK-2448 Type checks for TrackPriority and BandwidthProfileOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,34 @@ For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/suppor
 New Features
 ------------
 
-- In a **Group Room**, you can now have more control over how your available bandwidth
-  is distributed among the RemoteVideoTracks that you have subscribed to. twilio-video.js
-  introduces the [Bandwidth Profile API](TODO(mmalavalli)). Note that this feature is
+- In a **Group Room**, you can now control how your available downlink bandwidth is
+  distributed among the RemoteVideoTracks that you have subscribed to. twilio-video.js
+  introduces the [Bandwidth Profile APIs](TODO(mmalavalli)). Note that this feature is
   currently in **private beta** and hence will be **opt-in**. Please reach out to
   [email@address.com](TODO(mmalavalli)) for more information about how to enable these
   APIs for your Twilio Account. **Using these APIs in a Peer-to-Peer Room will have no effect**.
-  
+
+  ### Bandwidth Profile
+
+  You can now configure how your available downlink bandwidth will be distributed
+  among your subscribed RemoteVideoTracks by using a new optional ConnectOptions
+  parameter `bandwidthProfile`. For more details, please refer to the `BandwidthProfileOptions`
+  [documentation](//media.twiliocdn.com/sdk/js/video/releases/2.0.0-beta13/docs/global.html#BandwidthProfileOptions).
+  Here is an example:
+
+  ```js
+  const { connect } = require('twilio-video');
+  const room = await connect(token, {
+    bandwidthProfile: {
+      video: {
+        maxSubscriptionBitrate: 150000, // Max. bandwidth (bps) to be allocated to subscribed RemoteVideoTracks.
+        maxTracks: 3, // Max. number of visible RemoteVideoTracks. Other RemoteVideoTracks will be switched off.
+        mode: 'collaboration', // Subscription mode: "collaboration", "grid" or "presentation".
+      }
+    }
+  });  
+  ```
+
   ### Track Priority
 
   While publishing a LocalTrack, you can now optionally specify its publish priority
@@ -28,10 +49,10 @@ New Features
   assert.equal(localTrackPublication.priority, 'high');
   ```
 
-  This signals to the media server that this LocalTrack is more important than other
-  LocalTracks you may be publishing to the Room. The media server takes this into
-  account while allocating a subscribing RemoteParticipant's bandwidth to the LocalTrack.
-  If you do not specify a priority, then it defaults to `standard`.
+  This signals to the media server the relative importance of this LocalTrack with respect
+  to other Tracks that may be published to the Room. The media server takes this into
+  account while allocating a subscribing RemoteParticipant's bandwidth to the corresponding
+  RemoteTrack. If you do not specify a priority, then it defaults to `standard`.
   
   You can also find out about the priorities of RemoteTracks published by other
   RemoteParticipants by accessing a new property `publishPriority` on the corresponding
@@ -45,7 +66,7 @@ New Features
 
   ### Switching on/off RemoteVideoTracks
 
-  When a subscribing Participant's bandwidth is considerably low, the media server
+  When a subscribing Participant's downlink bandwidth is insufficient, the media server
   tries to preserve higher priority RemoteVideoTracks by switching off lower priority
   RemoteVideoTracks, which will stop receiving media until the media server decides
   to switch them back on. You can now get notified about these actions by listening
@@ -64,26 +85,6 @@ New Features
       console.log(`The RemoteTrack ${remoteTrack.name} was switched on`);
     });
   });
-  ```
-
-  ### Bandwidth Profile
-
-  You can now configure how your available downlink bandwidth will be distributed
-  among your subscribed RemoteVideoTracks by using a new optional ConnectOptions
-  parameter `bandwidthProfile`.   For more details, please refer to the `BandwidthProfileOptions`
-  [documentation](TODO(mmalavalli)). Here is an example:
-
-  ```js
-  const { connect } = require('twilio-video');
-  const room = await connect(token, {
-    bandwidthProfile: {
-      video: {
-        maxSubscriptionBitrate: 150000, // Max. bandwidth (bps) to be allocated to subscribed RemoteVideoTracks.
-        maxTracks: 3, // Max. number of visible RemoteVideoTracks. Other RemoteVideoTracks will be switched off.
-        mode: 'collaboration', // Subscription mode: "collaboration", "grid" or "presentation".
-      }
-    }
-  });  
   ```
 
 2.0.0-beta12 (July 12, 2019)

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -7,14 +7,14 @@ const createLocalTracks = require('./createlocaltracks');
 const ConstantIceServerSource = require('./iceserversource/constant');
 const constants = require('./util/constants');
 const Room = require('./room');
-const E = require('./util/constants').typeErrors;
+const { subscriptionMode, typeErrors: E } = require('./util/constants');
 const EncodingParametersImpl = require('./encodingparameters');
 const LocalAudioTrack = require('./media/track/es5/localaudiotrack');
 const LocalDataTrack = require('./media/track/es5/localdatatrack');
 const LocalParticipant = require('./localparticipant');
 const LocalVideoTrack = require('./media/track/es5/localvideotrack');
 const Log = require('./util/log');
-const MediaStreamTrack = require('@twilio/webrtc').MediaStreamTrack;
+const { MediaStreamTrack } = require('@twilio/webrtc');
 const NTSIceServerSource = require('./iceserversource/nts');
 const SignalingV2 = require('./signaling/v2');
 const util = require('./util');
@@ -203,6 +203,11 @@ function connect(token, options) {
     } catch (error) {
       return CancelablePromise.reject(error);
     }
+  }
+
+  const error = validateBandwidthProfile(options.bandwidthProfile);
+  if (error) {
+    return CancelablePromise.reject(error);
   }
 
   const Signaling = options.signaling;
@@ -591,6 +596,34 @@ function normalizeVideoCodecSettings(nameOrSettings) {
       return settings;
     }
   }
+}
+
+function validateBandwidthProfile(bandwidthProfile) {
+  if (typeof bandwidthProfile !== 'object' || Array.isArray(bandwidthProfile)) {
+    return E.INVALID_TYPE('options.bandwidthProfile', 'object');
+  }
+  if (!('video' in bandwidthProfile)) {
+    return null;
+  }
+  const video = bandwidthProfile.video;
+  if (typeof video !== 'object' || Array.isArray(video)) {
+    return E.INVALID_TYPE('options.bandwidthProfile.video', 'object');
+  }
+  return [
+    ['maxSubscriptionBitrate', 'number', E.INVALID_TYPE],
+    ['maxTracks', 'number', E.INVALID_TYPE],
+    ['mode', Object.values(subscriptionMode), E.INVALID_VALUE]
+  ].reduce((error, [prop, typeOrValues, Error]) => {
+    if (error || !(prop in video)) {
+      return error;
+    }
+    if (Array.isArray(typeOrValues)) {
+      return typeOrValues.includes(video[prop]) ? null
+        : Error(`options.bandwidthProfile.video.${prop}`, typeOrValues);
+    }
+    return typeof video[prop] === typeOrValues ? null
+      : Error(`options.bandwidthProfile.video.${prop}`, typeOrValues);
+  }, null);
 }
 
 module.exports = connect;

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -17,8 +17,14 @@ const Log = require('./util/log');
 const { MediaStreamTrack } = require('@twilio/webrtc');
 const NTSIceServerSource = require('./iceserversource/nts');
 const SignalingV2 = require('./signaling/v2');
-const util = require('./util');
 const NetworkQualityConfigurationImpl = require('./networkqualityconfiguration');
+
+const {
+  asLocalTrack,
+  buildLogLevels,
+  filterObject,
+  isNonArrayObject
+} = require('./util');
 
 // This is used to make out which connect() call a particular Log statement
 // belongs to. Each call to connect() increments this counter.
@@ -117,7 +123,7 @@ function connect(token, options) {
   if (typeof options === 'undefined') {
     options = {};
   }
-  if (typeof options !== 'object' || Array.isArray(options)) {
+  if (!isNonArrayObject(options)) {
     return CancelablePromise.reject(E.INVALID_TYPE('options', 'object'));
   }
 
@@ -147,14 +153,14 @@ function connect(token, options) {
     // TODO(mmalavalli): Remove once we decide to support Unified Plan on Chrome 72+
     sdpSemantics: constants.DEFAULT_CHROME_SDP_SEMANTICS,
     signaling: SignalingV2
-  }, util.filterObject(options));
+  }, filterObject(options));
 
   /* eslint new-cap:0 */
   const wsServer = constants.WS_SERVER(options.environment, options.region);
 
   options = Object.assign({ wsServer }, options);
 
-  const logLevels = util.buildLogLevels(options.logLevel);
+  const logLevels = buildLogLevels(options.logLevel);
   const logComponentName = `[connect #${++connectCalls}]`;
 
   let log;
@@ -199,7 +205,7 @@ function connect(token, options) {
         'Array of LocalAudioTrack, LocalVideoTrack or MediaStreamTrack'));
     }
     try {
-      options.tracks = options.tracks.map(track => util.asLocalTrack(track, localTrackOptions));
+      options.tracks = options.tracks.map(track => asLocalTrack(track, localTrackOptions));
     } catch (error) {
       return CancelablePromise.reject(error);
     }
@@ -238,11 +244,11 @@ function connect(token, options) {
   };
 
   const networkQualityConfiguration = new NetworkQualityConfigurationImpl(
-    typeof options.networkQuality === 'object' ? options.networkQuality : {}
+    isNonArrayObject(options.networkQuality) ? options.networkQuality : {}
   );
 
   // Convert options.networkQuality to boolean to configure Media Signaling
-  options.networkQuality = typeof options.networkQuality === 'object' || options.networkQuality;
+  options.networkQuality = isNonArrayObject(options.networkQuality) || options.networkQuality;
 
   // Create a CancelableRoomPromise<Room> that resolves after these steps:
   // 1 - Get the LocalTracks.
@@ -599,14 +605,14 @@ function normalizeVideoCodecSettings(nameOrSettings) {
 }
 
 function validateBandwidthProfile(bandwidthProfile) {
-  if (typeof bandwidthProfile !== 'object' || Array.isArray(bandwidthProfile)) {
+  if (bandwidthProfile === null || !isNonArrayObject(bandwidthProfile)) {
     return E.INVALID_TYPE('options.bandwidthProfile', 'object');
   }
   if (!('video' in bandwidthProfile)) {
     return null;
   }
   const video = bandwidthProfile.video;
-  if (typeof video !== 'object' || Array.isArray(video)) {
+  if (video === null || !isNonArrayObject(video)) {
     return E.INVALID_TYPE('options.bandwidthProfile.video', 'object');
   }
   return [

--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -376,7 +376,7 @@ class LocalParticipant extends Participant {
     }
 
     const priorityValues = Object.values(trackPriority);
-    if (typeof options.priority !== 'string' || !priorityValues.includes(options.priority)) {
+    if (!priorityValues.includes(options.priority)) {
       // eslint-disable-next-line new-cap
       return Promise.reject(E.INVALID_VALUE('LocalTrackPublishOptions.priority', priorityValues));
     }

--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -2,7 +2,7 @@
 
 const { MediaStreamTrack } = require('@twilio/webrtc');
 const util = require('./util');
-const { typeErrors: E, trackPriority: { PRIORITY_STANDARD } } = require('./util/constants');
+const { typeErrors: E, trackPriority } = require('./util/constants');
 const LocalAudioTrack = require('./media/track/es5/localaudiotrack');
 const LocalDataTrack = require('./media/track/es5/localdatatrack');
 const LocalVideoTrack = require('./media/track/es5/localvideotrack');
@@ -189,7 +189,7 @@ class LocalParticipant extends Participant {
     this.on('trackStopped', localTrackStopped);
 
     this._tracks.forEach(track => {
-      this._addLocalTrack(track, PRIORITY_STANDARD);
+      this._addLocalTrack(track, trackPriority.PRIORITY_STANDARD);
       this._getOrCreateLocalTrackPublication(track).catch(error => {
         // Just log a warning for now.
         log.warn(`Failed to get or create LocalTrackPublication for ${track}:`, error);
@@ -298,6 +298,8 @@ class LocalParticipant extends Participant {
    *   for publishing the {@link LocalTrack}
    * @returns {Promise<LocalTrackPublication>} - Resolves with the corresponding
    *   {@link LocalTrackPublication} if successful
+   * @throws {TypeError}
+   * @throws {RangeError}
    * @example
    * var Video = require('twilio-video');
    *
@@ -327,6 +329,8 @@ class LocalParticipant extends Participant {
    *   the MediaStreamTrack
    * @returns {Promise<LocalTrackPublication>} - Resolves with the corresponding
    *   {@link LocalTrackPublication} if successful
+   * @throws {TypeError}
+   * @throws {RangeError}
    * @example
    * var Video = require('twilio-video');
    *
@@ -357,7 +361,7 @@ class LocalParticipant extends Participant {
 
     options = Object.assign({
       log: this._log,
-      priority: PRIORITY_STANDARD,
+      priority: trackPriority.PRIORITY_STANDARD,
       LocalAudioTrack: this._LocalAudioTrack,
       LocalDataTrack: this._LocalDataTrack,
       LocalVideoTrack: this._LocalVideoTrack,
@@ -369,6 +373,12 @@ class LocalParticipant extends Participant {
       localTrack = util.asLocalTrack(localTrackOrMediaStreamTrack, options);
     } catch (error) {
       return Promise.reject(error);
+    }
+
+    const priorityValues = Object.values(trackPriority);
+    if (typeof options.priority !== 'string' || !priorityValues.includes(options.priority)) {
+      // eslint-disable-next-line new-cap
+      return Promise.reject(E.INVALID_VALUE('LocalTrackPublishOptions.priority', priorityValues));
     }
 
     let addedLocalTrack = this._addTrack(localTrack, localTrack.id, options.priority)

--- a/lib/media/track/remoteaudiotrack.js
+++ b/lib/media/track/remoteaudiotrack.js
@@ -13,6 +13,8 @@ const RemoteMediaAudioTrack = mixinRemoteMediaTrack(AudioTrack);
  * @emits RemoteAudioTrack#disabled
  * @emits RemoteAudioTrack#enabled
  * @emits RemoteAudioTrack#started
+ * @emits RemoteAudioTrack#switchedOff
+ * @emits RemoteAudioTrack#switchedOn
  */
 class RemoteAudioTrack extends RemoteMediaAudioTrack {
   /**
@@ -50,6 +52,20 @@ class RemoteAudioTrack extends RemoteMediaAudioTrack {
  * to begin playback.
  * @param {RemoteAudioTrack} track - The {@link RemoteAudioTrack} that started
  * @event RemoteAudioTrack#started
+ */
+
+/**
+ * A {@link RemoteAudioTrack} was switched off.
+ * @param {RemoteAudioTrack} track - The {@link RemoteAudioTrack} that was
+ *   switched off
+ * @event RemoteAudioTrack#switchedOff
+ */
+
+/**
+ * A {@link RemoteAudioTrack} was switched on.
+ * @param {RemoteAudioTrack} track - The {@link RemoteAudioTrack} that was
+ *   switched on
+ * @event RemoteAudioTrack#switchedOn
  */
 
 module.exports = RemoteAudioTrack;

--- a/lib/media/track/remotedatatrack.js
+++ b/lib/media/track/remotedatatrack.js
@@ -39,9 +39,19 @@ class RemoteDataTrack extends Track {
     super(dataTrackReceiver.id, 'data', options);
 
     Object.defineProperties(this, {
+      _isSwitchedOff: {
+        value: false,
+        writable: true
+      },
       isEnabled: {
         enumerable: true,
         value: true
+      },
+      isSwitchedOff: {
+        enumerable: true,
+        get() {
+          return this._isSwitchedOff;
+        }
       },
       maxPacketLifeTime: {
         enumerable: true,
@@ -98,18 +108,18 @@ class RemoteDataTrack extends Track {
  *   the message
  */
 
+/**
+ * A {@link RemoteDataTrack} was switched off.
+ * @param {RemoteDataTrack} track - The {@link RemoteDataTrack} that was
+ *   switched off
+ * @event RemoteDataTrack#switchedOff
+ */
+
  /**
  * A {@link RemoteDataTrack} was switched on.
  * @param {RemoteDataTrack} track - The {@link RemoteDataTrack} that was
  *   switched on
  * @event RemoteDataTrack#switchedOn
- */
-
- /**
- * A {@link RemoteDataTrack} was switched off.
- * @param {RemoteDataTrack} track - The {@link RemoteDataTrack} that was
- *   switched off
- * @event RemoteDataTrack#switchedOff
  */
 
 module.exports = RemoteDataTrack;

--- a/lib/media/track/remotemediatrack.js
+++ b/lib/media/track/remotemediatrack.js
@@ -87,13 +87,6 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
  * @event RemoteMediaTrack#enabled
  */
 
-/**
- * A {@link RemoteMediaTrack} was switched on.
- * @param {RemoteMediaTrack} track - The {@link RemoteMediaTrack} that was
- *   switched on
- * @event RemoteMediaTrack#switchedOn
- */
-
  /**
  * A {@link RemoteMediaTrack} was switched off.
  * @param {RemoteMediaTrack} track - The {@link RemoteMediaTrack} that was
@@ -101,4 +94,11 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
  * @event RemoteMediaTrack#switchedOff
  */
 
- module.exports = mixinRemoteMediaTrack;
+/**
+ * A {@link RemoteMediaTrack} was switched on.
+ * @param {RemoteMediaTrack} track - The {@link RemoteMediaTrack} that was
+ *   switched on
+ * @event RemoteMediaTrack#switchedOn
+ */
+
+module.exports = mixinRemoteMediaTrack;

--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -14,6 +14,8 @@ const RemoteMediaVideoTrack = mixinRemoteMediaTrack(VideoTrack);
  * @emits RemoteVideoTrack#disabled
  * @emits RemoteVideoTrack#enabled
  * @emits RemoteVideoTrack#started
+ * @emits RemoteVideoTrack#switchedOff
+ * @emits RemoteVideoTrack#switchedOn
  */
 class RemoteVideoTrack extends RemoteMediaVideoTrack {
   /**
@@ -51,6 +53,27 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
  * @param {RemoteVideoTrack} track - The {@link RemoteVideoTrack} that was
  *   enabled
  * @event RemoteVideoTrack#enabled
+ */
+
+/**
+ * The {@link RemoteVideoTrack} started. This means there is enough video data
+ * to begin playback.
+ * @param {RemoteVideoTrack} track - The {@link RemoteVideoTrack} that started
+ * @event RemoteVideoTrack#started
+ */
+
+/**
+ * A {@link RemoteVideoTrack} was switched off.
+ * @param {RemoteVideoTrack} track - The {@link RemoteVideoTrack} that was
+ *   switched off
+ * @event RemoteVideoTrack#switchedOff
+ */
+
+/**
+ * A {@link RemoteVideoTrack} was switched on.
+ * @param {RemoteVideoTrack} track - The {@link RemoteVideoTrack} that was
+ *   switched on
+ * @event RemoteVideoTrack#switchedOn
  */
 
 module.exports = RemoteVideoTrack;

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -353,10 +353,10 @@ class RoomV2 extends RoomSignaling {
       this.participants.forEach(participant => {
         participant.tracks.forEach(track => {
           if (tracksOff.includes(track.sid)) {
-            track.setSwitchedOff(true /* off */);
+            track.setSwitchedOff(true);
           }
           if (tracksOn.includes(track.sid)) {
-            track.setSwitchedOff(false /* on */);
+            track.setSwitchedOff(false);
           }
         });
       });

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -61,7 +61,7 @@ module.exports.typeErrors = {
     return new TypeError(`${name} must be ${article(type)} ${type}`);
   },
   INVALID_VALUE(name, values) {
-    return new RangeError(`${name} must be one of `, values.join(', '));
+    return new RangeError(`${name} must be one of ${values.join(', ')}`);
   },
   REQUIRED_ARGUMENT(name) {
     return new TypeError(`${name} must be specified`);

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -79,6 +79,12 @@ module.exports.DEFAULT_CHROME_SDP_SEMANTICS = 'plan-b';
 module.exports.ICE_ACTIVITY_CHECK_PERIOD_MS = 1000;
 module.exports.ICE_INACTIVITY_THRESHOLD_MS = 3000;
 
+module.exports.subscriptionMode = {
+  MODE_COLLABORATION: 'collaboration',
+  MODE_GRID: 'grid',
+  MODE_PRESENTATION: 'presentation'
+};
+
 module.exports.trackPriority = {
   PRIORITY_HIGH: 'high',
   PRIORITY_LOW: 'low',

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -279,6 +279,15 @@ function delegateMethods(source, wrapper, target) {
 }
 
 /**
+ * Whether the given argument is a non-array object.
+ * @param {*} object
+ * @return {boolean}
+ */
+function isNonArrayObject(object) {
+  return typeof object === 'object' && !Array.isArray(object);
+}
+
+/**
  * For each property name on the `source` prototype, add getters and/or setters
  * to `wrapper` that proxy to `target`.
  * @param {object} source
@@ -635,6 +644,7 @@ exports.flatMap = flatMap;
 exports.getUserAgent = getUserAgent;
 exports.hidePrivateProperties = hidePrivateProperties;
 exports.hidePrivateAndCertainPublicPropertiesInClass = hidePrivateAndCertainPublicPropertiesInClass;
+exports.isNonArrayObject = isNonArrayObject;
 exports.inRange = inRange;
 exports.makeUUID = makeUUID;
 exports.oncePerTick = oncePerTick;

--- a/test/unit/spec/connect.js
+++ b/test/unit/spec/connect.js
@@ -5,8 +5,9 @@ const { EventEmitter } = require('events');
 const sinon = require('sinon');
 const { inherits } = require('util');
 
+const { a } = require('../../lib/util');
 const connect = require('../../../lib/connect');
-const { DEFAULT_LOG_LEVEL, WS_SERVER, DEFAULT_REGION } = require('../../../lib/util/constants');
+const { DEFAULT_LOG_LEVEL, WS_SERVER, DEFAULT_REGION, subscriptionMode } = require('../../../lib/util/constants');
 const Signaling = require('../../../lib/signaling');
 const RoomSignaling = require('../../../lib/signaling/room');
 
@@ -48,6 +49,83 @@ describe('connect', () => {
       assert.equal(options.region, DEFAULT_REGION);
       /* eslint new-cap:0 */
       assert.equal(options.wsServer, WS_SERVER(options.environment, options.region));
+    });
+  });
+
+  describe('called with ConnectOptions#bandwidthProfile', () => {
+    const subscriptionModes = Object.values(subscriptionMode);
+    let mockSignaling;
+    let signaling;
+
+    beforeEach(() => {
+      mockSignaling = new Signaling();
+      mockSignaling.connect = () => Promise.resolve(() => new RoomSignaling());
+      signaling = sinon.spy(() => mockSignaling);
+    });
+
+    [
+      ['foo', 'that is not an object', TypeError, 'object'],
+      [['bar'], 'that is an Array', TypeError, 'object'],
+      [{ video: 'baz' }, 'whose .video is not an object', TypeError, 'object'],
+      [{ video: ['zee'] }, 'whose .video is an Array', TypeError, 'object'],
+      [{ video: { maxSubscriptionBitrate: false } }, 'whose .video.maxSubscriptionBitrate is not a number', TypeError, 'number'],
+      [{ video: { maxTracks: {} } }, 'whose .video.maxTracks is not a number', TypeError, 'number'],
+      [{ video: { mode: 'foo' } }, `whose .video.mode is not one of ${subscriptionModes.join(', ')}`, RangeError, subscriptionModes]
+    ].forEach(([bandwidthProfile, scenario, ExpectedError, expectedTypeOrValues]) => {
+      context(scenario, () => {
+        it(`should reject the CancelablePromise with a ${ExpectedError.name}`, async () => {
+          const cancelablePromise = connect(token, {
+            bandwidthProfile,
+            iceServers: [],
+            signaling
+          });
+          let error;
+          let expectedErrorMessage = 'options.bandwidthProfile';
+
+          if (typeof bandwidthProfile === 'object' && !Array.isArray(bandwidthProfile)) {
+            expectedErrorMessage += '.video';
+            if (typeof bandwidthProfile.video === 'object' && !Array.isArray(bandwidthProfile.video)) {
+              expectedErrorMessage += `.${Object.keys(bandwidthProfile.video)[0]}`;
+            }
+          }
+
+          if (ExpectedError === TypeError) {
+            expectedErrorMessage += ` must be ${a(expectedTypeOrValues)} ${expectedTypeOrValues}`;
+          } else {
+            expectedErrorMessage += ` must be one of ${expectedTypeOrValues.join(', ')}`;
+          }
+
+          try {
+            await cancelablePromise;
+          } catch (error_) {
+            error = error_;
+          } finally {
+            assert(error instanceof ExpectedError);
+            assert.equal(error.message, expectedErrorMessage);
+          }
+        });
+      });
+    });
+
+    ['foo', ['bar']].forEach(bandwidthProfile => {
+      context(`that is ${Array.isArray(bandwidthProfile) ? 'an Array' : 'not an object'}`, () => {
+        it('should reject the CancelablePromise with a TypeError', async () => {
+          const cancelablePromise = connect(token, {
+            bandwidthProfile,
+            iceServers: [],
+            signaling
+          });
+          let error;
+
+          try {
+            await cancelablePromise;
+          } catch (error_) {
+            error = error_;
+          } finally {
+            assert(error instanceof TypeError);
+          }
+        });
+      });
     });
   });
 

--- a/test/unit/spec/connect.js
+++ b/test/unit/spec/connect.js
@@ -64,8 +64,10 @@ describe('connect', () => {
     });
 
     [
+      [null, 'that is null', TypeError, 'object'],
       ['foo', 'that is not an object', TypeError, 'object'],
       [['bar'], 'that is an Array', TypeError, 'object'],
+      [{ video: null }, 'whose .video is null', TypeError, 'object'],
       [{ video: 'baz' }, 'whose .video is not an object', TypeError, 'object'],
       [{ video: ['zee'] }, 'whose .video is an Array', TypeError, 'object'],
       [{ video: { maxSubscriptionBitrate: false } }, 'whose .video.maxSubscriptionBitrate is not a number', TypeError, 'number'],
@@ -82,9 +84,9 @@ describe('connect', () => {
           let error;
           let expectedErrorMessage = 'options.bandwidthProfile';
 
-          if (typeof bandwidthProfile === 'object' && !Array.isArray(bandwidthProfile)) {
+          if (bandwidthProfile && typeof bandwidthProfile === 'object' && !Array.isArray(bandwidthProfile)) {
             expectedErrorMessage += '.video';
-            if (typeof bandwidthProfile.video === 'object' && !Array.isArray(bandwidthProfile.video)) {
+            if (bandwidthProfile.video && typeof bandwidthProfile.video === 'object' && !Array.isArray(bandwidthProfile.video)) {
               expectedErrorMessage += `.${Object.keys(bandwidthProfile.video)[0]}`;
             }
           }

--- a/test/unit/spec/localparticipant.js
+++ b/test/unit/spec/localparticipant.js
@@ -278,7 +278,7 @@ describe('LocalParticipant', () => {
       test = makeTest(options);
     });
 
-    context('when called with an invalid argument', () => {
+    context('when called with an invalid first argument', () => {
       [
         [
           'should return a rejected Promise with a TypeError',
@@ -294,6 +294,22 @@ describe('LocalParticipant', () => {
             await test.participant.publishTrack('invalid track argument');
           } catch (error) {
             assert(assertion(error, test.signaling.addTrack));
+            return;
+          }
+          throw new Error('Unexpected resolution');
+        });
+      });
+    });
+
+    [2, 'baz'].forEach(priority => {
+      context(`when called with a TrackPriority that is ${typeof priority === 'string' ? 'invalid' : 'not a string'}`, () => {
+        it('should return a rejected Promise with a RangeError', async () => {
+          const localTrack = new LocalVideoTrack(new FakeMediaStreamTrack('audio'));
+          try {
+            await test.participant.publishTrack(localTrack, { priority });
+          } catch (error) {
+            assert(error instanceof RangeError);
+            assert(test.signaling.addTrack.notCalled);
             return;
           }
           throw new Error('Unexpected resolution');

--- a/test/unit/spec/media/track/remotedatatrack.js
+++ b/test/unit/spec/media/track/remotedatatrack.js
@@ -29,7 +29,11 @@ describe('RemoteDataTrack', () => {
     });
 
     it('should set .isEnabled to true', () => {
-      assert(dataTrack.isEnabled);
+      assert.equal(dataTrack.isEnabled, true);
+    });
+
+    it('should set .isSwitchedOff to false', () => {
+      assert.equal(dataTrack.isSwitchedOff, false);
     });
 
     it('sets .kind to "data"', () => {
@@ -50,6 +54,62 @@ describe('RemoteDataTrack', () => {
 
     it('sets .ordered to the DataTrackReceiver\'s .ordered', () => {
       assert.equal(dataTrack.ordered, dataTrackReceiver.ordered);
+    });
+  });
+
+  describe('#_setSwitchedOff', () => {
+    [
+      [true, true],
+      [true, false],
+      [false, true],
+      [false, false]
+    ].forEach(([isSwitchedOff, newIsSwitchedOff]) => {
+      context(`when .isSwitchedOff is ${isSwitchedOff} and the new value is ${newIsSwitchedOff}`, () => {
+        let arg;
+        let track;
+        let trackSwitchedOff;
+        let trackSwitchedOn;
+
+        beforeEach(() => {
+          arg = null;
+          track = new RemoteDataTrack('foo', dataTrackReceiver);
+          if (isSwitchedOff) {
+            track._setSwitchedOff(isSwitchedOff);
+          }
+          track.once('switchedOff', _arg => {
+            trackSwitchedOff = true;
+            arg = _arg;
+          });
+          track.once('switchedOn', _arg => {
+            trackSwitchedOn = true;
+            arg = _arg;
+          });
+          track._setSwitchedOff(newIsSwitchedOff);
+        });
+
+        if (isSwitchedOff === newIsSwitchedOff) {
+          it('should not change the .isSwitchedOff property', () => {
+            assert.equal(track.isSwitchedOff, isSwitchedOff);
+          });
+
+          it('should not emit any events', () => {
+            assert(!trackSwitchedOff);
+            assert(!trackSwitchedOn);
+          });
+
+          return;
+        }
+
+        it(`should set .isSwitchedOff to ${newIsSwitchedOff}`, () => {
+          assert.equal(track.isSwitchedOff, newIsSwitchedOff);
+        });
+
+        it(`should emit "${newIsSwitchedOff ? 'switchedOff' : 'switchedOn'}" on the RemoteDatatrack with the RemoteDatatrack itself`, () => {
+          assert(newIsSwitchedOff ? trackSwitchedOff : trackSwitchedOn);
+          assert(!(newIsSwitchedOff ? trackSwitchedOn : trackSwitchedOff));
+          assert.equal(arg, track);
+        });
+      });
     });
   });
 
@@ -82,6 +142,7 @@ describe('RemoteDataTrack', () => {
         'kind',
         'name',
         'isEnabled',
+        'isSwitchedOff',
         'maxPacketLifeTime',
         'maxRetransmits',
         'ordered',
@@ -101,6 +162,7 @@ describe('RemoteDataTrack', () => {
     it('only returns public properties', () => {
       assert.deepEqual(track.toJSON(), {
         isEnabled: track.isEnabled,
+        isSwitchedOff: track.isSwitchedOff,
         kind: track.kind,
         maxPacketLifeTime: track.maxPacketLifeTime,
         maxRetransmits: track.maxRetransmits,

--- a/test/unit/spec/media/track/remotemediatrack.js
+++ b/test/unit/spec/media/track/remotemediatrack.js
@@ -37,7 +37,11 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
           });
 
           it('should set the .isEnabled property', () => {
-            assert(track.isEnabled);
+            assert.equal(track.isEnabled, true);
+          });
+
+          it('should set the .isSwitchedOff property', () => {
+            assert.equal(track.isSwitchedOff, false);
           });
 
           it('should set the .kind property', () => {
@@ -102,6 +106,62 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
           it(`should emit "${newIsEnabled ? 'enabled' : 'disabled'}" on the ${name} with the ${name} itself`, () => {
             assert(newIsEnabled ? trackEnabled : trackDisabled);
             assert(!(newIsEnabled ? trackDisabled : trackEnabled));
+            assert.equal(arg, track);
+          });
+        });
+      });
+    });
+
+    describe('#_setSwitchedOff', () => {
+      [
+        [true, true],
+        [true, false],
+        [false, true],
+        [false, false]
+      ].forEach(([isSwitchedOff, newIsSwitchedOff]) => {
+        context(`when .isSwitchedOff is ${isSwitchedOff} and the new value is ${newIsSwitchedOff}`, () => {
+          let arg;
+          let track;
+          let trackSwitchedOff;
+          let trackSwitchedOn;
+
+          before(() => {
+            arg = null;
+            track = makeTrack('foo', 'bar', kind, true, null, RemoteTrack);
+            if (isSwitchedOff) {
+              track._setSwitchedOff(isSwitchedOff);
+            }
+            track.once('switchedOff', _arg => {
+              trackSwitchedOff = true;
+              arg = _arg;
+            });
+            track.once('switchedOn', _arg => {
+              trackSwitchedOn = true;
+              arg = _arg;
+            });
+            track._setSwitchedOff(newIsSwitchedOff);
+          });
+
+          if (isSwitchedOff === newIsSwitchedOff) {
+            it('should not change the .isSwitchedOff property', () => {
+              assert.equal(track.isSwitchedOff, isSwitchedOff);
+            });
+
+            it('should not emit any events', () => {
+              assert(!trackSwitchedOff);
+              assert(!trackSwitchedOn);
+            });
+
+            return;
+          }
+
+          it(`should set .isSwitchedOff to ${newIsSwitchedOff}`, () => {
+            assert.equal(track.isSwitchedOff, newIsSwitchedOff);
+          });
+
+          it(`should emit "${newIsSwitchedOff ? 'switchedOff' : 'switchedOn'}" on the ${name} with the ${name} itself`, () => {
+            assert(newIsSwitchedOff ? trackSwitchedOff : trackSwitchedOn);
+            assert(!(newIsSwitchedOff ? trackSwitchedOn : trackSwitchedOff));
             assert.equal(arg, track);
           });
         });


### PR DESCRIPTION
@makarandp0 

This PR adds type checking logic to make sure only valid values are specified for TrackPriority and BandwidthProfileOptions.

TODO
=====

- [x] Add CHANGELOG.md for Bandwidth Profile API.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
