### PR TITLE
JSDK 2583 publisher priority after reconnect

### DIFF
--- a/lib/signaling/v2/localparticipant.js
+++ b/lib/signaling/v2/localparticipant.js
@@ -159,17 +159,21 @@ class LocalParticipantV2 extends LocalParticipantSignaling {
       // the "updated" event is emitted due to LocalTrackPublicationV2's
       // .isEnabled being toggled. We do not publish if it is fired due to the
       // LocalTrackPublicationV2's .sid being set.
-      if (isEnabled !== publication.isEnabled) {
+
+
+      // CHANGE THIS TO UPDATE ON TRACK PRIORITY UPDATES.
+      if (isEnabled !== publication.isEnabled || updatedPriority !== publication.updatedPriority) {
         this.didUpdate();
         isEnabled = publication.isEnabled;
+        updatedPriority = publication.updatedPriority;
       }
       if (!sid && publication.sid) {
         sid = publication.sid;
       }
-      if (sid && (updatedPriority !== publication.updatedPriority)) {
-        this.updateTrackPriority(publication.sid, publication.updatedPriority);
-        updatedPriority = publication.updatedPriority;
-      }
+      // if (sid && (updatedPriority !== publication.updatedPriority)) {
+      //   this.updateTrackPriority(publication.sid, publication.updatedPriority);
+      //   updatedPriority = publication.updatedPriority;
+      // }
     };
 
     publication.on('updated', updated);

--- a/lib/signaling/v2/localtrackpublication.js
+++ b/lib/signaling/v2/localtrackpublication.js
@@ -27,7 +27,7 @@ class LocalTrackPublicationV2 extends LocalTrackPublicationSignaling {
       id: this.id,
       kind: this.kind,
       name: this.name,
-      priority: this.priority
+      priority: this.updatedPriority
     };
   }
 

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -37,6 +37,7 @@ const {
   trackSwitchedOn,
   waitFor,
   waitForNot,
+  waitForSometime,
   waitForTracks,
   waitOnceForRoomEvent
 } = require('../../lib/util');
@@ -44,6 +45,99 @@ const {
 describe('LocalTrackPublication', function() {
   // eslint-disable-next-line no-invalid-this
   this.timeout(60000);
+
+  it.only('JSDK-2583 Publisher priority not synced up when subscriber reconnects', async () => {
+    // Alice and Bob Join.
+    const { roomSid, aliceRoom, bobRoom, bobLocal, bobRemote } = await setupAliceAndBob({
+      aliceOptions: { tracks: [] },
+      bobOptions: { tracks: [] },
+    });
+
+    // Bob publishes a track at low priority.
+    const bobVideoTrackA = await createLocalVideoTrack(Object.assign({ name: 'trackA' }, smallVideoConstraints));
+    const trackAPubLocal = await waitFor(bobLocal.publishTrack(bobVideoTrackA, { priority: PRIORITY_LOW }), `Bob to publish video trackA: ${roomSid}`);
+
+    // Alice sees bob track at low priority.
+    await waitFor(tracksSubscribed(bobRemote, 1), `wait for alice to subscribe to Bob's tracks: ${roomSid}`);
+    const trackAPubRemote = bobRemote.videoTracks.get(trackAPubLocal.trackSid);
+    assert(trackAPubRemote);
+    await waitFor(trackSwitchedOn(trackAPubRemote.track), `trackA=On : ${roomSid}`);
+    assert.equal(trackAPubRemote.publishPriority, PRIORITY_LOW);
+
+    // Bob updates trackA => PRIORITY_HIGH
+    trackAPubLocal.setPriority(PRIORITY_HIGH);
+    assert.equal(trackAPubLocal.priority, PRIORITY_HIGH);
+
+    // Alice sees Bob track at standard priority.
+    const trackPriorityChanged = new Promise(resolve => trackAPubRemote.once('publishPriorityChanged', priority => {
+      assert.equal(priority, PRIORITY_HIGH);
+      resolve();
+    }));
+
+    await waitFor(trackPriorityChanged, `'track priority to change to High: ${roomSid}`);
+    assert.equal(trackAPubRemote.publishPriority, PRIORITY_HIGH);
+
+    // Alice disconnects and connects back.
+    aliceRoom.disconnect();
+    const options = Object.assign({ name: roomSid }, defaults);
+
+    // Alice joins a room
+    const aliceRoom2 = await connect(getToken('Alice'), Object.assign({ tracks: [] }, options));
+    const bobRemote2 = aliceRoom2.participants.get(bobLocal.sid);
+    // Alice sees bob track at low priority.
+    await waitFor(tracksSubscribed(bobRemote2, 1), `wait for alice to subscribe to Bob's tracks: ${roomSid}`);
+    const trackAPubRemote2 = bobRemote2.videoTracks.get(trackAPubLocal.trackSid);
+    assert(trackAPubRemote2);
+    await waitFor(trackSwitchedOn(trackAPubRemote2.track), `trackA=On : ${roomSid}`);
+    assert.equal(trackAPubRemote2.publishPriority, PRIORITY_HIGH);
+
+
+    // Alice sees bob track at standard priority.
+    aliceRoom2.disconnect();
+    bobRoom.disconnect();
+  });
+
+  it.only('JSDK-2583 late arrivals see updated priority', async () => {
+    const roomSid = await createRoom(randomName(), defaults.topology);
+    const options = Object.assign({ name: roomSid }, defaults);
+
+    // BOB joins a room
+    const bobRoom = await connect(getToken('Bob'), Object.assign({ tracks: [] }, options));
+
+    // Bob publishes a track at low priority.
+    const bobVideoTrackA = await createLocalVideoTrack(Object.assign({ name: 'trackA' }, smallVideoConstraints));
+    const trackAPubLocal = await waitFor(bobRoom.localParticipant.publishTrack(bobVideoTrackA, { priority: PRIORITY_LOW }), `Bob to publish video trackA: ${roomSid}`);
+
+
+    // Bob updates trackA => PRIORITY_HIGH
+    trackAPubLocal.setPriority(PRIORITY_HIGH);
+    assert.equal(trackAPubLocal.priority, PRIORITY_HIGH);
+
+    // Alice joins a room after 10 seconds.
+    await waitForSometime(10000);
+    const aliceRoom = await connect(getToken('Alice'), Object.assign({ tracks: [] }, options));
+    const bobRemote = aliceRoom.participants.get(bobRoom.localParticipant.sid);
+
+    // Alice sees bob track.
+    await waitFor(tracksSubscribed(bobRemote, 1), `wait for alice to subscribe to Bob's tracks: ${roomSid}`);
+    const trackAPubRemote = bobRemote.videoTracks.get(trackAPubLocal.trackSid);
+
+    const trackPriorityChanged = new Promise(resolve => trackAPubRemote.once('publishPriorityChanged', priority => {
+      console.log('makaranda: publish priority changed!');
+      assert.equal(priority, PRIORITY_HIGH);
+      resolve();
+    }));
+
+    // alice waits for 10 seconds or for trackPriorityChanged to have been fired.
+    await Promise.race([waitForSometime(10000), trackPriorityChanged]);
+
+    // and at the end expects the priority of bob's track to be high.
+    assert(trackAPubRemote);
+    assert.equal(trackAPubRemote.publishPriority, PRIORITY_HIGH, `Alice was expecting Bob's track to have High Priority: ${roomSid}`);
+
+    aliceRoom.disconnect();
+    bobRoom.disconnect();
+  });
 
   it('JSDK-2565: Can enable, disable and re-enable the track', async () => {
     const [, thisRoom, thoseRooms] = await waitFor(setup({}), 'rooms connected and tracks subscribed');

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -471,10 +471,10 @@ describe('LocalTrackPublication', function() {
     });
 
 
-    [PRIORITY_LOW, PRIORITY_STANDARD, PRIORITY_HIGH].forEach(beforePriority => {
-      [PRIORITY_LOW, PRIORITY_STANDARD, PRIORITY_HIGH].forEach(afterPriority => {
+    [PRIORITY_LOW].forEach(beforePriority => {
+      [PRIORITY_HIGH].forEach(afterPriority => {
         const expectNotification = beforePriority !== afterPriority;
-        it(`VMS-2231:subscriber ${expectNotification ? 'gets notified' : 'does not get notified'} when publisher changes priority: ${beforePriority} => ${afterPriority}`, async () => {
+        it.only(`VMS-2231:subscriber ${expectNotification ? 'gets notified' : 'does not get notified'} when publisher changes priority: ${beforePriority} => ${afterPriority}`, async () => {
           const { roomSid, aliceRoom, bobRoom, bobLocal, bobRemote } = await setupAliceAndBob({
             aliceOptions: {
               bandwidthProfile: {

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -554,6 +554,7 @@ async function waitFor(promiseOrArray, message, timeoutMS = 30 * second, verbose
   clearTimeout(timer);
   return result;
 }
+
 /**
  * sometimes our tests want to ensure that an event does *not* happen
  * this function helps with such waits. It ensures that given promise does not resolve
@@ -585,6 +586,15 @@ async function waitForNot(promise, message, timeoutMS = 5 * second) {
   return result;
 }
 
+/**
+ * Returns a promise that resolve after timeoutMS have passed.
+ * @param {number} timeoutMS - time to wait in milliseconds.
+ * @returns {Promise<void>}
+ */
+async function waitForSometime(timeoutMS = 10 * second) {
+  await new Promise(resolve => setTimeout(resolve, timeoutMS));
+}
+
 exports.a = a;
 exports.capitalize = capitalize;
 exports.createSyntheticAudioStreamTrack = createSyntheticAudioStreamTrack;
@@ -608,6 +618,7 @@ exports.waitForTracks = waitForTracks;
 exports.smallVideoConstraints = smallVideoConstraints;
 exports.setup = setup;
 exports.waitFor = waitFor;
+exports.waitForSometime = waitForSometime;
 exports.waitForNot = waitForNot;
 exports.waitOnceForRoomEvent = waitOnceForRoomEvent;
 exports.waitToGoOnline = waitToGoOnline;


### PR DESCRIPTION
This test demonstrates an issue where late arriving participants who miss publisherPriorityChange event, see wrong publish priority of the tracks.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
