### PR TITLE
JSDK-2590 use rsp for publish priority updates

### DIFF
--- a/lib/participant.js
+++ b/lib/participant.js
@@ -330,7 +330,7 @@ class Participant extends EventEmitter {
       }
 
       const options = { log, name };
-      const setPriority = newPriority => participantSignaling.updateTrackPriority(sid, newPriority);
+      const setPriority = newPriority => participantSignaling.updateSubscriberTrackPriority(sid, newPriority);
       const track = kind === 'data'
         ? new RemoteTrack(sid, trackTransceiver, options)
         : new RemoteTrack(sid, trackTransceiver, isEnabled, setPriority, options);

--- a/lib/signaling/participant.js
+++ b/lib/signaling/participant.js
@@ -165,11 +165,9 @@ class ParticipantSignaling extends StateMachine {
    * @param {?Track.Priority} priority
    * @returns {void}
    */
-  updateTrackPriority(trackSid, priority) {
+  updateSubscriberTrackPriority(trackSid, priority) {
     if (this._trackPrioritySignaling) {
-      // this._trackAction = isLocaltrack ? 'publish' : 'subscribe'
-      // COPA: don't do this for 'publish' anymore.
-      this._trackPrioritySignaling.sendTrackPriorityUpdate(trackSid, this._trackAction, priority);
+      this._trackPrioritySignaling.sendTrackPriorityUpdate(trackSid, 'subscribe', priority);
     } else {
       this._enqueuedPriorityUpdates.set(trackSid, priority);
     }
@@ -184,7 +182,7 @@ class ParticipantSignaling extends StateMachine {
     this._trackPrioritySignaling = trackPrioritySignaling;
     if (trackPrioritySignaling) {
       this._enqueuedPriorityUpdates.forEach((priority, trackSid) => {
-        this._trackPrioritySignaling.sendTrackPriorityUpdate(trackSid, this._trackAction, priority);
+        this._trackPrioritySignaling.sendTrackPriorityUpdate(trackSid, 'subscribe', priority);
       });
       this._enqueuedPriorityUpdates.clear();
     }

--- a/lib/signaling/participant.js
+++ b/lib/signaling/participant.js
@@ -166,10 +166,10 @@ class ParticipantSignaling extends StateMachine {
    * @returns {void}
    */
   updateSubscriberTrackPriority(trackSid, priority) {
+    // note the most recent priority update for the track.
+    this._enqueuedPriorityUpdates.set(trackSid, priority);
     if (this._trackPrioritySignaling) {
       this._trackPrioritySignaling.sendTrackPriorityUpdate(trackSid, 'subscribe', priority);
-    } else {
-      this._enqueuedPriorityUpdates.set(trackSid, priority);
     }
   }
 
@@ -184,7 +184,9 @@ class ParticipantSignaling extends StateMachine {
       this._enqueuedPriorityUpdates.forEach((priority, trackSid) => {
         this._trackPrioritySignaling.sendTrackPriorityUpdate(trackSid, 'subscribe', priority);
       });
-      this._enqueuedPriorityUpdates.clear();
+
+      // NOTE(mpatwardhan)- we intentionally do not clear _enqueuedPriorityUpdates,
+      // this cache will be used to re-send the priorities in case of VMS-FailOver.
     }
     return this;
   }

--- a/lib/signaling/participant.js
+++ b/lib/signaling/participant.js
@@ -167,6 +167,8 @@ class ParticipantSignaling extends StateMachine {
    */
   updateTrackPriority(trackSid, priority) {
     if (this._trackPrioritySignaling) {
+      // this._trackAction = isLocaltrack ? 'publish' : 'subscribe'
+      // COPA: don't do this for 'publish' anymore.
       this._trackPrioritySignaling.sendTrackPriorityUpdate(trackSid, this._trackAction, priority);
     } else {
       this._enqueuedPriorityUpdates.set(trackSid, priority);

--- a/lib/signaling/v2/localparticipant.js
+++ b/lib/signaling/v2/localparticipant.js
@@ -147,7 +147,6 @@ class LocalParticipantV2 extends LocalParticipantSignaling {
 
     let {
       isEnabled,
-      sid,
       updatedPriority
     } = publication;
 
@@ -160,9 +159,6 @@ class LocalParticipantV2 extends LocalParticipantSignaling {
         this.didUpdate();
         isEnabled = publication.isEnabled;
         updatedPriority = publication.updatedPriority;
-      }
-      if (!sid && publication.sid) {
-        sid = publication.sid;
       }
     };
 

--- a/lib/signaling/v2/localparticipant.js
+++ b/lib/signaling/v2/localparticipant.js
@@ -39,10 +39,6 @@ class LocalParticipantV2 extends LocalParticipantSignaling {
       _removeListeners: {
         value: new Map()
       },
-      // COPA: can be removed.
-      _trackAction: {
-        value: 'publish'
-      },
       _LocalTrackPublicationV2: {
         value: options.LocalTrackPublicationV2
       },
@@ -171,10 +167,6 @@ class LocalParticipantV2 extends LocalParticipantSignaling {
       if (!sid && publication.sid) {
         sid = publication.sid;
       }
-      // if (sid && (updatedPriority !== publication.updatedPriority)) {
-      //   this.updateTrackPriority(publication.sid, publication.updatedPriority);
-      //   updatedPriority = publication.updatedPriority;
-      // }
     };
 
     publication.on('updated', updated);

--- a/lib/signaling/v2/localparticipant.js
+++ b/lib/signaling/v2/localparticipant.js
@@ -154,11 +154,8 @@ class LocalParticipantV2 extends LocalParticipantSignaling {
     const updated = () => {
       // NOTE(mmalavalli): The LocalParticipantV2's state is only published if
       // the "updated" event is emitted due to LocalTrackPublicationV2's
-      // .isEnabled being toggled. We do not publish if it is fired due to the
+      // .isEnabled or .updatedPriority being changed. We do not publish if it is fired due to the
       // LocalTrackPublicationV2's .sid being set.
-
-
-      // CHANGE THIS TO UPDATE ON TRACK PRIORITY UPDATES.
       if (isEnabled !== publication.isEnabled || updatedPriority !== publication.updatedPriority) {
         this.didUpdate();
         isEnabled = publication.isEnabled;

--- a/lib/signaling/v2/localparticipant.js
+++ b/lib/signaling/v2/localparticipant.js
@@ -39,6 +39,7 @@ class LocalParticipantV2 extends LocalParticipantSignaling {
       _removeListeners: {
         value: new Map()
       },
+      // COPA: can be removed.
       _trackAction: {
         value: 'publish'
       },
@@ -159,17 +160,21 @@ class LocalParticipantV2 extends LocalParticipantSignaling {
       // the "updated" event is emitted due to LocalTrackPublicationV2's
       // .isEnabled being toggled. We do not publish if it is fired due to the
       // LocalTrackPublicationV2's .sid being set.
-      if (isEnabled !== publication.isEnabled) {
+
+
+      // CHANGE THIS TO UPDATE ON TRACK PRIORITY UPDATES.
+      if (isEnabled !== publication.isEnabled || updatedPriority !== publication.updatedPriority) {
         this.didUpdate();
         isEnabled = publication.isEnabled;
+        updatedPriority = publication.updatedPriority;
       }
       if (!sid && publication.sid) {
         sid = publication.sid;
       }
-      if (sid && (updatedPriority !== publication.updatedPriority)) {
-        this.updateTrackPriority(publication.sid, publication.updatedPriority);
-        updatedPriority = publication.updatedPriority;
-      }
+      // if (sid && (updatedPriority !== publication.updatedPriority)) {
+      //   this.updateTrackPriority(publication.sid, publication.updatedPriority);
+      //   updatedPriority = publication.updatedPriority;
+      // }
     };
 
     publication.on('updated', updated);

--- a/lib/signaling/v2/localtrackpublication.js
+++ b/lib/signaling/v2/localtrackpublication.js
@@ -27,7 +27,7 @@ class LocalTrackPublicationV2 extends LocalTrackPublicationSignaling {
       id: this.id,
       kind: this.kind,
       name: this.name,
-      priority: this.priority
+      priority: this.updatedPriority
     };
   }
 

--- a/lib/signaling/v2/remoteparticipant.js
+++ b/lib/signaling/v2/remoteparticipant.js
@@ -26,10 +26,6 @@ class RemoteParticipantV2 extends RemoteParticipantSignaling {
         writable: true,
         value: null
       },
-      // COPA: can be removed.
-      _trackAction: {
-        value: 'subscribe'
-      },
       _RemoteTrackPublicationV2: {
         value: options.RemoteTrackPublicationV2
       },

--- a/lib/signaling/v2/remoteparticipant.js
+++ b/lib/signaling/v2/remoteparticipant.js
@@ -26,6 +26,7 @@ class RemoteParticipantV2 extends RemoteParticipantSignaling {
         writable: true,
         value: null
       },
+      // COPA: can be removed.
       _trackAction: {
         value: 'subscribe'
       },

--- a/lib/signaling/v2/remotetrackpublication.js
+++ b/lib/signaling/v2/remotetrackpublication.js
@@ -24,6 +24,8 @@ class RemoteTrackPublicationV2 extends RemoteTrackPublicationSignaling {
    */
   update(track) {
     this.enable(track.enabled);
+    // COPA: setPriority of the track here.
+    this.setPriority(track.priority);
     return this;
   }
 }

--- a/lib/signaling/v2/remotetrackpublication.js
+++ b/lib/signaling/v2/remotetrackpublication.js
@@ -24,7 +24,6 @@ class RemoteTrackPublicationV2 extends RemoteTrackPublicationSignaling {
    */
   update(track) {
     this.enable(track.enabled);
-    // COPA: setPriority of the track here.
     this.setPriority(track.priority);
     return this;
   }

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -771,7 +771,6 @@ function handleSubscriptions(room) {
   });
 
   trackSidsToTrackSignalings.forEach(trackSignaling => {
-    // update the priority of track here?
     const trackId = room._subscribed.get(trackSignaling.sid);
     if (!trackId || (trackSignaling.isSubscribed && trackSignaling.trackTransceiver.id !== trackId)) {
       trackSignaling.setTrackTransceiver(null);

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -407,10 +407,12 @@ class RoomV2 extends RoomSignaling {
     return this;
   }
 
+  // COPA: remove this function.
   _setupTrackPriorityUpdates(trackPrioritySignaling) {
     this._trackPrioritySignaling = trackPrioritySignaling;
     trackPrioritySignaling.on('updated', (trackSid, publishOrSubscribe, priority) => {
       const trackSignaling = this._getTrackSidsToTrackSignalings().get(trackSid);
+      // COPA: stop listening for 'publish' updates here.
       if (trackSignaling && publishOrSubscribe === 'publish') {
         trackSignaling.setPriority(priority);
       }
@@ -432,7 +434,11 @@ class RoomV2 extends RoomSignaling {
       receiver.once('close', () => this._teardownTrackPrioritySignaling());
 
       const trackPrioritySignaling = new this._TrackPrioritySignaling(receiver.toDataTransport());
+
+      // COPA: remove this call.
       this._setupTrackPriorityUpdates(trackPrioritySignaling);
+
+      // COPA: don't do this for local participant.
       [this.localParticipant, ...this.participants.values()].forEach(participant => {
         participant.setTrackPrioritySignaling(trackPrioritySignaling);
       });
@@ -780,6 +786,7 @@ function handleSubscriptions(room) {
   });
 
   trackSidsToTrackSignalings.forEach(trackSignaling => {
+    // update the priority of track here?
     const trackId = room._subscribed.get(trackSignaling.sid);
     if (!trackId || (trackSignaling.isSubscribed && trackSignaling.trackTransceiver.id !== trackId)) {
       trackSignaling.setTrackTransceiver(null);

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -407,18 +407,8 @@ class RoomV2 extends RoomSignaling {
     return this;
   }
 
-  // COPA: remove this function.
-  _setupTrackPriorityUpdates(trackPrioritySignaling) {
-    this._trackPrioritySignaling = trackPrioritySignaling;
-    trackPrioritySignaling.on('updated', (trackSid, publishOrSubscribe, priority) => {
-      const trackSignaling = this._getTrackSidsToTrackSignalings().get(trackSid);
-      // COPA: stop listening for 'publish' updates here.
-      if (trackSignaling && publishOrSubscribe === 'publish') {
-        trackSignaling.setPriority(priority);
-      }
-    });
-  }
-
+  // track priority signaling MSP is now used only for subscribe side priority changes.
+  // publisher side priority changes and notifications are handled by RSP.
   _setupTrackPrioritySignaling(id) {
     this._teardownTrackPrioritySignaling();
     const trackPriorityPromise = this._getTrackReceiver(id).then(receiver => {
@@ -434,12 +424,7 @@ class RoomV2 extends RoomSignaling {
       receiver.once('close', () => this._teardownTrackPrioritySignaling());
 
       const trackPrioritySignaling = new this._TrackPrioritySignaling(receiver.toDataTransport());
-
-      // COPA: remove this call.
-      this._setupTrackPriorityUpdates(trackPrioritySignaling);
-
-      // COPA: don't do this for local participant.
-      [this.localParticipant, ...this.participants.values()].forEach(participant => {
+      [...this.participants.values()].forEach(participant => {
         participant.setTrackPrioritySignaling(trackPrioritySignaling);
       });
     });

--- a/lib/signaling/v2/trackprioritysignaling.js
+++ b/lib/signaling/v2/trackprioritysignaling.js
@@ -1,48 +1,16 @@
 'use strict';
 
-const { EventEmitter } = require('events');
-
-/**
- * @emits TrackPrioritySignaling#updated
- */
-class TrackPrioritySignaling extends EventEmitter {
+class TrackPrioritySignaling  {
   /**
    * Construct a {@link TrackPrioritySignaling}.
    * @param {MediaSignalingTransport} mediaSignalingTransport
    */
   constructor(mediaSignalingTransport) {
-    super();
-
     Object.defineProperties(this, {
       _mediaSignalingTransport: {
         value: mediaSignalingTransport
       }
     });
-
-    mediaSignalingTransport.on('message', message => {
-      switch (message.type) {
-        case 'track_priority':
-          if (message.publish) {
-            this._setTrackPriorityUpdate(message.track, 'publish', message.publish);
-          } else if (message.subscribe) {
-            this._setTrackPriorityUpdate(message.track, 'subscribe', message.subscribe);
-          }
-          break;
-        default:
-          break;
-      }
-    });
-  }
-
-  /**
-   * @private
-   * @param {Track.SID} trackSid
-   * @param {'publish'|'subscribe'} publishOrSubscribe
-   * @param {Track.Priority} priority
-   * @returns {void}
-   */
-  _setTrackPriorityUpdate(trackSid, publishOrSubscribe, priority) {
-    this.emit('updated', trackSid, publishOrSubscribe, priority);
   }
 
   /**
@@ -51,7 +19,6 @@ class TrackPrioritySignaling extends EventEmitter {
    * @param {Track.Priority} priority
    */
   sendTrackPriorityUpdate(trackSid, publishOrSubscribe, priority) {
-    // COPA: publishOrSubscribe MUST NOT BE 'publish'
     this._mediaSignalingTransport.publish({
       type: 'track_priority',
       track: trackSid,
@@ -59,9 +26,5 @@ class TrackPrioritySignaling extends EventEmitter {
     });
   }
 }
-
-/**
- * @event TrackPrioritySignaling#updated
- */
 
 module.exports = TrackPrioritySignaling;

--- a/lib/signaling/v2/trackprioritysignaling.js
+++ b/lib/signaling/v2/trackprioritysignaling.js
@@ -51,6 +51,7 @@ class TrackPrioritySignaling extends EventEmitter {
    * @param {Track.Priority} priority
    */
   sendTrackPriorityUpdate(trackSid, publishOrSubscribe, priority) {
+    // COPA: publishOrSubscribe MUST NOT BE 'publish'
     this._mediaSignalingTransport.publish({
       type: 'track_priority',
       track: trackSid,

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -57,7 +57,6 @@ describe('LocalTrackPublication', function() {
     const bobVideoTrackA = await createLocalVideoTrack(Object.assign({ name: 'trackA' }, smallVideoConstraints));
     const trackAPubLocal = await waitFor(bobRoom.localParticipant.publishTrack(bobVideoTrackA, { priority: PRIORITY_LOW }), `Bob to publish video trackA: ${roomSid}`);
 
-
     // Bob updates trackA => PRIORITY_HIGH
     trackAPubLocal.setPriority(PRIORITY_HIGH);
     assert.equal(trackAPubLocal.priority, PRIORITY_HIGH);

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -554,6 +554,7 @@ async function waitFor(promiseOrArray, message, timeoutMS = 30 * second, verbose
   clearTimeout(timer);
   return result;
 }
+
 /**
  * sometimes our tests want to ensure that an event does *not* happen
  * this function helps with such waits. It ensures that given promise does not resolve
@@ -585,6 +586,15 @@ async function waitForNot(promise, message, timeoutMS = 5 * second) {
   return result;
 }
 
+/**
+ * Returns a promise that resolve after timeoutMS have passed.
+ * @param {number} timeoutMS - time to wait in milliseconds.
+ * @returns {Promise<void>}
+ */
+async function waitForSometime(timeoutMS = 10 * second) {
+  await new Promise(resolve => setTimeout(resolve, timeoutMS));
+}
+
 exports.a = a;
 exports.capitalize = capitalize;
 exports.createSyntheticAudioStreamTrack = createSyntheticAudioStreamTrack;
@@ -608,6 +618,7 @@ exports.waitForTracks = waitForTracks;
 exports.smallVideoConstraints = smallVideoConstraints;
 exports.setup = setup;
 exports.waitFor = waitFor;
+exports.waitForSometime = waitForSometime;
 exports.waitForNot = waitForNot;
 exports.waitOnceForRoomEvent = waitOnceForRoomEvent;
 exports.waitToGoOnline = waitToGoOnline;

--- a/test/unit/spec/signaling/v2/localparticipant.js
+++ b/test/unit/spec/signaling/v2/localparticipant.js
@@ -350,7 +350,7 @@ describe('LocalParticipantV2', () => {
 
     [
       ['isEnabled', 'enable', false, true],
-      ['updatedPriority', 'setPriority', makeUUID(), false],
+      ['updatedPriority', 'setPriority', makeUUID(), true],
       ['sid', 'setSid', makeUUID(), false]
     ].forEach(([prop, setProp, value, shouldEmitUpdated]) => {
       context(`when emitted due to a change in .${prop}`, () => {
@@ -374,13 +374,6 @@ describe('LocalParticipantV2', () => {
           it('should not emit "updated"', () => {
             assert(!updated);
           });
-
-          if (prop === 'updatedPriority') {
-            it('should call .sendTrackPriorityUpdate on the underlying TrackPrioritySignaling', () => {
-              localTrackPublication.setSid('foo');
-              sinon.assert.calledWith(trackPrioritySignaling.sendTrackPriorityUpdate, 'foo', 'publish', value);
-            });
-          }
         }
       });
     });

--- a/test/unit/spec/signaling/v2/remotetrackpublication.js
+++ b/test/unit/spec/signaling/v2/remotetrackpublication.js
@@ -38,7 +38,7 @@ describe('RemoteTrackPublicationV2', () => {
   describe('#update', () => {
     ['low', 'standard', 'high'].forEach(oldPriorityValue => {
       ['low', 'standard', 'high'].forEach(newPriorityValue => {
-        context.only(`called with priority change: ${oldPriorityValue} => ${newPriorityValue}`, () => {
+        context(`called with priority change: ${oldPriorityValue} => ${newPriorityValue}`, () => {
           it('returns the RemoteTrackPublicationV2', () => {
             const trackState = {
               enabled: true,

--- a/test/unit/spec/signaling/v2/remotetrackpublication.js
+++ b/test/unit/spec/signaling/v2/remotetrackpublication.js
@@ -36,6 +36,75 @@ describe('RemoteTrackPublicationV2', () => {
   });
 
   describe('#update', () => {
+    ['low', 'standard', 'high'].forEach(oldPriorityValue => {
+      ['low', 'standard', 'high'].forEach(newPriorityValue => {
+        context.only(`called with priority change: ${oldPriorityValue} => ${newPriorityValue}`, () => {
+          it('returns the RemoteTrackPublicationV2', () => {
+            const trackState = {
+              enabled: true,
+              kind: makeKind(),
+              name: makeUUID(),
+              priority: oldPriorityValue,
+              sid: makeSid()
+            };
+            const track = new RemoteTrackPublicationV2(trackState);
+            trackState.priority = newPriorityValue;
+            assert.equal(track, track.update(trackState));
+          });
+
+          it('sets .priority to new value', () => {
+            const trackState = {
+              enabled: true,
+              kind: makeKind(),
+              name: makeUUID(),
+              priority: oldPriorityValue,
+              sid: makeSid()
+            };
+            const track = new RemoteTrackPublicationV2(trackState);
+            trackState.priority = newPriorityValue;
+            track.update(trackState);
+            assert.equal(track.priority, newPriorityValue);
+          });
+
+          if (newPriorityValue !== oldPriorityValue) {
+            it('emits an "updated" event with .priority set to newValue', () => {
+              const trackState = {
+                enabled: true,
+                kind: makeKind(),
+                name: makeUUID(),
+                priority: oldPriorityValue,
+                sid: makeSid()
+              };
+
+              let priority;
+              const track = new RemoteTrackPublicationV2(trackState);
+              trackState.priority = newPriorityValue;
+              track.once('updated', () => { priority = track.priority; });
+              track.update(trackState);
+              assert.equal(priority, newPriorityValue);
+            });
+          } else {
+            it('does not emit an "updated" event', () => {
+              const trackState = {
+                enabled: true,
+                kind: makeKind(),
+                name: makeUUID(),
+                priority: oldPriorityValue,
+                sid: makeSid()
+              };
+
+              let updated = false;
+              const track = new RemoteTrackPublicationV2(trackState);
+              trackState.priority = newPriorityValue;
+              track.once('updated', () => { updated = true; });
+              track.update(trackState);
+              assert(!updated);
+            });
+          }
+        });
+      });
+    });
+
     context('called with a trackState setting .enabled to false when the RemoteTrackPublicationV2 is', () => {
       context('enabled', () => {
         it('returns the RemoteTrackPublicationV2', () => {

--- a/test/unit/spec/signaling/v2/room.js
+++ b/test/unit/spec/signaling/v2/room.js
@@ -1188,7 +1188,6 @@ describe('RoomV2', () => {
   describe('TrackPrioritySignaling', () => {
     let TrackPrioritySignaling;
     let trackPrioritySignaling1;
-    let trackPrioritySignaling2;
     let test;
 
     before(() => {
@@ -1196,8 +1195,6 @@ describe('RoomV2', () => {
         const trackPrioritySignaling =  new RealTrackPrioritySignaling(param);
         if (!trackPrioritySignaling1) {
           trackPrioritySignaling1 = trackPrioritySignaling;
-        } else {
-          trackPrioritySignaling2 = trackPrioritySignaling;
         }
         return trackPrioritySignaling;
       });

--- a/test/unit/spec/signaling/v2/room.js
+++ b/test/unit/spec/signaling/v2/room.js
@@ -1278,37 +1278,9 @@ describe('RoomV2', () => {
           sinon.assert.calledWith(TrackPrioritySignaling, dataTrackTransport1);
         });
 
-        it('should call .setTrackPrioritySignaling on the underlying LocalParticipantV2 with the TrackPrioritySignaling', () => {
-          sinon.assert.calledWith(test.localParticipant.setTrackPrioritySignaling, trackPrioritySignaling1);
-        });
-
         it('should call .setTrackPrioritySignaling on the RemoteParticipantV2 with the TrackPrioritySignaling', () => {
           [...test.room.participants.values()].forEach(participant => {
             sinon.assert.calledWith(participant.setTrackPrioritySignaling, trackPrioritySignaling1);
-          });
-        });
-
-        context('when a "message" is received un the underlying DataTrackTransport', () => {
-          it('should update the publish priority of the relevant RemoteTrackPublicationV2s', async () => {
-            const trackSignalings = new Map(flatMap([...test.room.participants.values()],
-              participant => [...participant.tracks]));
-            const trackUpdatedPromises = [...trackSignalings.values()].map(trackSignaling =>
-              new Promise(resolve => trackSignaling.once('updated', resolve)));
-
-            [
-              ['MT3', 'low'],
-              ['MT4', 'high']
-            ].forEach(([trackSid, priority]) => {
-              dataTrackTransport1.emit('message', {
-                type: 'track_priority',
-                track: trackSid,
-                publish: priority
-              });
-            });
-
-            await Promise.all(trackUpdatedPromises);
-            assert.equal(trackSignalings.get('MT3').priority, 'low');
-            assert.equal(trackSignalings.get('MT4').priority, 'high');
           });
         });
 
@@ -1320,10 +1292,6 @@ describe('RoomV2', () => {
             dataTrackReceiver2 = makeTrackReceiver({ id: 'bar', kind: 'data' });
             dataTrackReceiver2.toDataTransport = sinon.spy(() => dataTrackTransport2);
             test.peerConnectionManager.emit('trackAdded', dataTrackReceiver2);
-          });
-
-          it('should call .setTrackPrioritySignaling on the underlying LocalParticipantV2 with null', () => {
-            sinon.assert.calledWith(test.localParticipant.setTrackPrioritySignaling, null);
           });
 
           it('should call .setTrackPrioritySignaling on the RemoteParticipantV2 with null', () => {
@@ -1352,40 +1320,6 @@ describe('RoomV2', () => {
 
             it('should construct a TrackPrioritySignaling with the new DataTrackTransport,', () => {
               sinon.assert.calledWith(TrackPrioritySignaling, dataTrackTransport2);
-            });
-
-            it('should call .setTrackPrioritySignaling on the underlying LocalParticipantV2 with the new TrackPrioritySignaling', () => {
-              sinon.assert.calledWith(test.localParticipant.setTrackPrioritySignaling, trackPrioritySignaling2);
-            });
-
-            it('should call .setTrackPrioritySignaling on the underlying RemoteParticipantV2 with the new TrackPrioritySignaling', () => {
-              [...test.room.participants.values()].forEach(participant => {
-                sinon.assert.calledWith(participant.setTrackPrioritySignaling, trackPrioritySignaling2);
-              });
-            });
-
-            context('when a "message" is received un the underlying DataTrackTransport', () => {
-              it('should update the publish priority of the relevant RemoteTrackPublicationV2s', async () => {
-                const trackSignalings = new Map(flatMap([...test.room.participants.values()],
-                  participant => [...participant.tracks]));
-                const trackUpdatedPromises = [...trackSignalings.values()].map(trackSignaling =>
-                  new Promise(resolve => trackSignaling.once('updated', resolve)));
-
-                [
-                  ['MT3', 'high'],
-                  ['MT4', 'low']
-                ].forEach(([trackSid, priority]) => {
-                  dataTrackTransport2.emit('message', {
-                    type: 'track_priority',
-                    track: trackSid,
-                    publish: priority
-                  });
-                });
-
-                await Promise.all(trackUpdatedPromises);
-                assert.equal(trackSignalings.get('MT3').priority, 'high');
-                assert.equal(trackSignalings.get('MT4').priority, 'low');
-              });
             });
           });
         });

--- a/test/unit/spec/signaling/v2/trackprioritysignaling.js
+++ b/test/unit/spec/signaling/v2/trackprioritysignaling.js
@@ -3,7 +3,6 @@
 const assert = require('assert');
 const sinon = require('sinon');
 
-const { EventEmitter } = require('events');
 const MediaSignalingTransport = require('../../../../../lib/data/transport');
 const TrackPrioritySignaling = require('../../../../../lib/signaling/v2/trackprioritysignaling');
 
@@ -28,33 +27,6 @@ describe('TrackPrioritySignaling', () => {
             track: 'MT123',
             [action]: 'bar'
           });
-        });
-      });
-    });
-  });
-
-  describe('"updated" event', () => {
-    ['publish', 'subscribe'].forEach(action => {
-      context(`when the underlying MediaSignalingTransport emits a "message" event with an MSP payload with a .${action} property`, () => {
-        it(`should emit an "updated" event with the Track SID, "${action}" and the new priority`, async () => {
-          const mediaSignalingTransport = new EventEmitter();
-          const trackPrioritySignaling = new TrackPrioritySignaling(mediaSignalingTransport);
-          const updatedPromise = new Promise(resolve => trackPrioritySignaling.once('updated', (trackSid, publishOrSubscribe, priority) => resolve({
-            trackSid,
-            publishOrSubscribe,
-            priority
-          })));
-
-          mediaSignalingTransport.emit('message', {
-            type: 'track_priority',
-            track: 'MT123',
-            [action]: 'bar'
-          });
-
-          const { trackSid, publishOrSubscribe, priority } = await updatedPromise;
-          assert.equal(trackSid, 'MT123');
-          assert.equal(publishOrSubscribe, action);
-          assert.equal(priority, 'bar');
         });
       });
     });


### PR DESCRIPTION
Previously we used MSP objects for updating publish priority of tracks, and to receive updates about publish priority changes. 

But the approach [had a problem](https://issues.corp.twilio.com/browse/VMS-2262) that RS was not aware of the changes, and new participants (the ones who missed the `publishPriorityChanged` event would not see the updated priority of the tracks. 

we [decided](https://issues.corp.twilio.com/browse/VMS-2262?focusedCommentId=1646865&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1646865) to use RSP messages for updating and getting notified about updates on publish priorities. 

 TODO:
- [ ] merge after [RS changes](https://code.hq.twilio.com/twilio/rtc-room-service/pull/603) are available in stage
 
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
