### PR TITLE
initial circleci config that disables circleci builds. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,5 @@ jobs:
         - /.*circleci.*/
     docker:
       - image: circleci/node:lts
-    parallelism: 3
-    resource_class: large
     steps:
-      - run: echo Hello there!
+      - run: echo building $CIRCLE_BRANCH !


### PR DESCRIPTION
To start experimenting with circleCI, I needed to enable circleCI builds for this repo. Currently they run and fail for the branches that do not have `.circleci/config.yml`.

This placeholder config will instruct circleCI to not run builds for any brach that does not match `/.*circleci.*/` 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
