### PR TITLE
RemoteVideoTrack.setPriority missing doc entry

### DIFF
--- a/lib/media/track/remoteaudiotrack.js
+++ b/lib/media/track/remoteaudiotrack.js
@@ -44,8 +44,8 @@ class RemoteAudioTrack extends RemoteMediaAudioTrack {
    * @returns {this}
    * @throws {RangeError}
    */
-  setPriority() {
-    return super.setPriority.apply(this, arguments);
+  setPriority(priority) {
+    return super.setPriority(priority);
   }
 }
 

--- a/lib/media/track/remoteaudiotrack.js
+++ b/lib/media/track/remoteaudiotrack.js
@@ -36,6 +36,17 @@ class RemoteAudioTrack extends RemoteMediaAudioTrack {
   toString() {
     return `[RemoteAudioTrack #${this._instanceId}: ${this.sid}]`;
   }
+
+  /**
+   * Update the subscribe {@link Track.Priority} of the {@link RemoteAudioTrack}.
+   * @param {?Track.Priority} priority - the new subscribe {@link Track.Priority};
+   *   Currently setPriority has no effect on audio tracks.
+   * @returns {this}
+   * @throws {RangeError}
+   */
+  setPriority() {
+    return super.setPriority.apply(this, arguments);
+  }
 }
 
 /**

--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -37,6 +37,18 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
   toString() {
     return `[RemoteVideoTrack #${this._instanceId}: ${this.sid}]`;
   }
+
+  /**
+   * Update the subscribe {@link Track.Priority} of the {@link RemoteVideoTrack}.
+   * @param {?Track.Priority} priority - the new subscribe {@link Track.Priority};
+   *   If <code>null</code>, then the subscribe {@link Track.Priority} is cleared, which
+   *   means the {@link Track.Priority} set by the publisher is now the effective priority.
+   * @returns {this}
+   * @throws {RangeError}
+   */
+  setPriority() {
+    return super.setPriority.apply(this, arguments);
+  }
 }
 
 /**
@@ -54,7 +66,7 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
  */
 
 /**
- * The {@link RemoteVideoTrack} was enabled, i.e. "unpaused".
+ * The {@link RemoteVideoTrack} was enabled, i.e. "resumed".
  * @param {RemoteVideoTrack} track - The {@link RemoteVideoTrack} that was
  *   enabled
  * @event RemoteVideoTrack#enabled

--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -46,8 +46,8 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
    * @returns {this}
    * @throws {RangeError}
    */
-  setPriority() {
-    return super.setPriority.apply(this, arguments);
+  setPriority(priority) {
+    return super.setPriority(priority);
   }
 }
 


### PR DESCRIPTION
moved the documentation to derived classes so that it shows up in docs (https://6356-46595751-gh.circle-artifacts.com/0/home/circleci/project/dist/docs/RemoteVideoTrack.html#setPriority__anchor)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
