### PR TITLE
Prepping for 2.0.0-rc35

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -130,7 +130,6 @@ function connect(token, options) {
   options = Object.assign({
     abortOnIceServersTimeout: false,
     automaticSubscription: true,
-    bandwidthProfile: {},
     createLocalTracks,
     dominantSpeaker: false,
     environment: constants.DEFAULT_ENVIRONMENT,
@@ -605,7 +604,10 @@ function normalizeVideoCodecSettings(nameOrSettings) {
 }
 
 function validateBandwidthProfile(bandwidthProfile) {
-  if (bandwidthProfile === null || !isNonArrayObject(bandwidthProfile)) {
+  if (typeof bandwidthProfile === 'undefined' || bandwidthProfile === null) {
+    return null;
+  }
+  if (!isNonArrayObject(bandwidthProfile)) {
     return E.INVALID_TYPE('options.bandwidthProfile', 'object');
   }
   if (!('video' in bandwidthProfile)) {

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -372,9 +372,11 @@ function connect(token, options) {
  * @property {number} [maxSubscriptionBitrate] - Optional parameter to specify the maximum
  *   downlink video bandwidth in bits per second (bps). For mobile devices, it defaults to 2400000.
  *   For desktop browsers it defaults to 8000000 in Group Rooms and 4000000 in Small Group Rooms.
+ *   0 or a negative value will remove any limit on downlink bandwidth.
  * @property {number} [maxTracks] - Optional parameter to specify the maximum number of visible
  *   RemoteVideoTracks, which will be selected based on {@link Track.Priority} and an N-Loudest
  *   policy. By default there are no limits on the number of visible RemoteVideoTracks.
+ *   0 or a negative value will remove any limit on the maximum number of visible RemoteVideoTracks.
  * @property {BandwidthProfileMode} [mode="grid"] - Optional parameter to specify how the RemoteVideoTracks'
  *   TrackPriority values are mapped to bandwidth allocation in Group Rooms. This defaults to "grid",
  *   which results in equal bandwidth share allocation to all RemoteVideoTracks.
@@ -604,10 +606,10 @@ function normalizeVideoCodecSettings(nameOrSettings) {
 }
 
 function validateBandwidthProfile(bandwidthProfile) {
-  if (typeof bandwidthProfile === 'undefined' || bandwidthProfile === null) {
+  if (typeof bandwidthProfile === 'undefined') {
     return null;
   }
-  if (!isNonArrayObject(bandwidthProfile)) {
+  if (bandwidthProfile === null || !isNonArrayObject(bandwidthProfile)) {
     return E.INVALID_TYPE('options.bandwidthProfile', 'object');
   }
   if (!('video' in bandwidthProfile)) {

--- a/lib/signaling/v2/cancelableroomsignalingpromise.js
+++ b/lib/signaling/v2/cancelableroomsignalingpromise.js
@@ -55,9 +55,12 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
           transportOptions.NullInsightsPublisher = options.NullInsightsPublisher;
         }
 
+        if (options.bandwidthProfile) {
+          transportOptions.bandwidthProfile = options.bandwidthProfile;
+        }
+
         transportOptions = Object.assign({
           automaticSubscription: options.automaticSubscription,
-          bandwidthProfile: options.bandwidthProfile,
           dominantSpeaker: options.dominantSpeaker,
           environment: options.environment,
           logLevel: options.logLevel,

--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -223,8 +223,10 @@ class TwilioConnectionTransport extends StateMachine {
         user_agent: this._userAgent
       };
 
-      message.bandwidth_profile = createBandwidthProfilePayload(
-        this._bandwidthProfile);
+      if (this._bandwidthProfile) {
+        message.bandwidth_profile = createBandwidthProfilePayload(
+          this._bandwidthProfile);
+      }
 
       message.media_signaling = createMediaSignalingPayload(
         this._dominantSpeaker,

--- a/test/unit/spec/connect.js
+++ b/test/unit/spec/connect.js
@@ -64,6 +64,7 @@ describe('connect', () => {
     });
 
     [
+      [null, 'that is null', TypeError, 'object'],
       ['foo', 'that is not an object', TypeError, 'object'],
       [['bar'], 'that is an Array', TypeError, 'object'],
       [{ video: null }, 'whose .video is null', TypeError, 'object'],

--- a/test/unit/spec/connect.js
+++ b/test/unit/spec/connect.js
@@ -64,7 +64,6 @@ describe('connect', () => {
     });
 
     [
-      [null, 'that is null', TypeError, 'object'],
       ['foo', 'that is not an object', TypeError, 'object'],
       [['bar'], 'that is an Array', TypeError, 'object'],
       [{ video: null }, 'whose .video is null', TypeError, 'object'],

--- a/test/unit/spec/signaling/v2/twilioconnectiontransport.js
+++ b/test/unit/spec/signaling/v2/twilioconnectiontransport.js
@@ -104,7 +104,7 @@ describe('TwilioConnectionTransport', () => {
           revision: 1
         });
 
-        if (bandwidthProfile && bandwidthProfile !== 'not specified') {
+        if (bandwidthProfile) {
           assert.deepEqual(message.bandwidth_profile, expectedRspPayload);
         } else {
           assert(!('bandwidth_profile' in message));

--- a/test/unit/spec/signaling/v2/twilioconnectiontransport.js
+++ b/test/unit/spec/signaling/v2/twilioconnectiontransport.js
@@ -18,9 +18,7 @@ describe('TwilioConnectionTransport', () => {
     [true, false], // automaticSubscription
     [true, false], // trackSwitchOff
     [              // bandwidthProfile
-      ['not specified'],
       [undefined],
-      [null],
       [{}, {}],
       [{ video: {} }, {}],
       [{ video: { mode: 'foo' } }, { video: { mode: 'foo' } }],
@@ -58,7 +56,7 @@ describe('TwilioConnectionTransport', () => {
       let test;
 
       beforeEach(() => {
-        test = makeTest(Object.assign(bandwidthProfile === 'not specified' ? {} : { bandwidthProfile }, {
+        test = makeTest(Object.assign(bandwidthProfile ? { bandwidthProfile } : {}, {
           iceServerSourceStatus: [
             { foo: 'bar' }
           ],
@@ -74,7 +72,7 @@ describe('TwilioConnectionTransport', () => {
         assert.equal('connecting', test.transport.state);
       });
 
-      it(`should call .sendMessage on the underlying TwilioConnection with a Connect RSP message that ${networkQuality ? 'contains' : 'does not contain'} the "network_quality" payload and ${dominantSpeaker ? 'contains' : 'does not contain'} the "active_speaker" payload, the "subscribe-${automaticSubscription ? 'all' : 'none'}" subscription rule and ${bandwidthProfile && bandwidthProfile !== 'not specified' ? 'contains' : 'does not contain'} the "bandwidth_profile" payload`, () => {
+      it(`should call .sendMessage on the underlying TwilioConnection with a Connect RSP message that ${networkQuality ? 'contains' : 'does not contain'} the "network_quality" payload and ${dominantSpeaker ? 'contains' : 'does not contain'} the "active_speaker" payload, the "subscribe-${automaticSubscription ? 'all' : 'none'}" subscription rule and ${bandwidthProfile ? 'contains' : 'does not contain'} the "bandwidth_profile" payload`, () => {
         const message = test.twilioConnection.sendMessage.args[0][0];
         assert.equal(typeof message.format, 'string');
         assert.deepEqual(message.ice_servers, test.iceServerSourceStatus);

--- a/test/unit/spec/signaling/v2/twilioconnectiontransport.js
+++ b/test/unit/spec/signaling/v2/twilioconnectiontransport.js
@@ -18,6 +18,9 @@ describe('TwilioConnectionTransport', () => {
     [true, false], // automaticSubscription
     [true, false], // trackSwitchOff
     [              // bandwidthProfile
+      ['not specified'],
+      [undefined],
+      [null],
       [{}, {}],
       [{ video: {} }, {}],
       [{ video: { mode: 'foo' } }, { video: { mode: 'foo' } }],
@@ -55,16 +58,15 @@ describe('TwilioConnectionTransport', () => {
       let test;
 
       beforeEach(() => {
-        test = makeTest({
+        test = makeTest(Object.assign(bandwidthProfile === 'not specified' ? {} : { bandwidthProfile }, {
           iceServerSourceStatus: [
             { foo: 'bar' }
           ],
           automaticSubscription,
-          bandwidthProfile,
           networkQuality,
           dominantSpeaker,
           trackSwitchOff
-        });
+        }));
         test.open();
       });
 
@@ -72,7 +74,7 @@ describe('TwilioConnectionTransport', () => {
         assert.equal('connecting', test.transport.state);
       });
 
-      it(`should call .sendMessage on the underlying TwilioConnection with a Connect RSP message that ${networkQuality ? 'contains' : 'does not contain'} the "network_quality" payload and ${dominantSpeaker ? 'contains' : 'does not contain'} the "active_speaker" payload, the "subscribe-${automaticSubscription ? 'all' : 'none'}" subscription rule and the appropriate "bandwidth_profile" payload`, () => {
+      it(`should call .sendMessage on the underlying TwilioConnection with a Connect RSP message that ${networkQuality ? 'contains' : 'does not contain'} the "network_quality" payload and ${dominantSpeaker ? 'contains' : 'does not contain'} the "active_speaker" payload, the "subscribe-${automaticSubscription ? 'all' : 'none'}" subscription rule and ${bandwidthProfile && bandwidthProfile !== 'not specified' ? 'contains' : 'does not contain'} the "bandwidth_profile" payload`, () => {
         const message = test.twilioConnection.sendMessage.args[0][0];
         assert.equal(typeof message.format, 'string');
         assert.deepEqual(message.ice_servers, test.iceServerSourceStatus);
@@ -103,7 +105,12 @@ describe('TwilioConnectionTransport', () => {
           }],
           revision: 1
         });
-        assert.deepEqual(message.bandwidth_profile, expectedRspPayload);
+
+        if (bandwidthProfile && bandwidthProfile !== 'not specified') {
+          assert.deepEqual(message.bandwidth_profile, expectedRspPayload);
+        } else {
+          assert(!('bandwidth_profile' in message));
+        }
 
         assert.equal(message.participant, test.localParticipantState);
         assert.deepEqual(message.peer_connections, test.peerConnectionManager.getStates());
@@ -1578,7 +1585,6 @@ class FakeTwilioConnection extends EventEmitter {
 
 function makeTest(options) {
   options = options || {};
-  options.bandwidthProfile = options.bandwidthProfile || {};
   options.reconnectBackOffJitter = options.reconnectBackOffJitter || 0;
   options.reconnectBackOffMs = options.reconnectBackOffMs || 0;
   options.name = 'name' in options ? options.name : makeName();


### PR DESCRIPTION
@makarandp0 

This PR makes sure that we don't send the `bandwidth_profile` RSP payload if `bandwidthProfile` is not specified in ConnectOptions.

## TODO

- [x] Document `maxSubscriptionBitrate` behavior for values `<= 0`.
- [x] Modify CHANGELOG.md entry if required.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
