### PR TITLE
JSDK-2440 support dscp tagging (support-1.x-chrome-planb)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ For 2.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/master
 New Features
 ------------
 
-- You can now [enable dscp tagging](https://tools.ietf.org/html/draft-ietf-tsvwg-rtcweb-qos-18) for audio
-  packets by specifying new ConnectOptions property  `dscpTagging` and setting it to  `true`.
-  DSCP tagging allows you to request enhanced QoS treatment for RTP media packets from any firewall/routers
+- You can now enable [dscp tagging](https://tools.ietf.org/html/draft-ietf-tsvwg-rtcweb-qos-18) for audio
+  packets by specifying new ConnectOptions property `dscpTagging` and setting it to `true`.
+  DSCP tagging allows you to request enhanced QoS treatment for audio packets from any firewall/routers
   that support this feature. Setting this option to `true` will request DSCP tagging
   for audio packets on supported browsers (only Chrome supports this as of now). Audio packets will be
   sent with DSCP header value set to (0xb8) which corrosponds to EF = Expediated Forwarding.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@ For 2.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/master
 1.18.3 (in progress)
 ====================
 
+New Features
+------------
+
+- You can now [enable dscp tagging](https://tools.ietf.org/html/draft-ietf-tsvwg-rtcweb-qos-18) for audio
+  packets by specifying new ConnectOptions property  `dscpTagging` and setting it to  `true`.
+  DSCP tagging allows you to request enhanced QoS treatment for RTP media packets from any firewall/routers
+  that support this feature. Setting this option to `true` will request DSCP tagging
+  for audio packets on supported browsers (only Chrome supports this as of now). Audio packets will be
+  sent with DSCP header value set to (0xb8) which corrosponds to EF = Expediated Forwarding.
+
+  ```js
+  const { connect } = require('twilio-video');
+  const room = await connect(token, {
+    dscpTagging: true
+  });
+  ```
+
 Bug Fixes
 ---------
 

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -282,9 +282,9 @@ function connect(token, options) {
  *   Speaker API or not. This only takes effect in Group Rooms.
  * @property {boolean} [dscpTagging=false] - DSCP tagging allows you to request enhanced
  * QoS treatment for RTP media packets from any firewall that the client may be behind.
- * Setting this option to <code>true</code>, will request DSCP tagging for audio packets
- * on supported platforms. Audio packets will be sent with DSCP header value set to (0xb8)
- * which corrosponds to EF = Expediated Forwarding.
+ * Setting this option to <code>true</code> will request DSCP tagging for audio packets
+ * on supported browsers (only Chrome supports this as of now). Audio packets will be
+ * sent with DSCP header value set to (0xb8) which corrosponds to EF = Expediated Forwarding.
  * @property {Array<RTCIceServer>} iceServers - Override the STUN and TURN
  *   servers used when connecting to {@link Room}s
  * @property {number} [iceServersTimeout=3000] - Override the amount of time, in

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -125,6 +125,7 @@ function connect(token, options) {
     abortOnIceServersTimeout: false,
     createLocalTracks,
     dominantSpeaker: false,
+    dscpTagging: false,
     environment: constants.DEFAULT_ENVIRONMENT,
     iceServersTimeout: constants.ICE_SERVERS_TIMEOUT_MS,
     insights: true,
@@ -279,6 +280,11 @@ function connect(token, options) {
  *   are not provided.
  * @property {boolean} [dominantSpeaker=false] - Whether to enable the Dominant
  *   Speaker API or not. This only takes effect in Group Rooms.
+ * @property {boolean} [dscpTagging=false] - DSCP tagging allows you to request enhanced
+ * QoS treatment for RTP media packets from any firewall that the client may be behind.
+ * Setting this option to <code>true</code>, will request DSCP tagging for audio packets
+ * on supported platforms. Audio packets will be sent with DSCP header value set to (0xb8)
+ * which corrosponds to EF = Expediated Forwarding.
  * @property {Array<RTCIceServer>} iceServers - Override the STUN and TURN
  *   servers used when connecting to {@link Room}s
  * @property {number} [iceServersTimeout=3000] - Override the amount of time, in

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -111,6 +111,7 @@ class PeerConnectionV2 extends StateMachine {
     super('open', states);
 
     options = Object.assign({
+      dscpTagging: false,
       dummyAudioMediaStreamTrack: null,
       iceServers: [],
       isRTCRtpSenderParamsSupported,
@@ -128,6 +129,13 @@ class PeerConnectionV2 extends StateMachine {
     const configuration = getConfiguration(options);
     const logLevels = buildLogLevels(options.logLevel);
     const RTCPeerConnection = options.RTCPeerConnection;
+
+    if (options.dscpTagging === true) {
+      options.chromeSpecificConstraints = options.chromeSpecificConstraints || {};
+      options.chromeSpecificConstraints.optional = options.chromeSpecificConstraints.optional || [];
+      options.chromeSpecificConstraints.optional.push({ googDscp: true });
+    }
+
     const peerConnection = new RTCPeerConnection(configuration, options.chromeSpecificConstraints);
 
     const localMediaStream = isUnifiedPlan && RTCPeerConnection.prototype.addTransceiver
@@ -156,6 +164,9 @@ class PeerConnectionV2 extends StateMachine {
       _descriptionRevision: {
         writable: true,
         value: 0
+      },
+      _dscpTagging: {
+        value: options.dscpTagging
       },
       _encodingParameters: {
         value: encodingParameters
@@ -1210,17 +1221,21 @@ function updateEncodingParameters(pcv2) {
   pcv2._peerConnection.getSenders().filter(sender => sender.track).forEach(sender => {
     const maxBitrate = maxBitrates.get(sender.track.kind);
     const params = sender.getParameters();
+    const networkPriority = pcv2._dscpTagging && sender.track.kind === 'audio' ? 'high' : null;
 
     if (isFirefox) {
       params.encodings = [{ maxBitrate }];
     } else {
       params.encodings.forEach(encoding => {
         encoding.maxBitrate = maxBitrate;
+        if (networkPriority) {
+          encoding.networkPriority = networkPriority;
+        }
       });
     }
 
     sender.setParameters(params).catch(error => {
-      pcv2._log.warn(`Error while setting bitrate parameters for ${sender.track.kind} Track ${sender.track.id}: ${error.message || error.name}`);
+      pcv2._log.warn(`Error while setting encodings parameters for ${sender.track.kind} Track ${sender.track.id}: ${error.message || error.name}`);
     });
   });
 }

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undefined */
 'use strict';
 
 const assert = require('assert');
@@ -420,8 +421,7 @@ describe('connect', function() {
     });
   });
 
-  (isRTCRtpSenderParamsSupported ? describe.only : describe.skip)('dscpTagging', () => {
-    // eslint-disable-next-line no-undefined
+  (isRTCRtpSenderParamsSupported ? describe : describe.skip)('dscpTagging', () => {
     [true, false, undefined].forEach((dscpTagging) => {
       context(`when dscpTagging is ${typeof dscpTagging === 'undefined' ? 'not set' : dscpTagging ? 'set to true' : 'set to false'}`, () => {
         const connectOptions = {};

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -435,7 +435,7 @@ describe('connect', function() {
 
         before(async () => {
           [thisRoom, thoseRooms, peerConnections] = await setup(connectOptions, { tracks: [] }, 0);
-          // RTCRtpSender.setParameters() is an asynchronous operation,
+          // NOTE(mpatwardhan):RTCRtpSender.setParameters() is an asynchronous operation,
           // wait for a little while until the changes are applied.
           await new Promise(resolve => setTimeout(resolve, 5000));
         });

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -440,18 +440,13 @@ describe('connect', function() {
           await new Promise(resolve => setTimeout(resolve, 5000));
         });
 
-        ['audio', 'video'].forEach(kind => {
-          let expectedNetworkPriority = 'low';
-          if (dscpTagging === true && kind === 'audio') {
-            expectedNetworkPriority = 'high';
-          }
-          it(`networkPriority should be set to ${expectedNetworkPriority} for ${kind} track`, () => {
-            flatMap(peerConnections, pc => {
-              return pc.getSenders().filter(sender => sender.track.kind === kind);
-            }).forEach(sender => {
-              const { encodings } = sender.getParameters();
-              encodings.forEach(({ networkPriority }) => assert.equal(networkPriority, expectedNetworkPriority));
-            });
+        const expectedNetworkPriority = dscpTagging === true ? 'high' : 'low';
+        it(`networkPriority should be set to ${expectedNetworkPriority} for audio tracks`, () => {
+          flatMap(peerConnections, pc => {
+            return pc.getSenders().filter(sender => sender.track.kind === 'audio');
+          }).forEach(sender => {
+            const { encodings } = sender.getParameters();
+            encodings.forEach(({ networkPriority }) => assert.equal(networkPriority, expectedNetworkPriority));
           });
         });
 

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -678,8 +678,8 @@ describe('PeerConnectionV2', () => {
         x => `When RTCRtpSenderParameters is ${x ? '' : 'not '}supported by WebRTC`
       ],
       [
-        [true, false],
-        x => `When dscpTagging is ${x ? 'requested' : 'not requested'}`
+        [true, false, undefined],
+        x => `When dscpTagging is set to ${x}`
       ],
     ], ([initial, signalingState, type, newerEqualOrOlder, matching, isRTCRtpSenderParamsSupported, dscpTagging]) => {
       // The Test
@@ -1904,16 +1904,21 @@ function makePeerConnectionV2(options) {
   options.setBitrateParameters = options.setBitrateParameters || sinon.spy(sdp => sdp);
   options.setCodecPreferences = options.setCodecPreferences || sinon.spy(sdp => sdp);
   options.preferredCodecs = options.preferredcodecs || { audio: [], video: [] };
-  return new PeerConnectionV2(options.id, makeEncodingParameters(options), options.preferredCodecs, {
+  options.options = {
     Event: function(type) { return { type: type }; },
     RTCIceCandidate: identity,
     RTCPeerConnection: options.RTCPeerConnection,
     RTCSessionDescription: identity,
-    dscpTagging: options.dscpTagging,
     isRTCRtpSenderParamsSupported: options.isRTCRtpSenderParamsSupported,
     setBitrateParameters: options.setBitrateParameters,
     setCodecPreferences: options.setCodecPreferences
-  });
+  };
+
+  if (options.dscpTagging !== undefined) {
+    options.options.dscpTagging = options.dscpTagging;
+  }
+
+  return new PeerConnectionV2(options.id, makeEncodingParameters(options), options.preferredCodecs, options.options);
 }
 
 /**


### PR DESCRIPTION
This change adds an option `dscpTagging` to enable adding dscp headers for audio packets. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
