### PR TITLE
JSDK-2501 integration test for datatrack publish failures

### DIFF
--- a/test/integration/spec/datatrackPublish.js
+++ b/test/integration/spec/datatrackPublish.js
@@ -15,7 +15,7 @@ const {
   waitFor
 } = require('../../lib/util');
 
-describe('JSDK-2477: data track not getting published in firefox', function() {
+describe('JSDK-2501: data track not getting published in firefox', function() {
   // eslint-disable-next-line no-invalid-this
   this.timeout(60000);
   [true, false].forEach((dominantSpeaker) => {

--- a/test/integration/spec/datatrackPublish.js
+++ b/test/integration/spec/datatrackPublish.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const {
+  connect,
+  createLocalAudioTrack,
+  LocalDataTrack,
+} = require('../../../lib');
+
+const defaults = require('../../lib/defaults');
+const getToken = require('../../lib/token');
+
+const {
+  participantsConnected,
+  randomName,
+  waitFor
+} = require('../../lib/util');
+
+describe('JSDK-2477: data track not getting published in firefox', function() {
+  // eslint-disable-next-line no-invalid-this
+  this.timeout(60000);
+  [true, false].forEach((dominantSpeaker) => {
+    [0, 5000].forEach((delay) => {
+      it('delay: ' + delay + ', dominantSpeaker: ' + dominantSpeaker, async () => {
+        const roomName = randomName();
+        const audioTrack = await createLocalAudioTrack();
+        const options = Object.assign({
+          dominantSpeaker,
+          name: roomName,
+          networkQuality: false,
+          tracks: [audioTrack],
+        }, defaults);
+
+        const aliceRoom = await waitFor(connect(getToken('Alice'), options), 'Alice to connect to room');
+        await waitFor(new Promise(resolve => setTimeout(resolve, delay)), `wait for ${delay} ms`);
+
+        const bobRoom = await waitFor(connect(getToken('Bob'), options), 'Bob to connect to room');
+
+        await waitFor([aliceRoom, bobRoom].map(room => participantsConnected(room, 1)), `Alice and Bob to see each other connected::${aliceRoom.sid}`);
+
+        await waitFor(aliceRoom.localParticipant.publishTrack(new LocalDataTrack()), `Alice to publish data track:${aliceRoom.sid}`);
+
+        [aliceRoom, bobRoom].forEach(room => room.disconnect());
+      });
+    });
+  });
+});


### PR DESCRIPTION
We have been  seeing intermittent failures on firefox when publishing data tracks. This issue was fixed as VMS-2005, but has regressed since then. I found that the failures are timing sensitive, and have something to do with MSP objects. 

These tests help reproduce them more regularly, and also captures room sid on repro. They will prevent such regressions going forward.

Example failure: https://circleci.com/gh/twilio/twilio-video.js/2020#tests/containers/1

**Contributing to Twilio**

TODO: 
- [ ] Merge after [VMS-2202](https://issues.corp.twilio.com/browse/VMS-2202) is fixed

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
