### PR TITLE
JSDK-2584 move integration tests off travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,56 +26,50 @@ env:
 matrix:
   include:
     - os: linux
-      env: DOCKER=true BROWSER=chrome BVER=stable TOPOLOGY=group
+      env: BROWSER=chrome BVER=stable TOPOLOGY=peer-to-peer
 
     - os: linux
-      env: DOCKER=false BROWSER=chrome BVER=stable TOPOLOGY=peer-to-peer
+      env: BROWSER=chrome BVER=stable TOPOLOGY=group
 
     - os: linux
-      env: DOCKER=false BROWSER=chrome BVER=stable TOPOLOGY=group
+      env: BROWSER=chrome BVER=beta TOPOLOGY=peer-to-peer
 
     - os: linux
-      env: DOCKER=false BROWSER=chrome BVER=beta TOPOLOGY=peer-to-peer
+      env: BROWSER=chrome BVER=beta TOPOLOGY=group
 
     - os: linux
-      env: DOCKER=false BROWSER=chrome BVER=beta TOPOLOGY=group
+      env: BROWSER=chrome BVER=unstable TOPOLOGY=peer-to-peer
 
     - os: linux
-      env: DOCKER=false BROWSER=chrome BVER=unstable TOPOLOGY=peer-to-peer
+      env: BROWSER=chrome BVER=unstable TOPOLOGY=group
 
     - os: linux
-      env: DOCKER=false BROWSER=chrome BVER=unstable TOPOLOGY=group
+      env: BROWSER=firefox BVER=stable TOPOLOGY=peer-to-peer
 
     - os: linux
-      env: DOCKER=false BROWSER=firefox BVER=stable TOPOLOGY=peer-to-peer
+      env: BROWSER=firefox BVER=stable TOPOLOGY=group
 
     - os: linux
-      env: DOCKER=false BROWSER=firefox BVER=stable TOPOLOGY=group
+      env: BROWSER=firefox BVER=beta TOPOLOGY=peer-to-peer
 
     - os: linux
-      env: DOCKER=false BROWSER=firefox BVER=beta TOPOLOGY=peer-to-peer
+      env: BROWSER=firefox BVER=beta TOPOLOGY=group
 
     - os: linux
-      env: DOCKER=false BROWSER=firefox BVER=beta TOPOLOGY=group
+      env: BROWSER=firefox BVER=unstable TOPOLOGY=peer-to-peer
 
     - os: linux
-      env: DOCKER=false BROWSER=firefox BVER=unstable TOPOLOGY=peer-to-peer
-
-    - os: linux
-      env: DOCKER=false BROWSER=firefox BVER=unstable TOPOLOGY=group
+      env: BROWSER=firefox BVER=unstable TOPOLOGY=group
 
   allow_failures:
-    - env: DOCKER=false BROWSER=chrome BVER=unstable TOPOLOGY=peer-to-peer
-    - env: DOCKER=false BROWSER=chrome BVER=unstable TOPOLOGY=group
-    - env: DOCKER=false BROWSER=firefox BVER=stable TOPOLOGY=peer-to-peer
-    - env: DOCKER=false BROWSER=firefox BVER=stable TOPOLOGY=group
-    - env: DOCKER=false BROWSER=firefox BVER=beta TOPOLOGY=peer-to-peer
-    - env: DOCKER=false BROWSER=firefox BVER=beta TOPOLOGY=group
-    - env: DOCKER=false BROWSER=firefox BVER=unstable TOPOLOGY=peer-to-peer
-    - env: DOCKER=false BROWSER=firefox BVER=unstable TOPOLOGY=group
-    - env: DOCKER=false BROWSER=safari BVER=unstable TOPOLOGY=peer-to-peer
-    - env: DOCKER=false BROWSER=safari BVER=unstable TOPOLOGY=group
-    - env: DOCKER=true BROWSER=chrome BVER=stable TOPOLOGY=group
+    - env: BROWSER=chrome BVER=unstable TOPOLOGY=peer-to-peer
+    - env: BROWSER=chrome BVER=unstable TOPOLOGY=group
+    - env: BROWSER=firefox BVER=stable TOPOLOGY=peer-to-peer
+    - env: BROWSER=firefox BVER=stable TOPOLOGY=group
+    - env: BROWSER=firefox BVER=beta TOPOLOGY=peer-to-peer
+    - env: BROWSER=firefox BVER=beta TOPOLOGY=group
+    - env: BROWSER=firefox BVER=unstable TOPOLOGY=peer-to-peer
+    - env: BROWSER=firefox BVER=unstable TOPOLOGY=group
 
 script: ./scripts/travis-run-tests.sh
 

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "build:js": "node ./scripts/build.js ./src/twilio-video.js ./LICENSE.md ./dist/twilio-video.js",
     "build:min.js": "uglifyjs ./dist/twilio-video.js -o ./dist/twilio-video.min.js --comments \"/^! twilio-video.js/\" -b beautify=false,ascii_only=true",
     "build": "npm-run-all clean lint docs cover test:integration build:es5 build:js build:min.js test:umd",
-    "build:travis": "npm-run-all clean lint docs cover test:integration:travis build:es5 build:js build:min.js test:umd test:framework",
+    "build:travis": "npm-run-all clean lint docs cover build:es5 build:js build:min.js test:umd test:framework",
     "build:docker": "npm-run-all clean lint docs cover test:integration:travis build:es5 build:js build:min.js",
     "build:quick": "npm-run-all clean lint docs build:es5 build:js build:min.js",
     "docs": "node ./scripts/docs.js ./dist/docs",

--- a/scripts/travis-run-tests.sh
+++ b/scripts/travis-run-tests.sh
@@ -1,39 +1,26 @@
 #!/bin/bash
 set -ev
 echo PWD=$PWD
-if [ "${DOCKER}" = "true" ]; then
-  # when running inside docker
-  echo TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST}
-  if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
-    echo Not a pull request build. Skipping docker tests and failing the job.
-    exit 126
-  else
-    docker-compose build test
-    docker-compose run test npm run test:integration
-  fi
+cd node_modules/travis-multirunner
+if [ "${TRAVIS_OS_NAME}" == 'linux' ]; then
+  # Upgrade to dpkg >= 1.17.5ubuntu5.8, which fixes
+  # https://bugs.launchpad.net/ubuntu/+source/dpkg/+bug/1730627
+  # (https://github.com/travis-ci/travis-ci/issues/9361)
+  sudo apt-get install -y dpkg
+  BROWSER=chrome ./setup.sh
+  BROWSER=firefox ./setup.sh
+  export CHROME_BIN=$(pwd)/browsers/bin/chrome-$BVER
+  export FIREFOX_BIN=$(pwd)/browsers/bin/firefox-$BVER
 else
-  # when running outside docker
-  cd node_modules/travis-multirunner
-  if [ "${TRAVIS_OS_NAME}" == 'linux' ]; then
-    # Upgrade to dpkg >= 1.17.5ubuntu5.8, which fixes
-    # https://bugs.launchpad.net/ubuntu/+source/dpkg/+bug/1730627
-    # (https://github.com/travis-ci/travis-ci/issues/9361)
-    sudo apt-get install -y dpkg
-    BROWSER=chrome ./setup.sh
-    BROWSER=firefox ./setup.sh
-    export CHROME_BIN=$(pwd)/browsers/bin/chrome-$BVER
-    export FIREFOX_BIN=$(pwd)/browsers/bin/firefox-$BVER
-  else
-    BROWSER=safari ./setup.sh
-  fi
-  cd ../..
-  if [ "${TRAVIS_OS_NAME}" == 'linux' ]; then
-    sh -e /etc/init.d/xvfb start
-    pulseaudio --start
-    sleep 3
-  fi
-  if [ "${TOPOLOGY}" != 'peer-to-peer' ]; then
-    export ENABLE_REST_API_TESTS=1
-  fi
-  npm run build:travis
+  BROWSER=safari ./setup.sh
 fi
+cd ../..
+if [ "${TRAVIS_OS_NAME}" == 'linux' ]; then
+  sh -e /etc/init.d/xvfb start
+  pulseaudio --start
+  sleep 3
+fi
+if [ "${TOPOLOGY}" != 'peer-to-peer' ]; then
+  export ENABLE_REST_API_TESTS=1
+fi
+npm run build:travis


### PR DESCRIPTION
We have moved our integration tests to CircleCI - Travis is now only used with release-tool to cut releases and RCs. This change removes integration tests from travis. Travis will only build and run unit tests and tests against frameworks.

We eventually want to retire travis job and move to using circleCI for cutting releases (https://issues.corp.twilio.com/browse/JSDK-2586), But in the interim, this take burden off travis. This was an ask from (https://twilio.slack.com/archives/C0ANJHZLN/p1573684376320300)
and was also necessitated by our integration tests being flaky lately. Travis won't cut the releases, if tests don't pass.   
 
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
