### PR TITLE
JSDK-2662 Participant reconnecting state.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/support-1.x/CHANGELOG.md).
 
+2.1.0 (in progress)
+===================
+
+New Features
+------------
+
+- A RemoteParticipant will now emit a "reconnecting" event when it is trying to
+  re-establish its signaling connection to the Room after a network disruption/handoff.
+  Once it has successfully reconnected to the Room, it will emit a "reconnected"
+  event. (JSDK-2662)
+  
+  ```js
+  function reconnecting(participant) {
+    console.log(`${participant.identity} is rejoining the Room`);
+    assert.equal(participant.state, 'reconnecting');
+  }
+
+  function reconnected(participant) {
+    console.log(`${participant.identity} has rejoined the Room`);
+    assert.equal(participant.state, 'connected');
+  }
+
+  room.on('participantConnected', participant => {
+    participant.on('reconnecting', () => {
+      reconnecting(participant);
+    });
+
+    participant.on('reconnected', () => {
+      reconnected(participant);
+    });
+  });
+  ```
+
+  The LocalParticipant will now also emit "reconnecting" and "reconnected" events
+  when the local client is recovering/successfully recovered from a signaling connection
+  disruption:
+  
+  ```js
+  const { localParticipant } = room;
+
+  localParticipant.on('reconnecting', () => {
+    reconnecting(localParticipant);
+  });
+
+  localParticipant.on('reconnected', () => {
+    reconnected(localParticipant);
+  });
+  ```
+
 2.0.1 (January 21, 2020)
 ========================
 

--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -24,6 +24,8 @@ const Participant = require('./participant');
  *    The {@link LocalParticipant}'s {@link LocalTrackPublication}s
  * @property {Map<Track.SID, LocalVideoTrackPublication>} videoTracks -
  *    The {@link LocalParticipant}'s {@link LocalVideoTrackPublication}s
+ * @emits RemoteParticipant#reconnected
+ * @emits RemoteParticipant#reconnecting
  * @emits LocalParticipant#trackDimensionsChanged
  * @emits LocalParticipant#trackDisabled
  * @emits LocalParticipant#trackEnabled
@@ -554,6 +556,16 @@ class LocalParticipant extends Participant {
     }, []);
   }
 }
+
+/**
+ * The {@link LocalParticipant} has reconnected to the {@link Room} after a signaling connection disruption.
+ * @event LocalParticipant#reconnected
+ */
+
+/**
+ * The {@link LocalParticipant} is reconnecting to the {@link Room} after a signaling connection disruption.
+ * @event LocalParticipant#reconnecting
+ */
 
 /**
  * One of the {@link LocalParticipant}'s {@link LocalVideoTrack}'s dimensions changed.

--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -212,6 +212,12 @@ class LocalParticipant extends Participant {
         self._tracksToStop.forEach(track => {
           track.stop();
         });
+      } else if (state === 'reconnecting') {
+        log.info('reconnecting');
+        self.emit('reconnecting');
+      } else if (state === 'connected') {
+        log.info('reconnected');
+        self.emit('reconnected');
       }
     });
   }

--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -212,10 +212,10 @@ class LocalParticipant extends Participant {
         self._tracksToStop.forEach(track => {
           track.stop();
         });
-      } else if (state === 'reconnecting') {
-        log.info('reconnecting');
-        self.emit('reconnecting');
       } else if (state === 'connected') {
+        // NOTE(mmalavalli): Any transition to "connected" here is a result of
+        // successful signaling reconnection, and not a first-time establishment
+        // of the signaling connection.
         log.info('reconnected');
         self.emit('reconnected');
       }

--- a/lib/participant.js
+++ b/lib/participant.js
@@ -36,6 +36,8 @@ let nInstances = 0;
  *    The {@link Participant}'s {@link VideoTrackPublication}s
  * @emits Participant#disconnected
  * @emits Participant#networkQualityLevelChanged
+ * @emits Participant#reconnected
+ * @emits Participant#reconnecting
  * @emits Participant#trackDimensionsChanged
  * @emits Participant#trackStarted
  */
@@ -357,6 +359,15 @@ class Participant extends EventEmitter {
         participantSignaling.removeListener('stateChanged', stateChanged);
         participantSignaling.removeListener('trackAdded', trackSignalingAdded);
         participantSignaling.removeListener('trackRemoved', trackSignalingRemoved);
+      } else if (state === 'reconnecting') {
+        log.info('reconnecting');
+        self.emit('reconnecting');
+      } else if (state === 'connected') {
+        // NOTE(mmalavalli): Any transition to "connected" here is a result of
+        // successful signaling reconnection, and not a first-time establishment
+        // of the signaling connection.
+        log.info('reconnected');
+        self.emit('reconnected');
       }
     });
   }
@@ -452,6 +463,18 @@ class Participant extends EventEmitter {
  * @param {?NetworkQualityStats} networkQualityStats - The {@link NetworkQualityStats}
  *   based on which {@link NetworkQualityLevel} is calculated, if any
  * @event Participant#networkQualityLevelChanged
+ */
+
+/**
+ * The {@link Participant} has reconnected to the {@link Room} after a signaling connection disruption.
+ * @param {Participant} participant - The {@link Participant} that has reconnected.
+ * @event Participant#reconnected
+ */
+
+/**
+ * The {@link Participant} is reconnecting to the {@link Room} after a signaling connection disruption.
+ * @param {Participant} participant - The {@link Participant} that is reconnecting.
+ * @event Participant#reconnecting
  */
 
 /**

--- a/lib/participant.js
+++ b/lib/participant.js
@@ -29,7 +29,7 @@ let nInstances = 0;
  * @property {?NetworkQualityStats} networkQualityStats - The
  *    {@link Participant}'s current {@link NetworkQualityStats}, if any
  * @property {Participant.SID} sid - The {@link Participant}'s SID
- * @property {string} state - "connected", "disconnected" or "failed"
+ * @property {string} state - "connected", "disconnected" or "reconnecting"
  * @property {Map<Track.SID, TrackPublication>} tracks -
  *    The {@link Participant}'s {@link TrackPublication}s
  * @property {Map<Track.SID, VideoTrackPublication>} videoTracks -

--- a/lib/participant.js
+++ b/lib/participant.js
@@ -464,13 +464,11 @@ class Participant extends EventEmitter {
 
 /**
  * The {@link Participant} has reconnected to the {@link Room} after a signaling connection disruption.
- * @param {Participant} participant - The {@link Participant} that has reconnected.
  * @event Participant#reconnected
  */
 
 /**
  * The {@link Participant} is reconnecting to the {@link Room} after a signaling connection disruption.
- * @param {Participant} participant - The {@link Participant} that is reconnecting.
  * @event Participant#reconnecting
  */
 

--- a/lib/participant.js
+++ b/lib/participant.js
@@ -359,9 +359,6 @@ class Participant extends EventEmitter {
         participantSignaling.removeListener('stateChanged', stateChanged);
         participantSignaling.removeListener('trackAdded', trackSignalingAdded);
         participantSignaling.removeListener('trackRemoved', trackSignalingRemoved);
-      } else if (state === 'reconnecting') {
-        log.info('reconnecting');
-        self.emit('reconnecting');
       } else if (state === 'connected') {
         // NOTE(mmalavalli): Any transition to "connected" here is a result of
         // successful signaling reconnection, and not a first-time establishment

--- a/lib/remoteparticipant.js
+++ b/lib/remoteparticipant.js
@@ -14,6 +14,8 @@ const Participant = require('./participant');
  *    The {@link Participant}'s {@link RemoteTrackPublication}s
  * @property {Map<Track.SID, RemoteVideoTrackPublication>} videoTracks -
  *    The {@link Participant}'s {@link RemoteVideoTrackPublication}s
+ * @emits RemoteParticipant#reconnected
+ * @emits RemoteParticipant#reconnecting
  * @emits RemoteParticipant#trackDimensionsChanged
  * @emits RemoteParticipant#trackDisabled
  * @emits RemoteParticipant#trackEnabled
@@ -134,6 +136,16 @@ class RemoteParticipant extends Participant {
     return removedPublication;
   }
 }
+
+/**
+ * The {@link RemoteParticipant} has reconnected to the {@link Room} after a signaling connection disruption.
+ * @event RemoteParticipant#reconnected
+ */
+
+/**
+ * The {@link RemoteParticipant} is reconnecting to the {@link Room} after a signaling connection disruption.
+ * @event RemoteParticipant#reconnecting
+ */
 
 /**
  * One of the {@link RemoteParticipant}'s {@link RemoteVideoTrack}'s dimensions changed.

--- a/lib/room.js
+++ b/lib/room.js
@@ -448,8 +448,8 @@ function connectParticipant(room, participantSignaling) {
 
   // Reemit Track and RemoteParticipant events.
   const eventListeners = [
-    'reconnected',
-    'reconnecting',
+    ['reconnected', 'participantReconnected'],
+    ['reconnecting', 'participantReconnecting'],
     'trackDimensionsChanged',
     'trackDisabled',
     'trackEnabled',
@@ -463,10 +463,14 @@ function connectParticipant(room, participantSignaling) {
     'trackSwitchedOn',
     'trackUnpublished',
     'trackUnsubscribed'
-  ].map(event => {
+  ].map(eventOrPair => {
+    const [event, participantEvent] = Array.isArray(eventOrPair)
+      ? eventOrPair
+      : [eventOrPair, eventOrPair];
+
     function reemit() {
       const args = [].slice.call(arguments);
-      args.unshift(event);
+      args.unshift(participantEvent);
       args.push(participant);
       room.emit(...args);
     }

--- a/lib/room.js
+++ b/lib/room.js
@@ -29,6 +29,8 @@ let nInstances = 0;
  * @emits Room#disconnected
  * @emits Room#participantConnected
  * @emits Room#participantDisconnected
+ * @emits Room#participantReconnected
+ * @emits Room#participantReconnecting
  * @emits Room#reconnected
  * @emits Room#reconnecting
  * @emits Room#recordingStarted
@@ -223,6 +225,25 @@ function rewriteLocalTrackIds(room, trackStats) {
  *       mediaElement.remove();
  *     });
  *   });
+ * });
+ */
+
+/**
+ * A {@link RemoteParticipant} has reconnected to the {@link Room} after a signaling connection disruption.
+ * @param {RemoteParticipant} participant - The {@link RemoteParticipant} that has reconnected.
+ * @event Room#participantReconnected
+ * @example
+ * myRoom.on('participantReconnected', participant => {
+ *   console.log(participant.identity + ' reconnected to the Room');
+ * });
+ */
+
+/**
+ * A {@link RemoteParticipant} is reconnecting to the {@link Room} after a signaling connection disruption.
+ * @param {RemoteParticipant} participant - The {@link RemoteParticipant} that is reconnecting.
+ * @event Room#participantReconnecting
+ * myRoom.on('participantReconnected', participant => {
+ *   console.log(participant.identity + ' is reconnecting to the Room');
  * });
  */
 
@@ -425,8 +446,10 @@ function connectParticipant(room, participantSignaling) {
   room._participants.set(participant.sid, participant);
   room.emit('participantConnected', participant);
 
-  // Reemit Track events from the RemoteParticipant.
+  // Reemit Track and RemoteParticipant events.
   const eventListeners = [
+    'reconnected',
+    'reconnecting',
     'trackDimensionsChanged',
     'trackDisabled',
     'trackEnabled',
@@ -451,7 +474,6 @@ function connectParticipant(room, participantSignaling) {
     return [event, reemit];
   });
 
-  // Reemit state transition events from the RemoteParticipant.
   participant.once('disconnected', function participantDisconnected() {
     const dominantSpeaker = room.dominantSpeaker;
     log.info('RemoteParticipant disconnected:', participant);

--- a/lib/signaling/participant.js
+++ b/lib/signaling/participant.js
@@ -12,14 +12,25 @@ ParticipantSignaling States
     | connecting |---->| connected |---->| disconnected |
     |            |     |           |     |              |
     +------------+     +-----------+     +--------------+
-
+                           | ^                    ^
+                           | |  +--------------+  |
+                           | |--|              |  |
+                           |--->| reconnecting |--|
+                                |              |
+                                +--------------+
 */
 
 const states = {
   connecting: [
-    'connected'
+    'connected',
+    'reconnecting'
   ],
   connected: [
+    'disconnected',
+    'reconnecting'
+  ],
+  reconnecting: [
+    'connected',
     'disconnected'
   ],
   disconnected: []
@@ -184,7 +195,6 @@ class ParticipantSignaling extends StateMachine {
       this._enqueuedPriorityUpdates.forEach((priority, trackSid) => {
         this._trackPrioritySignaling.sendTrackPriorityUpdate(trackSid, 'subscribe', priority);
       });
-
       // NOTE(mpatwardhan)- we intentionally do not clear _enqueuedPriorityUpdates,
       // this cache will be used to re-send the priorities in case of VMS-FailOver.
     }
@@ -198,10 +208,26 @@ class ParticipantSignaling extends StateMachine {
    * @returns {boolean}
    */
   connect(sid, identity) {
-    if (this.state === 'connecting') {
-      this._sid = sid;
-      this._identity = identity;
+    if (this.state === 'connecting' || this.state === 'reconnecting') {
+      if (!this._sid) {
+        this._sid = sid;
+      }
+      if (!this._identity) {
+        this._identity = identity;
+      }
       this.preempt('connected');
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Transition to "reconnecting" state.
+   * @returns {boolean}
+   */
+  reconnecting() {
+    if (this.state === 'connecting' || this.state === 'connected') {
+      this.preempt('reconnecting');
       return true;
     }
     return false;

--- a/lib/signaling/participant.js
+++ b/lib/signaling/participant.js
@@ -22,8 +22,7 @@ ParticipantSignaling States
 
 const states = {
   connecting: [
-    'connected',
-    'reconnecting'
+    'connected'
   ],
   connected: [
     'disconnected',

--- a/lib/signaling/v2/remoteparticipant.js
+++ b/lib/signaling/v2/remoteparticipant.js
@@ -81,8 +81,16 @@ class RemoteParticipantV2 extends RemoteParticipantSignaling {
       }
     });
 
-    if (participantState.state === 'disconnected' && this.state === 'connected') {
-      this.preempt('disconnected');
+    switch (participantState.state) {
+      case 'disconnected':
+        this.disconnect();
+        break;
+      case 'reconnecting':
+        this.reconnecting();
+        break;
+      case 'connected':
+        this.connect(this.sid, this.identity);
+        break;
     }
 
     return this;

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -18,7 +18,10 @@ const {
   oncePerTick
 } = require('../../util');
 
-const { createTwilioError } = require('../../util/twilio-video-errors');
+const {
+  createTwilioError,
+  SignalingConnectionDisconnectedError
+} = require('../../util/twilio-video-errors');
 
 const STATS_PUBLISH_INTERVAL_MS = 1000;
 
@@ -659,13 +662,17 @@ function handleLocalParticipantEvents(roomV2, localParticipant) {
   localParticipant.on('trackRemoved', renegotiate);
   localParticipant.on('updated', localParticipantUpdated);
 
-  roomV2.on('stateChanged', function stateChanged(state) {
+  roomV2.on('stateChanged', function stateChanged(state, error) {
     if (state === 'disconnected') {
       localParticipant.removeListener('trackAdded', renegotiate);
       localParticipant.removeListener('trackRemoved', renegotiate);
       localParticipant.removeListener('updated', localParticipantUpdated);
       roomV2.removeListener('stateChanged', stateChanged);
       localParticipant.disconnect();
+    } else if (state === 'reconnecting' && error instanceof SignalingConnectionDisconnectedError) {
+      localParticipant.reconnecting();
+    } else if (state === 'connected') {
+      localParticipant.connect(localParticipant.sid, localParticipant.identity);
     }
   });
 }

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -18,10 +18,7 @@ const {
   oncePerTick
 } = require('../../util');
 
-const {
-  createTwilioError,
-  SignalingConnectionDisconnectedError
-} = require('../../util/twilio-video-errors');
+const { createTwilioError } = require('../../util/twilio-video-errors');
 
 const STATS_PUBLISH_INTERVAL_MS = 1000;
 
@@ -662,17 +659,26 @@ function handleLocalParticipantEvents(roomV2, localParticipant) {
   localParticipant.on('trackRemoved', renegotiate);
   localParticipant.on('updated', localParticipantUpdated);
 
-  roomV2.on('stateChanged', function stateChanged(state, error) {
+  roomV2.on('stateChanged', function stateChanged(state) {
     if (state === 'disconnected') {
       localParticipant.removeListener('trackAdded', renegotiate);
       localParticipant.removeListener('trackRemoved', renegotiate);
       localParticipant.removeListener('updated', localParticipantUpdated);
       roomV2.removeListener('stateChanged', stateChanged);
       localParticipant.disconnect();
-    } else if (state === 'reconnecting' && error instanceof SignalingConnectionDisconnectedError) {
-      localParticipant.reconnecting();
-    } else if (state === 'connected') {
-      localParticipant.connect(localParticipant.sid, localParticipant.identity);
+    }
+  });
+
+  roomV2.on('signalingConnectionStateChanged', () => {
+    const { localParticipant, signalingConnectionState } = roomV2;
+    const { identity, sid } = localParticipant;
+    switch (signalingConnectionState) {
+      case 'connected':
+        localParticipant.connect(sid, identity);
+        break;
+      case 'reconnecting':
+        localParticipant.reconnecting();
+        break;
     }
   });
 }

--- a/test/integration/spec/docker/reconnection.js
+++ b/test/integration/spec/docker/reconnection.js
@@ -321,7 +321,7 @@ describe('Reconnection states and events', function() {
 
       // TODO (mmalavalli): Remove environment check once RemoteParticipant "reconnecting"
       // state is available in prod version of Room Service.
-      (nPeople > 1 && defaults.environment === 'dev' ? describe : describe.skip)('RemoteParticipant reconnection events', () => {
+      (nPeople > 1 && defaults.environment !== 'prod' ? describe : describe.skip)('RemoteParticipant reconnection events', () => {
         it('should emit "reconnecting" and "reconnected" events on the RemoteParticipant which recovers from signaling connection disruption', async () => {
           const [aliceRoom, bobRoom] = rooms;
           const aliceRemote = bobRoom.participants.get(aliceRoom.localParticipant.sid);

--- a/test/integration/spec/docker/reconnection.js
+++ b/test/integration/spec/docker/reconnection.js
@@ -170,18 +170,12 @@ describe('Reconnection states and events', function() {
 
       describe('Network interruption', () => {
         let disconnectedPromises;
-        let localParticipantDisconnectedPromises;
-        let localParticipantReconnectedPromises;
-        let localParticipantReconnectingPromises;
         let reconnectedPromises;
         let reconnectingPromises;
 
         beforeEach(async () => {
           if (isRunningInsideDocker) {
             disconnectedPromises = rooms.map(room => new Promise(resolve => room.once('disconnected', resolve)));
-            localParticipantDisconnectedPromises = rooms.map(({ localParticipant }) => new Promise(resolve => localParticipant.once('disconnected', resolve)));
-            localParticipantReconnectedPromises = rooms.map(({ localParticipant }) => new Promise(resolve => localParticipant.once('reconnected', resolve)));
-            localParticipantReconnectingPromises = rooms.map(({ localParticipant }) => new Promise(resolve => localParticipant.once('reconnecting', resolve)));
             reconnectedPromises = rooms.map(room => new Promise(resolve => room.once('reconnected', resolve)));
             reconnectingPromises = rooms.map(room => new Promise(resolve => room.once('reconnecting', resolve)));
             await waitFor(currentNetworks.map(({ Id: networkId }) => dockerAPI.disconnectFromNetwork(networkId)), 'disconnect from all networks');
@@ -189,41 +183,26 @@ describe('Reconnection states and events', function() {
           }
         });
 
-        it('should emit "reconnecting" on the Rooms and LocalParticipants', () => {
-          return Promise.all([
-            waitFor(localParticipantReconnectingPromises, 'localParticipantReconnectingPromises', RECONNECTING_TIMEOUT),
-            waitFor(reconnectingPromises, 'reconnectingPromises', RECONNECTING_TIMEOUT)
-          ]);
+        it('should emit "reconnecting" on the Rooms', () => {
+          return waitFor(reconnectingPromises, 'reconnectingPromises', RECONNECTING_TIMEOUT);
         });
 
         context('that is longer than the session timeout', () => {
-          it('should emit "disconnected" on the Rooms and LocalParticipants' + isFirefox ? ' @unstable ' : '', async () => {
-            await Promise.all([
-              waitFor(localParticipantReconnectingPromises, 'localParticipantReconnectingPromises', RECONNECTING_TIMEOUT),
-              waitFor(reconnectingPromises, 'reconnectingPromises', RECONNECTING_TIMEOUT)
-            ]);
-            return Promise.all([
-              waitFor(localParticipantDisconnectedPromises, 'localParticipantDisconnectedPromises', DISCONNECTED_TIMEOUT),
-              waitFor(disconnectedPromises, 'disconnectPromises', DISCONNECTED_TIMEOUT)
-            ]);
+          it('should emit "disconnected" on the Rooms' + isFirefox ? ' @unstable ' : '', async () => {
+            await waitFor(reconnectingPromises, 'reconnectingPromises', RECONNECTING_TIMEOUT);
+            return waitFor(disconnectedPromises, 'disconnectPromises', DISCONNECTED_TIMEOUT);
           });
         });
 
         context('that recovers before the session timeout', () => {
-          it('should emit "reconnected" on the Rooms and LocalParticipants' + isFirefox ? ' @unstable ' : '', async () => {
-            await Promise.all([
-              waitFor(localParticipantReconnectingPromises, 'localParticipantReconnectingPromises', RECONNECTED_TIMEOUT),
-              waitFor(reconnectingPromises, 'reconnectingPromises', RECONNECTED_TIMEOUT)
-            ]);
+          it('should emit "reconnected" on the Rooms' + isFirefox ? ' @unstable ' : '', async () => {
+            await waitFor(reconnectingPromises, 'reconnectingPromises', RECONNECTED_TIMEOUT);
             await waitFor(currentNetworks.map(({ Id: networkId }) => dockerAPI.connectToNetwork(networkId)), 'reconnect to original networks');
             await readCurrentNetworks(dockerAPI);
             await waitToGoOnline();
 
             try {
-              await Promise.all([
-                waitFor(localParticipantReconnectedPromises, 'localParticipantReconnectedPromises', RECONNECTED_TIMEOUT),
-                waitFor(reconnectedPromises, 'reconnectingPromises', RECONNECTED_TIMEOUT)
-              ]);
+              await waitFor(reconnectedPromises, 'reconnectingPromises', RECONNECTED_TIMEOUT);
             } catch (err) {
               console.log('rooms - Failed to Reconnect:');
               rooms.forEach(room => console.log(`ConnectionStates: ${room.localParticipant.identity}: signalingConnectionState:${room._signaling.signalingConnectionState}  mediaConnectionState:${room._signaling.mediaConnectionState}`));
@@ -249,8 +228,6 @@ describe('Reconnection states and events', function() {
       // ([bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1548318))
       (isFirefox ? describe.skip : describe)('Network handoff reconnects to new network', () => {
         it('@unstable: Scenario 1 (jump): connected interface switches off and then a new interface switches on',  async () => {
-          const localParticipantReconnectedPromises = rooms.map(({ localParticipant }) => new Promise(resolve => localParticipant.once('reconnected', resolve)));
-          const localParticipantReconnectingPromises = rooms.map(({ localParticipant }) => new Promise(resolve => localParticipant.once('reconnecting', resolve)));
           const reconnectingPromises = rooms.map(room => new Promise(resolve => room.once('reconnecting', resolve)));
           const reconnectedPromises = rooms.map(room => new Promise(resolve => room.once('reconnected', resolve)));
           const newNetwork = await waitFor(dockerAPI.createNetwork(), 'create network');
@@ -260,14 +237,8 @@ describe('Reconnection states and events', function() {
           await readCurrentNetworks(dockerAPI);
 
           try {
-            await Promise.all([
-              waitFor(localParticipantReconnectingPromises, 'localParticipantReconnectingPromises', RECONNECTING_TIMEOUT),
-              waitFor(reconnectingPromises, 'reconnectingPromises', RECONNECTING_TIMEOUT)
-            ]);
-            await Promise.all([
-              waitFor(localParticipantReconnectedPromises, 'localParticipantReconnectedPromises', RECONNECTED_TIMEOUT),
-              waitFor(reconnectedPromises, 'reconnectedPromises', RECONNECTED_TIMEOUT)
-            ]);
+            await waitFor(reconnectingPromises, 'reconnectingPromises', RECONNECTING_TIMEOUT);
+            await waitFor(reconnectedPromises, 'reconnectedPromises', RECONNECTED_TIMEOUT);
           } catch (err) {
             console.log('rooms - Failed to Reconnect. Checking status:');
             rooms.forEach(room => console.log(`ConnectionStates: ${room.localParticipant.identity}: signalingConnectionState:${room._signaling.signalingConnectionState}  mediaConnectionState:${room._signaling.mediaConnectionState}`));
@@ -281,8 +252,6 @@ describe('Reconnection states and events', function() {
         });
 
         it('@unstable: Scenario 2 (step) : new interface switches on and then the connected interface switches off.', async () => {
-          const localParticipantReconnectedPromises = rooms.map(({ localParticipant }) => new Promise(resolve => localParticipant.once('reconnected', resolve)));
-          const localParticipantReconnectingPromises = rooms.map(({ localParticipant }) => new Promise(resolve => localParticipant.once('reconnecting', resolve)));
           const reconnectingPromises = rooms.map(room => new Promise(resolve => room.once('reconnecting', resolve)));
           const reconnectedPromises = rooms.map(room => new Promise(resolve => room.once('reconnected', resolve)));
 
@@ -298,14 +267,8 @@ describe('Reconnection states and events', function() {
           await waitToGoOnline();
 
           try {
-            await Promise.all([
-              waitFor(localParticipantReconnectingPromises, 'localParticipantReconnectingPromises', RECONNECTING_TIMEOUT),
-              waitFor(reconnectingPromises, 'reconnectingPromises', RECONNECTING_TIMEOUT)
-            ]);
-            await Promise.all([
-              waitFor(localParticipantReconnectedPromises, 'localParticipantReconnectedPromises', RECONNECTED_TIMEOUT),
-              waitFor(reconnectedPromises, 'reconnectedPromises', RECONNECTED_TIMEOUT)
-            ]);
+            await waitFor(reconnectingPromises, 'reconnectingPromises', RECONNECTING_TIMEOUT);
+            await waitFor(reconnectedPromises, 'reconnectedPromises', RECONNECTED_TIMEOUT);
           } catch (err) {
             console.log('rooms - Failed to Reconnect. Checking status:');
             rooms.forEach(room => console.log(`ConnectionStates: ${room.localParticipant.identity}: signalingConnectionState:${room._signaling.signalingConnectionState}  mediaConnectionState:${room._signaling.mediaConnectionState}`));

--- a/test/unit/spec/room.js
+++ b/test/unit/spec/room.js
@@ -80,18 +80,18 @@ describe('Room', () => {
       });
     });
 
-    it('should re-emit RemoteParticipant "reconnected" for matching RemoteParticipant only', () => {
+    it('should re-emit RemoteParticipant "participantReconnected" for matching RemoteParticipant only', () => {
       const spy = sinon.spy();
-      room.on('reconnected', spy);
+      room.on('participantReconnected', spy);
 
       participants.foo.emit('reconnected');
       assert.equal(spy.callCount, 1);
       assert(spy.calledWith(participants.foo));
     });
 
-    it('should re-emit RemoteParticipant "reconnecting" for matching RemoteParticipant only', () => {
+    it('should re-emit RemoteParticipant "participantReconnecting" for matching RemoteParticipant only', () => {
       const spy = sinon.spy();
-      room.on('reconnecting', spy);
+      room.on('participantReconnecting', spy);
 
       participants.foo.emit('reconnecting');
       assert.equal(spy.callCount, 1);

--- a/test/unit/spec/room.js
+++ b/test/unit/spec/room.js
@@ -80,6 +80,24 @@ describe('Room', () => {
       });
     });
 
+    it('should re-emit RemoteParticipant "reconnected" for matching RemoteParticipant only', () => {
+      const spy = sinon.spy();
+      room.on('reconnected', spy);
+
+      participants.foo.emit('reconnected');
+      assert.equal(spy.callCount, 1);
+      assert(spy.calledWith(participants.foo));
+    });
+
+    it('should re-emit RemoteParticipant "reconnecting" for matching RemoteParticipant only', () => {
+      const spy = sinon.spy();
+      room.on('reconnecting', spy);
+
+      participants.foo.emit('reconnecting');
+      assert.equal(spy.callCount, 1);
+      assert(spy.calledWith(participants.foo));
+    });
+
     it('should re-emit RemoteParticipant trackDimensionsChanged for matching RemoteParticipant only', () => {
       const spy = sinon.spy();
       room.on('trackDimensionsChanged', spy);

--- a/test/unit/spec/signaling/v2/room.js
+++ b/test/unit/spec/signaling/v2/room.js
@@ -6,7 +6,6 @@ const { inherits } = require('util');
 const sinon = require('sinon');
 
 const { flatMap } = require('../../../../../lib/util');
-const { MediaConnectionError, SignalingConnectionDisconnectedError } = require('../../../../../lib/util/twilio-video-errors');
 const StatsReport = require('../../../../../lib/stats/statsreport');
 const RoomV2 = require('../../../../../lib/signaling/v2/room');
 const RealDominantSpeakerSignaling = require('../../../../../lib/signaling/v2/dominantspeakersignaling');
@@ -1797,23 +1796,25 @@ describe('RoomV2', () => {
   });
 });
 
-describe('RoomSignaling reconnection states', () => {
-  describe('"reconnecting"', () => {
-    [SignalingConnectionDisconnectedError, MediaConnectionError].forEach(TwilioError => {
-      const shouldTransition = TwilioError === SignalingConnectionDisconnectedError;
-      context(`with a ${TwilioError.name}`, () => {
-        it(`should ${shouldTransition ? '' : 'not '}transition the LocalParticipantV2's .state to "reconnecting"`, () => {
-          const test = makeTest();
-          let newState;
-          test.localParticipant.once('stateChanged', state => { newState = state; });
-          test.room.emit('stateChanged', 'reconnecting', new TwilioError());
-          if (shouldTransition) {
-            assert.equal(newState, 'reconnecting');
-          } else {
-            assert(!newState);
-          }
-        });
-      });
+describe('"signalingConnectionStateChanged" event', () => {
+  context('when the RoomV2\'s .signalingConnectionState is "reconnecting"', () => {
+    it('should transition the LocalParticipantV2\'s .state to "reconnecting"', () => {
+      const test = makeTest();
+      let newState;
+      test.localParticipant.once('stateChanged', state => { newState = state; });
+      test.transport.sync();
+      assert.equal(newState, 'reconnecting');
+    });
+  });
+
+  context('when the RoomV2\'s .signalingConnectionState is "connected"', () => {
+    it('should transition the LocalParticipantV2\'s .state to "connected"', () => {
+      const test = makeTest();
+      let newState;
+      test.transport.sync();
+      test.localParticipant.once('stateChanged', state => { newState = state; });
+      test.transport.synced();
+      assert.equal(newState, 'connected');
     });
   });
 });
@@ -1911,7 +1912,18 @@ function makeTransport() {
   transport.disconnect = sinon.spy(() => {});
   transport.publish = sinon.spy(() => {});
   transport.publishEvent = sinon.spy(() => {});
-  transport.sync = sinon.spy(() => {});
+
+  transport.sync = sinon.spy(() => {
+    transport.state = 'syncing';
+    transport.emit('stateChanged', 'syncing');
+  });
+
+  transport.synced = sinon.spy(() => {
+    transport.state = 'connected';
+    transport.emit('stateChanged', 'connected');
+  });
+
+  transport.state = 'connected';
   return transport;
 }
 
@@ -2024,7 +2036,7 @@ function makeLocalParticipant(options) {
   localParticipant.revision = 0;
   localParticipant.getState = sinon.spy(() => ({ revision: localParticipant.revision }));
 
-  localParticipant.connect = () => {};
+  localParticipant.connect = sinon.spy(() => localParticipant.emit('stateChanged', 'connected'));
   localParticipant.reconnecting = sinon.spy(() => localParticipant.emit('stateChanged', 'reconnecting'));
   localParticipant.setTrackPrioritySignaling = sinon.spy();
   localParticipant.update = sinon.spy(localParticipantState => {


### PR DESCRIPTION
@makarandp0 

This PR implements the new Participant state "reconnecting", and new events "reconnecting" and "reconnected". The IDL changes can be referred to [here](https://code.hq.twilio.com/client/video-sdk-api/pull/57/files).

## Checklist

- [x] RemoteParticipant implementation
- [x] RemoteParticipant unit tests
- [x] LocalParticipant implementation
- [x] LocalParticipant unit tests
- [x] Integration tests
- [x] CHANGELOG.md entry

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
