### PR TITLE
JSDK-2548 doc: move classes in classes tab not module

### DIFF
--- a/lib/media/track/localaudiotrack.js
+++ b/lib/media/track/localaudiotrack.js
@@ -12,7 +12,6 @@ const LocalMediaAudioTrack = mixinLocalMediaTrack(AudioTrack);
  * {@link LocalAudioTrack#disable} or stopped completely with
  * {@link LocalAudioTrack#stop}.
  * @extends AudioTrack
- * @alias module:twilio-video.LocalAudioTrack
  * @property {Track.ID} id - The {@link LocalAudioTrack}'s ID
  * @property {boolean} isStopped - Whether or not the {@link LocalAudioTrack} is
  *   stopped

--- a/lib/media/track/localdatatrack.js
+++ b/lib/media/track/localdatatrack.js
@@ -7,7 +7,6 @@ const DefaultDataTrackSender = require('../../data/sender');
  * A {@link LocalDataTrack} is a {@link Track} representing data that your
  * {@link LocalParticipant} can publish to a {@link Room}.
  * @extends Track
- * @alias module:twilio-video.LocalDataTrack
  * @property {Track.ID} id - The {@link LocalDataTrack}'s ID
  * @property {Track.Kind} kind - "data"
  * @property {?number} maxPacketLifeTime - If non-null, this represents a time

--- a/lib/media/track/localvideotrack.js
+++ b/lib/media/track/localvideotrack.js
@@ -12,7 +12,6 @@ const LocalMediaVideoTrack = mixinLocalMediaTrack(VideoTrack);
  * {@link LocalVideoTrack#disable} or stopped completely with
  * {@link LocalVideoTrack#stop}.
  * @extends VideoTrack
- * @alias module:twilio-video.LocalVideoTrack
  * @property {Track.ID} id - The {@link LocalVideoTrack}'s ID
  * @property {boolean} isStopped - Whether or not the {@link LocalVideoTrack} is
  *   stopped


### PR DESCRIPTION
we moved some top level functions and properties (`connect`, `createLocalTrack`)  inside module when we documented missing properties: https://github.com/twilio/twilio-video.js/pull/753


See [new](https://media.twiliocdn.com/sdk/js/video/releases/2.0.0-beta15/docs/module-twilio-video.html) v/s [old](https://media.twiliocdn.com/sdk/js/video/releases/2.0.0-beta14/docs/global.html)

It also moved some top level classes - LocalAudioTrack, LocalVideoTrack, LocalDataTrack - inside the module.  

Moving these classes inside the module has made them less discoverable, has resulted in some [github issue](https://github.com/twilio/twilio-video.js/issues/810). And also some broken links within docs. For example links to Fires: section in https://media.twiliocdn.com/sdk/js/video/releases/2.0.0-beta15/docs/module-twilio-video.LocalAudioTrack.html#toc11__anchor  result in error. 

We should move them off the module  so that they are consistent with rest of the classes.

With this change only top level function stay in module definition. 