### PR TITLE
JSDK-2667: Media in room stops flowing when participant enables VPN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/support-1.x/CHANGELOG.md).
 
+
+2.1.1 (In Progress)
+===================
+
+- Fixed a bug where switching between networks (or connecting to VPN) sometimes caused media flow to stop. (JSDK-2667)
+
+
 2.1.0 (February 4, 2020)
 ========================
 
@@ -10,7 +17,7 @@ New Features
   re-establish its signaling connection to the Room after a network disruption/handoff.
   Once it has successfully reconnected to the Room, it will emit a "reconnected"
   event. (JSDK-2662)
-  
+
   ```js
   function reconnecting(participant) {
     console.log(`${participant.identity} is rejoining the Room`);
@@ -51,7 +58,7 @@ New Features
   The LocalParticipant will now also emit "reconnecting" and "reconnected" events
   when the local client is recovering/successfully recovered from a signaling connection
   disruption:
-  
+
   ```js
   const { localParticipant } = room;
 

--- a/lib/signaling/v2/iceconnectionmonitor.js
+++ b/lib/signaling/v2/iceconnectionmonitor.js
@@ -47,9 +47,8 @@ class IceConnectionMonitor {
     return this._peerConnection.getStats().then(stats => Array.from(stats.values()).find(stat => {
       return stat.type === 'candidate-pair' && stat.nominated;
     })).then(activePairStat => {
-      // NOTE(mpatwardhan): sometimes after getting disconnected while switching network
-      // we may not have active pair. Treat this as 0 bytesReceived so that we count it
-      // towards inactivity.
+      // NOTE(mpatwardhan): sometimes (JSDK-2667) after getting disconnected while switching network
+      // we may not find active pair. Treat this as 0 bytesReceived so that we count it towards inactivity.
       return activePairStat || {
         bytesReceived: 0,
         timestamp: Math.round((new Date()).getTime())

--- a/lib/signaling/v2/iceconnectionmonitor.js
+++ b/lib/signaling/v2/iceconnectionmonitor.js
@@ -46,7 +46,15 @@ class IceConnectionMonitor {
   _getIceConnectionStats() {
     return this._peerConnection.getStats().then(stats => Array.from(stats.values()).find(stat => {
       return stat.type === 'candidate-pair' && stat.nominated;
-    })).catch(() => {
+    })).then(activePairStat => {
+      // NOTE(mpatwardhan): sometimes after getting disconnected while switching network
+      // we may not have active pair. Treat this as 0 bytesReceived so that we count it
+      // towards inactivity.
+      return activePairStat || {
+        bytesReceived: 0,
+        timestamp: Math.round((new Date()).getTime())
+      };
+    }).catch(() => {
       return null;
     });
   }

--- a/test/unit/spec/signaling/v2/iceconnectionmonitor.js
+++ b/test/unit/spec/signaling/v2/iceconnectionmonitor.js
@@ -120,6 +120,90 @@ describe('IceConnectionMonitor', () => {
         assert.strictEqual(iceStats, null);
       });
     });
+
+    it('extracts active connection pair when found', () => {
+      const chromeFakeStats = new Map(Object.entries({
+        'RTCIceCandidatePair_4OFKCmYa_Mi4ThK96': {
+          'id': 'RTCIceCandidatePair_A',
+          'timestamp': 1543863871950.097,
+          'type': 'candidate-pair',
+          'localCandidateId': 'RTCIceCandidate_4OFKCmYa',
+          'remoteCandidateId': 'RTCIceCandidate_Mi4ThK96',
+          'state': 'waiting',
+          'priority': 395789001576824300,
+          'nominated': false,
+          'writable': false,
+          'bytesSent': 10,
+          'bytesReceived': 10,
+        },
+        'RTCIceCandidatePair_4OFKCmYa_Y0FHsxUI': {
+          'id': 'RTCIceCandidatePair_B',
+          'timestamp': 1543863871950.097,
+          'type': 'candidate-pair',
+          'localCandidateId': 'RTCIceCandidate_4OFKCmYa',
+          'remoteCandidateId': 'RTCIceCandidate_Y0FHsxUI',
+          'state': 'in-progress',
+          'priority': 9114723795305643000,
+          'nominated': true,
+          'writable': false,
+          'bytesSent': 20,
+          'bytesReceived': 20,
+        },
+      }));
+
+      const iceConnectionMonitor = new IceConnectionMonitor({
+        getStats: function() {
+          return Promise.resolve(chromeFakeStats);
+        }
+      });
+      return iceConnectionMonitor._getIceConnectionStats().then(activePair => {
+        assert.equal(activePair.bytesReceived, 20);
+        assert.equal(activePair.nominated, true);
+        assert.equal(activePair.id, 'RTCIceCandidatePair_B');
+      });
+    });
+
+    it('returns fake pair with bytesReceived=0 when no active connection pair found', () => {
+      const chromeFakeStats = new Map(Object.entries({
+        'RTCIceCandidatePair_4OFKCmYa_Mi4ThK96': {
+          'id': 'RTCIceCandidatePair_A',
+          'timestamp': 1543863871950.097,
+          'type': 'candidate-pair',
+          'localCandidateId': 'RTCIceCandidate_4OFKCmYa',
+          'remoteCandidateId': 'RTCIceCandidate_Mi4ThK96',
+          'state': 'waiting',
+          'priority': 395789001576824300,
+          'nominated': false,
+          'writable': false,
+          'bytesSent': 10,
+          'bytesReceived': 10,
+        },
+        'RTCIceCandidatePair_4OFKCmYa_Y0FHsxUI': {
+          'id': 'RTCIceCandidatePair_B',
+          'timestamp': 1543863871950.097,
+          'type': 'candidate-pair',
+          'localCandidateId': 'RTCIceCandidate_4OFKCmYa',
+          'remoteCandidateId': 'RTCIceCandidate_Y0FHsxUI',
+          'state': 'in-progress',
+          'priority': 9114723795305643000,
+          'nominated': false,
+          'writable': false,
+          'bytesSent': 20,
+          'bytesReceived': 20,
+        },
+      }));
+
+      const iceConnectionMonitor = new IceConnectionMonitor({
+        getStats: function() {
+          return Promise.resolve(chromeFakeStats);
+        }
+      });
+      return iceConnectionMonitor._getIceConnectionStats().then(activePair => {
+        assert.equal(activePair.bytesReceived, 0);
+        assert.equal(activePair.id, undefined);
+        assert.equal(typeof activePair.timestamp, 'number');
+      });
+    });
   });
 
   describe('.stop', () => {


### PR DESCRIPTION
I got a good repro (updated steps in the bug)   

This fixes issue with media-flow on switching to VPN. Switching network causes the iceConnection to move to `disconnected` state - so we start ice connection  monitor, but it was not triggering `onIceConnectionInactive` because in this case there was no active ice candidate pairs anymore. 

Updated the IceConnectionMonitor to treat no-active-ice-candidate-pair condition as no activity. This causes it to triggers the ice restart logic.

TODO:
- [ ] update unit tests

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
