### PR TITLE
JSDK-2591 update twilio-webrtc version to fix load errors on firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,8 @@ You can limit bitrates on outgoing tracks using [Localparticipant.setParameters]
 
 - Fixed a race condition, that would sometimes cause a track to not get published if multiple tracks were added in quick succession (JSDK-2573)
 
+- Fixed an issue where loading twilio-video.js in firefox with `media.peerconnection.enabled` set to false in `about:config` caused page errors. (JSDK-2591)
+
 2.0.0-beta15 (October 24, 2019)
 ===============================
 

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- ./test/unit/index.js"
   },
   "dependencies": {
-    "@twilio/webrtc": "4.1.2",
+    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#4.1.3-rc.1",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },


### PR DESCRIPTION
Loading twilo-video on firefox with `media.peerconnection.enabled` is set to `false` from `about:config` resulted in page errors. This change updates the webrtc version with the fix: https://code.hq.twilio.com/client/twilio-webrtc.js-burndowns/pull/48

Fixes: https://github.com/twilio/twilio-video.js/issues/811

 
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
