### PR TITLE
JSDK-2573: race condition when recycling transceiver.

### DIFF
--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -287,11 +287,8 @@ class PeerConnectionV2 extends StateMachine {
           video: []
         }
       },
-      _trackReplacePending: {
-        value: []
-      },
       _replaceTrackPromises: {
-        value: []
+        value: new Map()
       },
       _remoteCandidates: {
         writable: true,
@@ -447,13 +444,10 @@ class PeerConnectionV2 extends StateMachine {
       // NOTE(mpatwardhan):remember this transceiver while we replace track.
       // we recycle transceivers that are not in use after 'negotiationCompleted', but we want to prevent
       // this one from getting recycled while replaceTrack is pending.
-      this._trackReplacePending.push(transceiver);
-      this._replaceTrackPromises.push(transceiver.sender.replaceTrack(track).then(() => {
+      this._replaceTrackPromises.set(transceiver, transceiver.sender.replaceTrack(track).then(() => {
         transceiver.direction = 'sendrecv';
-        this._trackReplacePending.splice(this._trackReplacePending.indexOf(transceiver), 1);
-      }, () => {
-        // Do nothing.
-        this._trackReplacePending.splice(this._trackReplacePending.indexOf(transceiver), 1);
+      }).finally(() => {
+        this._replaceTrackPromises.delete(transceiver);
       }));
       return transceiver;
     }
@@ -761,7 +755,8 @@ class PeerConnectionV2 extends StateMachine {
       this._isRestartingIce = true;
       offerOptions.iceRestart = true;
     }
-    return Promise.all(this._replaceTrackPromises.splice(0)).then(() => {
+
+    return Promise.all(this._replaceTrackPromises.values()).then(() => {
       return this._peerConnection.createOffer(offerOptions);
     }).catch(() => {
       throw new MediaClientLocalDescFailedError();
@@ -1288,7 +1283,7 @@ function filterOutMediaStreamIds(sdp) {
  * @returns {boolean}
  */
 function shouldRecycleTransceiver(transceiver, pcv2) {
-  const shouldRecycle = !transceiver.stopped && !pcv2._trackReplacePending.includes(transceiver)
+  const shouldRecycle = !transceiver.stopped && !pcv2._replaceTrackPromises.has(transceiver)
     && (transceiver.currentDirection === 'inactive'
       || transceiver.currentDirection === 'recvonly'
       || transceiver.direction === 'recvonly');

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -446,6 +446,8 @@ class PeerConnectionV2 extends StateMachine {
       // this one from getting recycled while replaceTrack is pending.
       this._replaceTrackPromises.set(transceiver, transceiver.sender.replaceTrack(track).then(() => {
         transceiver.direction = 'sendrecv';
+      }, () => {
+        // Do nothing.
       }).finally(() => {
         this._replaceTrackPromises.delete(transceiver);
       }));
@@ -1283,11 +1285,10 @@ function filterOutMediaStreamIds(sdp) {
  * @returns {boolean}
  */
 function shouldRecycleTransceiver(transceiver, pcv2) {
-  const shouldRecycle = !transceiver.stopped && !pcv2._replaceTrackPromises.has(transceiver)
+  return !transceiver.stopped && !pcv2._replaceTrackPromises.has(transceiver)
     && (transceiver.currentDirection === 'inactive'
       || transceiver.currentDirection === 'recvonly'
       || transceiver.direction === 'recvonly');
-  return shouldRecycle;
 }
 
 /**

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 'use strict';
 
 const {
@@ -436,6 +437,10 @@ class PeerConnectionV2 extends StateMachine {
   _addOrUpdateTransceiver(track) {
     const transceiver = takeRecycledTransceiver(this, track.kind);
     if (transceiver && transceiver.sender) {
+      console.log(`makaranda: reusing transreceiver mid: ${transceiver.mid}`);
+      if (transceiver.sender.track)  {
+        console.log(`makaranda: reusing transreceiver:${transceiver.sender.track.id} => ${track.id}`);
+      }
       this._replaceTrackPromises.push(transceiver.sender.replaceTrack(track).then(() => {
         transceiver.direction = 'sendrecv';
       }, () => {
@@ -443,6 +448,7 @@ class PeerConnectionV2 extends StateMachine {
       }));
       return transceiver;
     }
+    console.log(`makaranda: creating new transreceiver: ${track.id}`);
     return this._peerConnection.addTransceiver(track);
   }
 
@@ -1041,6 +1047,10 @@ class PeerConnectionV2 extends StateMachine {
     } else {
       const transceiver = this._addOrUpdateTransceiver(mediaTrackSender.track);
       sender = transceiver.sender;
+      if (transceiver.sender.track)  {
+        console.log(`makaranda: addMediaTrackSender transceiver.sender.track.id:${transceiver.sender.track.id}`);
+      }
+
     }
     mediaTrackSender.addSender(sender);
     this._rtpSenders.set(mediaTrackSender, sender);
@@ -1273,10 +1283,22 @@ function filterOutMediaStreamIds(sdp) {
  * @param {RTCRtpTransceiver} transceiver
  * @returns {boolean}
  */
-function shouldRecycleTransceiver(transceiver) {
-  return !transceiver.stopped && (transceiver.currentDirection === 'inactive'
+function shouldRecycleTransceiver(transceiver, pcv2) {
+  // return false;
+  const shouldRecycle = !transceiver.stopped && (transceiver.currentDirection === 'inactive'
     || transceiver.currentDirection === 'recvonly'
     || transceiver.direction === 'recvonly');
+
+  let msg = `makaranda should recycle: ${shouldRecycle}, mid: ${transceiver.mid}`;
+  if (transceiver.sender) {
+    msg += 'has sender, ';
+    if (transceiver.sender.track)  {
+      msg += `transreceiver trackid:${transceiver.sender.track.id}`;
+    }
+  }
+
+  console.log(msg);
+  return shouldRecycle;
 }
 
 /**
@@ -1349,7 +1371,7 @@ function updateRecycledTransceivers(pcv2) {
   pcv2._recycledTransceivers.audio = [];
   pcv2._recycledTransceivers.video = [];
   pcv2._peerConnection.getTransceivers().forEach(transceiver => {
-    if (shouldRecycleTransceiver(transceiver)) {
+    if (shouldRecycleTransceiver(transceiver, pcv2)) {
       const track = transceiver.receiver.track;
       pcv2._recycledTransceivers[track.kind].push(transceiver);
     }

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 'use strict';
 
 const {
@@ -288,6 +287,9 @@ class PeerConnectionV2 extends StateMachine {
           video: []
         }
       },
+      _trackReplacePending: {
+        value: []
+      },
       _replaceTrackPromises: {
         value: []
       },
@@ -438,18 +440,23 @@ class PeerConnectionV2 extends StateMachine {
   _addOrUpdateTransceiver(track) {
     const transceiver = takeRecycledTransceiver(this, track.kind);
     if (transceiver && transceiver.sender) {
-      console.log(`makaranda: reusing transreceiver mid: ${transceiver.mid}`);
-      if (transceiver.sender.track)  {
-        console.log(`makaranda: reusing transreceiver:${transceiver.sender.track.id} => ${track.id}`);
+      const oldTrackId = transceiver.sender.track ? transceiver.sender.track.id : null;
+      if (oldTrackId) {
+        this._log.warn(`Reusing transceiver: ${transceiver.mid}] ${oldTrackId} => ${track.id}`);
       }
+      // NOTE(mpatwardhan):remember this transceiver while we replace track.
+      // we recycle transceivers that are not in use after 'negotiationCompleted', but we want to prevent
+      // this one from getting recycled while replaceTrack is pending.
+      this._trackReplacePending.push(transceiver);
       this._replaceTrackPromises.push(transceiver.sender.replaceTrack(track).then(() => {
         transceiver.direction = 'sendrecv';
+        this._trackReplacePending.splice(this._trackReplacePending.indexOf(transceiver), 1);
       }, () => {
         // Do nothing.
+        this._trackReplacePending.splice(this._trackReplacePending.indexOf(transceiver), 1);
       }));
       return transceiver;
     }
-    console.log(`makaranda: creating new transreceiver: ${track.id}`);
     return this._peerConnection.addTransceiver(track);
   }
 
@@ -1048,10 +1055,6 @@ class PeerConnectionV2 extends StateMachine {
     } else {
       const transceiver = this._addOrUpdateTransceiver(mediaTrackSender.track);
       sender = transceiver.sender;
-      if (transceiver.sender.track)  {
-        console.log(`makaranda: addMediaTrackSender transceiver.sender.track.id:${transceiver.sender.track.id}`);
-      }
-
     }
     mediaTrackSender.addSender(sender);
     this._rtpSenders.set(mediaTrackSender, sender);
@@ -1285,20 +1288,10 @@ function filterOutMediaStreamIds(sdp) {
  * @returns {boolean}
  */
 function shouldRecycleTransceiver(transceiver, pcv2) {
-  // return false;
-  const shouldRecycle = !transceiver.stopped && (transceiver.currentDirection === 'inactive'
-    || transceiver.currentDirection === 'recvonly'
-    || transceiver.direction === 'recvonly');
-
-  let msg = `makaranda should recycle: ${shouldRecycle}, mid: ${transceiver.mid}`;
-  if (transceiver.sender) {
-    msg += 'has sender, ';
-    if (transceiver.sender.track)  {
-      msg += `transreceiver trackid:${transceiver.sender.track.id}`;
-    }
-  }
-
-  console.log(msg);
+  const shouldRecycle = !transceiver.stopped && !pcv2._trackReplacePending.includes(transceiver)
+    && (transceiver.currentDirection === 'inactive'
+      || transceiver.currentDirection === 'recvonly'
+      || transceiver.direction === 'recvonly');
   return shouldRecycle;
 }
 

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -549,27 +549,25 @@ describe('LocalTrackPublication', function() {
       bobRoom.disconnect();
     });
 
-    [1, 2, 3, 4, 5].forEach((runNumber) => {
-      it.only('JSDK-2573 - race condition when recycling trans-receiver: ' + runNumber, async () => {
-        // Alice and Bob join without tracks, Alice has maxTracks property set to 1
-        const { roomSid, aliceRoom, bobRoom, bobLocal, bobRemote } = await setupAliceAndBob({
-          aliceOptions: { tracks: [] },
-          bobOptions: { tracks: [] /* , logLevel: 'debug' */},
-        });
-
-        const bobVideoTrackA = await createLocalVideoTrack(Object.assign({ name: 'trackA' }, smallVideoConstraints));
-        const bobVideoTrackB = await createLocalVideoTrack(Object.assign({ name: 'trackB' }, smallVideoConstraints));
-
-        // Bob publishes video trackA with standard priority, trackB with low priority.
-        await waitFor(bobLocal.publishTrack(bobVideoTrackA), `Bob to publish video trackA: ${roomSid}`);
-        await waitFor(bobLocal.publishTrack(bobVideoTrackB), `Bob to publish video trackB: ${roomSid}`);
-
-        // wait for alice to subscribe two tracks
-        await waitFor(tracksSubscribed(bobRemote, 2), `wait for alice to subscribe to Bobs tracks: ${roomSid}`);
-
-        aliceRoom.disconnect();
-        bobRoom.disconnect();
+    it.only('JSDK-2573 - race condition when recycling trans-receiver: ', async () => {
+      // Alice and Bob join without tracks, Alice has maxTracks property set to 1
+      const { roomSid, aliceRoom, bobRoom, bobLocal, bobRemote } = await setupAliceAndBob({
+        aliceOptions: { tracks: [] },
+        bobOptions: { tracks: [] },
       });
+
+      const bobVideoTrackA = await createLocalVideoTrack(Object.assign({ name: 'trackA' }, smallVideoConstraints));
+      const bobVideoTrackB = await createLocalVideoTrack(Object.assign({ name: 'trackB' }, smallVideoConstraints));
+
+      // Bob publishes video trackA with standard priority, trackB with low priority.
+      await waitFor(bobLocal.publishTrack(bobVideoTrackA), `Bob to publish video trackA: ${roomSid}`);
+      await waitFor(bobLocal.publishTrack(bobVideoTrackB), `Bob to publish video trackB: ${roomSid}`);
+
+      // wait for alice to subscribe two tracks
+      await waitFor(tracksSubscribed(bobRemote, 2), `wait for alice to subscribe to Bobs tracks: ${roomSid}`);
+
+      aliceRoom.disconnect();
+      bobRoom.disconnect();
     });
   });
 });

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -468,5 +468,28 @@ describe('LocalTrackPublication', function() {
       aliceRoom.disconnect();
       bobRoom.disconnect();
     });
+
+    [1, 2, 3, 4, 5].forEach((runNumber) => {
+      it.only('JSDK-2573 - race condition when recycling trans-receiver: ' + runNumber, async () => {
+        // Alice and Bob join without tracks, Alice has maxTracks property set to 1
+        const { roomSid, aliceRoom, bobRoom, bobLocal, bobRemote } = await setupAliceAndBob({
+          aliceOptions: { tracks: [] },
+          bobOptions: { tracks: [] /* , logLevel: 'debug' */},
+        });
+
+        const bobVideoTrackA = await createLocalVideoTrack(Object.assign({ name: 'trackA' }, smallVideoConstraints));
+        const bobVideoTrackB = await createLocalVideoTrack(Object.assign({ name: 'trackB' }, smallVideoConstraints));
+
+        // Bob publishes video trackA with standard priority, trackB with low priority.
+        await waitFor(bobLocal.publishTrack(bobVideoTrackA), `Bob to publish video trackA: ${roomSid}`);
+        await waitFor(bobLocal.publishTrack(bobVideoTrackB), `Bob to publish video trackB: ${roomSid}`);
+
+        // wait for alice to subscribe two tracks
+        await waitFor(tracksSubscribed(bobRemote, 2), `wait for alice to subscribe to Bobs tracks: ${roomSid}`);
+
+        aliceRoom.disconnect();
+        bobRoom.disconnect();
+      });
+    });
   });
 });

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -546,26 +546,24 @@ describe('LocalTrackPublication', function() {
     });
   });
 
-  [1, 2, 3, 4, 5].forEach(() => {
-    it.only('JSDK-2573 - race condition when recycling transceiver: ', async () => {
-      // Alice and Bob join without tracks, Alice has maxTracks property set to 1
-      const { roomSid, aliceRoom, bobRoom, bobLocal, bobRemote } = await setupAliceAndBob({
-        aliceOptions: { tracks: [] },
-        bobOptions: { tracks: [] },
-      });
-
-      const bobVideoTrackA = await createLocalVideoTrack(Object.assign({ name: 'trackA' }, smallVideoConstraints));
-      const bobVideoTrackB = await createLocalVideoTrack(Object.assign({ name: 'trackB' }, smallVideoConstraints));
-
-      // Bob publishes video trackA with standard priority, trackB with low priority.
-      await waitFor(bobLocal.publishTrack(bobVideoTrackA), `Bob to publish video trackA: ${roomSid}`);
-      await waitFor(bobLocal.publishTrack(bobVideoTrackB), `Bob to publish video trackB: ${roomSid}`);
-
-      // wait for alice to subscribe two tracks
-      await waitFor(tracksSubscribed(bobRemote, 2), `wait for alice to subscribe to Bobs tracks: ${roomSid}`);
-
-      aliceRoom.disconnect();
-      bobRoom.disconnect();
+  it('JSDK-2573 - race condition when recycling transceiver: ', async () => {
+    // Alice and Bob join without tracks, Alice has maxTracks property set to 1
+    const { roomSid, aliceRoom, bobRoom, bobLocal, bobRemote } = await setupAliceAndBob({
+      aliceOptions: { tracks: [] },
+      bobOptions: { tracks: [] },
     });
+
+    const bobVideoTrackA = await createLocalVideoTrack(Object.assign({ name: 'trackA' }, smallVideoConstraints));
+    const bobVideoTrackB = await createLocalVideoTrack(Object.assign({ name: 'trackB' }, smallVideoConstraints));
+
+    // Bob publishes video trackA with standard priority, trackB with low priority.
+    await waitFor(bobLocal.publishTrack(bobVideoTrackA), `Bob to publish video trackA: ${roomSid}`);
+    await waitFor(bobLocal.publishTrack(bobVideoTrackB), `Bob to publish video trackB: ${roomSid}`);
+
+    // wait for alice to subscribe two tracks
+    await waitFor(tracksSubscribed(bobRemote, 2), `wait for alice to subscribe to Bobs tracks: ${roomSid}`);
+
+    aliceRoom.disconnect();
+    bobRoom.disconnect();
   });
 });

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -546,24 +546,26 @@ describe('LocalTrackPublication', function() {
     });
   });
 
-  it('JSDK-2573 - race condition when recycling transceiver: ', async () => {
-    // Alice and Bob join without tracks, Alice has maxTracks property set to 1
-    const { roomSid, aliceRoom, bobRoom, bobLocal, bobRemote } = await setupAliceAndBob({
-      aliceOptions: { tracks: [] },
-      bobOptions: { tracks: [] },
+  [1, 2, 3, 4, 5].forEach(() => {
+    it.only('JSDK-2573 - race condition when recycling transceiver: ', async () => {
+      // Alice and Bob join without tracks, Alice has maxTracks property set to 1
+      const { roomSid, aliceRoom, bobRoom, bobLocal, bobRemote } = await setupAliceAndBob({
+        aliceOptions: { tracks: [] },
+        bobOptions: { tracks: [] },
+      });
+
+      const bobVideoTrackA = await createLocalVideoTrack(Object.assign({ name: 'trackA' }, smallVideoConstraints));
+      const bobVideoTrackB = await createLocalVideoTrack(Object.assign({ name: 'trackB' }, smallVideoConstraints));
+
+      // Bob publishes video trackA with standard priority, trackB with low priority.
+      await waitFor(bobLocal.publishTrack(bobVideoTrackA), `Bob to publish video trackA: ${roomSid}`);
+      await waitFor(bobLocal.publishTrack(bobVideoTrackB), `Bob to publish video trackB: ${roomSid}`);
+
+      // wait for alice to subscribe two tracks
+      await waitFor(tracksSubscribed(bobRemote, 2), `wait for alice to subscribe to Bobs tracks: ${roomSid}`);
+
+      aliceRoom.disconnect();
+      bobRoom.disconnect();
     });
-
-    const bobVideoTrackA = await createLocalVideoTrack(Object.assign({ name: 'trackA' }, smallVideoConstraints));
-    const bobVideoTrackB = await createLocalVideoTrack(Object.assign({ name: 'trackB' }, smallVideoConstraints));
-
-    // Bob publishes video trackA with standard priority, trackB with low priority.
-    await waitFor(bobLocal.publishTrack(bobVideoTrackA), `Bob to publish video trackA: ${roomSid}`);
-    await waitFor(bobLocal.publishTrack(bobVideoTrackB), `Bob to publish video trackB: ${roomSid}`);
-
-    // wait for alice to subscribe two tracks
-    await waitFor(tracksSubscribed(bobRemote, 2), `wait for alice to subscribe to Bobs tracks: ${roomSid}`);
-
-    aliceRoom.disconnect();
-    bobRoom.disconnect();
   });
 });

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -496,10 +496,6 @@ describe('LocalTrackPublication', function() {
       });
 
       const bobVideoTrackA = await createLocalVideoTrack(Object.assign({ name: 'trackA' }, smallVideoConstraints));
-
-      // workaround for JSDK-2573: race condition - video SDK recycles transceivers that is in use.
-      await new Promise(resolve => setTimeout(resolve, 1000));
-
       const bobVideoTrackB = await createLocalVideoTrack(Object.assign({ name: 'trackB' }, smallVideoConstraints));
 
       // Bob publishes video trackA with standard priority, trackB with low priority.
@@ -548,26 +544,26 @@ describe('LocalTrackPublication', function() {
       aliceRoom.disconnect();
       bobRoom.disconnect();
     });
+  });
 
-    it.only('JSDK-2573 - race condition when recycling trans-receiver: ', async () => {
-      // Alice and Bob join without tracks, Alice has maxTracks property set to 1
-      const { roomSid, aliceRoom, bobRoom, bobLocal, bobRemote } = await setupAliceAndBob({
-        aliceOptions: { tracks: [] },
-        bobOptions: { tracks: [] },
-      });
-
-      const bobVideoTrackA = await createLocalVideoTrack(Object.assign({ name: 'trackA' }, smallVideoConstraints));
-      const bobVideoTrackB = await createLocalVideoTrack(Object.assign({ name: 'trackB' }, smallVideoConstraints));
-
-      // Bob publishes video trackA with standard priority, trackB with low priority.
-      await waitFor(bobLocal.publishTrack(bobVideoTrackA), `Bob to publish video trackA: ${roomSid}`);
-      await waitFor(bobLocal.publishTrack(bobVideoTrackB), `Bob to publish video trackB: ${roomSid}`);
-
-      // wait for alice to subscribe two tracks
-      await waitFor(tracksSubscribed(bobRemote, 2), `wait for alice to subscribe to Bobs tracks: ${roomSid}`);
-
-      aliceRoom.disconnect();
-      bobRoom.disconnect();
+  it('JSDK-2573 - race condition when recycling transceiver: ', async () => {
+    // Alice and Bob join without tracks, Alice has maxTracks property set to 1
+    const { roomSid, aliceRoom, bobRoom, bobLocal, bobRemote } = await setupAliceAndBob({
+      aliceOptions: { tracks: [] },
+      bobOptions: { tracks: [] },
     });
+
+    const bobVideoTrackA = await createLocalVideoTrack(Object.assign({ name: 'trackA' }, smallVideoConstraints));
+    const bobVideoTrackB = await createLocalVideoTrack(Object.assign({ name: 'trackB' }, smallVideoConstraints));
+
+    // Bob publishes video trackA with standard priority, trackB with low priority.
+    await waitFor(bobLocal.publishTrack(bobVideoTrackA), `Bob to publish video trackA: ${roomSid}`);
+    await waitFor(bobLocal.publishTrack(bobVideoTrackB), `Bob to publish video trackB: ${roomSid}`);
+
+    // wait for alice to subscribe two tracks
+    await waitFor(tracksSubscribed(bobRemote, 2), `wait for alice to subscribe to Bobs tracks: ${roomSid}`);
+
+    aliceRoom.disconnect();
+    bobRoom.disconnect();
   });
 });


### PR DESCRIPTION
@syerrapragada, 

We have this logic to recyle the `RTCRtpTransceiver`s - wherein we check for any `recvonly` or `inactive` transceivers and mark them for reuse for next tracks that are added. The problem was a race condition caused a transceiver to be marked as recycle'ed even when it was in process of being used. 

This happens if a `negotiationCompleted` is triggered while the promise to `replaceTrack` on transreciver.sender was still pending. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
