### PR TITLE
Microsoft Edge + Docs Fix + Safari Warning Refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/support-1.x/CHANGELOG.md).
 
+2.1.0 (in progress)
+===================
+
+New Features
+------------
+
+- twilio-video.js now supports [Chromium-based Edge](https://www.microsoftedgeinsider.com/). (JSDK-2633)
+- Support for Safari is no longer experimental. Hence, twilio-video.js will not log
+  a console warning in Safari 12.1+. (JSDK-2635)
+
+Bug Fixes
+---------
+
+- Fixed a bug where Room.getStats() sometimes returned null stats in a Peer-to-Peer
+  Room on Chrome 81+. (JSDK-2639)
+
 2.0.0 (December 20, 2019)
 =========================
 

--- a/README.md
+++ b/README.md
@@ -24,15 +24,17 @@ Browser Support
 ---------------
 
 |             | Chrome | Edge | Firefox | Safari |
-| -----------:|:------ |:---- |:------- |:------ |
+| ------------|--------|------|---------|--------|
 | **Android** | ✓      | -    | ✓       | -      |
 | **iOS**     | *      | -    | *       | ✓      |
 | **Linux**   | ✓      | -    | ✓       | -      |
-| **macOS**   | ✓      | -    | ✓       | ✓      |
-| **Windows** | ✓      | ✘    | ✓       | -      |
+| **macOS**   | ✓      | **   | ✓       | ✓      |
+| **Windows** | ✓      | **   | ✓       | -      |
 
 \* Chrome and Firefox for iOS do not have access to WebRTC APIs, unlike Safari
 for iOS.
+
+\*\* twilio-video.js supports the [Chromium-based Edge](https://www.microsoftedgeinsider.com/) browser.
 
 Installation
 ------------

--- a/karma/makeconf.js
+++ b/karma/makeconf.js
@@ -21,7 +21,7 @@ function generateReportName(files) {
 
   // generate reportname like: DOCKER-true-BROWSER-chrome-BVER-beta-TOPOLOGY-group-2
   let strReportName = `DO-${isDocker}-`;
-  ['BROWSER', 'BVER', 'TOPOLOGY', 'TRAVIS_JOB_NUMBER'].forEach((dim) => {
+  ['BROWSER', 'BVER', 'TOPOLOGY', 'TRAVIS_JOB_NUMBER'].forEach(dim => {
     if (process.env[dim]) {
       const dimAbrr = dim.substr(0, 2);
       strReportName += `-${dimAbrr}-${process.env[dim]}`;
@@ -54,6 +54,7 @@ function makeConf(defaultFile, browserNoActivityTimeout, requires) {
 
     let browsers = {
       chrome: [isDocker ? 'ChromeInDocker' : 'ChromeWebRTC'],
+      edge: ['EdgeWebRTC'],
       electron: ['ElectronWebRTC'],
       firefox: [isDocker ? 'FirefoxInDocker' : 'FirefoxWebRTC'],
       safari: ['Safari']
@@ -67,7 +68,7 @@ function makeConf(defaultFile, browserNoActivityTimeout, requires) {
     } else if (isDocker) {
       browsers = ['ChromeInDocker', 'FirefoxInDocker'];
     } else if (process.platform === 'darwin') {
-      browsers = ['ChromeWebRTC', 'ElectronWebRTC', 'FirefoxWebRTC', 'Safari'];
+      browsers = ['ChromeWebRTC', 'EdgeWebRTC', 'ElectronWebRTC', 'FirefoxWebRTC', 'Safari'];
     } else {
       browsers = ['ChromeWebRTC', 'FirefoxWebRTC'];
     }
@@ -146,6 +147,14 @@ function makeConf(defaultFile, browserNoActivityTimeout, requires) {
         },
         ChromeWebRTC: {
           base: 'Chrome',
+          flags: [
+            '--autoplay-policy=no-user-gesture-required',
+            '--use-fake-device-for-media-stream',
+            '--use-fake-ui-for-media-stream'
+          ]
+        },
+        EdgeWebRTC: {
+          base: 'Edge',
           flags: [
             '--autoplay-policy=no-user-gesture-required',
             '--use-fake-device-for-media-stream',

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -36,12 +36,21 @@ const CancelablePromise = require('./util/cancelablepromise');
 const Log = require('./util/log');
 const { validateBandwidthProfile } = require('./util/validate');
 
+const safariVersion = guessBrowser() === 'safari'
+  && navigator.userAgent.match(/Version\/([^\s]+)/)[1];
+
 // This is used to make out which connect() call a particular Log statement
 // belongs to. Each call to connect() increments this counter.
 let connectCalls = 0;
 
 let didPrintSafariWarning = false;
 let didPrintDscpTaggingWarning = false;
+let isSafariWithoutVP8Support = false;
+
+if (safariVersion) {
+  const [safariMajorVersion, safariMinorVersion] = safariVersion.split('.').map(Number);
+  isSafariWithoutVP8Support = safariMajorVersion < 12 || (safariMajorVersion === 12 && safariMinorVersion < 1);
+}
 
 /**
  * Connect to a {@link Room}.
@@ -211,19 +220,18 @@ function connect(token, options) {
 
   // NOTE(mroberts): Print the Safari warning once if the log-level is at least
   // "warn", i.e. neither "error" nor "off".
-  if (guessBrowser() === 'safari'
+  // NOTE(mmalavalli): Print the Safari warning only for versions 12.0 and below.
+  if (isSafariWithoutVP8Support
     && !didPrintSafariWarning
     && (log.logLevel !== 'error' && log.logLevel !== 'off')) {
     didPrintSafariWarning = true;
     log.warn([
-      'This release of twilio-video.js includes experimental support for',
-      'Safari 11 and newer. Support for Safari is "experimental" because,',
-      'at the time of writing, Safari does not support VP8. This means you',
-      'may experience codec issues in Group Rooms. You may also experience',
-      'codec issues in Peer-to-Peer (P2P) Rooms containing Android- or',
+      'Support for Safari 12.0 and below is limited because it does not support VP8.',
+      'This means you may experience codec issues in Group Rooms. You may also',
+      'experience codec issues in Peer-to-Peer (P2P) Rooms containing Android- or',
       'iOS-based Participants who do not support H.264. However, P2P Rooms',
-      'with browser-based Participants should work. Please test this release',
-      'and report any issues to https://github.com/twilio/twilio-video.js'
+      'with browser-based Participants should work. For more information, please',
+      'refer to this guide: https://www.twilio.com/docs/video/javascript-v2-developing-safari-11'
     ].join(' '));
   }
 

--- a/lib/createlocaltrack.js
+++ b/lib/createlocaltrack.js
@@ -88,7 +88,9 @@ function createLocalVideoTrack(options) {
 }
 
 /**
- * Create {@link LocalTrack} options.
+ * Create {@link LocalTrack} options. Apart from the properties listed here, you can
+ * also specify any of the <a href="https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints" target="_blank">MediaTrackConstraints</a>
+ * properties.
  * @typedef {MediaTrackConstraints} CreateLocalTrackOptions
  * @property {LogLevel|LogLevels} logLevel
  * @property {string} [name] - The {@link LocalTrack}'s name; by default,

--- a/lib/media/track/localtrackpublication.js
+++ b/lib/media/track/localtrackpublication.js
@@ -7,6 +7,7 @@ const { typeErrors: E, trackPriority } = require('../../util/constants');
 /**
  * A {@link LocalTrackPublication} is a {@link LocalTrack} that has been
  * published to a {@link Room}.
+ * @extends TrackPublication
  * @property {boolean} isTrackEnabled - whether the published {@link LocalTrack}
  *   is enabled
  * @property {Track.Kind} kind - kind of the published {@link LocalTrack}

--- a/lib/media/track/remotetrackpublication.js
+++ b/lib/media/track/remotetrackpublication.js
@@ -5,6 +5,7 @@ const TrackPublication = require('./trackpublication');
 /**
  * A {@link RemoteTrackPublication} represents a {@link RemoteTrack} that has
  * been published to a {@link Room}.
+ * @extends TrackPublication
  * @property {boolean} isSubscribed - whether the published {@link RemoteTrack}
  *   is subscribed to
  * @property {boolean} isTrackEnabled - whether the published

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -520,6 +520,7 @@ class PeerConnectionV2 extends StateMachine {
   _close() {
     if (this._peerConnection.signalingState !== 'closed') {
       this._peerConnection.close();
+      this.preempt('closed');
       return true;
     }
     return false;
@@ -644,8 +645,6 @@ class PeerConnectionV2 extends StateMachine {
   _handleSignalingStateChange() {
     if (this._peerConnection.signalingState === 'stable') {
       this._appliedTrackIdsToAttributes = new Map(this._trackIdsToAttributes);
-    } else if (this._peerConnection.signalingState === 'closed' && this.state !== 'closed') {
-      this.preempt('closed');
     }
   }
 

--- a/lib/util/support.js
+++ b/lib/util/support.js
@@ -25,23 +25,11 @@ function isGetUserMediaSupported() {
 }
 
 /**
- * @returns {boolean} - true if the browser is explicitly unsupported.
- *  Note: this function returning false does not mean that browser is supported.
- */
-function isExplicitlyUnsupportedBrowser() {
-  if (typeof navigator !== 'undefined' && typeof navigator.userAgent === 'string') {
-    return /Edg(e)?/.test(navigator.userAgent);
-  }
-  return false;
-}
-
-/**
  * Check if the current environment is supported by the SDK.
  * @returns {boolean}
  */
 function isSupported() {
-  return !isExplicitlyUnsupportedBrowser()
-    && !!guessBrowser()
+  return !!guessBrowser()
     && isGetUserMediaSupported()
     && isRTCPeerConnectionSupported();
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "karma": "^1.6.0",
     "karma-browserify": "^5.1.1",
     "karma-chrome-launcher": "^2.0.0",
+    "karma-edgium-launcher": "^4.0.0-0",
     "karma-electron": "^6.1.0",
     "karma-firefox-launcher": "^1.0.1",
     "karma-htmlfile-reporter": "^0.3.8",

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -706,7 +706,7 @@ describe('LocalTrackPublication', function() {
   });
 
   it('JSDK-2573 - race condition when recycling transceiver: ', async () => {
-    // Alice and Bob join without tracks, Alice has maxTracks property set to 1
+    // Alice and Bob join without tracks
     const { roomSid, aliceRoom, bobRoom, bobLocal, bobRemote } = await setupAliceAndBob({
       aliceOptions: { tracks: [] },
       bobOptions: { tracks: [] },
@@ -715,7 +715,7 @@ describe('LocalTrackPublication', function() {
     const bobVideoTrackA = await createLocalVideoTrack(Object.assign({ name: 'trackA' }, smallVideoConstraints));
     const bobVideoTrackB = await createLocalVideoTrack(Object.assign({ name: 'trackB' }, smallVideoConstraints));
 
-    // Bob publishes video trackA with standard priority, trackB with low priority.
+    // Bob publishes video trackA and trackB in quick succession
     await waitFor(bobLocal.publishTrack(bobVideoTrackA), `Bob to publish video trackA: ${roomSid}`);
     await waitFor(bobLocal.publishTrack(bobVideoTrackB), `Bob to publish video trackB: ${roomSid}`);
 

--- a/test/unit/spec/util/support.js
+++ b/test/unit/spec/util/support.js
@@ -46,14 +46,6 @@ describe('isSupported', () => {
       'Firefox on Linux',
       'Mozilla/5.0 (X11; Linux i586; rv:31.0) Gecko/20100101 Firefox/69.0'
     ],
-  ].forEach(([browser, useragent]) => {
-    it('returns true for supported browser: ' + browser, () => {
-      navigator.userAgent = useragent;
-      assert.equal(isSupported(), true);
-    });
-  });
-
-  [
     [
       'Edge 42',
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64; Xbox; Xbox One) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.15063'
@@ -69,15 +61,11 @@ describe('isSupported', () => {
     [
       'Edg',
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64; Xbox; Xbox One) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edg/15.15063'
-    ],
-    [
-      'Just anything with Edge in it',
-      'Foo Edge Bar'
     ]
   ].forEach(([browser, useragent]) => {
-    it('returns false for explicitly unsupported browser: ' + browser, () => {
+    it('returns true for supported browser: ' + browser, () => {
       navigator.userAgent = useragent;
-      assert.equal(isSupported(), false);
+      assert.equal(isSupported(), true);
     });
   });
 });


### PR DESCRIPTION
@syerrapragada 

This PR has the following changes:

* JSDK-2625 - Enable integration tests for Chromium-based Edge.
* JSDK-2633 - `isSupported` should return `true` for Chromium-based Edge.
* JSDK-2567 - Add link to MediaTrackConstraints MDN docs.
* JSDK-2638 - JSDoc for LocalTrackPublication and RemoteTrackPublication should `@extend` TrackPublication.
* JSDK-2635 - Limit experimental support warning for Safari 12.0 and below.
* JSDK-2639 - Remove closed PeerConnections from the StatsReport object.
## Tasks

- [x] Unit tests
- [x] Integration tests
- [x] CHANGELOG.md entry
- [x] +1 from one or more reviewers

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
