### PR TITLE
JSDK-2408 pass room sid in connect message (support-1.x-chrome-planb)

### DIFF
--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -94,7 +94,7 @@ class RoomV2 extends RoomSignaling {
     handleLocalParticipantEvents(this, localParticipant);
     handlePeerConnectionEvents(this, peerConnectionManager);
     handleTransportEvents(this, transport);
-    periodicallyPublishStats(this, localParticipant, transport, options.statsPublishIntervalMs);
+    periodicallyPublishStats(this, transport, options.statsPublishIntervalMs);
 
     this._update(initialState);
   }
@@ -555,11 +555,10 @@ function handleTransportEvents(roomV2, transport) {
  * Periodically publish {@link StatsReport}s.
  * @private
  * @param {RoomV2} roomV2
- * @param {LocalParticipantV2} localParticipant
  * @param {Transport} transport
  * @param {Number} intervalMs
  */
-function periodicallyPublishStats(roomV2, localParticipant, transport, intervalMs) {
+function periodicallyPublishStats(roomV2, transport, intervalMs) {
   const interval = setInterval(() => {
     roomV2.getStats().then(stats => {
       stats.forEach((response, id) => {
@@ -572,9 +571,7 @@ function periodicallyPublishStats(roomV2, localParticipant, transport, intervalM
           audioTrackStats: report.remoteAudioTrackStats,
           localAudioTrackStats: report.localAudioTrackStats,
           localVideoTrackStats: report.localVideoTrackStats,
-          participantSid: localParticipant.sid,
           peerConnectionId: report.peerConnectionId,
-          roomSid: roomV2.sid,
           videoTrackStats: report.remoteVideoTrackStats
         });
 

--- a/lib/signaling/v2/transport.js
+++ b/lib/signaling/v2/transport.js
@@ -136,6 +136,10 @@ class Transport extends StateMachine {
       }
     });
     setupEventListeners(this, this._session, ua);
+
+    this.once('connected', ({ sid, participant }) => {
+        this._eventPublisher.connect(sid, participant.sid);
+    });
   }
 
   /**

--- a/lib/signaling/v2/transport.js
+++ b/lib/signaling/v2/transport.js
@@ -138,7 +138,7 @@ class Transport extends StateMachine {
     setupEventListeners(this, this._session, ua);
 
     this.once('connected', ({ sid, participant }) => {
-        this._eventPublisher.connect(sid, participant.sid);
+      this._eventPublisher.connect(sid, participant.sid);
     });
   }
 

--- a/lib/util/insightspublisher/index.js
+++ b/lib/util/insightspublisher/index.js
@@ -10,6 +10,7 @@ const WS_CLOSE_NORMAL = 1000;
 
 const toplevel = global.window || global;
 const WebSocket = toplevel.WebSocket ? toplevel.WebSocket : require('ws');
+const util = require('../../util');
 
 /**
  * Publish events to the Insights gateway.
@@ -46,6 +47,9 @@ class InsightsPublisher extends EventEmitter {
       _eventQueue: {
         value: []
       },
+      _readyToConnect: {
+        value: util.defer()
+      },
       _reconnectAttemptsLeft: {
         value: options.maxReconnectAttempts,
         writable: true
@@ -59,19 +63,31 @@ class InsightsPublisher extends EventEmitter {
       }
     });
 
-    const self = this;
-
-    this.on('disconnected', function maybeReconnect(error) {
-      self._session = null;
-      if (error && self._reconnectAttemptsLeft > 0) {
-        self.emit('reconnecting');
-        reconnect(self, token, sdkName, sdkVersion, options);
-        return;
-      }
-      self.removeListener('disconnected', maybeReconnect);
+    this._readyToConnect.promise.then(({ roomSid, participantSid }) => {
+      const self = this;
+      this.on('disconnected', function maybeReconnect(error) {
+        self._session = null;
+        if (error && self._reconnectAttemptsLeft > 0) {
+          self.emit('reconnecting');
+          reconnect(self, token, sdkName, sdkVersion, roomSid, participantSid, options);
+          return;
+        }
+        self.removeListener('disconnected', maybeReconnect);
+      });
+      connect(this, token, sdkName, sdkVersion, roomSid, participantSid, options);
+    }).catch(() => {
+      // ignore failures to connect
     });
+  }
 
-    connect(this, token, sdkName, sdkVersion, options);
+  /**
+   * Start connecting to the Insights gateway.
+   * @param {string} roomSid
+   * @param {string} participantSid
+   * @returns {void}
+   */
+  connect(roomSid, participantSid) {
+    this._readyToConnect.resolve({ roomSid, participantSid });
   }
 
   /**
@@ -89,7 +105,9 @@ class InsightsPublisher extends EventEmitter {
    * @returns {boolean} true if called when connecting/open, false if not
    */
   disconnect() {
-    if (this._ws.readyState === this._WebSocket.CLOSING || this._ws.readyState === this._WebSocket.CLOSED) {
+    if (this._ws === null
+      || this._ws.readyState === this._WebSocket.CLOSING
+      || this._ws.readyState === this._WebSocket.CLOSED) {
       return false;
     }
 
@@ -111,7 +129,9 @@ class InsightsPublisher extends EventEmitter {
    * @returns {boolean} true if queued or published, false if disconnect() called
    */
   publish(groupName, eventName, payload) {
-    if (this._ws.readyState === this._WebSocket.CLOSING || this._ws.readyState === this._WebSocket.CLOSED) {
+    if (this._ws !== null
+      && (this._ws.readyState === this._WebSocket.CLOSING
+        || this._ws.readyState === this._WebSocket.CLOSED)) {
       return false;
     }
 
@@ -140,9 +160,11 @@ class InsightsPublisher extends EventEmitter {
  * @param {string} token
  * @param {string} sdkName
  * @param {string} sdkVersion
+ * @param {string} roomSid
+ * @param {string} participantSid
  * @param {InsightsPublisherOptions} options
  */
-function connect(publisher, token, sdkName, sdkVersion, options) {
+function connect(publisher, token, sdkName, sdkVersion, roomSid, participantSid, options) {
   publisher._connectTimestamp = Date.now();
   publisher._reconnectAttemptsLeft--;
   publisher._ws = new options.WebSocket(options.gateway);
@@ -170,7 +192,9 @@ function connect(publisher, token, sdkName, sdkVersion, options) {
     connectRequest.publisher = {
       name: sdkName,
       sdkVersion,
-      userAgent: options.userAgent
+      userAgent: options.userAgent,
+      participantSid: participantSid,
+      roomSid: roomSid,
     };
 
     ws.send(JSON.stringify(connectRequest));
@@ -217,20 +241,22 @@ function handleConnectResponse(publisher, response, options) {
  * @param {string} token
  * @param {string} sdkName
  * @param {string} sdkVersion
+ * @param {string} roomSid
+ * @param {string} participantSid
  * @param {InsightsPublisherOptions} options
  */
-function reconnect(publisher, token, sdkName, sdkVersion, options) {
+function reconnect(publisher, token, sdkName, sdkVersion, roomSid, participantSid, options) {
   const connectInterval = Date.now() - publisher._connectTimestamp;
   const timeToWait = options.reconnectIntervalMs - connectInterval;
 
   if (timeToWait > 0) {
     setTimeout(() => {
-      connect(publisher, token, sdkName, sdkVersion, options);
+      connect(publisher, token, sdkName, sdkVersion, roomSid, participantSid, options);
     }, timeToWait);
     return;
   }
 
-  connect(publisher, token, sdkName, sdkVersion, options);
+  connect(publisher, token, sdkName, sdkVersion, roomSid, participantSid, options);
 }
 
 /**

--- a/lib/util/insightspublisher/null.js
+++ b/lib/util/insightspublisher/null.js
@@ -16,6 +16,13 @@ class InsightsPublisher {
   }
 
   /**
+   * Connect
+   * @returns {void}
+   */
+  connect() {
+  }
+
+  /**
    * Disconnect.
    * @returns {boolean}
    */

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -409,7 +409,7 @@ describe('connect', function() {
   });
 
   [true, false].forEach(insights => {
-    describe.only(`called with isInsightsEnabled = ${insights}`, () => {
+    describe(`called with isInsightsEnabled = ${insights}`, () => {
       let InsightsPublisher;
       let NullInsightsPublisher;
       let room;

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -119,6 +119,34 @@ describe('connect', function() {
     });
   });
 
+  describe('insights option', () => {
+    [true, false].forEach((insights) => {
+      it(`when set to  ${insights}`, async () => {
+        const token = getToken(randomName());
+        let cancelablePromise = null;
+        let room = null;
+        let error = null;
+        const regionOptions = {
+          insights
+        };
+
+        try {
+          const connectOptions = Object.assign({}, defaults, regionOptions, { tracks: [] });
+          cancelablePromise = connect(token, connectOptions);
+          assert(cancelablePromise instanceof CancelablePromise);
+          room = await cancelablePromise;
+        } catch (error_) {
+          error = error_;
+        } finally {
+          if (room) {
+            room.disconnect();
+          }
+        }
+        assert.equal(error, null);
+      });
+    });
+  });
+
   describe('called with an incorrect RTCIceServer url', () => {
     let cancelablePromise;
 
@@ -381,18 +409,20 @@ describe('connect', function() {
   });
 
   [true, false].forEach(insights => {
-    describe(`called with isInsightsEnabled = ${insights}`, () => {
+    describe.only(`called with isInsightsEnabled = ${insights}`, () => {
       let InsightsPublisher;
       let NullInsightsPublisher;
       let room;
 
       before(async () => {
         InsightsPublisher = sinon.spy(function InsightsPublisher() {
+          this.connect = sinon.spy();
           this.disconnect = sinon.spy();
           this.publish = sinon.spy();
         });
 
         NullInsightsPublisher = sinon.spy(function NullInsightsPublisher() {
+          this.connect = sinon.spy();
           this.disconnect = sinon.spy();
           this.publish = sinon.spy();
         });

--- a/test/integration/spec/util/insightspublisher.js
+++ b/test/integration/spec/util/insightspublisher.js
@@ -35,6 +35,7 @@ describe('InsightsPublisher', function() {
             'prod',
             'us1',
             options);
+          publisher.connect('roomSid', 'participantSid');
         });
 
         const description = tokenType !== 'valid'
@@ -70,6 +71,7 @@ describe('InsightsPublisher', function() {
         'us1',
         options);
 
+      publisher.connect('roomSid', 'participantSid');
       publisher.once('connected', () => publisher.disconnect());
       const error = await new Promise(resolve => publisher.once('disconnected', resolve));
       assert(!error);

--- a/test/unit/spec/signaling/v2/room.js
+++ b/test/unit/spec/signaling/v2/room.js
@@ -104,9 +104,7 @@ describe('RoomV2', () => {
           'quality',
           'stats-report',
           {
-            participantSid: test.localParticipant.sid,
             peerConnectionId: 'foo',
-            roomSid: test.sid,
             audioTrackStats: reports.foo.remoteAudioTrackStats,
             localAudioTrackStats: reports.foo.localAudioTrackStats,
             localVideoTrackStats: reports.foo.localVideoTrackStats,
@@ -125,9 +123,7 @@ describe('RoomV2', () => {
           'quality',
           'stats-report',
           {
-            participantSid: test.localParticipant.sid,
             peerConnectionId: 'bar',
-            roomSid: test.sid,
             audioTrackStats: reports.bar.remoteAudioTrackStats,
             localAudioTrackStats: reports.bar.localAudioTrackStats,
             localVideoTrackStats: reports.bar.localVideoTrackStats,

--- a/test/unit/spec/signaling/v2/transport.js
+++ b/test/unit/spec/signaling/v2/transport.js
@@ -900,7 +900,11 @@ describe('Transport', () => {
         context('"connected"', () => {
           const message = {
             type: 'connected',
-            foo: 'bar'
+            foo: 'bar',
+            sid: 'roomSid',
+            participant: {
+              sid: 'userSid',
+            }
           };
 
           let connectedEvent;
@@ -1077,7 +1081,7 @@ describe('Transport', () => {
           context('when the Transport\'s .state transitions to', () => {
             context('"connected"', () => {
               beforeEach(() => {
-                test.receiveRequest({ type: 'connected' });
+                test.receiveRequest({ type: 'connected', sid: 'roomSid', participant: { sid: 'userSid' } });
               });
 
               it('emits an "message" event with the RSP message with type "synced"', () => {
@@ -1128,7 +1132,7 @@ describe('Transport', () => {
           context('when the Transport\'s .state transitions to', () => {
             context('"connected"', () => {
               beforeEach(() => {
-                test.receiveRequest({ type: 'connected' });
+                test.receiveRequest({ type: 'connected', sid: 'roomSid', participant: { sid: 'userSid' } });
               });
 
               it('emits an "message" event with the RSP message with type "update"', () => {
@@ -1451,7 +1455,11 @@ describe('Transport', () => {
 
         context('"connected"', () => {
           const message = {
-            type: 'connected'
+            type: 'connected',
+            sid: 'roomSid',
+            participant: {
+              sid: 'userSid'
+            }
           };
 
           let emittedEvent;
@@ -1623,7 +1631,11 @@ describe('Transport', () => {
       context('"connecting", and the request contains an RSP message with type', () => {
         context('"connected"', () => {
           const message = {
-            type: 'connected'
+            type: 'connected',
+            sid: 'roomSid',
+            participant: {
+              sid: 'userSid'
+            }
           };
 
           let connectedEvent;
@@ -1764,7 +1776,7 @@ describe('Transport', () => {
           context('when the Transport\'s .state transitions to', () => {
             context('"connected"', () => {
               beforeEach(() => {
-                test.receiveRequest({ type: 'connected' });
+                test.receiveRequest({ type: 'connected', sid: 'roomSid', participant: { sid: 'userSid' } });
               });
 
               it('emits an "message" event with the RSP message with type "synced"', () => {
@@ -1809,7 +1821,7 @@ describe('Transport', () => {
           context('when the Transport\'s .state transitions to', () => {
             context('"connected"', () => {
               beforeEach(() => {
-                test.receiveRequest({ type: 'connected' });
+                test.receiveRequest({ type: 'connected', sid: 'roomSid', participant: { sid: 'userSid' } });
               });
 
               it('emits an "message" event with the RSP message with type "update"', () => {
@@ -2465,7 +2477,7 @@ function makeTest(options) {
   };
   options.accepted = message => options.receiveRequest(message, 'accepted');
   options.failed = () => options.session.emit('failed');
-  options.connect = () => options.accepted({ type: 'connected' });
+  options.connect = () => options.accepted({ type: 'connected', sid: 'roomSid', participant: { sid: 'userSid' } });
   options.sync = () => options.receiveRequest({ type: 'synced' });
   return options;
 }
@@ -2507,6 +2519,7 @@ function makeUA(options) {
 
 function makeInsightsPublisherConstructor(testOptions) {
   return function InsightsPublisher() {
+    this.connect = sinon.spy(() => {});
     this.disconnect = sinon.spy(() => {});
     this.publish = sinon.spy(() => 'baz');
     testOptions.eventPublisher = this;


### PR DESCRIPTION
* pass roomSid, participantSid along with connect for insights

This PR ports https://github.com/twilio/twilio-video.js/pull/692 into  1.x branch
mostly cherry-pick, except for following files which have diverged significantly from the master 

Following files 
```
lib/signaling/v2/transport.js
test/unit/spec/signaling/v2/transport.js
```
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
