### PR TITLE
Revert "JSDK-2641 set mediaEl.srcObject only if needed"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/suppor
 Bug Fixes
 ---------
 
-- Fixed a bug where attaching a VideoTrack to a HTMLVideoElement that was already in the DOM caused the video to flicker. (JSDK-2641)
 - Fixed a bug where switching between networks (or connecting to VPN) sometimes caused media flow to stop. (JSDK-2667)
 - Fixed a bug where twilio-video.js failed to load due to a TypeError on Chrome iOS. (JSDK-2670)
 

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -145,11 +145,8 @@ class MediaTrack extends Track {
     });
     mediaStream.addTrack(this.mediaStreamTrack);
 
-    // NOTE(mroberts): Although we don't necessarily need to reset `srcObject`,
-    // we've been doing it here for a while, and it turns out it has allowed us
-    // to sidestep the following issue:
-    //
-    //   https://bugs.chromium.org/p/chromium/issues/detail?id=720258
+    // NOTE(mpatwardhan): resetting `srcObject` here, causes flicker (JSDK-2641), but it lets us
+    // to sidestep the a chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1052353
     //
     el.srcObject = mediaStream;
     el.autoplay = true;

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -134,7 +134,6 @@ class MediaTrack extends Track {
     let mediaStream = el.srcObject;
     if (!(mediaStream instanceof this._MediaStream)) {
       mediaStream = new this._MediaStream();
-      el.srcObject = mediaStream;
     }
 
     const getTracks = this.mediaStreamTrack.kind === 'audio'
@@ -146,6 +145,13 @@ class MediaTrack extends Track {
     });
     mediaStream.addTrack(this.mediaStreamTrack);
 
+    // NOTE(mroberts): Although we don't necessarily need to reset `srcObject`,
+    // we've been doing it here for a while, and it turns out it has allowed us
+    // to sidestep the following issue:
+    //
+    //   https://bugs.chromium.org/p/chromium/issues/detail?id=720258
+    //
+    el.srcObject = mediaStream;
     el.autoplay = true;
     el.playsInline = true;
 


### PR DESCRIPTION
Reverts twilio/twilio-video.js#881 
@timmydoza found an issue where the video gets stuck sometimes. (thanks @timmydoza). I guess we have to live with flicker until we find better fix. 

I have filed a chrome bug to track this:
https://bugs.chromium.org/p/chromium/issues/detail?id=1052353