### PR TITLE
JSDK-2522 - Fix SDP error raised by a Participant with 2 VideoTracks when another Participant leaves.

### DIFF
--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -898,10 +898,12 @@ class PeerConnectionV2 extends StateMachine {
           this._localDescription.sdp,
           this._localDescriptionWithoutSimulcast.sdp,
           description.sdp);
-        return sdpWithoutSimulcastForNonVP8MediaSections === this._localDescription.sdp || this._rollbackAndApplyOffer({
-          type: this._localDescription.type,
-          sdp: sdpWithoutSimulcastForNonVP8MediaSections
-        });
+        if (sdpWithoutSimulcastForNonVP8MediaSections !== this._localDescription.sdp) {
+          return this._rollbackAndApplyOffer({
+            type: this._localDescription.type,
+            sdp: sdpWithoutSimulcastForNonVP8MediaSections
+          });
+        }
       }
     }).then(() => this._peerConnection.setRemoteDescription(description)).then(() => {
       if (description.type === 'answer') {

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -894,10 +894,13 @@ class PeerConnectionV2 extends StateMachine {
       // unset simulcast for sections in local offer where corresponding
       // sections in answer doesn't have vp8 as preferred codec and reapply offer.
       if (description.type === 'answer' && this._shouldApplySimulcast) {
-        return this._rollbackAndApplyOffer({
+        const sdpWithoutSimulcastForNonVP8MediaSections = this._revertSimulcastForNonVP8MediaSections(
+          this._localDescription.sdp,
+          this._localDescriptionWithoutSimulcast.sdp,
+          description.sdp);
+        return sdpWithoutSimulcastForNonVP8MediaSections === this._localDescription.sdp || this._rollbackAndApplyOffer({
           type: this._localDescription.type,
-          sdp: this._revertSimulcastForNonVP8MediaSections(
-            this._localDescription.sdp, this._localDescriptionWithoutSimulcast.sdp, description.sdp)
+          sdp: sdpWithoutSimulcastForNonVP8MediaSections
         });
       }
     }).then(() => this._peerConnection.setRemoteDescription(description)).then(() => {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- ./test/unit/index.js"
   },
   "dependencies": {
-    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#JSDK-2522",
+    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#924067e8d1ff9db29badc74421367387b62e40a0",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- ./test/unit/index.js"
   },
   "dependencies": {
-    "@twilio/webrtc": "4.1.1",
+    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#JSDK-2522",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },


### PR DESCRIPTION
@makarandp0 

The following PR makes the following changes:

* Only rollback and apply the offer (without H264 simulcast) only if at least one m= section has selected H264.
* Consume the twilio-webrtc.js change to make sure that the rolled back tracks to SSRCs Map is
  restored when setLocalDescription() is called immediately after a rollback.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
