### PR TITLE
JSDK-2250 Use RTCRtpSender.setParameters where available, instead of SDP munging.

### DIFF
--- a/lib/data/transport.js
+++ b/lib/data/transport.js
@@ -48,7 +48,11 @@ class DataTransport extends EventEmitter {
    */
   _publish(message) {
     const data = JSON.stringify(message);
-    this._dataChannel.send(data);
+    try {
+      this._dataChannel.send(data);
+    } catch (error) {
+      // Do nothing.
+    }
   }
 
   /**

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -53,6 +53,10 @@ const firefoxMajorVersion = isFirefox
   ? parseInt(navigator.userAgent.match(/Firefox\/(\d+)/)[1], 10)
   : null;
 
+const isRTCRtpSenderParamsSupported = typeof RTCRtpSender !== 'undefined'
+  && typeof RTCRtpSender.prototype.getParameters === 'function'
+  && typeof RTCRtpSender.prototype.setParameters === 'function';
+
 let nInstances = 0;
 
 /*
@@ -109,6 +113,7 @@ class PeerConnectionV2 extends StateMachine {
     options = Object.assign({
       dummyAudioMediaStreamTrack: null,
       iceServers: [],
+      isRTCRtpSenderParamsSupported,
       logLevel: DEFAULT_LOG_LEVEL,
       offerOptions: {},
       setBitrateParameters,
@@ -161,6 +166,9 @@ class PeerConnectionV2 extends StateMachine {
       _isRestartingIce: {
         writable: true,
         value: false
+      },
+      _isRTCRtpSenderParamsSupported: {
+        value: options.isRTCRtpSenderParamsSupported
       },
       _lastIceConnectionState: {
         writable: true,
@@ -268,7 +276,16 @@ class PeerConnectionV2 extends StateMachine {
       }
     });
 
-    encodingParameters.on('changed', oncePerTick(this.offer.bind(this)));
+    encodingParameters.on('changed', oncePerTick(() => {
+      if (this._isRTCRtpSenderParamsSupported) {
+        if (!this._needsAnswer) {
+          updateEncodingParameters(this);
+        }
+        return;
+      }
+      this.offer();
+    }));
+
     peerConnection.addEventListener('datachannel', this._handleDataChannelEvent.bind(this));
     peerConnection.addEventListener('icecandidate', this._handleIceCandidateEvent.bind(this));
     peerConnection.addEventListener('iceconnectionstatechange', this._handleIceConnectionStateChange.bind(this));
@@ -701,6 +718,7 @@ class PeerConnectionV2 extends StateMachine {
           this._descriptionRevision++;
         } else if (description.type === 'answer') {
           this._lastStableDescriptionRevision = this._descriptionRevision;
+          negotiationCompleted(this);
         }
         this._localUfrag = getUfrag(description);
         this.emit('description', this.getState());
@@ -716,11 +734,13 @@ class PeerConnectionV2 extends StateMachine {
    */
   _setRemoteDescription(description) {
     if (description.sdp) {
-      description.sdp = this._setBitrateParameters(
-        description.sdp,
-        isFirefox ? 'TIAS' : 'AS',
-        this._encodingParameters.maxAudioBitrate,
-        this._encodingParameters.maxVideoBitrate);
+      if (!this._isRTCRtpSenderParamsSupported) {
+        description.sdp = this._setBitrateParameters(
+          description.sdp,
+          isFirefox ? 'TIAS' : 'AS',
+          this._encodingParameters.maxAudioBitrate,
+          this._encodingParameters.maxVideoBitrate);
+      }
       description.sdp = this._setCodecPreferences(
         description.sdp,
         this._preferredAudioCodecs,
@@ -735,9 +755,12 @@ class PeerConnectionV2 extends StateMachine {
     }
     description = new this._RTCSessionDescription(description);
     return this._peerConnection.setRemoteDescription(description).then(() => {
-      if (description.type === 'answer' && this._isRestartingIce) {
-        this._log.debug('An ICE restart was in-progress and is now completed');
-        this._isRestartingIce = false;
+      if (description.type === 'answer') {
+        if (this._isRestartingIce) {
+          this._log.debug('An ICE restart was in-progress and is now completed');
+          this._isRestartingIce = false;
+        }
+        negotiationCompleted(this);
       }
       if (isUnifiedPlan) {
         this._peerConnection.getTransceivers().forEach(transceiver => {
@@ -805,7 +828,8 @@ class PeerConnectionV2 extends StateMachine {
     const revision = description.revision;
     return Promise.resolve().then(() => {
       return this._setRemoteDescription(description);
-    }).catch(() => {
+    }).catch((error) => {
+      console.error(error.message);
       throw new MediaClientRemoteDescFailedError();
     }).then(() => {
       this._lastStableDescriptionRevision = revision;
@@ -1157,6 +1181,48 @@ function shouldStopTransceiver(sdp, transceiver) {
   }
 
   return false;
+}
+
+/**
+ * Perform certain updates after an SDP negotiation is completed.
+ * @param {PeerConnectionV2} pcv2
+ * @returns {void}
+ */
+function negotiationCompleted(pcv2) {
+  if (pcv2._isRTCRtpSenderParamsSupported) {
+    updateEncodingParameters(pcv2);
+  }
+}
+
+/**
+ * Update the RTCRtpEncodingParameters of all active RTCRtpSenders.
+ * @param {PeerConnectionV2} pcv2
+ * @returns {void}
+ */
+function updateEncodingParameters(pcv2) {
+  const { maxAudioBitrate, maxVideoBitrate } = pcv2._encodingParameters;
+
+  const maxBitrates = new Map([
+    ['audio', maxAudioBitrate || 0],
+    ['video', maxVideoBitrate || 0]
+  ]);
+
+  pcv2._peerConnection.getSenders().filter(sender => sender.track).forEach(sender => {
+    const maxBitrate = maxBitrates.get(sender.track.kind);
+    const params = sender.getParameters();
+
+    if (isFirefox) {
+      params.encodings = [{ maxBitrate }];
+    } else {
+      params.encodings.forEach(encoding => {
+        encoding.maxBitrate = maxBitrate;
+      });
+    }
+
+    sender.setParameters(params).catch(error => {
+      pcv2._log.warn(`Error while setting bitrate parameters for ${sender.track.kind} Track ${sender.track.id}: ${error.message || error.name}`);
+    });
+  });
 }
 
 module.exports = PeerConnectionV2;

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -458,7 +458,7 @@ describe('connect', function() {
         // NOTE(mmalavalli): If applying bandwidth constraints using RTCRtpSender.setParameters(),
         // which is an asynchronous operation, wait for a little while until the changes are applied.
         if (isRTCRtpSenderParamsSupported) {
-          await new Promise(resolve => setTimeout(resolve, 1000));
+          await new Promise(resolve => setTimeout(resolve, 5000));
         }
       });
 

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -23,7 +23,18 @@ const {
 const defaults = require('../../lib/defaults');
 const { isChrome, isFirefox, isSafari } = require('../../lib/guessbrowser');
 const getToken = require('../../lib/token');
-const { capitalize, combinationContext, participantsConnected, pairs, randomName, smallVideoConstraints, tracksAdded, tracksPublished } = require('../../lib/util');
+
+const {
+  capitalize,
+  combinationContext,
+  isRTCRtpSenderParamsSupported,
+  participantsConnected,
+  pairs,
+  randomName,
+  smallVideoConstraints,
+  tracksAdded,
+  tracksPublished
+} = require('../../lib/util');
 
 const safariVersion = isSafari && Number(navigator.userAgent.match(/Version\/([0-9.]+)/)[1]);
 
@@ -410,10 +421,6 @@ describe('connect', function() {
   });
 
   describe('called with EncodingParameters', () => {
-    const isRTCRtpSenderParamsSupported = typeof RTCRtpSender !== 'undefined'
-      && typeof RTCRtpSender.prototype.getParameters === 'function'
-      && typeof RTCRtpSender.prototype.setParameters === 'function';
-
     combinationContext([
       [
         [undefined, null, 20000],
@@ -448,6 +455,11 @@ describe('connect', function() {
 
       before(async () => {
         [thisRoom, thoseRooms, peerConnections] = await setup(encodingParameters, { tracks: [] }, 0);
+        // NOTE(mmalavalli): If applying bandwidth constraints using RTCRtpSender.setParameters(),
+        // which is an asynchronous operation, wait for a little while until the changes are applied.
+        if (isRTCRtpSenderParamsSupported) {
+          await new Promise(resolve => setTimeout(resolve, 500));
+        }
       });
 
       ['audio', 'video'].forEach(kind => {

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -458,7 +458,7 @@ describe('connect', function() {
         // NOTE(mmalavalli): If applying bandwidth constraints using RTCRtpSender.setParameters(),
         // which is an asynchronous operation, wait for a little while until the changes are applied.
         if (isRTCRtpSenderParamsSupported) {
-          await new Promise(resolve => setTimeout(resolve, 500));
+          await new Promise(resolve => setTimeout(resolve, 1000));
         }
       });
 

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -1060,7 +1060,7 @@ describe('LocalParticipant', function() {
         if (isRTCRtpSenderParamsSupported) {
           // NOTE(mmalavalli): If applying bandwidth constraints using RTCRtpSender.setParameters(),
           // which is an asynchronous operation, wait for a little while until the changes are applied.
-          await new Promise(resolve => setTimeout(resolve, 500));
+          await new Promise(resolve => setTimeout(resolve, 1000));
           senders = flatMap(peerConnections, pc => pc.getSenders().filter(sender => sender.track));
           return;
         }

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -1060,7 +1060,7 @@ describe('LocalParticipant', function() {
         if (isRTCRtpSenderParamsSupported) {
           // NOTE(mmalavalli): If applying bandwidth constraints using RTCRtpSender.setParameters(),
           // which is an asynchronous operation, wait for a little while until the changes are applied.
-          await new Promise(resolve => setTimeout(resolve, 1000));
+          await new Promise(resolve => setTimeout(resolve, 5000));
           senders = flatMap(peerConnections, pc => pc.getSenders().filter(sender => sender.track));
           return;
         }

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -26,7 +26,7 @@ const { TrackNameIsDuplicatedError, TrackNameTooLongError } = require('../../../
 const defaults = require('../../lib/defaults');
 const { isChrome, isFirefox, isSafari } = require('../../lib/guessbrowser');
 const getToken = require('../../lib/token');
-const { smallVideoConstraints } = require('../../lib/util');
+const { isRTCRtpSenderParamsSupported, smallVideoConstraints } = require('../../lib/util');
 
 const {
   capitalize,
@@ -1003,10 +1003,6 @@ describe('LocalParticipant', function() {
       maxVideoBitrate: 40000
     };
 
-    const isRTCRtpSenderParamsSupported = typeof RTCRtpSender !== 'undefined'
-      && typeof RTCRtpSender.prototype.getParameters === 'function'
-      && typeof RTCRtpSender.prototype.setParameters === 'function';
-
     combinationContext([
       [
         [undefined, null, 25000],
@@ -1062,6 +1058,9 @@ describe('LocalParticipant', function() {
         thisRoom.localParticipant.setParameters(encodingParameters);
 
         if (isRTCRtpSenderParamsSupported) {
+          // NOTE(mmalavalli): If applying bandwidth constraints using RTCRtpSender.setParameters(),
+          // which is an asynchronous operation, wait for a little while until the changes are applied.
+          await new Promise(resolve => setTimeout(resolve, 500));
           senders = flatMap(peerConnections, pc => pc.getSenders().filter(sender => sender.track));
           return;
         }

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -320,10 +320,15 @@ const smallVideoConstraints = isSafari ? {} : {  width: 160,
   height: 120
 };
 
+const isRTCRtpSenderParamsSupported = typeof RTCRtpSender !== 'undefined'
+  && typeof RTCRtpSender.prototype.getParameters === 'function'
+  && typeof RTCRtpSender.prototype.setParameters === 'function';
+
 exports.a = a;
 exports.capitalize = capitalize;
 exports.combinationContext = combinationContext;
 exports.combinations = combinations;
+exports.isRTCRtpSenderParamsSupported = isRTCRtpSenderParamsSupported;
 exports.makeEncodingParameters = makeEncodingParameters;
 exports.pairs = pairs;
 exports.participantsConnected = participantsConnected;

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -671,8 +671,12 @@ describe('PeerConnectionV2', () => {
       [
         [true, false],
         x => `when matching ICE candidates have ${x ? '' : 'not '}been received`
+      ],
+      [
+        [true, false],
+        x => `When RTCRtpSenderParameters is ${x ? '' : 'not '}supported by WebRTC`
       ]
-    ], ([initial, signalingState, type, newerEqualOrOlder, matching]) => {
+    ], ([initial, signalingState, type, newerEqualOrOlder, matching, isRTCRtpSenderParamsSupported]) => {
       // The Test
       let test;
 
@@ -702,7 +706,8 @@ describe('PeerConnectionV2', () => {
           offers: 3,
           answers: 2,
           maxAudioBitrate: 40,
-          maxVideoBitrate: 50
+          maxVideoBitrate: 50,
+          isRTCRtpSenderParamsSupported
         });
         descriptions = [];
         const ufrag = 'foo';
@@ -841,6 +846,18 @@ describe('PeerConnectionV2', () => {
 
       function itShouldApplyBandwidthConstraints() {
         it('should apply the specified bandwidth constraints to the remote description', () => {
+          if (isRTCRtpSenderParamsSupported) {
+            test.pc.getSenders().forEach(sender => {
+              assert.deepEqual(sender.setParameters.args[0][0], {
+                encodings: [{
+                  maxBitrate: sender.track.kind === 'audio'
+                    ? test.maxAudioBitrate
+                    : test.maxVideoBitrate
+                }]
+              });
+            });
+            return;
+          }
           const maxVideoBitrate = test.setBitrateParameters.args[0].pop();
           const maxAudioBitrate = test.setBitrateParameters.args[0].pop();
           assert.equal(maxAudioBitrate, test.maxAudioBitrate);
@@ -1787,7 +1804,11 @@ class MockPeerConnection extends EventEmitter {
   }
 
   addTrack(track) {
-    const sender = { track };
+    const sender = {
+      getParameters: sinon.spy(() => ({ encodings: [{}] })),
+      setParameters: sinon.spy(() => Promise.resolve()),
+      track
+    };
     this.senders.push(sender);
     return sender;
   }
@@ -1856,6 +1877,9 @@ function makePeerConnectionV2(options) {
   options.id = options.id || makeId();
 
   const pc = options.pc || makePeerConnection(options);
+  pc.addTrack({ kind: 'audio' });
+  pc.addTrack({ kind: 'video' });
+
   function RTCPeerConnection() {
     return pc;
   }
@@ -1869,6 +1893,7 @@ function makePeerConnectionV2(options) {
     RTCIceCandidate: identity,
     RTCPeerConnection: options.RTCPeerConnection,
     RTCSessionDescription: identity,
+    isRTCRtpSenderParamsSupported: options.isRTCRtpSenderParamsSupported,
     setBitrateParameters: options.setBitrateParameters,
     setCodecPreferences: options.setCodecPreferences
   });


### PR DESCRIPTION
@makarandp0 

This PR implements setting max outgoing bitrate values for audio and video using `RTCRtpSender.setParameters()` instead of SDP munging.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
