### PR TITLE
Prepare for beta16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/support-1.x/CHANGELOG.md).
 
-2.0.0-beta16 (in progress)
-==========================
+2.0.0-beta16 (December 10, 2019)
+================================
 
 New Features
 ------------
+- This release completes implementation of [Track Priority and Bandwidth Profiles](https://www.twilio.com/docs/video/migrating-1x-2x#track-priority-and-bandwidth-profiles-group-rooms-only-private-beta).
+
 - You can now specify the mode to control track switch off behavior by specifying a
   property `trackSwitchOffMode` in BandwidthProfile options. This can be set to one of
   - `detected`  - In this mode, RemoteVideoTracks are switched off only when network congestion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/suppor
 
 New Features
 ------------
-- This release completes implementation of [Track Priority and Bandwidth Profiles API](https://www.twilio.com/docs/video/migrating-1x-2x#track-priority-and-bandwidth-profiles-group-rooms-only-private-beta) which gives you finer control over bandwidth usage by tracks
+- This release supports all the features of the [Track Priority and Bandwidth Profile APIs](https://www.twilio.com/docs/video/migrating-1x-2x#track-priority-and-bandwidth-profiles-group-rooms-only-private-beta).
 
-- You can now specify the mode to control track switch off behavior by specifying a
-  property `trackSwitchOffMode` in BandwidthProfile options. This can be set to one of
+- You can now specify the mode to control Track switch off behavior by specifying a
+  property `trackSwitchOffMode` in BandwidthProfileOptions. This can be set to one of
   - `detected`  - In this mode, RemoteVideoTracks are switched off only when network congestion
                 is detected.
   - `predicted` - In this mode, RemoteVideoTracks are pro-actively switched off when network

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/suppor
 ================================
 
 New Features
-------------
+ ------------
+
 - This release supports all the features of the [Track Priority and Bandwidth Profile APIs](https://www.twilio.com/docs/video/migrating-1x-2x#track-priority-and-bandwidth-profiles-group-rooms-only-private-beta).
 
 - You can now specify the mode to control Track switch off behavior by specifying a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,10 +76,6 @@ You can limit bitrates on outgoing tracks using [Localparticipant.setParameters]
 
 - Fixed an issue where loading twilio-video.js in firefox with `media.peerconnection.enabled` set to false in `about:config` caused page errors. (JSDK-2591)
 
-Known Issues
-------------
-- There are known issues in this and previous releases which may prevent subscribing to data tracks on Firefox.
-
 2.0.0-beta15 (October 24, 2019)
 ===============================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/suppor
 
 New Features
 ------------
-- This release completes implementation of [Track Priority and Bandwidth Profiles](https://www.twilio.com/docs/video/migrating-1x-2x#track-priority-and-bandwidth-profiles-group-rooms-only-private-beta).
+- This release completes implementation of [Track Priority and Bandwidth Profiles API](https://www.twilio.com/docs/video/migrating-1x-2x#track-priority-and-bandwidth-profiles-group-rooms-only-private-beta) which gives you finer control over bandwidth
+usage by tracks
 
 - You can now specify the mode to control track switch off behavior by specifying a
   property `trackSwitchOffMode` in BandwidthProfile options. This can be set to one of
@@ -75,6 +76,10 @@ You can limit bitrates on outgoing tracks using [Localparticipant.setParameters]
 - Fixed a bug where `publishPriorityChanged`, `trackDisabled` and `trackEnabled` events were getting fired for initial track state (JSDK-2603)
 
 - Fixed an issue where loading twilio-video.js in firefox with `media.peerconnection.enabled` set to false in `about:config` caused page errors. (JSDK-2591)
+
+Known Issues
+------------
+- There are some known issues in this and previous releases which may prevent subscribing to data tracks on Firefox.
 
 2.0.0-beta15 (October 24, 2019)
 ===============================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ New Features
 - This release supports all the features of the [Track Priority and Bandwidth Profile APIs](https://www.twilio.com/docs/video/migrating-1x-2x#track-priority-and-bandwidth-profiles-group-rooms-only-private-beta).
 
 - You can now specify the mode to control Track switch off behavior by specifying a
-  property `trackSwitchOffMode` in BandwidthProfileOptions. This can be set to one of
+  property `trackSwitchOffMode` in BandwidthProfileOptions (JSDK-2549).
+  `trackSwitchOffMode` can be set to one of
   - `detected`  - In this mode, RemoteVideoTracks are switched off only when network congestion
                 is detected.
   - `predicted` - In this mode, RemoteVideoTracks are pro-actively switched off when network

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@ For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/suppor
 
 New Features
 ------------
-- This release completes implementation of [Track Priority and Bandwidth Profiles API](https://www.twilio.com/docs/video/migrating-1x-2x#track-priority-and-bandwidth-profiles-group-rooms-only-private-beta) which gives you finer control over bandwidth
-usage by tracks
+- This release completes implementation of [Track Priority and Bandwidth Profiles API](https://www.twilio.com/docs/video/migrating-1x-2x#track-priority-and-bandwidth-profiles-group-rooms-only-private-beta) which gives you finer control over bandwidth usage by tracks
 
 - You can now specify the mode to control track switch off behavior by specifying a
   property `trackSwitchOffMode` in BandwidthProfile options. This can be set to one of
@@ -79,7 +78,7 @@ You can limit bitrates on outgoing tracks using [Localparticipant.setParameters]
 
 Known Issues
 ------------
-- There are some known issues in this and previous releases which may prevent subscribing to data tracks on Firefox.
+- There are known issues in this and previous releases which may prevent subscribing to data tracks on Firefox.
 
 2.0.0-beta15 (October 24, 2019)
 ===============================

--- a/COMMON_ISSUES.md
+++ b/COMMON_ISSUES.md
@@ -1,12 +1,24 @@
 Common Issues
 =============
 
+
 Having an issue with twilio-video.js? Unable to see remote Participants' Tracks?
 Review this list of common issues to determine whether or not your issue is
 known or a workaround is available. Please also take a look at the
 [CHANGELOG.md](CHANGELOG.md) to see if your issue is known for a particular
 release. If your issue hasn't been reported, consider submitting
 [a new issue](https://github.com/twilio/twilio-video.js/issues/new).
+
+
+Participants do not receive audio from Mobile Safari on iOS 13.0.1
+------------------------------------------------------------------
+Because of this [bug](https://bugs.webkit.org/show_bug.cgi?id=202405) sometimes Safari participants connected
+from iOS 13.0.1 devices fail to send audio.
+
+Firefox participants fail to subscribe to data tracks on P2P rooms
+------------------------------------------------------------------
+We have seen some instances where firefox participant when connected after a data track was published in the room,
+fail to subscribe to or receive messages on the track. This issue was observed only in P2P rooms.
 
 Working around the browsers' autoplay policy
 --------------------------------------------

--- a/COMMON_ISSUES.md
+++ b/COMMON_ISSUES.md
@@ -1,7 +1,6 @@
 Common Issues
 =============
 
-
 Having an issue with twilio-video.js? Unable to see remote Participants' Tracks?
 Review this list of common issues to determine whether or not your issue is
 known or a workaround is available. Please also take a look at the
@@ -10,15 +9,14 @@ release. If your issue hasn't been reported, consider submitting
 [a new issue](https://github.com/twilio/twilio-video.js/issues/new).
 
 
-Participants do not receive audio from Mobile Safari on iOS 13.0.1
+Mobile Safari Participants on iOS 13.0.1 sometimes fail to send audio
 ------------------------------------------------------------------
-Because of this [bug](https://bugs.webkit.org/show_bug.cgi?id=202405) sometimes Safari participants connected
-from iOS 13.0.1 devices fail to send audio.
+Because of this [bug](https://bugs.webkit.org/show_bug.cgi?id=202405), sometimes Mobile Safari Participants
+on iOS 13.0.1 fail to send audio.
 
-Firefox participants fail to subscribe to data tracks on P2P rooms
+Firefox Participants sometimes fail to subscribe to DataTracks on Peer-to-Peer Rooms
 ------------------------------------------------------------------
-We have seen some instances where firefox participant when connected after a data track was published in the room,
-fail to subscribe to or receive messages on the track. This issue was observed only in P2P rooms.
+We have seen some instances where Firefox Participants that join a Peer-to-Peer Room after a DataTrack has been published fail to subscribe to it. We have filed an internal JIRA bug JSDK-xxxx and started working on a fix, which will be available in a future release.
 
 Working around the browsers' autoplay policy
 --------------------------------------------

--- a/COMMON_ISSUES.md
+++ b/COMMON_ISSUES.md
@@ -16,7 +16,7 @@ on iOS 13.0.1 fail to send audio.
 
 Firefox Participants sometimes fail to subscribe to DataTracks on Peer-to-Peer Rooms
 ------------------------------------------------------------------
-We have seen some instances where Firefox Participants that join a Peer-to-Peer Room after a DataTrack has been published fail to subscribe to it. We have filed an internal JIRA bug JSDK-xxxx and started working on a fix, which will be available in a future release.
+We have seen some instances where Firefox Participants that join a Peer-to-Peer Room after a DataTrack has been published fail to subscribe to it. We have filed an internal JIRA bug (JSDK-2615) and started working on a fix, which will be available in a future release.
 
 Working around the browsers' autoplay policy
 --------------------------------------------

--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -614,7 +614,8 @@ class LocalParticipant extends Participant {
  *   set as a hint for variable bitrate codecs, but will not take effect for fixed
  *   bitrate codecs; Based on our tests, Chrome, Firefox and Safari all seem to support
  *   an average bitrate range of 20000 bps (20 kbps) to 8000000 bps (8 mbps) for a
- *   720p VideoTrack
+ *   720p VideoTrack.
+ *   Note: this limit is not applied for screen share tracks published on Chrome.
  */
 
 /**


### PR DESCRIPTION
This makes small changes to changelog to prepare for beta16 release. 
- added reference to bandwidth profile doc in change log
- updated `maxVideoBitrate` doc to mention chrome screen-share track exception.
- added known issues with data tracks on firefox. I have kept it vague intentionally because we there are multiple issues with data tracks on firefox.  


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
