### PR TITLE
JSDK-2565 enable disable tracks

### DIFF
--- a/lib/signaling/v2/localparticipant.js
+++ b/lib/signaling/v2/localparticipant.js
@@ -161,6 +161,7 @@ class LocalParticipantV2 extends LocalParticipantSignaling {
       // LocalTrackPublicationV2's .sid being set.
       if (isEnabled !== publication.isEnabled) {
         this.didUpdate();
+        isEnabled = publication.isEnabled;
       }
       if (!sid && publication.sid) {
         sid = publication.sid;

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -361,7 +361,6 @@ describe('LocalTrackPublication', function() {
       assert.equal(aliceRemoteVideoTrackPublication.publishPriority, PRIORITY_HIGH);
     });
 
-
     it('publisher can downgrade track\'s priority', async () => {
       await waitFor([
         trackSwitchedOn(bobRemoteVideoTrack),

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -244,7 +244,6 @@ describe('LocalTrackPublication', function() {
     });
   });
 
-
   // eslint-disable-next-line no-warning-comments
   // TODO: enable these tests when track_priority MSP is available in prod
   (defaults.topology === 'peer-to-peer' || (defaults.environment !== 'stage' && defaults.environment !== 'dev')

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -478,6 +478,14 @@ async function waitToGoOffline() {
 }
 
 /**
+ * Returns a promise that resolves after given room receives given event.
+ * @returns {Promise<void>}
+ */
+async function waitOnceForRoomEvent(room, event) {
+  await waitFor(new Promise(resolve => room.once(event, resolve)), `room to receive event:${event}`);
+}
+
+/**
  * Note: when a test waits for promise that fails to settle.
  *   1) The test fail w/o a good indication of what happened, as for Mocha the test never finished
  *   2) This also causes subsequent tests to not get executed.
@@ -544,7 +552,9 @@ exports.waitForTracks = waitForTracks;
 exports.smallVideoConstraints = smallVideoConstraints;
 exports.setup = setup;
 exports.waitFor = waitFor;
+exports.waitOnceForRoomEvent = waitOnceForRoomEvent;
 exports.waitToGoOnline = waitToGoOnline;
 exports.waitToGoOffline = waitToGoOffline;
 exports.trackPublishPriorityChanged = trackPublishPriorityChanged;
+
 

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -556,5 +556,3 @@ exports.waitOnceForRoomEvent = waitOnceForRoomEvent;
 exports.waitToGoOnline = waitToGoOnline;
 exports.waitToGoOffline = waitToGoOffline;
 exports.trackPublishPriorityChanged = trackPublishPriorityChanged;
-
-

--- a/test/unit/spec/signaling/v2/localparticipant.js
+++ b/test/unit/spec/signaling/v2/localparticipant.js
@@ -129,6 +129,30 @@ describe('LocalParticipantV2', () => {
             publication.emit('updated');
             assert(didEmitUpdated);
           });
+
+          it('emits "updated" for each change in enabled/disable status', () => {
+            publication.sid = 'MT123';
+            publication.emit('updated');
+
+            let updateCount = 0;
+            localParticipant.on('updated', () => updateCount++);
+
+            publication.enable(!publication.isEnabled);
+            publication.emit('updated');
+            assert.equal(updateCount, 1);
+
+            publication.enable(publication.isEnabled);
+            publication.emit('updated');
+            // should not change update count as
+            // publication enabled state was not changed.
+            assert.equal(updateCount, 1);
+
+            publication.enable(!publication.isEnabled);
+            assert.equal(updateCount, 2);
+
+            publication.enable(!publication.isEnabled);
+            assert.equal(updateCount, 3);
+          });
         });
       });
     });
@@ -308,7 +332,7 @@ describe('LocalParticipantV2', () => {
     });
   });
 
-  describe('LocalTrackPublicationV2#updated', () => {
+  describe.only('LocalTrackPublicationV2#updated', () => {
     let localTrackPublication;
     let revision;
     let trackPrioritySignaling;

--- a/test/unit/spec/signaling/v2/localparticipant.js
+++ b/test/unit/spec/signaling/v2/localparticipant.js
@@ -332,7 +332,7 @@ describe('LocalParticipantV2', () => {
     });
   });
 
-  describe.only('LocalTrackPublicationV2#updated', () => {
+  describe('LocalTrackPublicationV2#updated', () => {
     let localTrackPublication;
     let revision;
     let trackPrioritySignaling;


### PR DESCRIPTION
@syerrapragada :

Fixes regression JSDK-2565. This was caused by not updating the cached state of track enabled/disabled. causing it to use stale state and not send RSP update. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
