### PR TITLE
add debug info when tests fail.

### DIFF
--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -1223,11 +1223,6 @@ describe('connect', function() {
         });
 
         it(`should switch off RemoteVideoTracks that are published by the ${capitalize(switchOffParticipant)} Speaker`, async () => {
-          // const [aliceTracks, bobTracks] = await waitFor([1, 2].map(async () => [
-          //   createSyntheticAudioStreamTrack() || await createLocalAudioTrack({ fake: true }),
-          //   await createLocalVideoTrack(smallVideoConstraints)
-          // ]), 'local tracks');
-
           const [aliceTracks, bobTracks] = await waitFor(['alice', 'bob'].map(async name => [
             createSyntheticAudioStreamTrack() || await createLocalAudioTrack({ fake: true }),
             await createLocalVideoTrack(Object.assign({ name }, smallVideoConstraints))

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -1223,9 +1223,9 @@ describe('connect', function() {
         });
 
         it(`should switch off RemoteVideoTracks that are published by the ${capitalize(switchOffParticipant)} Speaker`, async () => {
-          const [aliceTracks, bobTracks] = await waitFor(['alice', 'bob'].map(async name => [
+          const [aliceTracks, bobTracks] = await waitFor([1, 2].map(async () => [
             createSyntheticAudioStreamTrack() || await createLocalAudioTrack({ fake: true }),
-            await createLocalVideoTrack(Object.assign({ name }, smallVideoConstraints))
+            await createLocalVideoTrack(smallVideoConstraints)
           ]), 'local tracks');
 
           // Initially disable Alice's audio
@@ -1256,15 +1256,6 @@ describe('connect', function() {
               on: { participant: bobRemote, remoteVideoTrack: bobRemoteVideoTrack }
             }
           }[switchOffParticipant];
-
-          Object.values(switched).forEach(({ participant, remoteVideoTrack }) => {
-            ['switchedOff', 'switchedOn'].forEach(event => {
-              remoteVideoTrack.on(event, () => {
-                // eslint-disable-next-line no-console
-                console.log(`${event}: ${remoteVideoTrack.name} | ${remoteVideoTrack.sid} | ${participant.sid} | ${thisRoom.sid}`);
-              });
-            });
-          });
 
           // Bob should be the Dominant Speaker
           await waitFor([

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -39,7 +39,8 @@ const {
   tracksSubscribed,
   trackSwitchedOff,
   tracksPublished,
-  trackSwitchedOn
+  trackSwitchedOn,
+  waitFor
 } = require('../../lib/util');
 
 const { trackPriority: { PRIORITY_HIGH, PRIORITY_LOW, PRIORITY_STANDARD } } = require('../../../lib/util/constants');
@@ -145,7 +146,7 @@ describe('connect', function() {
 
         it(`should ${shouldSubscribe ? '' : 'not '}subscribe to the RemoteTracks in the Room`, async () => {
           const participants = [...thisRoom.participants.values()];
-          await Promise.all(participants.map(participant => tracksPublished(participant, 2)));
+          await waitFor(participants.map(participant => tracksPublished(participant, 2)), 'tracksPublished');
 
           // Wait for a second for any "trackSubscribed" events.
           await Promise.race([
@@ -339,7 +340,7 @@ describe('connect', function() {
         options.name = sid;
       }
       cancelablePromises = tokens.map(token => connect(token, options));
-      rooms = await Promise.all(cancelablePromises);
+      rooms = waitFor(cancelablePromises, 'connecting to rooms');
     });
 
     after(() => {
@@ -417,7 +418,7 @@ describe('connect', function() {
       }
 
       it('should eventually update each Room\'s .participants Map to contain a Participant for every other Room\'s LocalParticipant', async () => {
-        await Promise.all(rooms.map(room => participantsConnected(room, n - 1)));
+        await waitFor(rooms.map(room => participantsConnected(room, n - 1)), 'participantsConnected');
         pairs(rooms).forEach(([{ participants }, otherRooms]) => {
           otherRooms.forEach(({ localParticipant }) => {
             const participant = participants.get(localParticipant.sid);
@@ -437,9 +438,9 @@ describe('connect', function() {
         }
 
         it('should eventually update each Participant\'s ._tracks Map to contain a RemoteTrack for every one of its corresponding LocalParticipant\'s LocalTracks', async () => {
-          await Promise.all(flatMap(rooms, ({ participants }) => {
+          await waitFor(flatMap(rooms, ({ participants }) => {
             return [...participants.values()].map(participant => tracksSubscribed(participant, 2));
-          }));
+          }), 'tracksSubscribed');
           pairs(rooms).forEach(([{ participants }, otherRooms]) => {
             otherRooms.forEach(({ localParticipant }) => {
               const participant = participants.get(localParticipant.sid);
@@ -482,7 +483,7 @@ describe('connect', function() {
       const options = Object.assign({ name: sid, tracks: [] }, defaults);
       const identities = [randomName(), randomName()];
       const tokens = identities.map(getToken);
-      rooms = await Promise.all(tokens.map(token => connect(token, options)));
+      rooms = await waitFor(tokens.map(token => connect(token, options)), 'rooms to connect');
       cancelablePromise = connect(getToken(randomName()), options);
       room = await cancelablePromise;
     });
@@ -821,7 +822,7 @@ describe('connect', function() {
           });
           thisParticipant = thisRoom.localParticipant;
           thisParticipants = thoseRooms.map(room => room.participants.get(thisParticipant.sid));
-          await Promise.all(thisParticipants.map(participant => tracksSubscribed(participant, tracks.length)));
+          await waitFor(thisParticipants.map(participant => tracksSubscribed(participant, tracks.length)), 'tracksSubscribed');
         });
 
         it(`should set each LocalTrack's .name to its ${names ? 'given name' : 'ID'}`, () => {
@@ -893,7 +894,7 @@ describe('connect', function() {
           });
           thisParticipant = thisRoom.localParticipant;
           thisParticipants = thoseRooms.map(room => room.participants.get(thisParticipant.sid));
-          await Promise.all(thisParticipants.map(participant => tracksSubscribed(participant, thisParticipant._tracks.size)));
+          await waitFor(thisParticipants.map(participant => tracksSubscribed(participant, thisParticipant._tracks.size)), 'tracksSubscribed');
         });
 
         ['audio', 'video'].forEach(kind => {
@@ -946,11 +947,11 @@ describe('connect', function() {
             {
               createLocalTracks() {
                 const name = 'foo';
-                return Promise.all([
+                return waitFor([
                   createLocalAudioTrack({ name }),
                   createLocalVideoTrack(Object.assign({ name }, smallVideoConstraints)),
                   new LocalDataTrack()
-                ]);
+                ], 'local tracks');
               },
               scenario: 'Tracks whose names are the same',
               TwilioError: TrackNameIsDuplicatedError
@@ -958,11 +959,11 @@ describe('connect', function() {
             {
               createLocalTracks() {
                 const name = '0'.repeat(129);
-                return Promise.all([
+                return waitFor([
                   createLocalAudioTrack(),
                   createLocalVideoTrack(Object.assign({ name }, smallVideoConstraints)),
                   new LocalDataTrack()
-                ]);
+                ], 'local tracks');
               },
               scenario: 'a Track whose name is too long',
               TwilioError: TrackNameTooLongError
@@ -1222,10 +1223,10 @@ describe('connect', function() {
         });
 
         it(`should switch off RemoteVideoTracks that are published by the ${capitalize(switchOffParticipant)} Speaker`, async () => {
-          const [aliceTracks, bobTracks] = await Promise.all([1, 2].map(async () => [
+          const [aliceTracks, bobTracks] = await waitFor([1, 2].map(async () => [
             createSyntheticAudioStreamTrack() || await createLocalAudioTrack({ fake: true }),
             await createLocalVideoTrack(smallVideoConstraints)
-          ]));
+          ]), 'local tracks');
 
           // Initially disable Alice's audio
           aliceTracks[0].enabled = false;
@@ -1234,12 +1235,12 @@ describe('connect', function() {
           const [aliceRemote, bobRemote] = [thisRoom.participants.get(aliceLocal.sid), thisRoom.participants.get(bobLocal.sid)];
 
           // Alice and Bob publish their LocalTracks
-          await Promise.all([
+          await waitFor([
             ...aliceTracks.map(track => aliceLocal.publishTrack(track, { priority: passiveSpeakerPublishPriority })),
             ...bobTracks.map(track => bobLocal.publishTrack(track, { priority: dominantSpeakerPublishPriority })),
             tracksSubscribed(aliceRemote, 2),
             tracksSubscribed(bobRemote, 2)
-          ]);
+          ], 'all tracks to get published and subscribed');
 
           const [aliceRemoteVideoTrack, bobRemoteVideoTrack] = [aliceRemote, bobRemote].map(({ videoTracks }) => {
             return [...videoTracks.values()][0].track;
@@ -1257,11 +1258,11 @@ describe('connect', function() {
           }[switchOffParticipant];
 
           // Bob should be the Dominant Speaker
-          await Promise.all([
+          await waitFor([
             dominantSpeakerChanged(thisRoom, bobRemote),
             trackSwitchedOn(switched.on.remoteVideoTrack),
             trackSwitchedOff(switched.off.remoteVideoTrack)
-          ]);
+          ], 'Bob to be dominant speaker');
 
           switched.on.participant.videoTracks.forEach(({ track }) => {
             assert.equal(track.isSwitchedOff, false);

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -1223,9 +1223,14 @@ describe('connect', function() {
         });
 
         it(`should switch off RemoteVideoTracks that are published by the ${capitalize(switchOffParticipant)} Speaker`, async () => {
-          const [aliceTracks, bobTracks] = await waitFor([1, 2].map(async () => [
+          // const [aliceTracks, bobTracks] = await waitFor([1, 2].map(async () => [
+          //   createSyntheticAudioStreamTrack() || await createLocalAudioTrack({ fake: true }),
+          //   await createLocalVideoTrack(smallVideoConstraints)
+          // ]), 'local tracks');
+
+          const [aliceTracks, bobTracks] = await waitFor(['alice', 'bob'].map(async name => [
             createSyntheticAudioStreamTrack() || await createLocalAudioTrack({ fake: true }),
-            await createLocalVideoTrack(smallVideoConstraints)
+            await createLocalVideoTrack(Object.assign({ name }, smallVideoConstraints))
           ]), 'local tracks');
 
           // Initially disable Alice's audio
@@ -1256,6 +1261,13 @@ describe('connect', function() {
               on: { participant: bobRemote, remoteVideoTrack: bobRemoteVideoTrack }
             }
           }[switchOffParticipant];
+
+          Object.values(switched).forEach(({ remoteVideoTrack }) => {
+            ['switchedOff', 'switchedOn'].forEach(event => {
+              // eslint-disable-next-line no-console
+              remoteVideoTrack.on(event, () => console.log(`${event}: ${remoteVideoTrack.name}`));
+            });
+          });
 
           // Bob should be the Dominant Speaker
           await waitFor([

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -1257,10 +1257,12 @@ describe('connect', function() {
             }
           }[switchOffParticipant];
 
-          Object.values(switched).forEach(({ remoteVideoTrack }) => {
+          Object.values(switched).forEach(({ participant, remoteVideoTrack }) => {
             ['switchedOff', 'switchedOn'].forEach(event => {
-              // eslint-disable-next-line no-console
-              remoteVideoTrack.on(event, () => console.log(`${event}: ${remoteVideoTrack.name}`));
+              remoteVideoTrack.on(event, () => {
+                // eslint-disable-next-line no-console
+                console.log(`${event}: ${remoteVideoTrack.name} | ${remoteVideoTrack.sid} | ${participant.sid} | ${thisRoom.sid}`);
+              });
             });
           });
 

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -340,7 +340,7 @@ describe('connect', function() {
         options.name = sid;
       }
       cancelablePromises = tokens.map(token => connect(token, options));
-      rooms = waitFor(cancelablePromises, 'connecting to rooms');
+      rooms = await waitFor(cancelablePromises, 'connecting to rooms');
     });
 
     after(() => {

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -41,6 +41,7 @@ const {
   tracksPublished,
   tracksUnpublished,
   trackStarted,
+  waitFor,
   waitForTracks
 } = require('../../lib/util');
 
@@ -166,10 +167,10 @@ describe('LocalParticipant', function() {
       sid = await createRoom(name, defaults.topology);
       const options = Object.assign({ name: sid, tracks: [] }, defaults);
       const token = getToken(randomName());
-      [room, tracks] = await Promise.all([
+      [room, tracks] = await waitFor([
         connect(token, options),
         createLocalTracks({ audio: true, video: smallVideoConstraints })
-      ]);
+      ], 'connect and create local tracks');
       tracks.push(new LocalDataTrack());
     }
 
@@ -187,16 +188,16 @@ describe('LocalParticipant', function() {
       [
         'when three LocalTracks (audio, video, and data) are published together',
         async () => {
-          trackPublications = await Promise.all(tracks.map(track => {
+          trackPublications = await waitFor(tracks.map(track => {
             return room.localParticipant.publishTrack(track);
-          }));
+          }), 'publish tracks');
         }
       ]
     ].forEach(([ctx, publish]) => {
       context(ctx, () => {
         before(async () => {
-          await setup();
-          await publish();
+          await waitFor(setup(), 'setup');
+          await waitFor(publish(), 'publish');
         });
 
         it('should return LocalTrackPublications for each LocalTrack', () => {
@@ -241,15 +242,15 @@ describe('LocalParticipant', function() {
         anotherSid =  await createRoom(randomName(), defaults.topology);
         const options = Object.assign({ name: anotherSid, tracks: [] }, defaults);
         const token = getToken(randomName());
-        [anotherRoom] = await Promise.all([
+        [anotherRoom] = await waitFor([
           connect(token, options),
           setup()
-        ]);
+        ], 'connect and setup');
 
-        trackPublications = await Promise.all([
+        trackPublications = await waitFor([
           room.localParticipant.publishTrack(tracks[0], { priority: PRIORITY_LOW }),
           anotherRoom.localParticipant.publishTrack(tracks[0], { priority: PRIORITY_HIGH })
-        ]);
+        ], 'publish tracks');
       });
 
       it('should add the LocalTrack to the LocalParticipant\'s ._tracks in both Rooms', () => {
@@ -402,24 +403,24 @@ describe('LocalParticipant', function() {
         const theseOptions = Object.assign({ tracks }, options);
         thisRoom = await connect(thisToken, theseOptions);
         thisParticipant = thisRoom.localParticipant;
-        await tracksPublished(thisParticipant, thisParticipant._tracks.size);
+        await waitFor(tracksPublished(thisParticipant, thisParticipant._tracks.size), 'tracksPublished');
 
         const thoseIdentities = identities.slice(1);
         const thoseTokens = thoseIdentities.map(getToken);
         const thoseOptions = Object.assign({ tracks: [] }, options);
-        thoseRooms = await Promise.all(thoseTokens.map(thatToken => connect(thatToken, thoseOptions)));
+        thoseRooms = await waitFor(thoseTokens.map(thatToken => connect(thatToken, thoseOptions)), 'rooms to connect');
 
-        await Promise.all([thisRoom].concat(thoseRooms).map(room => {
+        await waitFor([thisRoom].concat(thoseRooms).map(room => {
           return participantsConnected(room, identities.length - 1);
-        }));
+        }), 'all participants to connect');
 
         thoseParticipants = thoseRooms.map(thatRoom => {
           return thatRoom.participants.get(thisParticipant.sid);
         });
 
-        await Promise.all(thoseParticipants.map(thatParticipant => {
+        await waitFor(thoseParticipants.map(thatParticipant => {
           return tracksSubscribed(thatParticipant, thisParticipant._tracks.size);
-        }));
+        }), 'tracksSubscribed');
 
         thoseTracksBefore = flatMap(thoseParticipants, thatParticipant => {
           return [...thatParticipant._tracks.values()];
@@ -428,12 +429,12 @@ describe('LocalParticipant', function() {
         if (when === 'previously') {
           thisParticipant.unpublishTrack(thisTrack);
 
-          await Promise.all(thoseParticipants.map(thatParticipant => {
+          await waitFor(thoseParticipants.map(thatParticipant => {
             return tracksUnpublished(thatParticipant, thisParticipant._tracks.size);
-          }));
+          }), 'tracksUnpublished');
         }
 
-        [thisLocalTrackPublication, thoseTracksPublished, thoseTracksSubscribed] = await Promise.all([
+        [thisLocalTrackPublication, thoseTracksPublished, thoseTracksSubscribed] = await waitFor([
           thisParticipant.publishTrack.apply(thisParticipant, priority ? [thisTrack, { priority }] : [thisTrack]),
           ...['trackPublished', 'trackSubscribed'].map(event => {
             return Promise.all(thoseParticipants.map(async thatParticipant => {
@@ -441,7 +442,7 @@ describe('LocalParticipant', function() {
               return trackOrPublication;
             }));
           })
-        ]);
+        ], 'lots of things');
 
         thoseTracksMap = {
           trackPublished: thoseTracksPublished,
@@ -506,7 +507,7 @@ describe('LocalParticipant', function() {
               const thoseTracks = thoseTracksMap.trackSubscribed;
               const thoseTracksReceivedData = thoseTracks.map(track => new Promise(resolve => track.once('message', resolve)));
               const dataChannelSendInterval = setInterval(() => thisTrack.send(dataType === 'string' ? data : data.buffer), 1000);
-              const receivedData = await Promise.all(thoseTracksReceivedData);
+              const receivedData = await waitFor(thoseTracksReceivedData, 'thoseTracksReceivedData');
               clearInterval(dataChannelSendInterval);
               receivedData.forEach(item => dataType === 'string' ? assert.equal(item, data) : assert.deepEqual(new Uint32Array(item), data));
             });
@@ -664,31 +665,31 @@ describe('LocalParticipant', function() {
         const thoseIdentities = identities.slice(1);
         const thoseTokens = thoseIdentities.map(getToken);
         const thoseOptions = Object.assign({ tracks: [] }, options);
-        thoseRooms = await Promise.all(thoseTokens.map(thatToken => connect(thatToken, thoseOptions)));
+        thoseRooms = await waitFor(thoseTokens.map(thatToken => connect(thatToken, thoseOptions)), 'rooms to get connected');
 
-        await Promise.all([thisRoom].concat(thoseRooms).map(room => {
+        await waitFor([thisRoom].concat(thoseRooms).map(room => {
           return participantsConnected(room, identities.length - 1);
-        }));
+        }), 'all participant to get connected');
 
         thoseParticipants = thoseRooms.map(thatRoom => {
           return thatRoom.participants.get(thisParticipant.sid);
         });
 
-        await Promise.all(thoseParticipants.map(thatParticipant => {
+        await waitFor(thoseParticipants.map(thatParticipant => {
           return tracksSubscribed(thatParticipant, thisParticipant._tracks.size);
-        }));
+        }), 'all tracks to get subscribed');
 
         if (when !== 'published') {
           thisParticipant.unpublishTrack(thisTrack);
 
-          await Promise.all(thoseParticipants.map(thatParticipant => {
+          await waitFor(thoseParticipants.map(thatParticipant => {
             return tracksUnpublished(thatParticipant, thisParticipant._tracks.size);
-          }));
+          }), 'this participants track to get unpublished');
 
-          await Promise.all([
+          await waitFor([
             thisParticipant.publishTrack(thisTrack),
             ...thoseParticipants.map(thatParticipant => tracksSubscribed(thatParticipant, thisParticipant._tracks.size))
-          ]);
+          ], 'tracks to get reSubscribed');
         }
 
         thisLocalTrackPublication = thisParticipant.unpublishTrack(thisTrack);
@@ -697,7 +698,7 @@ describe('LocalParticipant', function() {
           return new Promise(resolve => publication.once('unsubscribed', resolve));
         });
 
-        [thoseTracksUnsubscribed, thoseTracksUnpublished] = await Promise.all([
+        [thoseTracksUnsubscribed, thoseTracksUnpublished] = await waitFor([
           'trackUnsubscribed',
           'trackUnpublished'
         ].map(event => {
@@ -705,7 +706,7 @@ describe('LocalParticipant', function() {
             const [trackOrPublication] = await waitForTracks(event, thatParticipant, 1);
             return trackOrPublication;
           }));
-        }));
+        }), 'tracks to get unsubscribed and unpublished');
 
         thoseTracksMap = {
           trackUnpublished: thoseTracksUnpublished,
@@ -722,7 +723,7 @@ describe('LocalParticipant', function() {
       });
 
       it('should raise "unsubscribed" events on the corresponding RemoteParticipant\'s RemoteTrackPublications', async () => {
-        const thoseTracks = await Promise.all(thosePublicationsUnsubscribed);
+        const thoseTracks = await waitFor(thosePublicationsUnsubscribed, 'thosePublicationsUnsubscribed');
         assert.deepEqual(thoseTracks, thoseTracksMap.trackUnsubscribed);
       });
 

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -459,7 +459,7 @@ describe('LocalParticipant', function() {
         return completeRoom(sid);
       });
 
-      it.only('should raise a "trackPublished" event on the corresponding RemoteParticipant with a RemoteTrackPublication', () => {
+      it('should raise a "trackPublished" event on the corresponding RemoteParticipant with a RemoteTrackPublication', () => {
         const thoseTrackPublications = thoseTracksMap.trackPublished;
         thoseTrackPublications.forEach(thatPublication => assert(thatPublication instanceof {
           audio: RemoteAudioTrackPublication,

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -434,15 +434,30 @@ describe('LocalParticipant', function() {
           }), 'tracksUnpublished');
         }
 
-        [thisLocalTrackPublication, thoseTracksPublished, thoseTracksSubscribed] = await waitFor([
-          thisParticipant.publishTrack.apply(thisParticipant, priority ? [thisTrack, { priority }] : [thisTrack]),
-          ...['trackPublished', 'trackSubscribed'].map(event => {
-            return Promise.all(thoseParticipants.map(async thatParticipant => {
-              const [trackOrPublication] = await waitForTracks(event, thatParticipant, 1);
-              return trackOrPublication;
-            }));
-          })
-        ], 'lots of things');
+        const thisLocalTrackPublicationPromise = priority ? thisParticipant.publishTrack(thisTrack, { priority }) : thisParticipant.publishTrack(thisTrack);
+        thisLocalTrackPublication = await waitFor(thisLocalTrackPublicationPromise, 'local track publish');
+        const thoseTracksPublishedPromise = Promise.all(thoseParticipants.map(thatParticipant => {
+          const [trackOrPublication] = waitForTracks('trackPublished', thatParticipant, 1);
+          return trackOrPublication;
+        }));
+
+        const thoseTracksSubscribedPromise = Promise.all(thoseParticipants.map(thatParticipant => {
+          const [trackOrPublication] = waitForTracks('trackSubscribed', thatParticipant, 1);
+          return trackOrPublication;
+        }));
+
+        thoseTracksPublished = await waitFor(thoseTracksPublishedPromise, 'thoseTracksPublishedPromise');
+        thoseTracksSubscribed = await waitFor(thoseTracksSubscribedPromise, 'thoseTracksSubscribedPromise');
+
+        // [thisLocalTrackPublication, thoseTracksPublished, thoseTracksSubscribed] = await waitFor([
+        //   thisParticipant.publishTrack.apply(thisParticipant, priority ? [thisTrack, { priority }] : [thisTrack]),
+        //   ...['trackPublished', 'trackSubscribed'].map(event => {
+        //     return Promise.all(thoseParticipants.map(async thatParticipant => {
+        //       const [trackOrPublication] = await waitForTracks(event, thatParticipant, 1);
+        //       return trackOrPublication;
+        //     }));
+        //   })
+        // ], 'lots of things');
 
         thoseTracksMap = {
           trackPublished: thoseTracksPublished,


### PR DESCRIPTION
Lately we are seeing few tests failing pretty consistently. This is an attempt at getting more information when tests fail. With this change failing tests will print a message about which promise failed to resolve, than test just timing out. 

for example instead of: https://circleci.com/gh/twilio/twilio-video.js/1061#tests/containers/3

```
Error: Timeout of 60000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
```

now we will get: https://circleci.com/gh/twilio/twilio-video.js/1161#tests/containers/3
```
Error: Timed out waiting for : participants to receive trackSubscribed
```

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
