### PR TITLE
JSDK-2515 - Video.isSupported should return false for Edge

### DIFF
--- a/lib/util/support.js
+++ b/lib/util/support.js
@@ -25,10 +25,10 @@ function isGetUserMediaSupported() {
 }
 
 /**
- * @returns {boolean} - true if the browser is explicitely unsupported.
+ * @returns {boolean} - true if the browser is explicitly unsupported.
  *  Note: this function returning false does not mean that browser is supported.
  */
-function isExplicitelyUnsupportedBrowser() {
+function isExplicitlyUnsupportedBrowser() {
   if (typeof navigator !== 'undefined' && typeof navigator.userAgent === 'string') {
     return /Edge/.test(navigator.userAgent);
   }
@@ -40,7 +40,7 @@ function isExplicitelyUnsupportedBrowser() {
  * @returns {boolean}
  */
 function isSupported() {
-  return !isExplicitelyUnsupportedBrowser()
+  return !isExplicitlyUnsupportedBrowser()
     && !!guessBrowser()
     && isGetUserMediaSupported()
     && isRTCPeerConnectionSupported();

--- a/lib/util/support.js
+++ b/lib/util/support.js
@@ -25,11 +25,23 @@ function isGetUserMediaSupported() {
 }
 
 /**
+ * @returns {boolean} - true if the browser is explicitely unsupported.
+ *  Note: this function returning false does not mean that browser is supported.
+ */
+function isExplicitelyUnsupportedBrowser() {
+  if (typeof navigator !== 'undefined' && typeof navigator.userAgent === 'string') {
+    return /Edge/.test(navigator.userAgent);
+  }
+  return false;
+}
+
+/**
  * Check if the current environment is supported by the SDK.
  * @returns {boolean}
  */
 function isSupported() {
-  return !!guessBrowser()
+  return !isExplicitelyUnsupportedBrowser()
+    && !!guessBrowser()
     && isGetUserMediaSupported()
     && isRTCPeerConnectionSupported();
 }

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -64,6 +64,7 @@ require('./spec/util/insightspublisher');
 require('./spec/util/log');
 require('./spec/util/sdp');
 require('./spec/util/sdp/issue8329');
+require('./spec/util/support');
 require('./spec/util/trackmatcher/mid');
 require('./spec/util/trackmatcher/ordered');
 require('./spec/util/twilioerror');

--- a/test/unit/spec/util/support.js
+++ b/test/unit/spec/util/support.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const assert = require('assert');
+// const { EventEmitter } = require('events');
+// const sinon = require('sinon');
+
+const isSupported = require('../../../../lib/util/support');
+
+describe.only('isSupported', () => {
+
+  let oldAgent;
+  before(() => {
+    // save useragent.
+    oldAgent = navigator.userAgent;
+  });
+
+  after(() => {
+    // restore useragent.
+    navigator.userAgent = oldAgent;
+  });
+
+  [
+    [
+      'chrome on windows',
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36'
+    ],
+    [
+      'chrome on mac',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36'
+    ],
+    [
+      'safari on mac',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13 Safari/605.1.15'
+    ],
+    [
+      'safari on ipad',
+      'Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13 Mobile/15E148 Safari/604.1'
+    ],
+    [
+      'safari on iphone touch',
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13 Mobile/15E148 Safari/604.1'
+    ],
+    [
+      'firefox on windows',
+      'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:54.0) Gecko/20100101 Firefox/69.0'
+    ],
+    [
+      'firefox on mac',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:61.0) Gecko/20100101 Firefox/69.0'
+    ],
+    [
+      'firefox on linux',
+      'Mozilla/5.0 (X11; Linux i586; rv:31.0) Gecko/20100101 Firefox/69.0'
+    ],
+  ].forEach(([browser, useragent]) => {
+    it('returns true for: ' + browser, () => {
+      navigator.userAgent = useragent;
+      assert.equal(isSupported(), true);
+    });
+  });
+
+  [
+    [
+      'Edge 42',
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64; Xbox; Xbox One) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.15063'
+    ],
+    [
+      'Edge 25',
+      'Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586'
+    ],
+    [
+      'Another Edge',
+      'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0'
+    ],
+    [
+      'Just anything with Edge in it',
+      'Foo Edge Bar'
+    ],
+  ].forEach(([browser, useragent]) => {
+    it('returns false for unsupported browser : ' + browser, () => {
+      navigator.userAgent = useragent;
+      assert.equal(isSupported(), false);
+    });
+  });
+});

--- a/test/unit/spec/util/support.js
+++ b/test/unit/spec/util/support.js
@@ -3,8 +3,7 @@
 const assert = require('assert');
 const isSupported = require('../../../../lib/util/support');
 
-describe.only('isSupported', () => {
-
+describe('isSupported', () => {
   let oldAgent;
   before(() => {
     oldAgent = navigator.userAgent;
@@ -72,7 +71,7 @@ describe.only('isSupported', () => {
       'Foo Edge Bar'
     ],
   ].forEach(([browser, useragent]) => {
-    it('returns false for explicitely unsupported browser: ' + browser, () => {
+    it('returns false for explicitly unsupported browser: ' + browser, () => {
       navigator.userAgent = useragent;
       assert.equal(isSupported(), false);
     });

--- a/test/unit/spec/util/support.js
+++ b/test/unit/spec/util/support.js
@@ -1,59 +1,54 @@
 'use strict';
 
 const assert = require('assert');
-// const { EventEmitter } = require('events');
-// const sinon = require('sinon');
-
 const isSupported = require('../../../../lib/util/support');
 
 describe.only('isSupported', () => {
 
   let oldAgent;
   before(() => {
-    // save useragent.
     oldAgent = navigator.userAgent;
   });
 
   after(() => {
-    // restore useragent.
     navigator.userAgent = oldAgent;
   });
 
   [
     [
-      'chrome on windows',
+      'Chrome on Windows',
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36'
     ],
     [
-      'chrome on mac',
+      'Chrome on Mac',
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36'
     ],
     [
-      'safari on mac',
+      'Safari on Mac',
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13 Safari/605.1.15'
     ],
     [
-      'safari on ipad',
+      'Safari on iPad',
       'Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13 Mobile/15E148 Safari/604.1'
     ],
     [
-      'safari on iphone touch',
+      'Safari on iPhone',
       'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13 Mobile/15E148 Safari/604.1'
     ],
     [
-      'firefox on windows',
+      'Firefox on Windows',
       'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:54.0) Gecko/20100101 Firefox/69.0'
     ],
     [
-      'firefox on mac',
+      'Firefox on Mac',
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:61.0) Gecko/20100101 Firefox/69.0'
     ],
     [
-      'firefox on linux',
+      'Firefox on Linux',
       'Mozilla/5.0 (X11; Linux i586; rv:31.0) Gecko/20100101 Firefox/69.0'
     ],
   ].forEach(([browser, useragent]) => {
-    it('returns true for: ' + browser, () => {
+    it('returns true for supported browser: ' + browser, () => {
       navigator.userAgent = useragent;
       assert.equal(isSupported(), true);
     });
@@ -77,7 +72,7 @@ describe.only('isSupported', () => {
       'Foo Edge Bar'
     ],
   ].forEach(([browser, useragent]) => {
-    it('returns false for unsupported browser : ' + browser, () => {
+    it('returns false for explicitely unsupported browser: ' + browser, () => {
       navigator.userAgent = useragent;
       assert.equal(isSupported(), false);
     });


### PR DESCRIPTION
This came up as a github [issue](https://github.com/twilio/twilio-video.js/issues/748). Since we do not officially support Edge, `isSupported` should return false for edge. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
