### PR TITLE
enable null priority test + add room sid for debugging

### DIFF
--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -370,11 +370,11 @@ describe('LocalTrackPublication', function() {
 
       // expect Alice's track to get switched on, and Bob's track to get switched off
       await waitFor([
-        waitFor(trackSwitchedOn(aliceRemoteVideoTrack), 'Alice\'s track to switch on'),
-        waitFor(trackSwitchedOff(bobRemoteVideoTrack), 'Bob\'s track to get switched off'),
+        waitFor(trackSwitchedOn(aliceRemoteVideoTrack), 'Alice\'s track to switched on:' + thisRoom.sid),
+        waitFor(trackSwitchedOff(bobRemoteVideoTrack), 'Bob\'s track to get switched off:' + thisRoom.sid),
       ], 'Alice track to get switched On, and Bob Switched Off');
 
-      await waitFor([p1, p2, p3], 'receive the trackPublishPriorityChanged on publication, participant and room.');
+      await waitFor([p1, p2, p3], 'receive the trackPublishPriorityChanged on publication, participant and room:' + thisRoom.sid);
       assert.equal(bobRemoteVideoTrackPublication.publishPriority, PRIORITY_LOW);
     });
   });

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -370,11 +370,11 @@ describe('LocalTrackPublication', function() {
 
       // expect Alice's track to get switched on, and Bob's track to get switched off
       await waitFor([
-        waitFor(trackSwitchedOn(aliceRemoteVideoTrack), 'Alice\'s track to switched on:' + thisRoom.sid),
-        waitFor(trackSwitchedOff(bobRemoteVideoTrack), 'Bob\'s track to get switched off:' + thisRoom.sid),
+        waitFor(trackSwitchedOn(aliceRemoteVideoTrack), `Alice's track to switched on: ${thisRoom.sid}`),
+        waitFor(trackSwitchedOff(bobRemoteVideoTrack), `Bob's track to get switched off:' ${thisRoom.sid}`),
       ], 'Alice track to get switched On, and Bob Switched Off');
 
-      await waitFor([p1, p2, p3], 'receive the trackPublishPriorityChanged on publication, participant and room:' + thisRoom.sid);
+      await waitFor([p1, p2, p3], `receive the trackPublishPriorityChanged on publication, participant and room: ${thisRoom.sid}`);
       assert.equal(bobRemoteVideoTrackPublication.publishPriority, PRIORITY_LOW);
     });
   });

--- a/test/integration/spec/remotetracks.js
+++ b/test/integration/spec/remotetracks.js
@@ -112,24 +112,24 @@ describe('RemoteVideoTrack', function() {
     if (defaults.topology !== 'peer-to-peer' && (defaults.environment === 'stage' || defaults.environment === 'dev')) {
       it('subscriber can upgrade track\'s effective priority', async () => {
         await waitFor([
-          waitFor(trackSwitchedOn(bobRemoteVideoTrack), 'Bob\'s track to get switched On:' + thisRoom.sid),
-          waitFor(trackSwitchedOff(aliceRemoteVideoTrack), 'Alice\'s track to get switched off:' + thisRoom.sid)
-        ], 'Bobs track to get switched On, and Alice Switched Off:' + thisRoom.sid);
+          waitFor(trackSwitchedOn(bobRemoteVideoTrack), `Bob's track to get switched on: ${thisRoom.sid}`),
+          waitFor(trackSwitchedOff(aliceRemoteVideoTrack), `Alice's track to get switched off: ${thisRoom.sid})`
+        ], `Bob's track to get switched on, and alice switched off: ${thisRoom.sid}`);
 
         // change subscriber priority of the Alice track to high
         aliceRemoteVideoTrack.setPriority(PRIORITY_HIGH);
 
         // expect Alice's track to get switched on, and Bob's track to get switched off
         await waitFor([
-          waitFor(trackSwitchedOn(aliceRemoteVideoTrack), 'Alice\'s track to get switched on:' + thisRoom.sid),
-          waitFor(trackSwitchedOff(bobRemoteVideoTrack), 'Bob\'s track to get switched off:' + thisRoom.sid)
+          waitFor(trackSwitchedOn(aliceRemoteVideoTrack), `Alice's track to get switched on: ${thisRoom.sid}`),
+          waitFor(trackSwitchedOff(bobRemoteVideoTrack), `Bob's track to get switched off: ${thisRoom.sid}`)
         ], 'Alice track to get switched On, and Bob Switched Off:' + thisRoom.sid);
       });
 
       it('subscriber can downgrade track\'s effective priority', async () => {
         await waitFor([
-          waitFor(trackSwitchedOn(bobRemoteVideoTrack), 'Bob\'s track to get switched On:' + thisRoom.sid),
-          waitFor(trackSwitchedOff(aliceRemoteVideoTrack), 'Alice\'s track to get switched off:' + thisRoom.sid)
+          waitFor(trackSwitchedOn(bobRemoteVideoTrack), `Bob's track to get switched on: ${thisRoom.sid}`),
+          waitFor(trackSwitchedOff(aliceRemoteVideoTrack), `Alice's track to get switched off: ${thisRoom.sid}`)
         ], 'Bobs track to get switched On, and Alice Switched Off');
 
         // change subscriber priority of the Alice track to high
@@ -138,33 +138,33 @@ describe('RemoteVideoTrack', function() {
 
         // expect Alice's track to get switched on, and Bob's track to get switched off
         await waitFor([
-          waitFor(trackSwitchedOn(aliceRemoteVideoTrack), 'Alice\'s track to get switched on:' + thisRoom.sid),
-          waitFor(trackSwitchedOff(bobRemoteVideoTrack), 'Bob\'s track to get switched off:' + thisRoom.sid)
-        ], 'Alice track to get switched On, and Bob Switched Off:' + thisRoom.sid);
+          waitFor(trackSwitchedOn(aliceRemoteVideoTrack), `Alice's track to get switched on: ${thisRoom.sid}`),
+          waitFor(trackSwitchedOff(bobRemoteVideoTrack), `Bob's track to get switched off: ${thisRoom.sid}`)
+        ], `Alice track to get switched on, and Bob switched off: ${thisRoom.sid}`);
       });
 
       it('subscriber can revert to track\'s effective priority', async () => {
         await waitFor([
-          waitFor(trackSwitchedOn(bobRemoteVideoTrack), 'Bob\'s track to get switched On:' + thisRoom.sid),
-          waitFor(trackSwitchedOff(aliceRemoteVideoTrack), 'Alice\'s track to get switched off:' + thisRoom.sid)
-        ], 'Bobs track to get switched On, and Alice Switched Off:' + thisRoom.sid);
+          waitFor(trackSwitchedOn(bobRemoteVideoTrack), `Bob's track to get switched on: ${thisRoom.sid}`),
+          waitFor(trackSwitchedOff(aliceRemoteVideoTrack), `Alice's track to get switched off: ${thisRoom.sid}`)
+        ], `Bob's track to get switched on, and Alice switched off: ${thisRoom.sid}`);
 
         // change subscriber priority of the Alice track to high
         aliceRemoteVideoTrack.setPriority(PRIORITY_HIGH);
 
         // expect Alice's track to get switched on, and Bob's track to get switched off
         await waitFor([
-          waitFor(trackSwitchedOn(aliceRemoteVideoTrack), 'Alice\'s track to get switched on:' + thisRoom.sid),
-          waitFor(trackSwitchedOff(bobRemoteVideoTrack), 'Bob\'s track to get switched off:' + thisRoom.sid)
-        ], 'Alice track to get switched On, and Bob Switched Off:' + thisRoom.sid);
+          waitFor(trackSwitchedOn(aliceRemoteVideoTrack), `Alice's track to get switched on: ${thisRoom.sid}`),
+          waitFor(trackSwitchedOff(bobRemoteVideoTrack), `Bob's track to get switched off: ${thisRoom.sid}`)
+        ], `Alice track to get switched on, and Bob switched off: ${thisRoom.sid}`);
 
         // reset subscriber priority of the Alice track
         aliceRemoteVideoTrack.setPriority(null);
 
         await waitFor([
-          waitFor(trackSwitchedOn(bobRemoteVideoTrack), 'Bob\'s track to get switched On:' + thisRoom.sid),
-          waitFor(trackSwitchedOff(aliceRemoteVideoTrack), 'Alice\'s track to get switched off:' + thisRoom.sid)
-        ], 'Bobs track to get switched On, and Alice Switched Off:' + thisRoom.sid);
+          waitFor(trackSwitchedOn(bobRemoteVideoTrack), `Bob's track to get switched on: ${thisRoom.sid}`),
+          waitFor(trackSwitchedOff(aliceRemoteVideoTrack), `Alice's track to get switched off: ${thisRoom.sid}`)
+        ], `Bob's track to get switched on, and Alice switched off: ${thisRoom.sid}`);
       });
     }
   });

--- a/test/integration/spec/remotetracks.js
+++ b/test/integration/spec/remotetracks.js
@@ -113,7 +113,7 @@ describe('RemoteVideoTrack', function() {
       it('subscriber can upgrade track\'s effective priority', async () => {
         await waitFor([
           waitFor(trackSwitchedOn(bobRemoteVideoTrack), `Bob's track to get switched on: ${thisRoom.sid}`),
-          waitFor(trackSwitchedOff(aliceRemoteVideoTrack), `Alice's track to get switched off: ${thisRoom.sid})`
+          waitFor(trackSwitchedOff(aliceRemoteVideoTrack), `Alice's track to get switched off: ${thisRoom.sid}`)
         ], `Bob's track to get switched on, and alice switched off: ${thisRoom.sid}`);
 
         // change subscriber priority of the Alice track to high

--- a/test/integration/spec/remotetracks.js
+++ b/test/integration/spec/remotetracks.js
@@ -112,63 +112,59 @@ describe('RemoteVideoTrack', function() {
     if (defaults.topology !== 'peer-to-peer' && (defaults.environment === 'stage' || defaults.environment === 'dev')) {
       it('subscriber can upgrade track\'s effective priority', async () => {
         await waitFor([
-          trackSwitchedOn(bobRemoteVideoTrack),
-          trackSwitchedOff(aliceRemoteVideoTrack)
-        ], 'Bobs track to get switched On, and Alice Switched Off');
+          waitFor(trackSwitchedOn(bobRemoteVideoTrack), 'Bob\'s track to get switched On:' + thisRoom.sid),
+          waitFor(trackSwitchedOff(aliceRemoteVideoTrack), 'Alice\'s track to get switched off:' + thisRoom.sid)
+        ], 'Bobs track to get switched On, and Alice Switched Off:' + thisRoom.sid);
 
         // change subscriber priority of the Alice track to high
         aliceRemoteVideoTrack.setPriority(PRIORITY_HIGH);
 
-        // eslint-disable-next-line no-warning-comments
         // expect Alice's track to get switched on, and Bob's track to get switched off
         await waitFor([
-          trackSwitchedOn(aliceRemoteVideoTrack),
-          trackSwitchedOff(bobRemoteVideoTrack)
-        ], 'Alice track to get switched On, and Bob Switched Off');
+          waitFor(trackSwitchedOn(aliceRemoteVideoTrack), 'Alice\'s track to get switched on:' + thisRoom.sid),
+          waitFor(trackSwitchedOff(bobRemoteVideoTrack), 'Bob\'s track to get switched off:' + thisRoom.sid)
+        ], 'Alice track to get switched On, and Bob Switched Off:' + thisRoom.sid);
       });
 
       it('subscriber can downgrade track\'s effective priority', async () => {
         await waitFor([
-          trackSwitchedOn(bobRemoteVideoTrack),
-          trackSwitchedOff(aliceRemoteVideoTrack)
+          waitFor(trackSwitchedOn(bobRemoteVideoTrack), 'Bob\'s track to get switched On:' + thisRoom.sid),
+          waitFor(trackSwitchedOff(aliceRemoteVideoTrack), 'Alice\'s track to get switched off:' + thisRoom.sid)
         ], 'Bobs track to get switched On, and Alice Switched Off');
 
         // change subscriber priority of the Alice track to high
         bobRemoteVideoTrack.setPriority(PRIORITY_LOW);
         aliceRemoteVideoTrack.setPriority(PRIORITY_STANDARD);
 
-        // eslint-disable-next-line no-warning-comments
         // expect Alice's track to get switched on, and Bob's track to get switched off
         await waitFor([
-          trackSwitchedOn(aliceRemoteVideoTrack),
-          trackSwitchedOff(bobRemoteVideoTrack)
-        ], 'Alice track to get switched On, and Bob Switched Off');
+          waitFor(trackSwitchedOn(aliceRemoteVideoTrack), 'Alice\'s track to get switched on:' + thisRoom.sid),
+          waitFor(trackSwitchedOff(bobRemoteVideoTrack), 'Bob\'s track to get switched off:' + thisRoom.sid)
+        ], 'Alice track to get switched On, and Bob Switched Off:' + thisRoom.sid);
       });
 
-      it.skip('VMS-2128: subscriber can revert to track\'s effective priority', async () => {
+      it('subscriber can revert to track\'s effective priority', async () => {
         await waitFor([
-          trackSwitchedOn(bobRemoteVideoTrack),
-          trackSwitchedOff(aliceRemoteVideoTrack)
-        ], 'Bobs track to get switched On, and Alice Switched Off');
+          waitFor(trackSwitchedOn(bobRemoteVideoTrack), 'Bob\'s track to get switched On:' + thisRoom.sid),
+          waitFor(trackSwitchedOff(aliceRemoteVideoTrack), 'Alice\'s track to get switched off:' + thisRoom.sid)
+        ], 'Bobs track to get switched On, and Alice Switched Off:' + thisRoom.sid);
 
         // change subscriber priority of the Alice track to high
         aliceRemoteVideoTrack.setPriority(PRIORITY_HIGH);
 
-        // eslint-disable-next-line no-warning-comments
         // expect Alice's track to get switched on, and Bob's track to get switched off
         await waitFor([
-          trackSwitchedOn(aliceRemoteVideoTrack),
-          trackSwitchedOff(bobRemoteVideoTrack)
-        ], 'Alice track to get switched On, and Bob Switched Off');
+          waitFor(trackSwitchedOn(aliceRemoteVideoTrack), 'Alice\'s track to get switched on:' + thisRoom.sid),
+          waitFor(trackSwitchedOff(bobRemoteVideoTrack), 'Bob\'s track to get switched off:' + thisRoom.sid)
+        ], 'Alice track to get switched On, and Bob Switched Off:' + thisRoom.sid);
 
         // reset subscriber priority of the Alice track
         aliceRemoteVideoTrack.setPriority(null);
 
-        // eslint-disable-next-line no-warning-comments
         await waitFor([
-          trackSwitchedOn(bobRemoteVideoTrack),
-          trackSwitchedOff(aliceRemoteVideoTrack)
-        ], 'Bobs track to get switched On, and Alice Switched Off');
+          waitFor(trackSwitchedOn(bobRemoteVideoTrack), 'Bob\'s track to get switched On:' + thisRoom.sid),
+          waitFor(trackSwitchedOff(aliceRemoteVideoTrack), 'Alice\'s track to get switched off:' + thisRoom.sid)
+        ], 'Bobs track to get switched On, and Alice Switched Off:' + thisRoom.sid);
       });
     }
   });


### PR DESCRIPTION
This change 
- re-enables null priority test now that VMS-2128 is fixed in stage. 
- logs room sid to go along with debug info to help debug.

Example output:
https://circleci.com/gh/twilio/twilio-video.js/1851

 
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
