### PR TITLE
JSDK-2537 migrate integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,13 +77,16 @@ executors:
     environment:
       <<: *defaultEnv
 commands:
-  get-code-and-dependencies:
+  get-code:
     steps:
       - checkout
       - when:
           condition: << pipeline.parameters.tag >>
           steps:
             - run: git checkout << pipeline.parameters.tag >>
+  get-code-and-dependencies:
+    steps:
+      - get-code
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run:
@@ -124,7 +127,7 @@ commands:
       - save-test-results
   network-tests:
     steps:
-      - checkout
+      - get-code # note: network tests run inside docker - the dependencies will be fetched inside docker image.
       - run:
           name: Running Network Tests
           command: scripts/circleci-run-tests.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,12 +10,18 @@ parameters:
     type: enum
     enum: ["prod", "stage", "dev"]
     default: "prod"
-  pr_workflow:
+  pr_workflow:    # runs for every pull request.
     type: boolean
     default: true # by default pr workflow will get executed.
-  custom_workflow:
+  custom_workflow: # runs just one custom config.
     type: boolean
     default: false
+  backend_workflow: # runs JS integration.
+    type: boolean
+    default: false
+  tag:
+    type: string
+    default: "" # use something like: "2.0.0-beta15" when invoking with parameters.
   browser:
     type: enum
     enum: ["chrome", "firefox"]
@@ -74,6 +80,10 @@ commands:
   get-code-and-dependencies:
     steps:
       - checkout
+      - when:
+          condition: << pipeline.parameters.tag >>
+          steps:
+            - run: git checkout << pipeline.parameters.tag >>
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run:
@@ -252,7 +262,45 @@ workflows:
           browser: << pipeline.parameters.browser >>
           bver: << pipeline.parameters.bver >>
           topology: << pipeline.parameters.topology >>
-
+  Backend_Workflow:
+    when: << pipeline.parameters.backend_workflow >>
+    jobs:
+      - run-integration-tests:
+          name: "chrome stable group"
+          <<: *browser_chrome
+          <<: *bver_stable
+          <<: *topology_group
+      - run-integration-tests:
+          name: "chrome stable p2p"
+          <<: *browser_chrome
+          <<: *bver_stable
+          <<: *topology_p2p
+      - run-network-tests:
+          name: "chrome network p2p"
+          <<: *browser_chrome
+          <<: *topology_p2p
+      - run-network-tests:
+          name: "chrome network group"
+          <<: *browser_chrome
+          <<: *topology_group
+      - run-integration-tests:
+          name: "firefox stable group"
+          <<: *browser_firefox
+          <<: *bver_stable
+          <<: *topology_group
+      - run-integration-tests:
+          name: "firefox stable p2p"
+          <<: *browser_firefox
+          <<: *bver_stable
+          <<: *topology_p2p
+      - run-network-tests:
+          name: "firefox network p2p"
+          <<: *browser_firefox
+          <<: *topology_p2p
+      - run-network-tests:
+          name: "firefox network group"
+          <<: *browser_firefox
+          <<: *topology_group
   Pull_Request_Workflow:
     when: << pipeline.parameters.pr_workflow >>
     jobs:

--- a/.circleci/runbuild.js
+++ b/.circleci/runbuild.js
@@ -6,6 +6,27 @@ const http = require('https');
 const inquirer = require('inquirer');
 const simpleGit = require('simple-git')();
 
+
+/*
+posts a request for a circleci workflow
+you can alternatively use a curl command like:
+
+curl -u ${CIRCLECI_TOKEN}: -X POST \
+  --header 'Content-Type: application/json' \
+  -d '{
+    "branch": "JSDK-2537_migrate_integration_tests",
+    "parameters": {
+        "pr_workflow": false,
+        "custom_workflow": false,
+        "backend_workflow": true,
+        "environment": "stage",
+        "tag": "2.0.0-beta15"
+    }
+}' \
+https://circleci.com/api/v2/project/github/twilio/twilio-video.js/pipeline
+
+*/
+
 // returns a Promise that resolves with branch information
 let branchesPromise = null;
 function getBranches() {
@@ -39,6 +60,7 @@ function generateBuildRequest(program) {
   };
 
   const body = {
+    branch: 'master',
     parameters: {
       pr_workflow: program.workflow === 'pr',
       custom_workflow: program.workflow === 'custom',
@@ -55,6 +77,7 @@ function generateBuildRequest(program) {
     body.parameters.bver = program.bver;
     body.parameters.topology = program.topology;
   } else if (program.workflow === 'backend') {
+    body.branch = program.branch;
     body.parameters.tag = program.tag;
   }
 
@@ -95,7 +118,7 @@ const workflowPrompt = {
 
 // you may pick branch for pr or custom workflow.
 const branchPrompt = {
-  when: (answers) => answers.workflow !== 'backend',
+  // when: (answers) => answers.workflow !== 'backend',
   type: 'list',
   name: 'branch',
   message: 'Branch:',

--- a/.circleci/runbuild.js
+++ b/.circleci/runbuild.js
@@ -7,16 +7,20 @@ const inquirer = require('inquirer');
 const simpleGit = require('simple-git')();
 
 // returns a Promise that resolves with branch information
+let branchesPromise = null;
 function getBranches() {
-  return new Promise((resolve, reject) => {
-    simpleGit.branchLocal((e, branches) => {
-      if (e) {
-        reject(e);
-      } else {
-        resolve(branches);
-      }
+  if (branchesPromise === null) {
+    branchesPromise = new Promise((resolve, reject) => {
+      simpleGit.branchLocal((e, branches) => {
+        if (e) {
+          reject(e);
+        } else {
+          resolve(branches);
+        }
+      });
     });
-  });
+  }
+  return branchesPromise;
 }
 
 // generates a circleCI request using parameters provided
@@ -35,18 +39,23 @@ function generateBuildRequest(program) {
   };
 
   const body = {
-    branch: program.branch,
     parameters: {
       pr_workflow: program.workflow === 'pr',
       custom_workflow: program.workflow === 'custom',
+      backend_workflow: program.workflow === 'backend',
       environment: program.environment,
     }
   };
 
-  if (program.workflow === 'custom') {
+  if (program.workflow === 'pr') {
+    body.branch = program.branch;
+  } else if (program.workflow === 'custom') {
+    body.branch = program.branch;
     body.parameters.browser = program.browser;
     body.parameters.bver = program.bver;
     body.parameters.topology = program.topology;
+  } else if (program.workflow === 'backend') {
+    body.parameters.tag = program.tag;
   }
 
   return { options, body };
@@ -69,94 +78,107 @@ function triggerBuild({options, body}) {
   });
 }
 
-getBranches().then(branches => {
-  const branchPrompt = {
-    type: 'list',
-    name: 'branch',
-    message: 'Branch:',
-    choices: [branches.current, new inquirer.Separator(), ...branches.all],
-    default: branches.current
-  };
+const tokenPrompt = {
+  type: 'input',
+  name: 'token',
+  message: 'Circle CI Token:',
+  validate: (val) => { return typeof val === 'string' && val.length > 5; }
+};
 
-  const environmentPrompt = {
-    type: 'list',
-    name: 'environment',
-    message: 'Environment:',
-    choices: ['prod', 'stage', 'dev'],
-    default: 'prod'
-  };
+const workflowPrompt = {
+  type: 'list',
+  name: 'workflow',
+  message: 'Workflow:',
+  choices: ['pr', 'custom', 'backend'],
+  default: 'pr'
+};
 
-  const workflowPrompt = {
-    type: 'list',
-    name: 'workflow',
-    message: 'Workflow:',
-    choices: ['pr', 'custom'],
-    default: 'pr'
-  };
+// you may pick branch for pr or custom workflow.
+const branchPrompt = {
+  when: (answers) => answers.workflow !== 'backend',
+  type: 'list',
+  name: 'branch',
+  message: 'Branch:',
+  choices: () => getBranches().then(branches => [branches.current, new inquirer.Separator(), ...branches.all]),
+  default: () => getBranches().then(branches => branches.current)
+};
 
-  const browserPrompt = {
-    when: (answers) => answers.workflow === 'custom',
-    type: 'list',
-    name: 'browser',
-    message: 'Browser:',
-    choices: ['chrome', 'firefox'],
-    default: 'chrome'
-  };
+// environment defaults to stage for backend workflow.
+const environmentPrompt = {
+  type: 'list',
+  name: 'environment',
+  message: 'Environment:',
+  choices: ['prod', 'stage', 'dev'],
+  default: (answers) => answers.workflow === 'backend' ? 'stage' :'prod'
+};
 
-  const confirmPrompt = {
-    type: 'confirm',
-    name: 'confirm',
-    message: 'Confirm the build request:',
-    default: true,
-  };
+const browserPrompt = {
+  when: (answers) => answers.workflow === 'custom',
+  type: 'list',
+  name: 'browser',
+  message: 'Browser:',
+  choices: ['chrome', 'firefox'],
+  default: 'chrome'
+};
 
-  const bverPrompt = {
-    when: (answers) => answers.workflow === 'custom',
-    type: 'list',
-    name: 'bver',
-    message: 'Bver:',
-    choices: ['stable', 'beta', 'unstable'],
-    default: 'stable'
-  };
+const bverPrompt = {
+  when: (answers) => answers.workflow === 'custom',
+  type: 'list',
+  name: 'bver',
+  message: 'Bver:',
+  choices: ['stable', 'beta', 'unstable'],
+  default: 'stable'
+};
 
-  const topologyPrompt = {
-    when: (answers) => answers.workflow === 'custom',
-    type: 'list',
-    name: 'topology',
-    message: 'Topology:',
-    choices: ['group', 'peer-to-peer'],
-    default: 'group'
-  };
+const topologyPrompt = {
+  when: (answers) => answers.workflow === 'custom',
+  type: 'list',
+  name: 'topology',
+  message: 'Topology:',
+  choices: ['group', 'peer-to-peer'],
+  default: 'group'
+};
 
-  const tokenPrompt = {
-    type: 'input',
-    name: 'token',
-    message: 'Circle CI Token:',
-    validate: (val) => { return typeof val === 'string' && val.length > 5; }
-  };
+// tag can be chosen only for backend workflow
+const tagPrompt = {
+  when: (answers) => answers.workflow === 'backend',
+  type: 'input',
+  name: 'tag',
+  message: 'Tag to use:',
+  default: '2.0.0-beta15',
+  validate: (val) => { return typeof val === 'string' && val.length > 5; }
+};
 
-  if (process.env.CIRCLECI_TOKEN) {
-    tokenPrompt.default = process.env.CIRCLECI_TOKEN;
-  }
+const confirmPrompt = {
+  type: 'confirm',
+  name: 'confirm',
+  message: 'Confirm the build request:',
+  default: true,
+};
 
-  inquirer.prompt([
-    tokenPrompt,
-    environmentPrompt,
-    workflowPrompt,
-    branchPrompt,
-    browserPrompt,
-    bverPrompt,
-    topologyPrompt,
-  ]).then(answers => {
-    const {options, body} = generateBuildRequest(answers);
-    console.log('Will make a CI request with:', options, body);
-    inquirer.prompt([confirmPrompt]).then(({ confirm }) => {
-      if (confirm) {
-        triggerBuild({options, body}).then((result) => {
-          console.log(result);
-        }).catch(e => console.log('Failed to trigger a build:', e));
-      }
-    });
+if (process.env.CIRCLECI_TOKEN) {
+  tokenPrompt.default = process.env.CIRCLECI_TOKEN;
+}
+
+inquirer.prompt([
+  tokenPrompt,
+  workflowPrompt,
+  tagPrompt,
+  environmentPrompt,
+  branchPrompt,
+  browserPrompt,
+  bverPrompt,
+  topologyPrompt,
+]).then(answers => {
+  const {options, body} = generateBuildRequest(answers);
+  console.log('Will make a CI request with:', options, body);
+  inquirer.prompt([confirmPrompt]).then(({ confirm }) => {
+    if (confirm) {
+      triggerBuild({options, body}).then((result) => {
+        console.log(result);
+      }).catch(e => console.log('Failed to trigger a build:', e));
+    }
   });
 });
+
 

--- a/scripts/circleci-run-tests.sh
+++ b/scripts/circleci-run-tests.sh
@@ -11,6 +11,8 @@ echo "os info:"
 uname -a
 echo "directory:"
 ls -alt
+echo "Package.json version:"
+cat package.json | grep version
 echo "running tests"
 
 case ${ENVIRONMENT} in


### PR DESCRIPTION
@syerrapragada, 

This change enables using circleci for running JS integration tests against backend for specific tag.

- added a new `backend_workflow`
This workflow will run 8 configurations `(stable chrome, stable  firefox) * (p2, group) * (integration, network)` against  specified environment.
- added support for specifying tag for any workflow.
- updated runBuild.js tool to allow for running this new workflow

To execute this workflow - You can use command like:
```
curl -u ${CIRCLECI_TOKEN}: -X POST \
  --header 'Content-Type: application/json' \
  -d '{
    "branch": "JSDK-2537_migrate_integration_tests",
    "parameters": {
        "pr_workflow": false,
        "custom_workflow": false,
        "backend_workflow": true,
        "environment": "stage",
        "tag": "2.0.0-beta15"
    }
}' \
https://circleci.com/api/v2/project/github/twilio/twilio-video.js/pipeline
```
You can see sample workflow run here: https://circleci.com/workflow-run/657c8e4a-0ade-4993-9163-f8ca942340eb

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
