### PR TITLE
JSDK-2484 bubbleup publish priority changed

### DIFF
--- a/lib/remoteparticipant.js
+++ b/lib/remoteparticipant.js
@@ -19,6 +19,7 @@ const Participant = require('./participant');
  * @emits RemoteParticipant#trackEnabled
  * @emits RemoteParticipant#trackMessage
  * @emits RemoteParticipant#trackPublished
+ * @emits RemoteParticipant#trackPublishPriorityChanged
  * @emits RemoteParticipant#trackStarted
  * @emits RemoteParticipant#trackSubscribed
  * @emits RemoteParticipant#trackSubscriptionFailed
@@ -81,6 +82,7 @@ class RemoteParticipant extends Participant {
       ['subscriptionFailed', 'trackSubscriptionFailed'],
       ['trackDisabled', 'trackDisabled'],
       ['trackEnabled', 'trackEnabled'],
+      ['publishPriorityChanged', 'trackPublishPriorityChanged'],
       ['trackSwitchedOff', 'trackSwitchedOff'],
       ['trackSwitchedOn', 'trackSwitchedOn']
     ];
@@ -212,6 +214,17 @@ class RemoteParticipant extends Participant {
  * @param {RemoteTrackPublication} publication - The {@link RemoteTrackPublication}
  *   for the {@link RemoteTrack} that was switched off
  * @event RemoteParticipant#trackSwitchedOff
+ */
+
+/**
+ * The {@link RemoteTrack}'s publish {@link Track.Priority} was changed.
+ * @param {Track.Priority} priority - the {@link RemoteTrack}'s new publish
+ *   {@link Track.Priority};
+ * @param {RemoteTrackPublication} publication - The
+ *   {@link RemoteTrackPublication} for the {@link RemoteTrack} that changed priority
+ * @param {RemoteParticipant} participant - The {@link RemoteParticipant} whose
+ *   {@link RemoteTrack} changed priority
+ * @event Room#trackPublishPriorityChanged
  */
 
 /**

--- a/lib/room.js
+++ b/lib/room.js
@@ -38,6 +38,7 @@ let nInstances = 0;
  * @emits Room#trackEnabled
  * @emits Room#trackMessage
  * @emits Room#trackPublished
+ * @emits Room#trackPublishPriorityChanged
  * @emits Room#trackStarted
  * @emits Room#trackSubscribed
  * @emits Room#trackSwitchedOff
@@ -378,6 +379,18 @@ function rewriteLocalTrackIds(room, trackStats) {
  */
 
 /**
+ * The {@link RemoteTrack}'s publish {@link Track.Priority} was changed by the
+ * {@link RemoteParticipant}.
+ * @param {Track.Priority} priority - the {@link RemoteTrack}'s new publish
+ *   {@link Track.Priority};
+ * @param {RemoteTrackPublication} publication - The
+ *   {@link RemoteTrackPublication} for the {@link RemoteTrack} that changed priority
+ * @param {RemoteParticipant} participant - The {@link RemoteParticipant} whose
+ *   {@link RemoteTrack} changed priority
+ * @event Room#trackPublishPriorityChanged
+ */
+
+/**
  * A {@link RemoteTrack} was unpublished by a {@link RemoteParticipant} to the {@link Room}.
  * @event Room#trackUnpublished
  * @param {RemoteTrackPublication} publication - The {@link RemoteTrackPublication}
@@ -417,6 +430,7 @@ function connectParticipant(room, participantSignaling) {
     'trackEnabled',
     'trackMessage',
     'trackPublished',
+    'trackPublishPriorityChanged',
     'trackStarted',
     'trackSubscribed',
     'trackSubscriptionFailed',


### PR DESCRIPTION
**WIP**
This change bubbles up `publishPriorityChange` event from trackSubscription to participant and room objects.

TODO:
- [ ] Add integration test once #733 merges
- [ ] Add CHANGELOG entry
- [ ] Rebase once #733  merges.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
