### PR TITLE
JSDK-2557 Chrome screen share does not start

### DIFF
--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1393,7 +1393,7 @@ function updateEncodingParameters(pcv2) {
     if (maxBitrate === null || maxBitrate === 0) {
       removeMaxBitrate(params);
     } else if (utils.isChromeScreenShareTrack(sender.track)) {
-      // JSDK-2557: sometimes chrome does not send any bytes on screen track if MaxBitRate is set on it via setParameters,
+      // Note(mpatwardhan): Sometimes (JSDK-2557) chrome does not send any bytes on screen track if MaxBitRate is set on it via setParameters,
       // To workaround this issue we will not apply maxBitrate if the track appears to be a screen share track created by chrome
       pcv2._log.warn(`Not setting maxBitrate for ${sender.track.kind} Track ${sender.track.id} because it appears to be screen share track: ${sender.track.label}`);
     } else {

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -29,11 +29,12 @@ const {
   MediaClientRemoteDescFailedError
 } = require('../../util/twilio-video-errors');
 
+const utils = require('../../util');
 const {
   buildLogLevels,
   makeUUID,
   oncePerTick
-} = require('../../util');
+} = utils;
 
 const IceBox = require('./icebox');
 const DefaultIceConnectionMonitor = require('./iceconnectionmonitor.js');
@@ -1391,6 +1392,10 @@ function updateEncodingParameters(pcv2) {
 
     if (maxBitrate === null || maxBitrate === 0) {
       removeMaxBitrate(params);
+    } else if (utils.isChromeScreenShareTrack(sender.track)) {
+      // JSDK-2557: sometimes chrome does not send any bytes on screen track if MaxBitRate is set on it via setParameters,
+      // To workaround this issue we will not apply maxBitrate if the track appears to be a screen share track created by chrome
+      pcv2._log.warn(`Not setting maxBitrate for ${sender.track.kind} Track ${sender.track.id} because it appears to be screen share track: ${sender.track.label}`);
     } else {
       setMaxBitrate(params, maxBitrate);
     }

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1393,7 +1393,7 @@ function updateEncodingParameters(pcv2) {
     if (maxBitrate === null || maxBitrate === 0) {
       removeMaxBitrate(params);
     } else if (utils.isChromeScreenShareTrack(sender.track)) {
-      // Note(mpatwardhan): Sometimes (JSDK-2557) chrome does not send any bytes on screen track if MaxBitRate is set on it via setParameters,
+      // NOTE(mpatwardhan): Sometimes (JSDK-2557) chrome does not send any bytes on screen track if MaxBitRate is set on it via setParameters,
       // To workaround this issue we will not apply maxBitrate if the track appears to be a screen share track created by chrome
       pcv2._log.warn(`Not setting maxBitrate for ${sender.track.kind} Track ${sender.track.id} because it appears to be screen share track: ${sender.track.label}`);
     } else {

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -701,7 +701,7 @@ function inRange(num, min, max) {
  * @returns {boolean}
  */
 function isChromeScreenShareTrack(track) {
-  // Note(mpatwardhan): Chrome creates screen share tracks with label like: "screen:69734272*"
+  // NOTE(mpatwardhan): Chrome creates screen share tracks with label like: "screen:69734272*"
   // we will check for label that starts with "screen:D" where D being a digit.
   const isChrome = util.guessBrowser() === 'chrome';
   return isChrome && track.kind === 'video' && track.label && /^screen:[0-9]+/.test(track.label);

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -701,9 +701,8 @@ function inRange(num, min, max) {
  * @returns {boolean}
  */
 function isChromeScreenShareTrack(track) {
-  // Chrome creates screen share tracks with label like: "screen:69734272*"
+  // Note(mpatwardhan): Chrome creates screen share tracks with label like: "screen:69734272*"
   // we will check for label that starts with "screen:D" where D being a digit.
-  // console check the track name.
   const isChrome = util.guessBrowser() === 'chrome';
   return isChrome && track.kind === 'video' && track.label && /^screen:[0-9]+/.test(track.label);
 }

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -2,6 +2,8 @@
 
 const constants = require('./constants');
 const { typeErrors: E, trackPriority } = constants;
+const util = require('@twilio/webrtc/lib/util');
+
 /**
  * Return the given {@link LocalTrack} or a new {@link LocalTrack} for the
  * given MediaStreamTrack.
@@ -692,6 +694,20 @@ function inRange(num, min, max) {
   return min <= num && num <= max;
 }
 
+/**
+ * returns true if given MediaStreamTrack is a screen share track
+ * @private
+ * @param {MediaStreamTrack} track
+ * @returns {boolean}
+ */
+function isChromeScreenShareTrack(track) {
+  // Chrome creates screen share tracks with label like: "screen:69734272*"
+  // we will check for label that starts with "screen:D" where D being a digit.
+  // console check the track name.
+  const isChrome = util.guessBrowser() === 'chrome';
+  return isChrome && track.kind === 'video' && track.label && /^screen:[0-9]+/.test(track.label);
+}
+
 exports.constants = constants;
 exports.createBandwidthProfilePayload = createBandwidthProfilePayload;
 exports.createMediaSignalingPayload = createMediaSignalingPayload;
@@ -722,3 +738,4 @@ exports.trackClass = trackClass;
 exports.trackPublicationClass = trackPublicationClass;
 exports.valueToJSON = valueToJSON;
 exports.withJitter = withJitter;
+exports.isChromeScreenShareTrack = isChromeScreenShareTrack;

--- a/scripts/karma.js
+++ b/scripts/karma.js
@@ -67,7 +67,7 @@ async function main() {
     });
 
     if (exitCode && !processExitCode) {
-      // Note(mpatwardhan) if tests fail for one file,
+      // NOTE(mpatwardhan) if tests fail for one file,
       // note the exitcode but continue running for rest
       // of the files.
       processExitCode = exitCode;


### PR DESCRIPTION
This works around an issue in chrome where it sometimes do not send any data on screenshare track if there was a maxBitate value on the RTCRtpEncodingParameters for the RTCRtpSender associated with the screen share Track: 

This resulted in some issues like the one reported by this github issue: https://github.com/twilio/twilio-video.js/issues/736
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
