### PR TITLE
JSDK-2474 - Update common_issues.md - chrome 76 + ios 2.2.0 incompatibility

### DIFF
--- a/COMMON_ISSUES.md
+++ b/COMMON_ISSUES.md
@@ -8,7 +8,6 @@ known or a workaround is available. Please also take a look at the
 release. If your issue hasn't been reported, consider submitting
 [a new issue](https://github.com/twilio/twilio-video.js/issues/new).
 
-
 Working around the browsers' autoplay policy
 --------------------------------------------
 
@@ -48,7 +47,7 @@ to ensure playback:
 Chrome 76+ DataTrack incompatibility with 2.X Mobile SDKs in P2P Rooms
 ----------------------------------------------------------------------
 
-Chrome 76 [added support](https://groups.google.com/forum/#!msg/discuss-webrtc/Y7TIuNbgP8M/UoXP-RuxAwAJ) for a [new SDP format](https://bugs.chromium.org/p/webrtc/issues/detail?id=4612) for data channel negotiation. This new SDP format is not compatible with 2.x Android and iOS Video SDKs when used with P2P Rooms. In a P2P room, Chrome 76+ Participants and affected mobile SDKs might not be able to subscribe to each other’s data tracks. Please refer to the upgrade paths listed in https://github.com/twilio/twilio-video-ios/issues/52 to address this issue.
+Chrome 76 [added support](https://groups.google.com/forum/#!msg/discuss-webrtc/Y7TIuNbgP8M/UoXP-RuxAwAJ) for a [new SDP format](https://bugs.chromium.org/p/webrtc/issues/detail?id=4612) for data channel negotiation. This new SDP format is not compatible with 2.x Android and iOS Video SDKs when used with P2P Rooms. In a P2P room, Chrome 76+ Participants and affected mobile SDKs might not be able to subscribe to each other’s data tracks. Please refer to the upgrade paths listed in [this issue](https://github.com/twilio/twilio-video-ios/issues/52) to address this.
 
 Firefox Participants are not able to recover media after network interruptions or handoffs
 ------------------------------------------------------------------------------------------

--- a/COMMON_ISSUES.md
+++ b/COMMON_ISSUES.md
@@ -44,10 +44,10 @@ to ensure playback:
   video.muted = true;
   ```
 
-Chrome 76+ DataTrack incompatibility with 2.X Mobile SDKs in P2P Rooms
-----------------------------------------------------------------------
+Chrome 76+ DataTrack incompatibility with 2.X Mobile SDKs in Peer-to-Peer Rooms
+-------------------------------------------------------------------------------
 
-Chrome 76 [added support](https://groups.google.com/forum/#!msg/discuss-webrtc/Y7TIuNbgP8M/UoXP-RuxAwAJ) for a [new SDP format](https://bugs.chromium.org/p/webrtc/issues/detail?id=4612) for data channel negotiation. This new SDP format is not compatible with 2.x Android and iOS Video SDKs when used with P2P Rooms. In a P2P room, Chrome 76+ Participants and affected mobile SDKs might not be able to subscribe to each other’s data tracks. Please refer to the upgrade paths listed in [this issue](https://github.com/twilio/twilio-video-ios/issues/52) to address this.
+Chrome 76 [added support](https://groups.google.com/forum/#!msg/discuss-webrtc/Y7TIuNbgP8M/UoXP-RuxAwAJ) for a [new SDP format](https://bugs.chromium.org/p/webrtc/issues/detail?id=4612) for RTCDataChannel negotiation. This new SDP format is not compatible with 2.x Android and iOS Video SDKs when used with Peer-to-Peer Rooms. In a Peer-to-Peer room, Chrome 76+ Participants and affected mobile SDKs might not be able to subscribe to each other’s DataTracks. Please refer to the upgrade paths listed in [this issue](https://github.com/twilio/twilio-video-ios/issues/52) to address this.
 
 Firefox Participants are not able to recover media after network interruptions or handoffs
 ------------------------------------------------------------------------------------------

--- a/COMMON_ISSUES.md
+++ b/COMMON_ISSUES.md
@@ -8,6 +8,7 @@ known or a workaround is available. Please also take a look at the
 release. If your issue hasn't been reported, consider submitting
 [a new issue](https://github.com/twilio/twilio-video.js/issues/new).
 
+
 Working around the browsers' autoplay policy
 --------------------------------------------
 
@@ -26,7 +27,7 @@ to ensure playback:
 
 - Make sure that the user interacts with your application before joining a Room.
   Here is an example:
-  
+
   ```js
   document.getElementById('join_room').addEventListener('click', () => {
     Twilio.Video.connect(token, {
@@ -38,11 +39,16 @@ to ensure playback:
 - If your application needs to join a Room on page load, set the `muted` attribute
   of the \<video\> element returned by `VideoTrack.attach()` to true. The autoplay
   policy allows muted video to be automatically played.
-  
+
   ```js
   const video = videoTrack.attach();
   video.muted = true;
   ```
+
+Chrome 76+ DataTrack incompatibility with 2.X Mobile SDKs in P2P Rooms
+----------------------------------------------------------------------
+
+Chrome 76 [added support](https://groups.google.com/forum/#!msg/discuss-webrtc/Y7TIuNbgP8M/UoXP-RuxAwAJ) for a [new SDP format](https://bugs.chromium.org/p/webrtc/issues/detail?id=4612) for data channel negotiation. This new SDP format is not compatible with 2.x Android and iOS Video SDKs when used with P2P Rooms. In a P2P room, Chrome 76+ Participants and affected mobile SDKs might not be able to subscribe to each other’s data tracks. Please refer to the upgrade paths listed in https://github.com/twilio/twilio-video-ios/issues/52 to address this issue.
 
 Firefox Participants are not able to recover media after network interruptions or handoffs
 ------------------------------------------------------------------------------------------


### PR DESCRIPTION
Update common_issues.md to mention Chrome 76 + older mobile sdk data track compatibility issue. This was brought up by a customer [here](https://github.com/twilio/twilio-video.js/issues/714), and @ceaglest created a explained it nicely [here](https://github.com/twilio/twilio-video-ios/issues/52) 
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
