### PR TITLE
JSDK-2456 port dscp fix + RTCRtpSender.setParameters use.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ New Features
   DSCP tagging allows you to request enhanced QoS treatment for audio packets from any firewall/routers
   that support this feature. Setting this option to `true` will request DSCP tagging
   for audio packets on supported browsers (only Chrome supports this as of now). Audio packets will be
-  sent with DSCP header value set to (0xb8) which corrosponds to EF = Expediated Forwarding.
+  sent with DSCP header value set to (0xb8) which corrosponds to EF = Expedited Forwarding. (JSDK-2456)
 
   ```js
   const { connect } = require('twilio-video');

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@ For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/suppor
 2.0.0-beta13 (in progress)
 ==========================
 
+New Features
+------------
+
+- You can now enable [dscp tagging](https://tools.ietf.org/html/draft-ietf-tsvwg-rtcweb-qos-18) for audio
+  packets by specifying new ConnectOptions property `dscpTagging` and setting it to `true`.
+  DSCP tagging allows you to request enhanced QoS treatment for audio packets from any firewall/routers
+  that support this feature. Setting this option to `true` will request DSCP tagging
+  for audio packets on supported browsers (only Chrome supports this as of now). Audio packets will be
+  sent with DSCP header value set to (0xb8) which corrosponds to EF = Expediated Forwarding.
+
+  ```js
+  const { connect } = require('twilio-video');
+  const room = await connect(token, {
+    dscpTagging: true
+  });
+  ```
+
 Bug Fixes
 ---------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/suppor
 New Features
 ------------
 
-- You can now enable [dscp tagging](https://tools.ietf.org/html/draft-ietf-tsvwg-rtcweb-qos-18) for audio
+- You can now enable [DSCP tagging](https://tools.ietf.org/html/draft-ietf-tsvwg-rtcweb-qos-18) for audio
   packets by specifying new ConnectOptions property `dscpTagging` and setting it to `true`.
   DSCP tagging allows you to request enhanced QoS treatment for audio packets from any firewall/routers
   that support this feature. Setting this option to `true` will request DSCP tagging

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -294,7 +294,7 @@ function connect(token, options) {
  * QoS treatment for RTP media packets from any firewall that the client may be behind.
  * Setting this option to <code>true</code> will request DSCP tagging for audio packets
  * on supported browsers (only Chrome supports this as of now). Audio packets will be
- * sent with DSCP header value set to (0xb8) which corrosponds to EF = Expediated Forwarding.
+ * sent with DSCP header value set to (0xb8) which corrosponds to EF = Expedited Forwarding.
  * @property {Array<RTCIceServer>} iceServers - Override the STUN and TURN
  *   servers used when connecting to {@link Room}s
  * @property {number} [iceServersTimeout=3000] - Override the amount of time, in

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -126,6 +126,7 @@ function connect(token, options) {
     automaticSubscription: true,
     createLocalTracks,
     dominantSpeaker: false,
+    dscpTagging: false,
     environment: constants.DEFAULT_ENVIRONMENT,
     iceServersTimeout: constants.ICE_SERVERS_TIMEOUT_MS,
     insights: true,
@@ -289,6 +290,11 @@ function connect(token, options) {
  *   flag does not have any effect in a Peer-to-Peer Room.
  * @property {boolean} [dominantSpeaker=false] - Whether to enable the Dominant
  *   Speaker API or not. This only takes effect in Group Rooms.
+ * @property {boolean} [dscpTagging=false] - DSCP tagging allows you to request enhanced
+ * QoS treatment for RTP media packets from any firewall that the client may be behind.
+ * Setting this option to <code>true</code> will request DSCP tagging for audio packets
+ * on supported browsers (only Chrome supports this as of now). Audio packets will be
+ * sent with DSCP header value set to (0xb8) which corrosponds to EF = Expediated Forwarding.
  * @property {Array<RTCIceServer>} iceServers - Override the STUN and TURN
  *   servers used when connecting to {@link Room}s
  * @property {number} [iceServersTimeout=3000] - Override the amount of time, in

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -113,6 +113,7 @@ class PeerConnectionV2 extends StateMachine {
     super('open', states);
 
     options = Object.assign({
+      dscpTagging: false,
       dummyAudioMediaStreamTrack: null,
       iceServers: [],
       isRTCRtpSenderParamsSupported,
@@ -136,6 +137,13 @@ class PeerConnectionV2 extends StateMachine {
     const localMediaStream = isUnifiedPlan ? null : new options.MediaStream();
     const logLevels = buildLogLevels(options.logLevel);
     const RTCPeerConnection = options.RTCPeerConnection;
+
+    if (options.dscpTagging === true) {
+      options.chromeSpecificConstraints = options.chromeSpecificConstraints || {};
+      options.chromeSpecificConstraints.optional = options.chromeSpecificConstraints.optional || [];
+      options.chromeSpecificConstraints.optional.push({ googDscp: true });
+    }
+
     const peerConnection = new RTCPeerConnection(configuration, options.chromeSpecificConstraints);
 
     if (options.dummyAudioMediaStreamTrack) {
@@ -160,6 +168,9 @@ class PeerConnectionV2 extends StateMachine {
       _descriptionRevision: {
         writable: true,
         value: 0
+      },
+      _dscpTagging: {
+        value: options.dscpTagging
       },
       _encodingParameters: {
         value: encodingParameters
@@ -1369,17 +1380,21 @@ function updateEncodingParameters(pcv2) {
   pcv2._peerConnection.getSenders().filter(sender => sender.track).forEach(sender => {
     const maxBitrate = maxBitrates.get(sender.track.kind);
     const params = sender.getParameters();
+    const networkPriority = pcv2._dscpTagging && sender.track.kind === 'audio' ? 'high' : null;
 
     if (isFirefox) {
       params.encodings = [{ maxBitrate }];
     } else {
       params.encodings.forEach(encoding => {
         encoding.maxBitrate = maxBitrate;
+        if (networkPriority) {
+          encoding.networkPriority = networkPriority;
+        }
       });
     }
 
     sender.setParameters(params).catch(error => {
-      pcv2._log.warn(`Error while setting bitrate parameters for ${sender.track.kind} Track ${sender.track.id}: ${error.message || error.name}`);
+      pcv2._log.warn(`Error while setting encodings parameters for ${sender.track.kind} Track ${sender.track.id}: ${error.message || error.name}`);
     });
   });
 }

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1352,7 +1352,6 @@ function negotiationCompleted(pcv2) {
     updateLocalCodecs(pcv2);
     updateRemoteCodecMaps(pcv2);
   }
-
   if (pcv2._isRTCRtpSenderParamsSupported) {
     updateEncodingParameters(pcv2);
   }

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -840,11 +840,6 @@ class PeerConnectionV2 extends StateMachine {
           this._descriptionRevision++;
         } else if (description.type === 'answer') {
           this._lastStableDescriptionRevision = this._descriptionRevision;
-          if (this._isUnifiedPlan) {
-            updateRecycledTransceivers(this);
-            updateLocalCodecs(this);
-            updateRemoteCodecMaps(this);
-          }
           negotiationCompleted(this);
         }
         this._localUfrag = getUfrag(description);
@@ -902,12 +897,6 @@ class PeerConnectionV2 extends StateMachine {
           this._isRestartingIce = false;
         }
         negotiationCompleted(this);
-      }
-
-      if (description.type === 'answer' && this._isUnifiedPlan) {
-        updateRecycledTransceivers(this);
-        updateLocalCodecs(this);
-        updateRemoteCodecMaps(this);
       }
     }, error => {
       this._log.warn(`Calling setRemoteDescription with an RTCSessionDescription of type "${description.type}" failed with the error "${error.message}".`);
@@ -968,8 +957,7 @@ class PeerConnectionV2 extends StateMachine {
     const revision = description.revision;
     return Promise.resolve().then(() => {
       return this._setRemoteDescription(description);
-    }).catch((error) => {
-      console.error(error.message);
+    }).catch(() => {
       throw new MediaClientRemoteDescFailedError();
     }).then(() => {
       this._lastStableDescriptionRevision = revision;
@@ -1359,6 +1347,12 @@ function updateRecycledTransceivers(pcv2) {
  * @returns {void}
  */
 function negotiationCompleted(pcv2) {
+  if (pcv2._isUnifiedPlan) {
+    updateRecycledTransceivers(pcv2);
+    updateLocalCodecs(pcv2);
+    updateRemoteCodecMaps(pcv2);
+  }
+
   if (pcv2._isRTCRtpSenderParamsSupported) {
     updateEncodingParameters(pcv2);
   }

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -55,6 +55,10 @@ const firefoxMajorVersion = isFirefox
   ? parseInt(navigator.userAgent.match(/Firefox\/(\d+)/)[1], 10)
   : null;
 
+const isRTCRtpSenderParamsSupported = typeof RTCRtpSender !== 'undefined'
+  && typeof RTCRtpSender.prototype.getParameters === 'function'
+  && typeof RTCRtpSender.prototype.setParameters === 'function';
+
 let nInstances = 0;
 
 /*
@@ -111,6 +115,7 @@ class PeerConnectionV2 extends StateMachine {
     options = Object.assign({
       dummyAudioMediaStreamTrack: null,
       iceServers: [],
+      isRTCRtpSenderParamsSupported,
       logLevel: DEFAULT_LOG_LEVEL,
       offerOptions: {},
       revertSimulcastForNonVP8MediaSections,
@@ -176,6 +181,9 @@ class PeerConnectionV2 extends StateMachine {
       },
       _isUnifiedPlan: {
         value: isUnifiedPlan
+      },
+      _isRTCRtpSenderParamsSupported: {
+        value: options.isRTCRtpSenderParamsSupported
       },
       _lastIceConnectionState: {
         writable: true,
@@ -315,7 +323,16 @@ class PeerConnectionV2 extends StateMachine {
       }
     });
 
-    encodingParameters.on('changed', oncePerTick(this.offer.bind(this)));
+    encodingParameters.on('changed', oncePerTick(() => {
+      if (this._isRTCRtpSenderParamsSupported) {
+        if (!this._needsAnswer) {
+          updateEncodingParameters(this);
+        }
+        return;
+      }
+      this.offer();
+    }));
+
     peerConnection.addEventListener('datachannel', this._handleDataChannelEvent.bind(this));
     peerConnection.addEventListener('icecandidate', this._handleIceCandidateEvent.bind(this));
     peerConnection.addEventListener('iceconnectionstatechange', this._handleIceConnectionStateChange.bind(this));
@@ -817,6 +834,7 @@ class PeerConnectionV2 extends StateMachine {
             updateLocalCodecs(this);
             updateRemoteCodecMaps(this);
           }
+          negotiationCompleted(this);
         }
         this._localUfrag = getUfrag(description);
         this.emit('description', this.getState());
@@ -832,11 +850,13 @@ class PeerConnectionV2 extends StateMachine {
    */
   _setRemoteDescription(description) {
     if (description.sdp) {
-      description.sdp = this._setBitrateParameters(
-        description.sdp,
-        isFirefox ? 'TIAS' : 'AS',
-        this._encodingParameters.maxAudioBitrate,
-        this._encodingParameters.maxVideoBitrate);
+      if (!this._isRTCRtpSenderParamsSupported) {
+        description.sdp = this._setBitrateParameters(
+          description.sdp,
+          isFirefox ? 'TIAS' : 'AS',
+          this._encodingParameters.maxAudioBitrate,
+          this._encodingParameters.maxVideoBitrate);
+      }
       description.sdp = this._setCodecPreferences(
         description.sdp,
         this._preferredAudioCodecs,
@@ -865,10 +885,14 @@ class PeerConnectionV2 extends StateMachine {
         });
       }
     }).then(() => this._peerConnection.setRemoteDescription(description)).then(() => {
-      if (description.type === 'answer' && this._isRestartingIce) {
-        this._log.debug('An ICE restart was in-progress and is now completed');
-        this._isRestartingIce = false;
+      if (description.type === 'answer') {
+        if (this._isRestartingIce) {
+          this._log.debug('An ICE restart was in-progress and is now completed');
+          this._isRestartingIce = false;
+        }
+        negotiationCompleted(this);
       }
+
       if (description.type === 'answer' && this._isUnifiedPlan) {
         updateRecycledTransceivers(this);
         updateLocalCodecs(this);
@@ -933,7 +957,8 @@ class PeerConnectionV2 extends StateMachine {
     const revision = description.revision;
     return Promise.resolve().then(() => {
       return this._setRemoteDescription(description);
-    }).catch(() => {
+    }).catch((error) => {
+      console.error(error.message);
       throw new MediaClientRemoteDescFailedError();
     }).then(() => {
       this._lastStableDescriptionRevision = revision;
@@ -1314,6 +1339,48 @@ function updateRecycledTransceivers(pcv2) {
       const track = transceiver.receiver.track;
       pcv2._recycledTransceivers[track.kind].push(transceiver);
     }
+  });
+}
+
+/**
+ * Perform certain updates after an SDP negotiation is completed.
+ * @param {PeerConnectionV2} pcv2
+ * @returns {void}
+ */
+function negotiationCompleted(pcv2) {
+  if (pcv2._isRTCRtpSenderParamsSupported) {
+    updateEncodingParameters(pcv2);
+  }
+}
+
+/**
+ * Update the RTCRtpEncodingParameters of all active RTCRtpSenders.
+ * @param {PeerConnectionV2} pcv2
+ * @returns {void}
+ */
+function updateEncodingParameters(pcv2) {
+  const { maxAudioBitrate, maxVideoBitrate } = pcv2._encodingParameters;
+
+  const maxBitrates = new Map([
+    ['audio', maxAudioBitrate || 0],
+    ['video', maxVideoBitrate || 0]
+  ]);
+
+  pcv2._peerConnection.getSenders().filter(sender => sender.track).forEach(sender => {
+    const maxBitrate = maxBitrates.get(sender.track.kind);
+    const params = sender.getParameters();
+
+    if (isFirefox) {
+      params.encodings = [{ maxBitrate }];
+    } else {
+      params.encodings.forEach(encoding => {
+        encoding.maxBitrate = maxBitrate;
+      });
+    }
+
+    sender.setParameters(params).catch(error => {
+      pcv2._log.warn(`Error while setting bitrate parameters for ${sender.track.kind} Track ${sender.track.id}: ${error.message || error.name}`);
+    });
   });
 }
 

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -33,7 +33,6 @@ const {
   pairs,
   randomName,
   smallVideoConstraints,
-  tracksAdded,
   tracksSubscribed,
   tracksPublished
 } = require('../../lib/util');
@@ -525,7 +524,7 @@ describe('connect', function() {
 
         before(async () => {
           const connectOptions = typeof dscpTagging === 'boolean' ? { dscpTagging } : {};
-          [thisRoom, thoseRooms, peerConnections] = await setup(connectOptions, { tracks: [] }, 0);
+          [, thisRoom, thoseRooms, peerConnections] = await setup(randomName(), connectOptions, { tracks: [] }, 0);
           // NOTE(mpatwardhan): RTCRtpSender.setParameters() is an asynchronous operation,
           // so wait for a little while until the changes are applied.
           await new Promise(resolve => setTimeout(resolve, 5000));
@@ -559,7 +558,7 @@ describe('connect', function() {
     });
   });
 
-  describe('called with EncodingParameters', () => {
+  describe.only('called with EncodingParameters', () => {
     combinationContext([
       [
         // eslint-disable-next-line no-undefined
@@ -596,7 +595,7 @@ describe('connect', function() {
       let thoseRooms;
 
       before(async () => {
-        [thisRoom, thoseRooms, peerConnections] = await setup(encodingParameters, { tracks: [] }, 0);
+        [sid, thisRoom, thoseRooms, peerConnections] = await setup(randomName(), encodingParameters, { tracks: [] }, 0);
         // NOTE(mmalavalli): If applying bandwidth constraints using RTCRtpSender.setParameters(),
         // which is an asynchronous operation, wait for a little while until the changes are applied.
         if (isRTCRtpSenderParamsSupported) {

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -558,7 +558,7 @@ describe('connect', function() {
     });
   });
 
-  describe.only('called with EncodingParameters', () => {
+  describe('called with EncodingParameters', () => {
     combinationContext([
       [
         // eslint-disable-next-line no-undefined

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -24,7 +24,18 @@ const defaults = require('../../lib/defaults');
 const { isChrome, isFirefox, isSafari } = require('../../lib/guessbrowser');
 const { createRoom, completeRoom } = require('../../lib/rest');
 const getToken = require('../../lib/token');
-const { capitalize, combinationContext, participantsConnected, pairs, randomName, smallVideoConstraints, tracksSubscribed, tracksPublished } = require('../../lib/util');
+const {
+  capitalize,
+  combinationContext,
+  isRTCRtpSenderParamsSupported,
+  participantsConnected,
+  pairs,
+  randomName,
+  smallVideoConstraints,
+  tracksAdded,
+  tracksSubscribed,
+  tracksPublished
+} = require('../../lib/util');
 
 const safariVersion = isSafari && Number(navigator.userAgent.match(/Version\/([0-9.]+)/)[1]);
 
@@ -541,11 +552,26 @@ describe('connect', function() {
       let thoseRooms;
 
       before(async () => {
-        [sid, thisRoom, thoseRooms, peerConnections] = await setup(randomName(), encodingParameters, { tracks: [] }, 0);
+        [thisRoom, thoseRooms, peerConnections] = await setup(encodingParameters, { tracks: [] }, 0);
+        // NOTE(mmalavalli): If applying bandwidth constraints using RTCRtpSender.setParameters(),
+        // which is an asynchronous operation, wait for a little while until the changes are applied.
+        if (isRTCRtpSenderParamsSupported) {
+          await new Promise(resolve => setTimeout(resolve, 5000));
+        }
       });
 
       ['audio', 'video'].forEach(kind => {
         it(`should ${maxBitrates[kind] ? '' : 'not '}set the .max${capitalize(kind)}Bitrate`, () => {
+          if (isRTCRtpSenderParamsSupported) {
+            flatMap(peerConnections, pc => {
+              return pc.getSenders().filter(sender => sender.track);
+            }).forEach(sender => {
+              const { encodings } = sender.getParameters();
+              encodings.forEach(({ maxBitrate }) => assert.equal(maxBitrate, maxBitrates[sender.track.kind] || 0));
+            });
+            return;
+          }
+
           flatMap(peerConnections, pc => {
             assert(pc.remoteDescription.sdp);
             return getMediaSections(pc.remoteDescription.sdp, kind, '(recvonly|sendrecv)');

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -28,7 +28,7 @@ const defaults = require('../../lib/defaults');
 const { isChrome, isFirefox, isSafari } = require('../../lib/guessbrowser');
 const { createRoom, completeRoom } = require('../../lib/rest');
 const getToken = require('../../lib/token');
-const { smallVideoConstraints } = require('../../lib/util');
+const { isRTCRtpSenderParamsSupported, smallVideoConstraints } = require('../../lib/util');
 
 const {
   capitalize,
@@ -1002,6 +1002,7 @@ describe('LocalParticipant', function() {
       let peerConnections;
       let remoteDescriptions;
       let sid;
+      let senders;
       let thisRoom;
       let thoseRooms;
 
@@ -1028,6 +1029,14 @@ describe('LocalParticipant', function() {
         }));
         peerConnections = [...thisRoom._signaling._peerConnectionManager._peerConnections.values()].map(pcv2 => pcv2._peerConnection);
         thisRoom.localParticipant.setParameters(encodingParameters);
+
+        if (isRTCRtpSenderParamsSupported) {
+          // NOTE(mmalavalli): If applying bandwidth constraints using RTCRtpSender.setParameters(),
+          // which is an asynchronous operation, wait for a little while until the changes are applied.
+          await new Promise(resolve => setTimeout(resolve, 5000));
+          senders = flatMap(peerConnections, pc => pc.getSenders().filter(sender => sender.track));
+          return;
+        }
 
         function getRemoteDescription(pc) {
           return Object.keys(encodingParameters).length > 0
@@ -1056,6 +1065,16 @@ describe('LocalParticipant', function() {
           : 'existing';
 
         it(`should ${action} the ${newOrExisting} .max${capitalize(kind)}Bitrate`, () => {
+          if (isRTCRtpSenderParamsSupported) {
+            senders.filter(({ track }) => track.kind === kind).forEach(sender => {
+              const { encodings } = sender.getParameters();
+              encodings.forEach(({ maxBitrate }) => assert.equal(maxBitrate, action === 'preserve'
+                ? initialEncodingParameters[`max${capitalize(kind)}Bitrate`]
+                : maxBitrates[sender.track.kind] || 0));
+            });
+            return;
+          }
+
           flatMap(remoteDescriptions, description => {
             return getMediaSections(description.sdp, kind, '(recvonly|sendrecv)');
           }).forEach(section => {

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -331,10 +331,15 @@ const smallVideoConstraints = isSafari ? {} : {
   height: 120
 };
 
+const isRTCRtpSenderParamsSupported = typeof RTCRtpSender !== 'undefined'
+  && typeof RTCRtpSender.prototype.getParameters === 'function'
+  && typeof RTCRtpSender.prototype.setParameters === 'function';
+
 exports.a = a;
 exports.capitalize = capitalize;
 exports.combinationContext = combinationContext;
 exports.combinations = combinations;
+exports.isRTCRtpSenderParamsSupported = isRTCRtpSenderParamsSupported;
 exports.makeEncodingParameters = makeEncodingParameters;
 exports.pairs = pairs;
 exports.participantsConnected = participantsConnected;

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undefined */
 'use strict';
 
 const assert = require('assert');
@@ -784,8 +785,12 @@ describe('PeerConnectionV2', () => {
       [
         [true, false],
         x => `When RTCRtpSenderParameters is ${x ? '' : 'not '}supported by WebRTC`
-      ]
-    ], ([initial, signalingState, type, newerEqualOrOlder, matching, iceLite, isRTCRtpSenderParamsSupported]) => {
+      ],
+      [
+        [true, false, undefined],
+        x => `When dscpTagging is set to ${x}`
+      ],
+    ], ([initial, signalingState, type, newerEqualOrOlder, matching, iceLite, isRTCRtpSenderParamsSupported, dscpTagging]) => {
       // The Test
       let test;
 
@@ -816,6 +821,7 @@ describe('PeerConnectionV2', () => {
           answers: 2,
           maxAudioBitrate: 40,
           maxVideoBitrate: 50,
+          dscpTagging,
           isRTCRtpSenderParamsSupported
         });
         descriptions = [];
@@ -957,13 +963,8 @@ describe('PeerConnectionV2', () => {
         it('should apply the specified bandwidth constraints to the remote description', () => {
           if (isRTCRtpSenderParamsSupported) {
             test.pc.getSenders().forEach(sender => {
-              assert.deepEqual(sender.setParameters.args[0][0], {
-                encodings: [{
-                  maxBitrate: sender.track.kind === 'audio'
-                    ? test.maxAudioBitrate
-                    : test.maxVideoBitrate
-                }]
-              });
+              const experctedMaxBitRate = sender.track.kind === 'audio' ? test.maxAudioBitrate : test.maxVideoBitrate;
+              sinon.assert.calledWith(sender.setParameters, sinon.match.hasNested('encodings[0].maxBitrate', experctedMaxBitRate));
             });
             return;
           }
@@ -972,6 +973,20 @@ describe('PeerConnectionV2', () => {
           assert.equal(maxAudioBitrate, test.maxAudioBitrate);
           assert.equal(maxVideoBitrate, test.maxVideoBitrate);
         });
+      }
+
+      function itShouldSetNetworkPriority() {
+        if (isRTCRtpSenderParamsSupported) {
+          it('should set networkPriority to high for audio track senders', () => {
+            test.pc.getSenders().forEach(sender => {
+              if (sender.track.kind === 'audio' && dscpTagging) {
+                  sinon.assert.calledWith(sender.setParameters, sinon.match.hasNested('encodings[0].networkPriority', 'high'));
+              } else {
+                  sinon.assert.neverCalledWith(sender.setParameters, sinon.match.hasNested('encodings[0].networkPriority', 'high'));
+              }
+            });
+          });
+        }
       }
 
       // NOTE(mroberts): This test should really be extended. Instead of popping
@@ -1019,6 +1034,7 @@ describe('PeerConnectionV2', () => {
 
         itShouldApplyBandwidthConstraints();
         itShouldApplyCodecPreferences();
+        itShouldSetNetworkPriority();
       }
 
       function itMightEventuallyAnswer() {
@@ -2055,7 +2071,7 @@ function makePeerConnectionV2(options) {
   options.setBitrateParameters = options.setBitrateParameters || sinon.spy(sdp => sdp);
   options.setCodecPreferences = options.setCodecPreferences || sinon.spy(sdp => sdp);
   options.preferredCodecs = options.preferredcodecs || { audio: [], video: [] };
-  return new PeerConnectionV2(options.id, makeEncodingParameters(options), options.preferredCodecs, {
+  options.options = {
     Event: function(type) { return { type: type }; },
     RTCIceCandidate: identity,
     RTCPeerConnection: options.RTCPeerConnection,
@@ -2063,7 +2079,13 @@ function makePeerConnectionV2(options) {
     isRTCRtpSenderParamsSupported: options.isRTCRtpSenderParamsSupported,
     setBitrateParameters: options.setBitrateParameters,
     setCodecPreferences: options.setCodecPreferences
-  });
+  };
+
+  if (options.dscpTagging !== undefined) {
+    options.options.dscpTagging = options.dscpTagging;
+  }
+
+  return new PeerConnectionV2(options.id, makeEncodingParameters(options), options.preferredCodecs, options.options);
 }
 
 /**


### PR DESCRIPTION
This change cherry-picks and merges following PRs that were already merged into 1.x branch
 
https://github.com/twilio/twilio-video.js/pull/707 Fixing failing DSCP tagging test. 
https://github.com/twilio/twilio-video.js/pull/704 JSDK-2440 support dscp tagging (support-1.x-chrome-planb) 
https://github.com/twilio/twilio-video.js/pull/700 JSDK-2250 Use RTCRtpSender.setParameters where available, instead of SDP munging. 



**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
