### PR TITLE
JSDK-2467 Update Room's "trackSubscribed" and "trackUnsubscribed" events docs

### DIFF
--- a/lib/room.js
+++ b/lib/room.js
@@ -333,11 +333,13 @@ function rewriteLocalTrackIds(room, trackStats) {
 /**
  * A {@link RemoteParticipant}'s {@link RemoteTrack} was subscribed to.
  * @param {RemoteTrack} track - The {@link RemoteTrack} that was subscribed
+ * @param {RemoteTrackPublication} publication - The {@link RemoteTrackPublication}
+ *   for the {@link RemoteTrack} that was subscribed to
  * @param {RemoteParticipant} participant - The {@link RemoteParticipant} whose
  *   {@link RemoteTrack} was subscribed
  * @event Room#trackSubscribed
  * @example
- * room.on('trackSubscribed', function(track, participant) {
+ * room.on('trackSubscribed', function(track, publication, participant) {
  *   var participantView = document.getElementById('participant-view-' + participant.identity);
  *   participantView.appendChild(track.attach());
  * });
@@ -367,11 +369,13 @@ function rewriteLocalTrackIds(room, trackStats) {
 /**
  * A {@link RemoteParticipant}'s {@link RemoteTrack} was unsubscribed from.
  * @param {RemoteTrack} track - The {@link RemoteTrack} that was unsubscribed
+ * @param {RemoteTrackPublication} publication - The {@link RemoteTrackPublication}
+ *   for the {@link RemoteTrack} that was unsubscribed from
  * @param {RemoteParticipant} participant - The {@link RemoteParticipant} whose
  *   {@link RemoteTrack} was unsubscribed
  * @event Room#trackUnsubscribed
  * @example
- * room.on('trackUnsubscribed', function(track, participant) {
+ * room.on('trackUnsubscribed', function(track, publication, participant) {
  *   track.detach().forEach(function(mediaElement) {
  *     mediaElement.remove();
  *   });


### PR DESCRIPTION
@makarandp0 

This PR includes RemoteTrackPublication as the second argument in the event docs. This doc error was pointed out by a customer.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
