### PR TITLE
JSDK-2490 enable/disable MediaStream track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/support-1.x/CHANGELOG.md).
 
-2.0.0-beta15 (In Progress)
+2.0.0-beta15 (In progress)
 ==========================
 
 Bug Fixes
 ---------
 
-- Worked around an [issue](https://bugs.chromium.org/p/chromium/issues/detail?id=749928)
-  in Chrome and Safari where browser continued to play WebRTC-based MediaStreamTrack even
-  after corresponding `audio` element was removed from the DOM. With this fix twilio-video.js
+- Worked around a bug in [Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=749928)
+  and Safari where browser continued to play WebRTC-based MediaStreamTrack even after
+  corresponding `audio` element was removed from the DOM. With this fix twilio-video.js
   now disables any RemoteMediaTrack when it's not attached to any media elements. (JSDK-2490)
 
 2.0.0-beta14 (September 17, 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/support-1.x/CHANGELOG.md).
 
+2.0.0-beta15 (In Progress)
+==========================
+
+Bug Fixes
+---------
+
+- Worked around an [issue](https://bugs.chromium.org/p/chromium/issues/detail?id=749928)
+  in Chrome and Safari where browser continued to play WebRTC-based MediaStreamTrack even
+  after corresponding `audio` element was removed from the DOM. With this fix twilio-video.js
+  now disables any RemoteMediaTrack when it's not attached to any media elements. (JSDK-2490)
+
 2.0.0-beta14 (September 17, 2019)
 =================================
 
@@ -46,7 +57,7 @@ New Features
         }
       }
     }
-  });  
+  });
   ```
 
   ### Track Priority (private beta)
@@ -68,7 +79,7 @@ New Features
   to other Tracks that may be published to the Room. The media server takes this into
   account while allocating a subscribing RemoteParticipant's bandwidth to the corresponding
   RemoteTrack. If you do not specify a priority, then it defaults to `standard`.
-  
+
   You can also find out about the priorities of RemoteTracks published by other
   RemoteParticipants by accessing a new property `publishPriority` on the corresponding
   RemoteTrackPublications:

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -221,7 +221,6 @@ class MediaTrack extends Track {
     }
 
     this._attachments.delete(el);
-
     return el;
   }
 

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -159,6 +159,9 @@ class MediaTrack extends Track {
       this._attachments.add(el);
     }
 
+    // enable the track;
+    this.mediaStreamTrack.enabled = true;
+
     return el;
   }
 
@@ -218,17 +221,20 @@ class MediaTrack extends Track {
     const mediaStream = el.srcObject;
     if (mediaStream instanceof this._MediaStream) {
       mediaStream.removeTrack(this.mediaStreamTrack);
-      // NOTE(mroberts): It's as if, in Chrome and Safari, the <audio> element's
-      // `srcObject` setter is taking a "snapshot" of the MediaStream's
-      // MediaStreamTracks in order to playback; hence, calls to `removeTrack`
-      // don't take effect unless you set the <audio> element's `srcObject` again.
-      //
-      //   https://bugs.chromium.org/p/chromium/issues/detail?id=749928
-      //
-      el.srcObject = mediaStream;
     }
 
     this._attachments.delete(el);
+
+    if (this._attachments.size === 0) {
+      // NOTE(mpatwardhan): chrome continues playing audio track
+      // even after audio element is removed from the DOM.
+      // Removing track from the stream does not work either.
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=749928
+      // So here we mark the track.enabled = false when there are
+      // no elements attached to it.
+      this.mediaStreamTrack.enabled = false;
+    }
+
     return el;
   }
 

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -159,9 +159,6 @@ class MediaTrack extends Track {
       this._attachments.add(el);
     }
 
-    // enable the track;
-    this.mediaStreamTrack.enabled = true;
-
     return el;
   }
 
@@ -224,16 +221,6 @@ class MediaTrack extends Track {
     }
 
     this._attachments.delete(el);
-
-    if (this._attachments.size === 0) {
-      // NOTE(mpatwardhan): chrome continues playing audio track
-      // even after audio element is removed from the DOM.
-      // Removing track from the stream does not work either.
-      // https://bugs.chromium.org/p/chromium/issues/detail?id=749928
-      // So here we mark the track.enabled = false when there are
-      // no elements attached to it.
-      this.mediaStreamTrack.enabled = false;
-    }
 
     return el;
   }

--- a/lib/media/track/remotemediatrack.js
+++ b/lib/media/track/remotemediatrack.js
@@ -77,10 +77,8 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
       const result = super.attach(el);
       if (this.mediaStreamTrack.enabled !== true) {
         // NOTE(mpatwardhan): we disable mediaStreamTrack when there
-        // are no attchments to it (see notes below). Now that there are attachments.
-        // reenable the track.
-        // eslint-disable-next-line no-console
-        console.log('enabling the track: ', this.sid);
+        // are no attchments to it (see notes below). Now that there
+        // are attachments reenable the track.
         this.mediaStreamTrack.enabled = true;
       }
       return result;
@@ -89,8 +87,6 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
     detach(el) {
       const result = super.detach(el);
       if (this._attachments.size === 0) {
-        // eslint-disable-next-line no-console
-        console.log('disabling the track: ', this.sid);
         // NOTE(mpatwardhan): chrome continues playing webrtc audio
         // track even after audio element is removed from the DOM.
         // https://bugs.chromium.org/p/chromium/issues/detail?id=749928

--- a/lib/media/track/remotemediatrack.js
+++ b/lib/media/track/remotemediatrack.js
@@ -72,6 +72,35 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
         this.emit(isSwitchedOff ? 'switchedOff' : 'switchedOn', this);
       }
     }
+
+    attach(el) {
+      const result = super.attach(el);
+      if (this.mediaStreamTrack.enabled !== true) {
+        // NOTE(mpatwardhan): we disable mediaStreamTrack when there
+        // are no attchments to it (see notes below). Now that there are attachments.
+        // reenable the track.
+        // eslint-disable-next-line no-console
+        console.log('enabling the track: ', this.sid);
+        this.mediaStreamTrack.enabled = true;
+      }
+      return result;
+
+    }
+
+    detach(el) {
+      const result = super.detach(el);
+      if (this._attachments.size === 0) {
+        // eslint-disable-next-line no-console
+        console.log('disabling the track: ', this.sid);
+        // NOTE(mpatwardhan): chrome continues playing webrtc audio
+        // track even after audio element is removed from the DOM.
+        // https://bugs.chromium.org/p/chromium/issues/detail?id=749928
+        // to workaround: here disable the track when
+        // there are no elements attached to it.
+        this.mediaStreamTrack.enabled = false;
+      }
+      return result;
+    }
   };
 }
 

--- a/lib/media/track/remotemediatrack.js
+++ b/lib/media/track/remotemediatrack.js
@@ -84,7 +84,6 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
         this.mediaStreamTrack.enabled = true;
       }
       return result;
-
     }
 
     detach(el) {

--- a/test/unit/spec/media/track/remotemediatrack.js
+++ b/test/unit/spec/media/track/remotemediatrack.js
@@ -298,6 +298,5 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
 function makeTrack(id, sid, kind, isEnabled, options, RemoteTrack) {
   const mediaStreamTrack = new FakeMediaStreamTrack(kind);
   const mediaTrackReceiver = new MediaTrackReceiver(id, mediaStreamTrack);
-  let track = new RemoteTrack(sid, mediaTrackReceiver, isEnabled, options);
-  return track;
+  return new RemoteTrack(sid, mediaTrackReceiver, isEnabled, options);
 }


### PR DESCRIPTION
This change  workarounds an [issue in chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=749928) where it continues to play audio even when audio element is not part of the DOM.

The matters were more complicated because we always create a dummy media element (audio/video)  at the start of media track creation (https://github.com/twilio/twilio-video.js/blob/JSDK_2490_audio_detached/lib/media/track/mediatrack.js#L102)

With this fix we will use `enabled` [property of MediaStreamTrack](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/enabled) 

We will mark the `track.enabled = false` when its not attached to any element - This prevents it from rendering into the MediaStream.

To see this fix in action: checkout https://github.com/twilio/video-quickstart-js/tree/JSDK-2490-detach-tracks,  which lets you attach/detach tracks individually. Notice that before the fix, detached audio track continue to play.

TODO
- [x] update CHANGELOG
> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
