### PR TITLE
JSDK-2320: doc'ed isSupported

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -47,6 +47,7 @@ let didPrintDscpTaggingWarning = false;
  *   {@link LocalAudioTrack} and {@link LocalVideoTrack} automatically, you can
  *   pass your own array which you can stop yourself. See {@link ConnectOptions}
  *   for more information.
+ * @alias module:twilio-video.connect
  * @param {string} token - The Access Token string
  * @param {ConnectOptions} [options] - Options to override the default behavior
  * @returns {CancelablePromise<Room>}

--- a/lib/createlocaltrack.js
+++ b/lib/createlocaltrack.js
@@ -58,7 +58,7 @@ function createLocalAudioTrack(options) {
 }
 
 /**
-  * Request a {@link LocalVideoTrack}.
+ * Request a {@link LocalVideoTrack}.
  * @alias module:twilio-video.createLocalVideoTrack
  * @param {CreateLocalTrackOptions} [options] - Options for requesting a {@link LocalVideoTrack}
  * @returns {Promise<LocalVideoTrack>}

--- a/lib/createlocaltrack.js
+++ b/lib/createlocaltrack.js
@@ -29,6 +29,7 @@ function createLocalTrack(kind, options) {
 
 /**
  * Request a {@link LocalAudioTrack}.
+ * @alias module:twilio-video.createLocalAudioTrack
  * @param {CreateLocalTrackOptions} [options] - Options for requesting a {@link LocalAudioTrack}
  * @returns {Promise<LocalAudioTrack>}
  * @example
@@ -57,7 +58,8 @@ function createLocalAudioTrack(options) {
 }
 
 /**
- * Request a {@link LocalVideoTrack}.
+  * Request a {@link LocalVideoTrack}.
+ * @alias module:twilio-video.createLocalVideoTrack
  * @param {CreateLocalTrackOptions} [options] - Options for requesting a {@link LocalVideoTrack}
  * @returns {Promise<LocalVideoTrack>}
  * @example

--- a/lib/createlocaltracks.js
+++ b/lib/createlocaltracks.js
@@ -19,6 +19,7 @@ let createLocalTrackCalls = 0;
 /**
  * Request {@link LocalTrack}s. By default, it requests a
  * {@link LocalAudioTrack} and a {@link LocalVideoTrack}.
+ * @alias module:twilio-video.createLocalTracks
  * @param {CreateLocalTracksOptions} [options]
  * @returns {Promise<Array<LocalTrack>>}
  * @example

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,8 @@
 'use strict';
 /**
  * @module twilio-video
- * @property {boolean} isSupported - true if the current browser is officially supported by the SDK.
- * @property {string} version - current twilio-video SDK version
+ * @property {boolean} isSupported - true if the current browser is officially supported by twilio-video.js.
+ * @property {string} version - current version of twilio-video.js.
  */
 const version = require('../package.json').version;
 const Video = {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,12 @@
 'use strict';
 /**
- * twilio-video module.
  * @module twilio-video
  * @property {boolean} isSupported - true if the current browser is officially supported by the SDK.
- * @property {string} version -  current SDK version
+ * @property {string} version - current twilio-video SDK version
  */
 const version = require('../package.json').version;
 const Video = {};
+
 Object.defineProperties(Video, {
   connect: {
     enumerable: true,

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,12 @@
 'use strict';
-
+/**
+ * twilio-video module.
+ * @module twilio-video
+ * @property {boolean} isSupported - true if the current browser is officially supported by the SDK.
+ * @property {string} version -  current SDK version
+ */
 const version = require('../package.json').version;
 const Video = {};
-
 Object.defineProperties(Video, {
   connect: {
     enumerable: true,

--- a/lib/media/track/localaudiotrack.js
+++ b/lib/media/track/localaudiotrack.js
@@ -12,6 +12,7 @@ const LocalMediaAudioTrack = mixinLocalMediaTrack(AudioTrack);
  * {@link LocalAudioTrack#disable} or stopped completely with
  * {@link LocalAudioTrack#stop}.
  * @extends AudioTrack
+ * @alias module:twilio-video.LocalAudioTrack
  * @property {Track.ID} id - The {@link LocalAudioTrack}'s ID
  * @property {boolean} isStopped - Whether or not the {@link LocalAudioTrack} is
  *   stopped

--- a/lib/media/track/localdatatrack.js
+++ b/lib/media/track/localdatatrack.js
@@ -54,7 +54,7 @@ const DefaultDataTrackSender = require('../../data/sender');
  */
 class LocalDataTrack extends Track {
   /**
-   * Construct a {@link LocalDataTrack} and alises
+   * Construct a {@link LocalDataTrack}
    * @param {LocalDataTrackOptions} [options] - {@link LocalDataTrack} options
    */
   constructor(options) {

--- a/lib/media/track/localdatatrack.js
+++ b/lib/media/track/localdatatrack.js
@@ -54,7 +54,7 @@ const DefaultDataTrackSender = require('../../data/sender');
  */
 class LocalDataTrack extends Track {
   /**
-   * Construct a {@link LocalDataTrack}
+   * Construct a {@link LocalDataTrack}.
    * @param {LocalDataTrackOptions} [options] - {@link LocalDataTrack} options
    */
   constructor(options) {

--- a/lib/media/track/localdatatrack.js
+++ b/lib/media/track/localdatatrack.js
@@ -7,6 +7,7 @@ const DefaultDataTrackSender = require('../../data/sender');
  * A {@link LocalDataTrack} is a {@link Track} representing data that your
  * {@link LocalParticipant} can publish to a {@link Room}.
  * @extends Track
+ * @alias module:twilio-video.LocalDataTrack
  * @property {Track.ID} id - The {@link LocalDataTrack}'s ID
  * @property {Track.Kind} kind - "data"
  * @property {?number} maxPacketLifeTime - If non-null, this represents a time
@@ -53,7 +54,7 @@ const DefaultDataTrackSender = require('../../data/sender');
  */
 class LocalDataTrack extends Track {
   /**
-   * Construct a {@link LocalDataTrack}.
+   * Construct a {@link LocalDataTrack} and alises
    * @param {LocalDataTrackOptions} [options] - {@link LocalDataTrack} options
    */
   constructor(options) {

--- a/lib/media/track/localvideotrack.js
+++ b/lib/media/track/localvideotrack.js
@@ -12,6 +12,7 @@ const LocalMediaVideoTrack = mixinLocalMediaTrack(VideoTrack);
  * {@link LocalVideoTrack#disable} or stopped completely with
  * {@link LocalVideoTrack#stop}.
  * @extends VideoTrack
+ * @alias module:twilio-video.LocalVideoTrack
  * @property {Track.ID} id - The {@link LocalVideoTrack}'s ID
  * @property {boolean} isStopped - Whether or not the {@link LocalVideoTrack} is
  *   stopped

--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -13,6 +13,7 @@ const publicClasses = [
   'lib/connect.js',
   'lib/createlocaltrack.js',
   'lib/createlocaltracks.js',
+  'lib/index.js',
   'lib/room.js',
   'lib/media/track/index.js',
   'lib/media/track/audiotrack.js',


### PR DESCRIPTION
Documented `isSupported` and `version` properties of the twilio-video SDK.
While at it, also updated the docs to declare twilio-video as a module, and all direct methods/properties/classes off it are now listed under the module instead of Globals.  

- [ ] 1.x change: #754 
- [ ] video-docs change: https://github.com/twilio/video-docs/pull/255

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
