### PR TITLE
JSDK-2615 late arrivals do not subscribe to datatracks on firefox.

### DIFF
--- a/COMMON_ISSUES.md
+++ b/COMMON_ISSUES.md
@@ -16,7 +16,7 @@ on iOS 13.0.1 fail to send audio.
 
 Firefox Participants sometimes fail to subscribe to DataTracks on Peer-to-Peer Rooms
 ------------------------------------------------------------------------------------
-Because of this Firefox [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1603887) participants that join a Peer-to-Peer Room after a DataTrack has been published by firefox participant fail to subscribe to it. You can workaround this issue by publishing a data track while connecting to a peer-to-peer room. (JSDK-2615)
+Because of this Firefox [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1603887) Participants that join a Peer-to-Peer Room after a DataTrack has been published by a Firefox Participant fail to subscribe to it. You can work around this issue by publishing a DataTrack while connecting to the Room. (JSDK-2615)
 
 Working around the browsers' autoplay policy
 --------------------------------------------

--- a/COMMON_ISSUES.md
+++ b/COMMON_ISSUES.md
@@ -16,7 +16,7 @@ on iOS 13.0.1 fail to send audio.
 
 Firefox Participants sometimes fail to subscribe to DataTracks on Peer-to-Peer Rooms
 ------------------------------------------------------------------------------------
-We have seen some instances where Firefox Participants that join a Peer-to-Peer Room after a DataTrack has been published fail to subscribe to it. We have filed an internal JIRA bug (JSDK-2615) and started working on a fix, which will be available in a future release.
+Because of this Firefox [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1603887) participants that join a Peer-to-Peer Room after a DataTrack has been published by firefox participant fail to subscribe to it. You can workaround this issue by publishing a data track while connecting to a peer-to-peer room. (JSDK-2615)
 
 Working around the browsers' autoplay policy
 --------------------------------------------

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -151,11 +151,11 @@ class PeerConnectionV2 extends StateMachine {
       peerConnection.addTrack(options.dummyAudioMediaStreamTrack, localMediaStream || new options.MediaStream());
     }
 
-    // NOTE(mroberts): We do this to workaround the following bug:
-    //
+    // NOTE(mpatwardhan): We do this to workaround the following bugs:
     //   https://bugzilla.mozilla.org/show_bug.cgi?id=1481335
-    //
-    if (isFirefox && firefoxMajorVersion < 65) {
+    //   https://bugzilla.mozilla.org/show_bug.cgi?id=1603887
+
+    if (isFirefox) {
       peerConnection.createDataChannel(makeUUID());
     }
 
@@ -388,9 +388,13 @@ class PeerConnectionV2 extends StateMachine {
    * @returns {boolean}
    */
   get isApplicationSectionNegotiated() {
-    return this._peerConnection.localDescription
-      ? getMediaSections(this._peerConnection.localDescription.sdp, 'application').length > 0
-      : false;
+    if (this._peerConnection.signalingState !== 'closed') {
+      // accessing .localDescription in 'closed' state causes it throw exceptions.
+      return this._peerConnection.localDescription
+        ? getMediaSections(this._peerConnection.localDescription.sdp, 'application').length > 0
+        : false;
+    }
+    return true;
   }
 
   /**
@@ -1039,7 +1043,7 @@ class PeerConnectionV2 extends StateMachine {
       dataTrackSender.addDataChannel(dataChannel);
       this._dataChannels.set(dataTrackSender, dataChannel);
     } catch (error) {
-      // Do nothing.
+      this._log.warn('Error creating data channel', error.message);
     }
   }
 

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -32,7 +32,6 @@ const {
 const utils = require('../../util');
 const {
   buildLogLevels,
-  makeUUID,
   oncePerTick
 } = utils;
 

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -148,9 +148,8 @@ class PeerConnectionV2 extends StateMachine {
     }
 
     // NOTE(mpatwardhan): We do this to workaround the following bugs:
-    //   https://bugzilla.mozilla.org/show_bug.cgi?id=1481335
     //   https://bugzilla.mozilla.org/show_bug.cgi?id=1603887
-
+    //
     if (isFirefox) {
       peerConnection.createDataChannel(makeUUID());
     }

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -52,10 +52,6 @@ const isChrome = guess === 'chrome';
 const isFirefox = guess === 'firefox';
 const isSafari = guess === 'safari';
 
-const firefoxMajorVersion = isFirefox
-  ? parseInt(navigator.userAgent.match(/Firefox\/(\d+)/)[1], 10)
-  : null;
-
 const isRTCRtpSenderParamsSupported = typeof RTCRtpSender !== 'undefined'
   && typeof RTCRtpSender.prototype.getParameters === 'function'
   && typeof RTCRtpSender.prototype.setParameters === 'function';

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -147,13 +147,6 @@ class PeerConnectionV2 extends StateMachine {
       peerConnection.addTrack(options.dummyAudioMediaStreamTrack, localMediaStream || new options.MediaStream());
     }
 
-    // NOTE(mpatwardhan): We do this to workaround the following bugs:
-    //   https://bugzilla.mozilla.org/show_bug.cgi?id=1603887
-    //
-    if (isFirefox) {
-      peerConnection.createDataChannel(makeUUID());
-    }
-
     Object.defineProperties(this, {
       _appliedTrackIdsToAttributes: {
         value: new Map(),

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1030,7 +1030,7 @@ class PeerConnectionV2 extends StateMachine {
       dataTrackSender.addDataChannel(dataChannel);
       this._dataChannels.set(dataTrackSender, dataChannel);
     } catch (error) {
-      this._log.warn('Error creating data channel', error.message);
+      this._log.warn(`Error creating an RTCDataChannel for DataTrack "${dataTrackSender.id}": ${error.message}`);
     }
   }
 

--- a/test/integration/spec/remotetracks.js
+++ b/test/integration/spec/remotetracks.js
@@ -22,7 +22,6 @@ const {
   trackSwitchedOff,
   trackSwitchedOn,
   setupAliceAndBob,
-  waitForSometime,
   waitFor
 } = require('../../lib/util');
 

--- a/test/integration/spec/remotetracks.js
+++ b/test/integration/spec/remotetracks.js
@@ -23,7 +23,6 @@ const {
   tracksSubscribed,
   trackSwitchedOff,
   trackSwitchedOn,
-  setupAliceAndBob,
   waitFor
 } = require('../../lib/util');
 

--- a/test/integration/spec/remotetracks.js
+++ b/test/integration/spec/remotetracks.js
@@ -177,7 +177,7 @@ describe('RemoteVideoTrack', function() {
   });
 });
 
-describe.only('RemoteDataTrack', function() {
+describe('RemoteDataTrack', function() {
   // eslint-disable-next-line no-invalid-this
   this.timeout(60000);
   it('messages can be sent and received on data tracks', async () => {


### PR DESCRIPTION
This is caused by a firefox issue. I have [filed a bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1603887) to track it, where dataChannel gets closed unexpected after a round of negotiation. This issue is demonstrated by [this simple JSFiddle](https://jsfiddle.net/makarandp/wynouqhp/). 

This change workarounds the issue by always ensuring that `m=application` section exists in every offer/answer on firefox. This avoid an extra round of negotiation that results into data channel getting disconnected. 

Good part is we had same workaround in the code for a while for another firefox issue :) 
Added two tests that fail on firefox w/o this fix.

**Update**
The workaround only works for firefox participant, if chrome/mobile participant connect without data channels to firefox, they would see the same issue.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
