### PR TITLE
JSDK-2488 Enabling DSCP tagging for video packets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 For 2.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/master/CHANGELOG.md).
 
+1.19.1 (in progress)
+====================
+
+New Features
+------------
+
+- Previously, we introduced a new ConnectOptions flag `dscpTagging` which tagged audio packets with
+  a DSCP header value to `0xb8` (Expedited Forwarding - EF). Now, enabling this flag will also tag video
+  packets with a DSCP header value of `0x88` (Assured Forwarding - AF41). (JSDK-2488)
+
 1.19.0 (August 21, 2019)
 ========================
 
@@ -9,7 +19,7 @@ New Features
 - You can now enable [DSCP tagging](https://tools.ietf.org/html/draft-ietf-tsvwg-rtcweb-qos-18) for audio
   packets on supported browsers (only Chrome supports this as of now) by setting a new ConnectOptions property
   `dscpTagging` to `true`. This will request enhanced QoS treatment for audio packets from any firewalls or
-  routers that support this feature. Audio packets will be sent with DSCP header value set to (0xb8) which
+  routers that support this feature. Audio packets will be sent with DSCP header value set to `0xb8` which
   corresponds to EF (Expedited Forwarding). (JSDK-2440)
 
   ```js

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -281,10 +281,12 @@ function connect(token, options) {
  * @property {boolean} [dominantSpeaker=false] - Whether to enable the Dominant
  *   Speaker API or not. This only takes effect in Group Rooms.
  * @property {boolean} [dscpTagging=false] - DSCP tagging allows you to request enhanced
- * QoS treatment for RTP media packets from any firewall that the client may be behind.
- * Setting this option to <code>true</code> will request DSCP tagging for audio packets
- * on supported browsers (only Chrome supports this as of now). Audio packets will be
- * sent with DSCP header value set to (0xb8) which corresponds to EF = Expedited Forwarding.
+ *   QoS treatment for RTP media packets from any firewall that the client may be behind.
+ *   Setting this option to <code>true</code> will request DSCP tagging for media packets
+ *   on supported browsers (only Chrome supports this as of now). Audio packets will be
+ *   sent with DSCP header value set to 0xb8 which corresponds to Expedited Forwarding (EF).
+ *   Video packets will be sent with DSCP header value set to 0x88 which corresponds to
+ *   Assured Forwarding (AF41).
  * @property {Array<RTCIceServer>} iceServers - Override the STUN and TURN
  *   servers used when connecting to {@link Room}s
  * @property {number} [iceServersTimeout=3000] - Override the amount of time, in

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1221,15 +1221,14 @@ function updateEncodingParameters(pcv2) {
   pcv2._peerConnection.getSenders().filter(sender => sender.track).forEach(sender => {
     const maxBitrate = maxBitrates.get(sender.track.kind);
     const params = sender.getParameters();
-    const networkPriority = pcv2._dscpTagging && sender.track.kind === 'audio' ? 'high' : null;
 
     if (isFirefox) {
       params.encodings = [{ maxBitrate }];
     } else {
       params.encodings.forEach(encoding => {
         encoding.maxBitrate = maxBitrate;
-        if (networkPriority) {
-          encoding.networkPriority = networkPriority;
+        if (pcv2._dscpTagging) {
+          encoding.networkPriority = 'high';
         }
       });
     }

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -466,23 +466,18 @@ describe('connect', function() {
           await new Promise(resolve => setTimeout(resolve, 5000));
         });
 
-        ['audio', 'video'].forEach(kind => {
-          const expectedNetworkPriority = isChrome ? {
-            audio: { true: 'high', false: 'low' },
-            video: { true: 'low', false: 'low' }
-          }[kind][dscpTagging || false] : undefined;
+        const expectedNetworkPriority = isChrome
+          ? { false: 'low', true: 'high' }[!!dscpTagging]
+          : undefined;
 
-          it(`networkPriority should ${expectedNetworkPriority ? `be set to "${expectedNetworkPriority}"` : 'not be set'} for ${kind} RTCRtpEncodingParameters`, () => {
-            flatMap(peerConnections, pc => {
-              return pc.getSenders().filter(sender => sender.track && sender.track.kind === kind);
-            }).forEach(sender => {
-              sender.getParameters().encodings.forEach(encoding => {
-                if (typeof expectedNetworkPriority === 'string') {
-                  assert.equal(encoding.networkPriority, expectedNetworkPriority);
-                } else {
-                  assert(!('networkPriority' in encoding));
-                }
-              });
+        it(`networkPriority should ${expectedNetworkPriority ? `be set to "${expectedNetworkPriority}"` : 'not be set'} for RTCRtpEncodingParameters`, () => {
+          flatMap(peerConnections, pc => pc.getSenders()).forEach(sender => {
+            sender.getParameters().encodings.forEach(encoding => {
+              if (typeof expectedNetworkPriority === 'string') {
+                assert.equal(encoding.networkPriority, expectedNetworkPriority);
+              } else {
+                assert(!('networkPriority' in encoding));
+              }
             });
           });
         });

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -679,7 +679,7 @@ describe('PeerConnectionV2', () => {
       ],
       [
         [true, false, undefined],
-        x => `When dscpTagging is set to ${x}`
+        x => `When dscpTagging is ${typeof x === 'undefined' ? 'not specified' : `set to ${x}`}`
       ],
     ], ([initial, signalingState, type, newerEqualOrOlder, matching, isRTCRtpSenderParamsSupported, dscpTagging]) => {
       // The Test
@@ -866,15 +866,17 @@ describe('PeerConnectionV2', () => {
         });
       }
 
-      function itShouldSetNetworkPriority() {
-        if (isRTCRtpSenderParamsSupported) {
-          it('should set networkPriority to high for audio track senders', () => {
+      function itShouldMaybeSetNetworkPriority() {
+        if (dscpTagging && isRTCRtpSenderParamsSupported) {
+          it('should set RTCRtpEncodingParameters.networkPriority to "high" all RTCRtpSenders', () => {
             test.pc.getSenders().forEach(sender => {
-              if (sender.track.kind === 'audio' && dscpTagging) {
-                  sinon.assert.calledWith(sender.setParameters, sinon.match.hasNested('encodings[0].networkPriority', 'high'));
-              } else {
-                  sinon.assert.neverCalledWith(sender.setParameters, sinon.match.hasNested('encodings[0].networkPriority', 'high'));
-              }
+              sinon.assert.calledWith(sender.setParameters, sinon.match.hasNested('encodings[0].networkPriority', 'high'));
+            });
+          });
+        } else {
+          it('should not try to set RTCRtpEncodingParameters.networkPriority to "high" all RTCRtpSenders', () => {
+            test.pc.getSenders().forEach(sender => {
+              sinon.assert.neverCalledWith(sender.setParameters, sinon.match.hasNested('encodings[0].networkPriority', 'high'));
             });
           });
         }
@@ -921,7 +923,7 @@ describe('PeerConnectionV2', () => {
 
         itShouldApplyBandwidthConstraints();
         itShouldApplyCodecPreferences();
-        itShouldSetNetworkPriority();
+        itShouldMaybeSetNetworkPriority();
       }
 
       function itMightEventuallyAnswer() {


### PR DESCRIPTION
@makarandp0 @aymenn 

This PR enables DSCP tagging for video packets when `dscpTagging` is enabled.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
