### PR TITLE
fix assert.equal usage (master)

### DIFF
--- a/test/crossbrowser/test/integration/spec/localparticipant.ts
+++ b/test/crossbrowser/test/integration/spec/localparticipant.ts
@@ -283,7 +283,7 @@ describe('LocalParticipantDriver', function() {
             const { localParticipant: { trackPublications } } = roomDrivers[0];
             const { track } = trackPublications.get(remoteTrack.sid);
 
-            assert.equal(track);
+            assert(!track);
             ['id', 'kind', 'name'].forEach(prop => {
               assert.equal(remoteTrack[prop], track[prop]);
             });

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -285,7 +285,7 @@ describe('PeerConnectionV2', () => {
         });
 
         it('returns undefined', () => {
-          assert.equal(result);
+          assert(!result);
         });
 
         if (scenario === 'been added') {
@@ -337,7 +337,7 @@ describe('PeerConnectionV2', () => {
         });
 
         it('returns undefined', () => {
-          assert.equal(result);
+          assert(!result);
         });
 
         if (signalingState === 'closed') {
@@ -512,7 +512,7 @@ describe('PeerConnectionV2', () => {
         }[signalingState];
 
         it('returns a Promise that resolves to undefined', () => {
-          assert.equal(result);
+          assert(!result);
         });
 
         it('should call createOffer on the underlying RTCPeerConnection', () => {
@@ -552,7 +552,7 @@ describe('PeerConnectionV2', () => {
 
       function itShouldEventuallyCreateOffer() {
         it('returns a Promise that resolves to undefined', () => {
-          assert.equal(result);
+          assert(!result);
         });
 
         it('should not emit a "description" event', () => {
@@ -704,7 +704,7 @@ describe('PeerConnectionV2', () => {
         });
 
         it('returns undefined', () => {
-          assert.equal(result);
+          assert(!result);
         });
 
         if (scenario === 'been added') {
@@ -1008,7 +1008,7 @@ describe('PeerConnectionV2', () => {
 
       function itShouldAnswer() {
         it('returns a Promise that resolves to undefined', () => {
-          assert.equal(result);
+          assert(!result);
         });
 
         it('should call createAnswer on the underlying RTCPeerConnection', () => {
@@ -1058,7 +1058,7 @@ describe('PeerConnectionV2', () => {
           }
 
           it('returns a Promise that resolves to undefined', () => {
-            assert.equal(result);
+            assert(!result);
           });
 
           it('should not emit a "description" event', () => {
@@ -1082,7 +1082,7 @@ describe('PeerConnectionV2', () => {
         const expectedOfferIndex = initial ? 1 : 2;
 
         it('returns a Promise that resolves to undefined', () => {
-          assert.equal(result);
+          assert(!result);
         });
 
         it('should call setLocalDescription on the underlying RTCPeerConnection with a rollback description', () => {
@@ -1150,7 +1150,7 @@ describe('PeerConnectionV2', () => {
 
       function itShouldApplyAnswer() {
         it('returns a Promise that resolves to undefined', () => {
-          assert.equal(result);
+          assert(!result);
         });
 
         it('should call setRemoteDescrption on the underlying RTCPeerConnection', () => {
@@ -1195,7 +1195,7 @@ describe('PeerConnectionV2', () => {
         expectedOfferIndex += signalingState === 'have-local-offer' ? 1 : 0;
 
         it('returns a Promise that resolves to undefined', () => {
-          assert.equal(result);
+          assert(!result);
         });
 
         it('should call createOffer on the underlying RTCPeerConnection', () => {
@@ -1237,7 +1237,7 @@ describe('PeerConnectionV2', () => {
           });
 
           it('returns a Promise that resolves to undefined', () => {
-            assert.equal(result);
+            assert(!result);
           });
 
           it('should call createOffer on the underlying RTCPeerConnection', () => {
@@ -1273,7 +1273,7 @@ describe('PeerConnectionV2', () => {
 
       function itShouldClose() {
         it('returns a Promise that resolves to undefined', () => {
-          assert.equal(result);
+          assert(!result);
         });
 
         it('should call close on the underlying RTCPeerConnection', () => {
@@ -1295,7 +1295,7 @@ describe('PeerConnectionV2', () => {
 
       function itDoesNothing() {
         it('returns a Promise that resolves to undefined', () => {
-          assert.equal(result);
+          assert(!result);
         });
 
         it('should not emit a "description" event', () => {
@@ -1451,7 +1451,7 @@ describe('PeerConnectionV2', () => {
         });
 
         it('should return a Promise that resolves to undefined', () => {
-          assert.equal(result);
+          assert(!result);
         });
 
         it('should called createAnswer on the underlying RTCPeerConnection', () => {


### PR DESCRIPTION
port https://github.com/twilio/twilio-video.js/pull/795 to master. 

This is just a cherry-pick `git cherry-pick f77c98f21d2116beed38acf30ff5b5e99b821687`

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
