### PR TITLE
Fixing failing DSCP tagging test.

### DIFF
--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -452,31 +452,38 @@ describe('connect', function() {
   });
 
   (isRTCRtpSenderParamsSupported ? describe : describe.skip)('dscpTagging', () => {
-    [true, false, undefined].forEach((dscpTagging) => {
-      context(`when dscpTagging is ${typeof dscpTagging === 'undefined' ? 'not set' : dscpTagging ? 'set to true' : 'set to false'}`, () => {
-        const connectOptions = {};
-        if (dscpTagging !== undefined) {
-          connectOptions.dscpTagging = dscpTagging;
-        }
-
+    [true, false, undefined].forEach(dscpTagging => {
+      context(`when dscpTagging is ${typeof dscpTagging === 'boolean' ? `set to ${dscpTagging}` : 'not set'}`, () => {
         let peerConnections;
         let thisRoom;
         let thoseRooms;
 
         before(async () => {
+          const connectOptions = typeof dscpTagging === 'boolean' ? { dscpTagging } : {};
           [thisRoom, thoseRooms, peerConnections] = await setup(connectOptions, { tracks: [] }, 0);
-          // NOTE(mpatwardhan):RTCRtpSender.setParameters() is an asynchronous operation,
-          // wait for a little while until the changes are applied.
+          // NOTE(mpatwardhan): RTCRtpSender.setParameters() is an asynchronous operation,
+          // so wait for a little while until the changes are applied.
           await new Promise(resolve => setTimeout(resolve, 5000));
         });
 
-        const expectedNetworkPriority = dscpTagging === true ? 'high' : 'low';
-        it(`networkPriority should be set to ${expectedNetworkPriority} for audio tracks`, () => {
-          flatMap(peerConnections, pc => {
-            return pc.getSenders().filter(sender => sender.track.kind === 'audio');
-          }).forEach(sender => {
-            const { encodings } = sender.getParameters();
-            encodings.forEach(({ networkPriority }) => assert.equal(networkPriority, expectedNetworkPriority));
+        ['audio', 'video'].forEach(kind => {
+          const expectedNetworkPriority = isChrome ? {
+            audio: { true: 'high', false: 'low' },
+            video: { true: 'low', false: 'low' }
+          }[kind][dscpTagging || false] : undefined;
+
+          it(`networkPriority should ${expectedNetworkPriority ? `be set to "${expectedNetworkPriority}"` : 'not be set'} for ${kind} RTCRtpEncodingParameters`, () => {
+            flatMap(peerConnections, pc => {
+              return pc.getSenders().filter(sender => sender.track && sender.track.kind === kind);
+            }).forEach(sender => {
+              sender.getParameters().encodings.forEach(encoding => {
+                if (typeof expectedNetworkPriority === 'string') {
+                  assert.equal(encoding.networkPriority, expectedNetworkPriority);
+                } else {
+                  assert(!('networkPriority' in encoding));
+                }
+              });
+            });
           });
         });
 


### PR DESCRIPTION
@makarandp0 

I failed to notice that your DSCP tagging test was not written properly in #702 which resulted in failure on Travis. So I've refactored it to check `networkPriority` for both audio and video only for Chrome. For Firefox and Safari, it should check that `networkPriority` should not exist even after trying to set it.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
