### PR TITLE
JSDK 2603 - fire events only on change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,9 @@ You can limit bitrates on outgoing tracks using [Localparticipant.setParameters]
 
 - Fixed a race condition, that would sometimes cause a track to not get published if multiple tracks were added in quick succession (JSDK-2573)
 
+- Fixed a bug where `publishPriorityChanged`, `trackDisabled` `trackEnabled` events were getting fired for initial track state.
+With this fix these events will fire only when the state changes. (JSDK-2603)
+
 2.0.0-beta15 (October 24, 2019)
 ===============================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,8 +95,7 @@ You can limit bitrates on outgoing tracks using [Localparticipant.setParameters]
 
 - Fixed a race condition, that would sometimes cause a track to not get published if multiple tracks were added in quick succession (JSDK-2573)
 
-- Fixed a bug where `publishPriorityChanged`, `trackDisabled` `trackEnabled` events were getting fired for initial track state.
-With this fix these events will fire only when the state changes. (JSDK-2603)
+- Fixed a bug where `publishPriorityChanged`, `trackDisabled` and `trackEnabled` events were getting fired for initial track state (JSDK-2603)
 
 - Fixed an issue where loading twilio-video.js in firefox with `media.peerconnection.enabled` set to false in `about:config` caused page errors. (JSDK-2591)
 

--- a/lib/media/track/remotetrackpublication.js
+++ b/lib/media/track/remotetrackpublication.js
@@ -72,13 +72,13 @@ class RemoteTrackPublication extends TrackPublication {
       }
     });
 
-    // NOTE(mpatwardhan) - we must not initialize these using signaling object's initial values
-    //  because SDK expects events even for initial values. For example if track is started as disabled,
-    //  sdk expects trackDisabled event.
-    let error = null;
-    let isEnabled;
-    let isSwitchedOff = false;
-    let priority;
+    // remember original state, and fire events only on change.
+    let {
+      error,
+      isEnabled,
+      isSwitchedOff,
+      priority
+    } = signaling;
 
     signaling.on('updated', () => {
       if (error !== signaling.error) {

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -110,7 +110,7 @@ describe('LocalTrackPublication', function() {
   });
 
   [true, false].forEach((trackInitiallyEnabled) => {
-    it(`JSDK-2603: ${trackInitiallyEnabled ? 'trackDisabled' : 'trackEnabled'} should fire only on change`, async () => {
+    it(`JSDK-2603: ${trackInitiallyEnabled ? 'trackEnabled' : 'trackDisabled'} should fire only on change`, async () => {
       const roomSid = await createRoom(randomName(), defaults.topology);
       const options = Object.assign({ name: roomSid }, defaults);
 
@@ -139,9 +139,15 @@ describe('LocalTrackPublication', function() {
       if (trackInitiallyEnabled) {
         bobLocalAudioTrack.disable();
         await waitFor(trackDisabledPromise, `Alice to receive trackDisabled event: ${roomSid}`);
+
+        bobLocalAudioTrack.enable();
+        await waitFor(trackEnabledPromise, `Alice to receive trackEnabled event: ${roomSid}`);
       } else {
         bobLocalAudioTrack.enable();
         await waitFor(trackEnabledPromise, `Alice to receive trackEnabled event: ${roomSid}`);
+
+        bobLocalAudioTrack.disable();
+        await waitFor(trackDisabledPromise, `Alice to receive trackDisabled event: ${roomSid}`);
       }
 
       [aliceRoom, bobRoom].forEach(room => room.disconnect());


### PR DESCRIPTION
for sometime during 2.x beta releases events `trackDisabled`, `trackEnabled` `publishPriorirtyChanged` were getting fired even on initial track state. For example when a track was published with disabled state, the subscriber would get `trackDisabled` event. With this fix these events will fire only when the track state changes.
 
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
