### PR TITLE
JSDK-2483 revert to non-dockerized build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ node_js:
 # https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356362524
 sudo: required
 
-services:
-  - docker
-
 addons:
   apt:
     packages:
@@ -83,9 +80,29 @@ matrix:
     - env: BROWSER=safari BVER=unstable TOPOLOGY=peer-to-peer
     - env: BROWSER=safari BVER=unstable TOPOLOGY=group
 
-script:
-  - docker-compose build test
-  - docker-compose run test npm run test:integration
+before_script:
+  - |
+    set -e
+    cd node_modules/travis-multirunner
+    if [ "${TRAVIS_OS_NAME}" == 'linux' ]; then
+      BROWSER=chrome ./setup.sh
+      BROWSER=firefox ./setup.sh
+      export CHROME_BIN=$(pwd)/browsers/bin/chrome-$BVER
+      export FIREFOX_BIN=$(pwd)/browsers/bin/firefox-$BVER
+    else
+      BROWSER=safari ./setup.sh
+    fi
+    cd ../..
+    if [ "${TRAVIS_OS_NAME}" == 'linux' ]; then
+      sh -e /etc/init.d/xvfb start
+      pulseaudio --start
+      sleep 3
+    fi
+    if [ "${TOPOLOGY}" != 'peer-to-peer' ]; then
+      export ENABLE_REST_API_TESTS=1
+    fi
+
+script: npm run build:travis
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,8 @@ node_js:
 # https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356362524
 sudo: required
 
-addons:
-  apt:
-    packages:
-      - pulseaudio
+before_install:
+  - sudo apt-get install -y pulseaudio
 
 # https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-directly
 dist: trusty


### PR DESCRIPTION
When moving our travis tests to run inside docker (https://github.com/twilio/twilio-video.js/pull/712), Instead of running `travis:build` I had it run `test:integration` which skipped some essential steps of the job. It breaks our release process. Our release process uses the travis job to generate dependent files + validate the release and tag the builds. 

This change reverts the docker related changes to travis job. Will figure  out how to re-introduce docker w/o breaking the release process soon. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
