### PR TITLE
JSDK-2605: fix doc + store artifacts for the build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,9 @@ commands:
       - run:
           name: Building Quick
           command: npm run build:quick
+      - store_artifacts:
+          path: ./dist
+          prefix: dist
   unit-tests:
     steps:
       - get-code-and-dependencies

--- a/lib/room.js
+++ b/lib/room.js
@@ -350,21 +350,23 @@ function rewriteLocalTrackIds(room, trackStats) {
 
 /**
  * A {@link RemoteParticipant}'s {@link RemoteTrack} was switched off.
- * @param {RemoteTrack} track - The {@link RemoteTrack} that was subscribed
+ * @param {RemoteTrack} track - The {@link RemoteTrack} that was switched off
  * @param {RemoteTrackPublication} publication - The {@link RemoteTrackPublication}
  *   for the {@link RemoteTrack} that was subscribed to
  * @param {RemoteParticipant} participant - The {@link RemoteParticipant} whose
  *   {@link RemoteTrack} was switched off
  * @event Room#trackSwitchedOff
+ */
 
 /**
  * A {@link RemoteParticipant}'s {@link RemoteTrack} was switched on.
- * @param {RemoteTrack} track - The {@link RemoteTrack} that was subscribed
+ * @param {RemoteTrack} track - The {@link RemoteTrack} that was switched on
  * @param {RemoteTrackPublication} publication - The {@link RemoteTrackPublication}
  *   for the {@link RemoteTrack} that was subscribed to
  * @param {RemoteParticipant} participant - The {@link RemoteParticipant} whose
  *   {@link RemoteTrack} was switched on
  * @event Room#trackSwitchedOn
+ */
 
 /**
  * A {@link RemoteParticipant}'s {@link RemoteTrack} could not be subscribed to.


### PR DESCRIPTION
Fixes doc error. 
Before:
http://stage.twiliocdn.com/sdk/js/video/releases/2.0.0-rc49/docs/Room.html

After:
https://4973-46595751-gh.circle-artifacts.com/0/home/circleci/project/dist/docs/Room.html

Also stores artifacts as part of the build, so that these docs can be viewed. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
