### PR TITLE
JSDK-2588: identify and mark unstable tests (develop branch)

### DIFF
--- a/.circleci/images/docker-compose.yml
+++ b/.circleci/images/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     - API_KEY_SECRET
     - TOPOLOGY
     - ENABLE_REST_API_TESTS
-    - STABILITY
+    - TEST_STABILITY
     volumes:
       - "../../:/opt/app"
       - /var/run/docker.sock:/var/run/docker.sock

--- a/.circleci/images/docker-compose.yml
+++ b/.circleci/images/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     - API_KEY_SECRET
     - TOPOLOGY
     - ENABLE_REST_API_TESTS
+    - STABILITY
     volumes:
       - "../../:/opt/app"
       - /var/run/docker.sock:/var/run/docker.sock

--- a/test/integration/spec/docker/reconnection.js
+++ b/test/integration/spec/docker/reconnection.js
@@ -178,7 +178,7 @@ describe('Reconnection states and events', function() {
         });
 
         context('that is longer than the session timeout', () => {
-          (isFirefox ? it.skip : it)('should emit "disconnected" on the Rooms', async () => {
+          it('should emit "disconnected" on the Rooms' + isFirefox ? ' @unstable ' : '', async () => {
             const disconnectPromises = rooms.map(room => new Promise(resolve => room.once('disconnected', resolve)));
             await waitFor(reconnectingPromises, 'reconnectingPromises', RECONNECTING_TIMEOUT);
             await waitFor(disconnectPromises, 'disconnectPromises', DISCONNECTED_TIMEOUT);
@@ -186,7 +186,7 @@ describe('Reconnection states and events', function() {
         });
 
         context('that recovers before the session timeout', () => {
-          it('should emit "reconnected on the Rooms', async () => {
+          it('should emit "reconnected on the Rooms' + isFirefox ? ' @unstable ' : '', async () => {
             const reconnectedPromises = rooms.map(room => new Promise(resolve => room.once('reconnected', resolve)));
 
             await waitFor(reconnectingPromises, 'reconnectingPromises', RECONNECTING_TIMEOUT);

--- a/test/integration/spec/docker/reconnection.js
+++ b/test/integration/spec/docker/reconnection.js
@@ -220,7 +220,7 @@ describe('Reconnection states and events', function() {
       // ([bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1546562))
       // ([bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1548318))
       (isFirefox ? describe.skip : describe)('Network handoff reconnects to new network', () => {
-        it('Known Unstable JSDK-2503: Scenario 1 (jump): connected interface switches off and then a new interface switches on',  async () => {
+        it('@unstable: Scenario 1 (jump): connected interface switches off and then a new interface switches on',  async () => {
           const reconnectingPromises = rooms.map(room => new Promise(resolve => room.once('reconnecting', resolve)));
           const reconnectedPromises = rooms.map(room => new Promise(resolve => room.once('reconnected', resolve)));
           const newNetwork = await waitFor(dockerAPI.createNetwork(), 'create network');
@@ -244,7 +244,7 @@ describe('Reconnection states and events', function() {
           }
         });
 
-        it('Known Unstable JSDK-2503: Scenatio 2 (step) : new interface switches on and then the connected interface switches off.', async () => {
+        it('@unstable: Scenario 2 (step) : new interface switches on and then the connected interface switches off.', async () => {
           const reconnectingPromises = rooms.map(room => new Promise(resolve => room.once('reconnecting', resolve)));
           const reconnectedPromises = rooms.map(room => new Promise(resolve => room.once('reconnected', resolve)));
 

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -1130,22 +1130,22 @@ describe('LocalParticipant', function() {
         const subscriberLocal = subscriberRoom.localParticipant;
 
         // Subscriber waits until it recognizes the Dominant Speaker and subscribes to its AudioTrack.
-        await Promise.all([
+        await waitFor([
           dominantSpeakerChanged(subscriberRoom, dominantSpeakerRemote),
           tracksSubscribed(dominantSpeakerRemote, 1)
-        ]);
+        ], `dominantSpeaker change and track to subscribe: ${sid}`);
 
         const [dominantSpeakerVideoTrack, passiveSpeakerVideoTrack] = await Promise.all([1, 2].map(() =>
           createLocalVideoTrack(smallVideoConstraints)));
 
         // The Dominant Speaker and Passive Speaker publish their VideoTracks. The
         // Subscriber waits until it has subscribed to them.
-        await Promise.all([
+        await waitFor([
           dominantSpeakerLocal.publishTrack(dominantSpeakerVideoTrack, { priority: dominantSpeakerPublishPriority }),
           passiveSpeakerLocal.publishTrack(passiveSpeakerVideoTrack, { priority: passiveSpeakerPublishPriority }),
           tracksSubscribed(dominantSpeakerRemote, 2),
           tracksSubscribed(passiveSpeakerRemote, 1)
-        ]);
+        ], `tracks to get published and subscribed: ${sid}`);
 
         const dominantSpeakerRemoteVideoTrack = [...dominantSpeakerRemote.videoTracks.values()][0].track;
         const passiveSpeakerRemoteVideoTrack = [...passiveSpeakerRemote.videoTracks.values()][0].track;
@@ -1164,10 +1164,10 @@ describe('LocalParticipant', function() {
         // Since the initial .maxTracks set by the Subscriber is 1, it makes sure the
         // appropriate VideoTrack is switched off.
         const switched1 = switchedParticipants[getSwitchOffParticipant(bandwidthProfile.video.dominantSpeakerPriority)];
-        await Promise.all([
+        await waitFor([
           trackSwitchedOn(switched1.on.remoteVideoTrack),
           trackSwitchedOff(switched1.off.remoteVideoTrack)
-        ]);
+        ], `one track to switch on and other off: ${sid}`);
 
         switched1.off.participant.videoTracks.forEach(({ track }) => {
           assert.equal(track.isSwitchedOff, true);
@@ -1187,10 +1187,10 @@ describe('LocalParticipant', function() {
 
         if (maxTracks > 1) {
           // Since the updated .maxTracks > 1, all VideoTracks should be switched on.
-          await Promise.all([
+          await waitFor([
             trackSwitchedOn(dominantSpeakerRemoteVideoTrack),
             trackSwitchedOn(passiveSpeakerRemoteVideoTrack)
-          ]);
+          ], `both tracks to switch on: ${sid}`);
 
           dominantSpeakerRemote.videoTracks.forEach(({ track }) => {
             assert.equal(track.isSwitchedOff, false);
@@ -1203,10 +1203,10 @@ describe('LocalParticipant', function() {
           // The Subscriber makes sure that the appropriate VideoTracks are switched
           // off based on the new .dominantSpeakerPriority value.
           const switched2 = switchedParticipants[expectedSwitchOffParticipant];
-          await Promise.all([
+          await waitFor([
             trackSwitchedOn(switched2.on.remoteVideoTrack),
             trackSwitchedOff(switched2.off.remoteVideoTrack)
-          ]);
+          ], `tracks stay switched on and off: ${sid}`);
 
           switched2.off.participant.videoTracks.forEach(({ track }) => {
             assert.equal(track.isSwitchedOff, true);

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -582,7 +582,7 @@ describe('LocalTrackPublication', function() {
       bobRoom.disconnect();
     });
 
-    it.only('publisher can upgrade and downgrade track priorities', async () => {
+    it('publisher can upgrade and downgrade track priorities', async () => {
       // Alice and Bob join without tracks, Alice has maxTracks property set to 1
       const { roomSid, aliceRoom, bobRoom, bobLocal, bobRemote } = await setupAliceAndBob({
         aliceOptions: {

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -316,7 +316,7 @@ describe('LocalTrackPublication', function() {
 
   // eslint-disable-next-line no-warning-comments
   // TODO: enable these tests when track_priority MSP is available in prod
-  (defaults.topology === 'peer-to-peer' ? describe.skip : describe)('#setPriority', function() {
+  (defaults.topology === 'peer-to-peer' ? describe.skip : describe.only)('#setPriority', function() {
     // eslint-disable-next-line no-invalid-this
     describe('three participant tests', () => {
       let thisRoom;
@@ -346,7 +346,8 @@ describe('LocalTrackPublication', function() {
             tracks: [dataTrack]
           },
           otherOptions: { tracks: [dataTrack] },
-          nTracks: 0
+          nTracks: 0,
+          participantNames: ['Observer', 'Alice', 'Bob']
         });
 
         [aliceTracks, bobTracks] = await Promise.all(['alice', 'bob'].map(async () => [

--- a/test/integration/spec/room.js
+++ b/test/integration/spec/room.js
@@ -534,7 +534,7 @@ describe('Room', function() {
       await waitFor([p1, p2, p3, p4], `trackSwitch off to get fired on track, trackPub, participant and room: ${aliceRoom.sid}`);
     });
 
-    it('trackSwitchedOn fires on track, trackSubscription, participant and Room object', async () => {
+    it('trackSwitchedOn fires on track, trackSubscription, participant and Room object( @unstable ) ', async () => {
       // listen for switch off event on bob's track
       const trackSwitchOffPromise = new Promise(resolve => loPriTrackPub.track.once('switchedOff', resolve));
 

--- a/test/integration/spec/room.js
+++ b/test/integration/spec/room.js
@@ -576,7 +576,10 @@ describe('Room', function() {
       charlieRoom = null;
 
       // Alice should see track switch on event on all 4 objects.
-      await waitFor([p1, p2, p3, p4], `${alice.sid} to receive trackSwitchOn on track, trackPub, participant and room objects: ${aliceRoom.sid}`);
+      await waitFor(p1, `Alice to receive switchedOn on track: ${aliceRoom.sid}`);
+      await waitFor(p2, `Alice to receive trackSwitchedOn on trackPub: ${aliceRoom.sid}`);
+      await waitFor(p3, `Alice to receive trackSwitchedOn on Participant: ${aliceRoom.sid}`);
+      await waitFor(p4, `Alice to receive trackSwitchedOn on Room: ${aliceRoom.sid}`);
     });
   });
 });

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -434,13 +434,14 @@ async function setupAliceAndBob({ aliceOptions, bobOptions }) {
   return { aliceRoom, bobRoom, aliceLocal, bobLocal, aliceRemote, bobRemote, roomSid };
 }
 
-async function setup({ name, testOptions, otherOptions, nTracks, alone, roomOptions }) {
+async function setup({ name, testOptions, otherOptions, nTracks, alone, roomOptions, participantNames }) {
+  participantNames = participantNames || [randomName(), randomName(), randomName()];
   name = name || randomName();
   const options = Object.assign({
     audio: true,
     video: smallVideoConstraints
   }, testOptions, defaults);
-  const token = getToken(randomName());
+  const token = getToken(participantNames[0]);
   options.name = await createRoom(name, options.topology, roomOptions);
   const thisRoom = await connect(token, options);
   if (alone) {
@@ -452,7 +453,7 @@ async function setup({ name, testOptions, otherOptions, nTracks, alone, roomOpti
     video: smallVideoConstraints
   }, otherOptions);
   const thoseOptions = Object.assign({ name: thisRoom.name }, otherOptions, defaults);
-  const thoseTokens = [randomName(), randomName()].map(getToken);
+  const thoseTokens = [participantNames[1], participantNames[2]].map(getToken);
   const thoseRooms = await Promise.all(thoseTokens.map(token => connect(token, thoseOptions)));
 
   await Promise.all([thisRoom].concat(thoseRooms).map(room => {


### PR DESCRIPTION
This continues the work I  started with  https://github.com/twilio/twilio-video.js/pull/815
This change 
- adds instrumentation to print roomSid when tests fails.
- passes TEST_STABLILITY to network tests.
- Fixed a bug in `'publisher can downgrade track\'s priority` where it was expecting track swtich off when both tracks had same priority
- Fixed a bug in `publisher can upgrade and downgrade track priorities` where test was not waiting for publishPriorityChange before validating the `publishPriority`

Example Run with `stability: "stable"`: https://app.circleci.com/github/twilio/twilio-video.js/pipelines/c974e135-7627-471e-bf72-328566fa144f/workflows/65ce914e-c13f-4509-a2e6-088139e35aba 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
