### PR TITLE
eslint rule to enforce arrow paren only when needed

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,10 @@
     "array-callback-return": "error",
     "array-element-newline": "off",
     "arrow-body-style": "off",
-    "arrow-parens": "off",
+    "arrow-parens": [
+      "error",
+      "as-needed"
+    ],
     "arrow-spacing": [
       "error",
       {
@@ -38,7 +41,10 @@
     ],
     "brace-style": [
       "error",
-      "1tbs", { "allowSingleLine": true }
+      "1tbs",
+      {
+        "allowSingleLine": true
+      }
     ],
     "callback-return": "error",
     "camelcase": "error",
@@ -75,7 +81,7 @@
     "dot-notation": [
       "error",
       {
-          "allowKeywords": true
+        "allowKeywords": true
       }
     ],
     "eol-last": "error",
@@ -86,7 +92,9 @@
     "func-style": [
       "error",
       "declaration",
-      { "allowArrowFunctions": true }
+      {
+        "allowArrowFunctions": true
+      }
     ],
     "function-call-argument-newline": "off",
     "function-paren-newline": "off",
@@ -98,7 +106,13 @@
     "id-length": "off",
     "id-match": "error",
     "implicit-arrow-linebreak": "off",
-    "indent": ["error", 2, { "SwitchCase": 1 }],
+    "indent": [
+      "error",
+      2,
+      {
+        "SwitchCase": 1
+      }
+    ],
     "indent-legacy": "off",
     "init-declarations": "off",
     "jsx-quotes": "error",
@@ -144,7 +158,7 @@
     "no-else-return": [
       "error",
       {
-          "allowElseIf": true
+        "allowElseIf": true
       }
     ],
     "no-empty-function": "off",
@@ -299,7 +313,8 @@
     "sort-vars": "error",
     "space-before-blocks": "error",
     "space-before-function-paren": [
-      "error", {
+      "error",
+      {
         "anonymous": "never",
         "named": "never",
         "asyncArrow": "always"

--- a/docker/dockerProxyServer.js
+++ b/docker/dockerProxyServer.js
@@ -55,7 +55,7 @@ class DockerProxyServer {
       { endpoint: '/connectToDefaultNetwork', handleRequest: '_connectToDefaultNetwork' },
       { endpoint: '/getAllNetworks', handleRequest: '_getAllNetworks' },
       { endpoint: '/getCurrentNetworks', handleRequest: '_getCurrentNetworks' },
-    ].forEach((route) => {
+    ].forEach(route => {
       app.get(route.endpoint, async (req, res, next) => {
         try {
           const data = await this[route.handleRequest](req.params);
@@ -153,7 +153,7 @@ class DockerProxyServer {
   async _getCurrentNetworks() {
     const currentContainer = await this._inspectCurrentContainer();
     const networkNames = Object.keys(currentContainer.NetworkSettings.Networks);
-    return networkNames.map((networkName) => {
+    return networkNames.map(networkName => {
       return {
         Name: networkName,
         Id: currentContainer.NetworkSettings.Networks[networkName].NetworkID

--- a/docker/fetchRequest.js
+++ b/docker/fetchRequest.js
@@ -6,7 +6,7 @@ let requestId = 200;
 function fetchRequest(options, postdata) {
   const thisRequest = requestId++;
   return new Promise((resolve, reject) => {
-    let clientRequest = http.request(options, (res) => {
+    let clientRequest = http.request(options, res => {
       const requestFailed = res.statusCode !== 200 && res.statusCode !== 201;
       if (requestFailed) {
         console.warn(`${thisRequest}: request returned:`, res.statusCode, options, postdata);

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -541,7 +541,7 @@ class RoomV2 extends RoomSignaling {
       this.localParticipant.setNetworkQualityLevel(
         networkQualityMonitor.level,
         networkQualityMonitor.levels);
-      this.participants.forEach((participant) => {
+      this.participants.forEach(participant => {
         const levels = networkQualityMonitor.remoteLevels.get(participant.sid);
         if (levels) {
           participant.setNetworkQualityLevel(levels.level, levels);

--- a/test/integration/spec/bandwidthprofile.js
+++ b/test/integration/spec/bandwidthprofile.js
@@ -151,7 +151,7 @@ describe('Bandwidth Management', function() {
     });
 
     describe('bandwidthProfile.video.trackSwitchOffMode', () => {
-      [MODE_DISABLED, MODE_DETECTED, MODE_PREDICTED].forEach((trackSwitchOffMode) => {
+      [MODE_DISABLED, MODE_DETECTED, MODE_PREDICTED].forEach(trackSwitchOffMode => {
         it(`should accept trackSwitchOffMode=${trackSwitchOffMode}`,  async () => {
           const sid = await createRoom(randomName(), defaults.topology);
           try {

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -177,7 +177,7 @@ describe('connect', function() {
       sid = await createRoom(randomName(), defaults.topology);
     });
 
-    [true, false].forEach((insights) => {
+    [true, false].forEach(insights => {
       it(`when set to  ${insights}`, async () => {
         let cancelablePromise = null;
         let room = null;

--- a/test/integration/spec/docker/reconnection.js
+++ b/test/integration/spec/docker/reconnection.js
@@ -26,7 +26,7 @@ const DISCONNECTED_TIMEOUT = 4 * minute;
 // resolves when room received n track started events.
 function waitForTrackToStart(room, n) {
   let tracksRemaining = n;
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     room.on('trackStarted', function trackStarted() {
       tracksRemaining--;
       if (!tracksRemaining) {
@@ -70,9 +70,9 @@ async function setup(nPeople) {
 
 function getTotalBytesReceived(statReports) {
   let totalBytesReceived = 0;
-  statReports.forEach((statReport) => {
-    ['remoteVideoTrackStats', 'remoteAudioTrackStats'].forEach((trackType) => {
-      statReport[trackType].forEach((trackStats) => {
+  statReports.forEach(statReport => {
+    ['remoteVideoTrackStats', 'remoteAudioTrackStats'].forEach(trackType => {
+      statReport[trackType].forEach(trackStats => {
         totalBytesReceived += trackStats.bytesReceived;
       });
     });
@@ -133,7 +133,7 @@ describe('Reconnection states and events', function() {
     rooms.forEach(room => room.disconnect());
   });
 
-  [1, 2].forEach((nPeople) => {
+  [1, 2].forEach(nPeople => {
     describe(`${nPeople} participant(s)`, () => {
       let rooms = [];
       let currentNetworks = null;

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -109,7 +109,7 @@ describe('LocalTrackPublication', function() {
     [thisRoom, ...thoseRooms].forEach(room => room && room.disconnect());
   });
 
-  [true, false].forEach((trackInitiallyEnabled) => {
+  [true, false].forEach(trackInitiallyEnabled => {
     it(`JSDK-2603: ${trackInitiallyEnabled ? 'trackEnabled' : 'trackDisabled'} should fire only on change`, async () => {
       const roomSid = await createRoom(randomName(), defaults.topology);
       const options = Object.assign({ name: roomSid }, defaults);

--- a/test/integration/spec/room.js
+++ b/test/integration/spec/room.js
@@ -505,7 +505,7 @@ describe('Room', function() {
       const p1 = new Promise(resolve => loPriTrackPub.track.once('switchedOff', resolve));
 
       // 2) TrackPublication
-      const p2 = new Promise(resolve => loPriTrackPub.once('trackSwitchedOff', (track) => {
+      const p2 = new Promise(resolve => loPriTrackPub.once('trackSwitchedOff', track => {
         assert.equal(track, loPriTrackPub.track, 'unexpected value for the track');
         resolve();
       }));
@@ -551,7 +551,7 @@ describe('Room', function() {
       const p1 = new Promise(resolve => loPriTrackPub.track.once('switchedOn', resolve));
 
       // 2) TrackPublication
-      const p2 = new Promise(resolve => loPriTrackPub.once('trackSwitchedOn', (track) => {
+      const p2 = new Promise(resolve => loPriTrackPub.once('trackSwitchedOn', track => {
         assert.equal(track, loPriTrackPub.track, 'unexpected value for the track');
         resolve();
       }));

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -473,7 +473,7 @@ async function setup({ name, testOptions, otherOptions, nTracks, alone, roomOpti
 function waitToGo(onlineOrOffline) {
   const wantonline = onlineOrOffline === 'online';
   // eslint-disable-next-line no-console
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     if (window.navigator.onLine !== wantonline) {
       window.addEventListener(onlineOrOffline, resolve, { once: true });
     } else {

--- a/test/unit/spec/media/track/localmediatrack.js
+++ b/test/unit/spec/media/track/localmediatrack.js
@@ -159,7 +159,7 @@ const log = require('../../../../lib/fakelog');
         track._createElement = sinon.spy(() => dummyElement);
       });
 
-      it('should not change the value of isEnabled', (done) => {
+      it('should not change the value of isEnabled', done => {
         const startedTimeout = setTimeout(
           done.bind(null, new Error('track#started didn\'t fire')),
           1000

--- a/test/unit/spec/media/track/remotedatatrack.js
+++ b/test/unit/spec/media/track/remotedatatrack.js
@@ -115,7 +115,7 @@ describe('RemoteDataTrack', () => {
   });
 
   describe('#setPriority', () => {
-    [null, ...Object.values(trackPriority)].forEach((priorityValue) => {
+    [null, ...Object.values(trackPriority)].forEach(priorityValue => {
       it('does not throw when called with valid priority value: ' + priorityValue, () => {
         const track = new RemoteDataTrack('foo', dataTrackReceiver);
         track.setPriority(priorityValue);
@@ -123,7 +123,7 @@ describe('RemoteDataTrack', () => {
       });
     });
 
-    [undefined, '', 'foo', {}, 42, true].forEach((priorityValue) => {
+    [undefined, '', 'foo', {}, 42, true].forEach(priorityValue => {
       it('throws RangeError for invalid priority value: ' + priorityValue, () => {
         const track = new RemoteDataTrack('foo', dataTrackReceiver);
         let errorThrown = false;

--- a/test/unit/spec/media/track/remotemediatrack.js
+++ b/test/unit/spec/media/track/remotemediatrack.js
@@ -71,7 +71,7 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
         track = makeTrack('foo', 'bar', kind, true, options, RemoteTrack, onPriorityChange);
       });
 
-      [null, ...Object.values(trackPriority)].forEach((priorityValue) => {
+      [null, ...Object.values(trackPriority)].forEach(priorityValue => {
         it('sets priority when called with valid priority value: ' + priorityValue, () => {
           let originalPriority = track.priority;
           track.setPriority(priorityValue);
@@ -82,7 +82,7 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
         });
       });
 
-      [undefined, '', 'foo', {}, 42, true].forEach((priorityValue) => {
+      [undefined, '', 'foo', {}, 42, true].forEach(priorityValue => {
         it('throws RangeError for invalid priority value: ' + priorityValue, () => {
           let errorThrown = false;
           try {

--- a/test/unit/spec/signaling/v2/iceconnectionmonitor.js
+++ b/test/unit/spec/signaling/v2/iceconnectionmonitor.js
@@ -42,7 +42,7 @@ describe('IceConnectionMonitor', () => {
       assert.notEqual(monitor._timer, null);
     });
 
-    it('fires when it detects inactivity in bytesReceived', (done) => {
+    it('fires when it detects inactivity in bytesReceived', done => {
       monitor = new IceConnectionMonitor(pc, {
         activityCheckPeriodMs: 1,
         inactivityThresholdMs: 3
@@ -64,7 +64,7 @@ describe('IceConnectionMonitor', () => {
       });
     });
 
-    it('does not fire when it detects inactivity in bytesSent', (done) => {
+    it('does not fire when it detects inactivity in bytesSent', done => {
       monitor = new IceConnectionMonitor(pc, {
         activityCheckPeriodMs: 1,
         inactivityThresholdMs: 3
@@ -105,7 +105,7 @@ describe('IceConnectionMonitor', () => {
           return Promise.resolve();
         }
       });
-      return iceConnectionMonitor._getIceConnectionStats().then((iceStats) => {
+      return iceConnectionMonitor._getIceConnectionStats().then(iceStats => {
         assert.strictEqual(iceStats, null);
       });
     });
@@ -116,7 +116,7 @@ describe('IceConnectionMonitor', () => {
           return Promise.reject(new Error('boo'));
         }
       });
-      return iceConnectionMonitor._getIceConnectionStats().then((iceStats) => {
+      return iceConnectionMonitor._getIceConnectionStats().then(iceStats => {
         assert.strictEqual(iceStats, null);
       });
     });

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -23,7 +23,7 @@ describe('PeerConnectionV2', () => {
     didStartMonitor = false;
     didStopMonitor = false;
     inactiveCallback = null;
-    sinon.stub(IceConnectionMonitor.prototype, 'start').callsFake((callback) => {
+    sinon.stub(IceConnectionMonitor.prototype, 'start').callsFake(callback => {
       inactiveCallback = callback;
       didStartMonitor = true;
     });

--- a/test/unit/spec/signaling/v2/remoteparticipant.js
+++ b/test/unit/spec/signaling/v2/remoteparticipant.js
@@ -892,7 +892,7 @@ function makeTest(options) {
 
   options.participant = options.participant || makeRemoteParticipantV2(options);
 
-  options.state = (revision) => {
+  options.state = revision => {
     return new RemoteParticipantStateBuilder(options.participant, revision);
   };
 


### PR DESCRIPTION
@manjeshbhargav, you might like [this](https://eslint.org/docs/rules/arrow-parens) eslint rule.
I always end-up adding extra parens. This rule would avoids that mistake.

All the code file changes were auto-fixed with:
```
eslint --fix ./lib ./test/*.js ./docker/**/*.js ./test/framework/*.js ./test/lib/*.js ./test/integration/** ./test/unit/** 
```
 
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
