### PR TITLE
JSDK-2670 Handle Chrome iOS user agent, which does not contain "Version/*".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/support-1.x/CHANGELOG.md).
 
-
-2.1.1 (In Progress)
+2.2.0 (in progress)
 ===================
 
-- Fixed a bug where switching between networks (or connecting to VPN) sometimes caused media flow to stop. (JSDK-2667)
+Bug Fixes
+---------
 
+- Fixed a bug where switching between networks (or connecting to VPN) sometimes caused media flow to stop. (JSDK-2667)
+- Fixed a bug where twilio-video.js failed to load due to a TypeError on Chrome iOS. (JSDK-2670)
 
 2.1.0 (February 4, 2020)
 ========================

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { MediaStreamTrack } = require('@twilio/webrtc');
-const { guessBrowser } = require('@twilio/webrtc/lib/util');
+const { guessBrowser, guessBrowserVersion } = require('@twilio/webrtc/lib/util');
 const createCancelableRoomPromise = require('./cancelableroompromise');
 const createLocalTracks = require('./createlocaltracks');
 const EncodingParametersImpl = require('./encodingparameters');
@@ -40,9 +40,7 @@ const CancelablePromise = require('./util/cancelablepromise');
 const Log = require('./util/log');
 const { validateBandwidthProfile } = require('./util/validate');
 
-const safariVersion = guessBrowser() === 'safari' && (
-  navigator.userAgent.match(/Version\/([^\s]+)/) || [null, null]
-)[1];
+const safariVersion = guessBrowser() === 'safari' && guessBrowserVersion();
 
 // This is used to make out which connect() call a particular Log statement
 // belongs to. Each call to connect() increments this counter.
@@ -53,7 +51,7 @@ let didPrintDscpTaggingWarning = false;
 let isSafariWithoutVP8Support = false;
 
 if (safariVersion) {
-  const [safariMajorVersion, safariMinorVersion] = safariVersion.split('.').map(Number);
+  const { major: safariMajorVersion, minor: safariMinorVersion } = safariVersion;
   isSafariWithoutVP8Support = safariMajorVersion < 12 || (safariMajorVersion === 12 && safariMinorVersion < 1);
 }
 

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -40,8 +40,9 @@ const CancelablePromise = require('./util/cancelablepromise');
 const Log = require('./util/log');
 const { validateBandwidthProfile } = require('./util/validate');
 
-const safariVersion = guessBrowser() === 'safari'
-  && navigator.userAgent.match(/Version\/([^\s]+)/)[1];
+const safariVersion = guessBrowser() === 'safari' && (
+  navigator.userAgent.match(/Version\/([^\s]+)/) || [null, null]
+)[1];
 
 // This is used to make out which connect() call a particular Log statement
 // belongs to. Each call to connect() increments this counter.

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- ./test/unit/index.js"
   },
   "dependencies": {
-    "@twilio/webrtc": "4.1.3",
+    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#JSDK-2670",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- ./test/unit/index.js"
   },
   "dependencies": {
-    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#JSDK-2670",
+    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#0d91284101dd36f176ff0c60b3abc32aaaf4dd7f",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },


### PR DESCRIPTION
@makarandp0 

This PR fixes JSDK-2670, which was created due to #869 . Please confirm that your local version of Simpler Signaling does not crash with this change on Chrome and Firefox on iOS (iPhone and iPad).

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
