### PR TITLE
JSDK-2463 Undoing updates to "_trackIdsToAttributes" when an offer is rolled back.

### DIFF
--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -614,9 +614,7 @@ class PeerConnectionV2 extends StateMachine {
   _handleSignalingStateChange() {
     if (this._peerConnection.signalingState === 'stable') {
       this._appliedTrackIdsToAttributes = new Map(this._trackIdsToAttributes);
-      return;
-    }
-    if (this._peerConnection.signalingState === 'closed' && this.state !== 'closed') {
+    } else if (this._peerConnection.signalingState === 'closed' && this.state !== 'closed') {
       this.preempt('closed');
     }
   }

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -146,6 +146,10 @@ class PeerConnectionV2 extends StateMachine {
     }
 
     Object.defineProperties(this, {
+      _appliedTrackIdsToAttributes: {
+        value: new Map(),
+        writable: true
+      },
       _dataChannels: {
         value: new Map()
       },
@@ -303,7 +307,8 @@ class PeerConnectionV2 extends StateMachine {
         value: false
       },
       _trackIdsToAttributes: {
-        value: new Map()
+        value: new Map(),
+        writable: true
       },
       _trackMatcher: {
         writable: true,
@@ -523,6 +528,7 @@ class PeerConnectionV2 extends StateMachine {
       this._shouldRestartIce = true;
     }
     return Promise.resolve().then(() => {
+      this._trackIdsToAttributes = new Map(this._appliedTrackIdsToAttributes);
       return this._setLocalDescription({ type: 'rollback' });
     }).then(() => {
       this._needsAnswer = false;
@@ -606,6 +612,10 @@ class PeerConnectionV2 extends StateMachine {
    * @returns {void}
    */
   _handleSignalingStateChange() {
+    if (this._peerConnection.signalingState === 'stable') {
+      this._appliedTrackIdsToAttributes = new Map(this._trackIdsToAttributes);
+      return;
+    }
     if (this._peerConnection.signalingState === 'closed' && this.state !== 'closed') {
       this.preempt('closed');
     }

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- ./test/unit/index.js"
   },
   "dependencies": {
-    "@twilio/webrtc": "4.1.0",
+    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#JSDK-2463",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- ./test/unit/index.js"
   },
   "dependencies": {
-    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#JSDK-2463",
+    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#5a2d3e6baa5bec07488d945edc72cf51504a042d",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -969,7 +969,7 @@ describe('connect', function() {
       });
 
       if (roomCodec === 'VP8' && defaults.topology !== 'peer-to-peer') {
-        describe('JSDK-2463', () => {
+        describe('JSDK-2463: two simulcast groups in SDP instead of one after a rollback (glare)', () => {
           let peerConnections;
           let sid;
           let thisRoom;

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -967,6 +967,66 @@ describe('connect', function() {
           return completeRoom(sid);
         });
       });
+
+      if (roomCodec === 'VP8' && defaults.topology !== 'peer-to-peer') {
+        describe('JSDK-2463', () => {
+          let peerConnections;
+          let sid;
+          let thisRoom;
+
+          before(async () => {
+            const localVideoTrack = await createLocalVideoTrack(smallVideoConstraints);
+
+            [sid, thisRoom] = await setup({
+              alone: true,
+              testOptions: { preferredVideoCodecs: [{ codec: 'VP8', simulcast: true }], video: false },
+              roomOptions: { VideoCodecs: [roomCodec] }
+            });
+
+            peerConnections = [...thisRoom._signaling._peerConnectionManager._peerConnections.values()].map(pcv2 => pcv2._peerConnection);
+            // NOTE(mmalavalli): Glare is induced by publishing the LocalVideoTrack
+            // soon after joining the Room.
+            await thisRoom.localParticipant.publishTrack(localVideoTrack);
+
+            // NOTE(mmalavalli): Ensuring that the local RTCSessionDescription is set
+            // before verifying that simulcast has been enabled. This was added to remove
+            // flakiness of this test in Travis.
+            await Promise.all(peerConnections.map(pc => pc.localDescription ? Promise.resolve() : new Promise(resolve => {
+              pc.addEventListener('signalingstatechange', () => pc.localDescription && resolve());
+            })));
+          });
+
+          it('is fixed', () => {
+            flatMap(peerConnections, pc => {
+              assert(pc.localDescription.sdp);
+              return getMediaSections(pc.localDescription.sdp, 'video', '(sendonly|sendrecv)');
+            }).forEach(section => {
+              const simSSRCs = new Set(flatMap(section.match(/^a=ssrc-group:SIM .+$/gm), line => {
+                return line.split(' ').slice(1);
+              }));
+
+              const trackSSRCs = new Set(section.match(/^a=ssrc:.+$/gm).map(line => {
+                return line.match(/a=ssrc:([0-9]+)/)[1];
+              }));
+
+              // NOTE(mmalavalli): The bug manifests itself as 2 "a=ssrc-group:SIM..." lines in
+              // the m= section as follows:
+              // 1. a=ssrc-group:SIM <ssrc1> <ssrc4> <ssrc3>
+              // 2. a=ssrc-group:SIM <ssrc1> <ssrc2> <ssrc3>
+              // This results in 4 unique simulcast SSRCs as opposed to the expected 3.
+              assert.equal(simSSRCs.size, 3);
+              simSSRCs.forEach(ssrc => assert(trackSSRCs.has(ssrc)));
+            });
+          });
+
+          after(() => {
+            if (thisRoom) {
+              thisRoom.disconnect();
+            }
+            return completeRoom(sid);
+          });
+        });
+      }
     });
   });
 


### PR DESCRIPTION
@makarandp0 

This PR consumes https://github.com/twilio/twilio-webrtc.js/pull/109 and makes sure updates to "_trackIdsToAttributes" are undone when an offer is rolled back.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.