### PR TITLE
JSDK 2658 simulcast media does not flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Bug Fixes
 - Fixed a bug where Room.getStats() sometimes returned null stats in a Peer-to-Peer
   Room on Chrome 81+. (JSDK-2640)
 
+- Fixed a bug where sometimes enabling simulcast prevented media flow on screen share tracks on Chrome 81+. (JSDK-2658)
+
 1.20.0 (November 11, 2019)
 ==========================
 

--- a/lib/util/sdp/simulcast.js
+++ b/lib/util/sdp/simulcast.js
@@ -261,8 +261,14 @@ function setSimulcastInMediaSection(section, sdpFormat, trackIdsToAttributes) {
   // Add the simulcast SSRC SDP lines to the media section. The Set ensures
   // that the duplicates of the SSRC SDP lines that are in both "section" and
   // "relevantSdpLines" are removed.
-  const sectionLines = new Set(section.split('\r\n').concat(relevantSdpLines));
-  return flatMap(sectionLines).join('\r\n');
+  const sectionLines = flatMap(new Set(section.split('\r\n').concat(relevantSdpLines)));
+
+  const xGoogleFlagConference = 'a=x-google-flag:conference';
+  if (!section.match(xGoogleFlagConference)) {
+    sectionLines.push(xGoogleFlagConference);
+  }
+
+  return sectionLines.join('\r\n');
 }
 
 /**

--- a/test/integration/spec/util/simulcast.js
+++ b/test/integration/spec/util/simulcast.js
@@ -65,6 +65,12 @@ describe('setSimulcast', () => {
         answer2 = await pc2.createAnswer();
       });
 
+      it('should add GoogleFlagConference flag to modified sdp', () => {
+        const xGoogleFlagConference = 'a=x-google-flag:conference';
+        const sdp1 = createSdp === 'createOffer' ? offer1.sdp : answer1.sdp;
+        assert(sdp1.match(xGoogleFlagConference));
+      });
+
       it('should preserve simulcast SSRCs during renegotiation', () => {
         const sdp1 = createSdp === 'createOffer' ? offer1.sdp : answer1.sdp;
         const sdp2 = createSdp === 'createOffer' ? offer2.sdp : answer2.sdp;

--- a/test/unit/spec/util/sdp/index.js
+++ b/test/unit/spec/util/sdp/index.js
@@ -215,6 +215,11 @@ describe('setSimulcast', () => {
       }
     });
 
+    it('should add "a=x-google-flag:conference" flag to modified sdp', () => {
+      const xGoogleFlagConference = 'a=x-google-flag:conference';
+      assert(simSdp.match(xGoogleFlagConference));
+    });
+
     context('when the SDP contains a previously added MediaStreamTrack ID', () => {
       before(() => {
         simSdp = setSimulcast(sdp, sdpType, trackIdsToAttributes);


### PR DESCRIPTION
on v1 we were missing `a=x-google-flag:conference` line in the sdp updated to include simulcast. Newer chrome (81+) seems to care more about it. Maybe they are finally rolling out changes mentioned [here](https://groups.google.com/forum/#!topic/discuss-webrtc/hckBc35579w) 

This ports the lines from v2 into v1. This fixes the issue with screen-share media flow with simulcast enabled.
 
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
