### PR TITLE
JSDK-2561" wait for initial DLTS handshake before handling glare

### DIFF
--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -954,17 +954,12 @@ class PeerConnectionV2 extends StateMachine {
           return Promise.resolve();
         }
         if (this._peerConnection.signalingState === 'have-local-offer') {
-          // For a peer connection -
+          // Note(mpatwardhan): For a peer connection
           // 1) createOffer always generate SDP with `setup:actpass`
           // 2) when remote description is set `setup:active`  - the answer generated selects the dtls role of setup:passive
           // 3) when remote description is set `setup:passive` - the answer generated selects the dtls role of setup:active
           // 4) when remote description is set `setup:actpass` - the answer generated uses the previously negotiated role (if not negotiated previously setup:active is used)
-          // This test makes the behavior super clear.
-          // https://github.com/twilio/twilio-webrtc.js/blob/master/test/integration/spec/rtcpeerconnection.js#L936
-          // if (this._needsAnswer && this._descriptionRevision === 1) {
-          //   this._queuedDescription = description;
-          //   return Promise.resolve();
-          // }
+          // This test shows the  behavior: https://github.com/twilio/twilio-webrtc.js/blob/master/test/integration/spec/rtcpeerconnection.js#L936
           // with glare handling (if dtls role was not negotiated before ) the generated answer will set setup:active.
           // we do not want that. lets wait for "initial negotiation" before attempting glare handling.
           if (this._needsAnswer && this._lastStableDescriptionRevision === 0) {

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -777,7 +777,6 @@ class PeerConnectionV2 extends StateMachine {
         };
         updatedSdp = this._setSimulcast(updatedSdp, this._sdpFormat, this._trackIdsToAttributes);
       }
-
       return this._setLocalDescription({
         type: 'offer',
         sdp: updatedSdp
@@ -955,7 +954,20 @@ class PeerConnectionV2 extends StateMachine {
           return Promise.resolve();
         }
         if (this._peerConnection.signalingState === 'have-local-offer') {
-          if (this._needsAnswer && this._descriptionRevision === 1) {
+          // For a peer connection -
+          // 1) createOffer always generate SDP with `setup:actpass`
+          // 2) when remote description is set `setup:active`  - the answer generated selects the dtls role of setup:passive
+          // 3) when remote description is set `setup:passive` - the answer generated selects the dtls role of setup:active
+          // 4) when remote description is set `setup:actpass` - the answer generated uses the previously negotiated role (if not negotiated previously setup:active is used)
+          // This test makes the behavior super clear.
+          // https://github.com/twilio/twilio-webrtc.js/blob/master/test/integration/spec/rtcpeerconnection.js#L936
+          // if (this._needsAnswer && this._descriptionRevision === 1) {
+          //   this._queuedDescription = description;
+          //   return Promise.resolve();
+          // }
+          // with glare handling (if dtls role was not negotiated before ) the generated answer will set setup:active.
+          // we do not want that. lets wait for "initial negotiation" before attempting glare handling.
+          if (this._needsAnswer && this._lastStableDescriptionRevision === 0) {
             this._queuedDescription = description;
             return Promise.resolve();
           }

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -954,7 +954,7 @@ class PeerConnectionV2 extends StateMachine {
           return Promise.resolve();
         }
         if (this._peerConnection.signalingState === 'have-local-offer') {
-          // Note(mpatwardhan): For a peer connection
+          // NOTE(mpatwardhan): For a peer connection
           // 1) createOffer always generate SDP with `setup:actpass`
           // 2) when remote description is set `setup:active`  - the answer generated selects the dtls role of setup:passive
           // 3) when remote description is set `setup:passive` - the answer generated selects the dtls role of setup:active

--- a/scripts/karma.js
+++ b/scripts/karma.js
@@ -67,7 +67,7 @@ async function main() {
     });
 
     if (exitCode && !processExitCode) {
-      // Note(mpatwardhan) if tests fail for one file,
+      // NOTE(mpatwardhan) if tests fail for one file,
       // note the exitcode but continue running for rest
       // of the files.
       processExitCode = exitCode;

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -804,7 +804,6 @@ describe('PeerConnectionV2', () => {
       ],
     // eslint-disable-next-line consistent-return
     ], ([initial, vmsFailOver, signalingState, type, newerEqualOrOlder, matching, iceLite, isRTCRtpSenderParamsSupported, enableDscp, chromeScreenTrack]) => {
-
       // these combinations grow exponentially
       // skip the ones that do not make much sense to test.
       if (vmsFailOver && (!initial || type !== 'offer' || signalingState !== 'have-local-offer')) {
@@ -812,7 +811,7 @@ describe('PeerConnectionV2', () => {
         return;
       }
 
-      if (!isRTCRtpSenderParamsSupported && ( chromeScreenTrack || enableDscp )) {
+      if (!isRTCRtpSenderParamsSupported && (chromeScreenTrack || enableDscp)) {
         // screen share track and dscp options have special cases only when isRTCRtpSenderParamsSupported.
         return;
       }

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -798,7 +798,7 @@ describe('PeerConnectionV2', () => {
         x => `When enableDscp is ${typeof x === 'undefined' ? 'not specified' : `set to ${x}`}`
       ],
       [
-        [true],
+        [true, false],
         x => `When chromeScreenTrack is ${x ? 'present' : 'not present'}`
       ],
     // eslint-disable-next-line consistent-return

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -759,10 +759,6 @@ describe('PeerConnectionV2', () => {
     });
   });
 
-  // @ceaglest - I think we already have very comprehensive unit-tests for overall flow.
-  // And the newly added tests (https://github.com/twilio/twilio-video.js/pull/796/files#diff-5621864bdc387556a6924c0a722195f3R884)
-  // cover this vms-failover case pretty well.
-
   describe('#update, called', () => {
     combinationContext([
       [

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -818,7 +818,7 @@ describe('PeerConnectionV2', () => {
       }
 
       if (iceLite && (isRTCRtpSenderParamsSupported || enableDscp || chromeScreenTrack)) {
-        // iceLite doe not need repeat for all combination of unrelated variables.
+        // iceLite does not need repeat for all combination of unrelated variables.
         return;
       }
 


### PR DESCRIPTION
We did not handle glare when `this._descriptionRevision === 1` - This ensured that DTLS role was negotiated. But that works only for 1st peer connection, when a new peer connection is created in response to VMS failover - the `descriptionRevision` would not be 1. To ensure that every new peerConnection does not handle glare before DLTS negotiation is finished, we will wait for `this._lastStableDescriptionRevision` to be set.


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
