### PR TITLE
Prep for 1.20.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ test.json
 yarn.lock
 .idea
 .vscode
+logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 For 2.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/master/CHANGELOG.md).
 
-1.20.0 (in progress)
-====================
+1.20.0 (November 11, 2019)
+==========================
 
 - twilio-video.js will now support the Unified Plan SDP format for Google Chrome.
   Google Chrome enabled Unified Plan as the default SDP format starting from version 72.
@@ -17,7 +17,7 @@ For 2.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/master
 Bug Fixes
 ---------
 
-- Fixed a bug where, the local and remote AudioTracks' audioLevels returned by 
+- Fixed a bug where, the local and remote AudioTracks' audioLevels returned by
   `Room.getStats()` were not in the range [0-32767]. (JSDK-2318)
 - Fixed a bug where `Video.isSupported` evaluated to `true` on Chromium-based Edge browser,
   even though twilio-video.js does not support it at this moment. (JSDK-2515)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@ For 2.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/master
 1.20.0 (November 11, 2019)
 ==========================
 
-- twilio-video.js will now support the Unified Plan SDP format for Google Chrome.
-  Google Chrome enabled Unified Plan as the default SDP format starting from version 72.
-  In Q1 2020 Google will completely remove support of previous plan "Plan B". We strongly
-  recommend updating to SDK version 1.20.0+ which uses Unified plan in order to avoid
-  breaking changes related to upcoming removal of Plan B. (JSDK-2313)
+- As of this release, twilio-video.js will no longer use the deprecated Plan B SDP format when
+publishing or subscribing to tracks. It will use the [Unified Plan](https://webrtc.org/web-apis/chrome/unified-plan/)
+format. Google has advised that they will remove Plan B support from Chrome during Q1 2020. Therefore, we recommend
+updating to SDK 1.20.0+ as soon as possible. This change will not impact interoperability with existing twilio-video.js
+versions or other supported versions.
 
 Bug Fixes
 ---------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,9 @@ For 2.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/master
 
 - twilio-video.js will now support the Unified Plan SDP format for Google Chrome.
   Google Chrome enabled Unified Plan as the default SDP format starting from version 72.
-  In December 2018, we published an [advisory](https://support.twilio.com/hc/en-us/articles/360012782494-Breaking-Changes-in-Twilio-Video-JavaScript-SDKs-December-2018-)
-  recommending customers to upgrade to the latest versions of twilio-video.js
-  in order to not be affected by Google Chrome switching to Unified Plan starting
-  from version 72. The way we ensured support of newer versions of Google Chrome
-  in the versions of twilio-video.js released between December 2018 and now was
-  by overriding the default SDP format to Plan B. Starting with this version,
-  twilio-video.js will use Unified Plan where available, while also maintaining
-  support for earlier browser versions with Plan B as the default SDP format. (JSDK-2313)
+  In Q1 2020 Google will completely remove support of previous plan "Plan B". We strongly
+  recommend updating to SDK version 1.20.0+ which uses Unified plan in order to avoid
+  breaking changes related to upcoming removal of Plan B. (JSDK-2313)
 
 Bug Fixes
 ---------

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
   },
   "dependencies": {
     "@twilio/sip.js": "^0.7.7",
-    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#2.4.0-rc1",
+    "@twilio/webrtc": "2.4.0",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },

--- a/test/crossbrowser/test/integration/spec/localparticipant.ts
+++ b/test/crossbrowser/test/integration/spec/localparticipant.ts
@@ -283,7 +283,7 @@ describe('LocalParticipantDriver', function() {
             const { localParticipant: { trackPublications } } = roomDrivers[0];
             const { track } = trackPublications.get(remoteTrack.sid);
 
-            assert.equal(track);
+            assert(!track);
             ['id', 'kind', 'name'].forEach(prop => {
               assert.equal(remoteTrack[prop], track[prop]);
             });

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -179,7 +179,7 @@ describe('PeerConnectionV2', () => {
         });
 
         it('returns undefined', () => {
-          assert.equal(result);
+          assert(!result);
         });
 
         if (scenario === 'been added') {
@@ -231,7 +231,7 @@ describe('PeerConnectionV2', () => {
         });
 
         it('returns undefined', () => {
-          assert.equal(result);
+          assert(!result);
         });
 
         if (signalingState === 'closed') {
@@ -406,7 +406,7 @@ describe('PeerConnectionV2', () => {
         }[signalingState];
 
         it('returns a Promise that resolves to undefined', () => {
-          assert.equal(result);
+          assert(!result);
         });
 
         it('should call createOffer on the underlying RTCPeerConnection', () => {
@@ -446,7 +446,7 @@ describe('PeerConnectionV2', () => {
 
       function itShouldEventuallyCreateOffer() {
         it('returns a Promise that resolves to undefined', () => {
-          assert.equal(result);
+          assert(!result);
         });
 
         it('should not emit a "description" event', () => {
@@ -597,7 +597,7 @@ describe('PeerConnectionV2', () => {
         });
 
         it('returns undefined', () => {
-          assert.equal(result);
+          assert(!result);
         });
 
         if (scenario === 'been added') {
@@ -896,7 +896,7 @@ describe('PeerConnectionV2', () => {
 
       function itShouldAnswer() {
         it('returns a Promise that resolves to undefined', () => {
-          assert.equal(result);
+          assert(!result);
         });
 
         it('should call createAnswer on the underlying RTCPeerConnection', () => {
@@ -941,7 +941,7 @@ describe('PeerConnectionV2', () => {
           }
 
           it('returns a Promise that resolves to undefined', () => {
-            assert.equal(result);
+            assert(!result);
           });
 
           it('should not emit a "description" event', () => {
@@ -965,7 +965,7 @@ describe('PeerConnectionV2', () => {
         const expectedOfferIndex = initial ? 1 : 2;
 
         it('returns a Promise that resolves to undefined', () => {
-          assert.equal(result);
+          assert(!result);
         });
 
         it('should call setLocalDescription on the underlying RTCPeerConnection with a rollback description', () => {
@@ -1029,7 +1029,7 @@ describe('PeerConnectionV2', () => {
 
       function itShouldApplyAnswer() {
         it('returns a Promise that resolves to undefined', () => {
-          assert.equal(result);
+          assert(!result);
         });
 
         it('should call setRemoteDescrption on the underlying RTCPeerConnection', () => {
@@ -1070,7 +1070,7 @@ describe('PeerConnectionV2', () => {
         expectedOfferIndex += signalingState === 'have-local-offer' ? 1 : 0;
 
         it('returns a Promise that resolves to undefined', () => {
-          assert.equal(result);
+          assert(!result);
         });
 
         it('should call createOffer on the underlying RTCPeerConnection', () => {
@@ -1112,7 +1112,7 @@ describe('PeerConnectionV2', () => {
           });
 
           it('returns a Promise that resolves to undefined', () => {
-            assert.equal(result);
+            assert(!result);
           });
 
           it('should call createOffer on the underlying RTCPeerConnection', () => {
@@ -1144,7 +1144,7 @@ describe('PeerConnectionV2', () => {
 
       function itShouldClose() {
         it('returns a Promise that resolves to undefined', () => {
-          assert.equal(result);
+          assert(!result);
         });
 
         it('should call close on the underlying RTCPeerConnection', () => {
@@ -1166,7 +1166,7 @@ describe('PeerConnectionV2', () => {
 
       function itDoesNothing() {
         it('returns a Promise that resolves to undefined', () => {
-          assert.equal(result);
+          assert(!result);
         });
 
         it('should not emit a "description" event', () => {
@@ -1322,7 +1322,7 @@ describe('PeerConnectionV2', () => {
         });
 
         it('should return a Promise that resolves to undefined', () => {
-          assert.equal(result);
+          assert(!result);
         });
 
         it('should called createAnswer on the underlying RTCPeerConnection', () => {


### PR DESCRIPTION
Prepping for releasing 1.20.0. Main change is adding date in Changelog. + port https://github.com/twilio/twilio-video.js/pull/799 to fix unit tests. 

Before merge:
- [x] merge  and release https://github.com/twilio/twilio-webrtc.js/pull/112
-  [x] update twilio-webrtc dependency

 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
