### PR TITLE
JSDK 2582 track disabled is not fired, when track is added as disabled.

### DIFF
--- a/lib/media/track/remotetrackpublication.js
+++ b/lib/media/track/remotetrackpublication.js
@@ -72,7 +72,7 @@ class RemoteTrackPublication extends TrackPublication {
       }
     });
 
-    // NOTE(mpatwardhan) - we must not use initial these using signaling object's initial values
+    // NOTE(mpatwardhan) - we must not initialize these using signaling object's initial values
     //  because SDK expects events even for initial values. For example if track is started as disabled,
     //  sdk expects trackDisabled event.
     let error = null;

--- a/lib/media/track/remotetrackpublication.js
+++ b/lib/media/track/remotetrackpublication.js
@@ -72,12 +72,13 @@ class RemoteTrackPublication extends TrackPublication {
       }
     });
 
-    let {
-      error,
-      isEnabled,
-      isSwitchedOff,
-      priority
-    } = signaling;
+    // NOTE(mpatwardhan) - we must not use initial these using signaling object's initial values
+    //  because SDK expects events even for initial values. For example if track is started as disabled,
+    //  sdk expects trackDisabled event.
+    let error = null;
+    let isEnabled;
+    let isSwitchedOff = false;
+    let priority;
 
     signaling.on('updated', () => {
       if (error !== signaling.error) {

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -71,13 +71,13 @@ describe('LocalTrackPublication', function() {
     const roomSid = await createRoom(randomName(), defaults.topology);
     const options = Object.assign({ name: roomSid }, defaults);
 
-    // Alice joins P2P/Group room
+    // Alice joins a room
     const aliceRoom = await connect(getToken('Alice'), Object.assign({ tracks: [] }, options));
 
     // Alice adds listener for trackDisabled events (e.g., in room level)
     const trackDisabledPromise = waitOnceForRoomEvent(aliceRoom, 'trackDisabled');
 
-    // Participant 2 joins the room with audio and disabled video track
+    // Bob joins the room with a disabled track
     const bobLocalAudioTrack = await createLocalAudioTrack({ fake: true });
     bobLocalAudioTrack.disable();
     const bobRoom = await connect(getToken('Bob'), Object.assign({ tracks: [bobLocalAudioTrack] }, options));

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -67,6 +67,28 @@ describe('LocalTrackPublication', function() {
     [thisRoom, ...thoseRooms].forEach(room => room && room.disconnect());
   });
 
+  it('JSDK-2582 trackDisabled event is not fired when participant joins room with already disabled track', async () => {
+    const roomSid = await createRoom(randomName(), defaults.topology);
+    const options = Object.assign({ name: roomSid }, defaults);
+
+    // Alice joins P2P/Group room
+    const aliceRoom = await connect(getToken('Alice'), Object.assign({ tracks: [] }, options));
+
+    // Alice adds listener for trackDisabled events (e.g., in room level)
+    const trackDisabledPromise = waitOnceForRoomEvent(aliceRoom, 'trackDisabled');
+
+    // Participant 2 joins the room with audio and disabled video track
+    const bobLocalAudioTrack = await createLocalAudioTrack({ fake: true });
+    bobLocalAudioTrack.disable();
+    const bobRoom = await connect(getToken('Bob'), Object.assign({ tracks: [bobLocalAudioTrack] }, options));
+
+    // Alice expects trackDisabled event.
+    await waitFor(trackDisabledPromise, `Alice to receive trackDisabled event: ${roomSid}`);
+
+    [aliceRoom, bobRoom].forEach(room => room.disconnect());
+    return completeRoom(roomSid);
+  });
+
   describe('#unpublish', () => {
     combinationContext([
       [

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -508,7 +508,7 @@ async function waitToGoOffline() {
  * @returns {Promise<void>}
  */
 async function waitOnceForRoomEvent(room, event) {
-  await waitFor(new Promise(resolve => room.once(event, resolve)), `room to receive event:${event}`);
+  await waitFor(new Promise(resolve => room.once(event, resolve)), `room ${room.sid} to receive event:${event}`);
 }
 
 /**


### PR DESCRIPTION
https://github.com/twilio/twilio-video.js/commit/9a3f660d8aa1307f8824fa78ce80f387f160ff8c#diff-e2551442b3b2b2bbe92b9d0d5d4a2135  introduced this issue. The change caused events to be fired only when state of track changed. Now reverted the change to mimic existing behavior. We will fire trackDisabled/Enabled trackSwitchOff events even for new tracks. 

+ added integration test. 

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
