### PR TITLE
JSDK-2509 - Instead of setting maxBitrate to 0, remove the property instead.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,7 @@ before_script:
     set -e
     cd node_modules/travis-multirunner
     if [ "${TRAVIS_OS_NAME}" == 'linux' ]; then
+      sudo apt-get install -y dpkg
       BROWSER=chrome ./setup.sh
       BROWSER=firefox ./setup.sh
       export CHROME_BIN=$(pwd)/browsers/bin/chrome-$BVER

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 For 2.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/master/CHANGELOG.md).
 
+1.19.2 (in progress)
+====================
+
+Bug Fixes
+---------
+
+- Fixed a bug where LocalVideoTracks were being published at a very low bitrate even
+  when there was sufficient bandwidth to publish at higher bitrates. (JSDK-2509)
+
 1.19.1 (August 28, 2019)
 ========================
 

--- a/COMMON_ISSUES.md
+++ b/COMMON_ISSUES.md
@@ -44,6 +44,24 @@ to ensure playback:
   video.muted = true;
   ```
 
+Chrome 76+ Group Room Participants downgrade outgoing video bitrate for high `maxAudioBitrate` values
+-----------------------------------------------------------------------------------------------------
+
+Because of this [bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1002875), if you
+set the maximum outgoing audio bitrate (`maxAudioBitrate`) to values greater than or equal to
+64000 bps in a Group Room, then the outgoing video bitrate gets stuck at a very low value
+resulting in degraded quality for Participants subscribing to your VideoTrack.
+
+Chrome 76+ DataTrack incompatibility with 2.X Mobile SDKs in Peer-to-Peer Rooms
+-------------------------------------------------------------------------------
+
+Chrome 76 [added support](https://groups.google.com/forum/#!msg/discuss-webrtc/Y7TIuNbgP8M/UoXP-RuxAwAJ) for a
+[new SDP format](https://bugs.chromium.org/p/webrtc/issues/detail?id=4612) for RTCDataChannel negotiation. This
+new SDP format is not compatible with 2.x Android and iOS Video SDKs when used with Peer-to-Peer Rooms. In a
+Peer-to-Peer room, Chrome 76+ Participants and affected mobile SDKs might not be able to subscribe to each other’s
+DataTracks. Please refer to the upgrade paths listed in [this issue](https://github.com/twilio/twilio-video-ios/issues/52)
+to address this.
+
 Firefox Participants cannot constrain their audio bandwidth
 -----------------------------------------------------------
 

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1222,26 +1222,52 @@ function updateEncodingParameters(pcv2) {
     const maxBitrate = maxBitrates.get(sender.track.kind);
     const params = sender.getParameters();
 
-    if (isFirefox) {
-      params.encodings = [{ maxBitrate }];
+    if (maxBitrate === null || maxBitrate === 0) {
+      removeMaxBitrate(params);
     } else {
-      params.encodings.forEach(encoding => {
-        encoding.maxBitrate = maxBitrate;
-      });
-      if (pcv2._dscpTagging && params.encodings.length > 0) {
-        // NOTE(mmalavalli): "networkPriority" is a per-sender property and not
-        // a per-encoding-layer property. So, we set the value only on the first
-        // encoding layer. Any attempt to set the value on subsequent encoding
-        // layers (in the case of simulcast) will result in the Promise returned
-        // by RTCRtpSender.setParameters() being rejected.
-        params.encodings[0].networkPriority = 'high';
-      }
+      setMaxBitrate(params, maxBitrate);
+    }
+
+    if (!isFirefox && pcv2._dscpTagging && params.encodings.length > 0) {
+      // NOTE(mmalavalli): "networkPriority" is a per-sender property and not
+      // a per-encoding-layer property. So, we set the value only on the first
+      // encoding layer. Any attempt to set the value on subsequent encoding
+      // layers (in the case of simulcast) will result in the Promise returned
+      // by RTCRtpSender.setParameters() being rejected.
+      params.encodings[0].networkPriority = 'high';
     }
 
     sender.setParameters(params).catch(error => {
       pcv2._log.warn(`Error while setting encodings parameters for ${sender.track.kind} Track ${sender.track.id}: ${error.message || error.name}`);
     });
   });
+}
+
+/**
+ * Remove maxBitrate from the RTCRtpSendParameters' encodings.
+ * @param {RTCRtpSendParameters} params
+ * @returns {void}
+ */
+function removeMaxBitrate(params) {
+  if (Array.isArray(params.encodings)) {
+    params.encodings.forEach(encoding => delete encoding.maxBitrate);
+  }
+}
+
+/**
+ * Set the given maxBitrate in the RTCRtpSendParameters' encodings.
+ * @param {RTCRtpSendParameters} params
+ * @param {number} maxBitrate
+ * @returns {void}
+ */
+function setMaxBitrate(params, maxBitrate) {
+  if (isFirefox) {
+    params.encodings = [{ maxBitrate }];
+  } else {
+    params.encodings.forEach(encoding => {
+      encoding.maxBitrate = maxBitrate;
+    });
+  }
 }
 
 module.exports = PeerConnectionV2;

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -508,12 +508,12 @@ describe('connect', function() {
   describe('called with EncodingParameters', () => {
     combinationContext([
       [
-        [undefined, null, 20000],
-        x => `when .maxAudioBitrate is ${typeof x === 'undefined' ? 'absent' : x ? 'present' : 'null'}`
+        [undefined, null, 20000, 0],
+        x => `when .maxAudioBitrate is ${typeof x === 'undefined' ? 'absent' : x}`
       ],
       [
-        [undefined, null, 40000],
-        x => `when .maxVideoBitrate is ${typeof x === 'undefined' ? 'absent' : x ? 'present' : 'null'}`
+        [undefined, null, 40000, 0],
+        x => `when .maxVideoBitrate is ${typeof x === 'undefined' ? 'absent' : x}`
       ]
     ], ([maxAudioBitrate, maxVideoBitrate]) => {
       const encodingParameters = [
@@ -551,10 +551,14 @@ describe('connect', function() {
         it(`should ${maxBitrates[kind] ? '' : 'not '}set the .max${capitalize(kind)}Bitrate`, () => {
           if (isRTCRtpSenderParamsSupported) {
             flatMap(peerConnections, pc => {
-              return pc.getSenders().filter(sender => sender.track);
+              return pc.getSenders().filter(({ track }) => track && track.kind === kind);
             }).forEach(sender => {
               const { encodings } = sender.getParameters();
-              encodings.forEach(({ maxBitrate }) => assert.equal(maxBitrate, maxBitrates[sender.track.kind] || 0));
+              if (maxBitrates[kind]) {
+                encodings.forEach(encoding => assert.equal(encoding.maxBitrate, maxBitrates[kind]));
+              } else {
+                encodings.forEach(encoding => assert.equal('maxBitrate' in encoding, false));
+              }
             });
             return;
           }

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -1005,12 +1005,12 @@ describe('LocalParticipant', function() {
 
     combinationContext([
       [
-        [undefined, null, 25000],
-        x => `when .maxAudioBitrate is ${typeof x === 'undefined' ? 'absent' : x ? 'present' : 'null'}`
+        [undefined, null, 25000, 0],
+        x => `when .maxAudioBitrate is ${typeof x === 'undefined' ? 'absent' : x}`
       ],
       [
-        [undefined, null, 45000],
-        x => `when .maxVideoBitrate is ${typeof x === 'undefined' ? 'absent' : x ? 'present' : 'null'}`
+        [undefined, null, 45000, 0],
+        x => `when .maxVideoBitrate is ${typeof x === 'undefined' ? 'absent' : x}`
       ]
     ], ([maxAudioBitrate, maxVideoBitrate]) => {
       const encodingParameters = [
@@ -1095,9 +1095,13 @@ describe('LocalParticipant', function() {
           if (isRTCRtpSenderParamsSupported) {
             senders.filter(({ track }) => track.kind === kind).forEach(sender => {
               const { encodings } = sender.getParameters();
-              encodings.forEach(({ maxBitrate }) => assert.equal(maxBitrate, action === 'preserve'
-                ? initialEncodingParameters[`max${capitalize(kind)}Bitrate`]
-                : maxBitrates[sender.track.kind] || 0));
+              if (action === 'preserve') {
+                encodings.forEach(({ maxBitrate }) => assert.equal(maxBitrate, initialEncodingParameters[`max${capitalize(kind)}Bitrate`]));
+              } else if (action === 'set') {
+                encodings.forEach(({ maxBitrate }) => assert.equal(maxBitrate, maxBitrates[kind]));
+              } else {
+                encodings.forEach(encoding => assert.equal('maxBitrate' in encoding, false));
+              }
             });
             return;
           }


### PR DESCRIPTION
@makarandp0 

Porting the changes to fix JSDK-2509 from #743 .

* Instead of setting maxBitrate to 0, remove the property instead.
* Adding CHANGELOG.md entry.
* Adding COMMON_ISSUES.md entry.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
