### PR TITLE
JSDK-2678 fix track disabled event params doc

### DIFF
--- a/lib/remoteparticipant.js
+++ b/lib/remoteparticipant.js
@@ -155,13 +155,13 @@ class RemoteParticipant extends Participant {
 
 /**
  * A {@link RemoteTrack} was disabled by the {@link RemoteParticipant}.
- * @param {RemoteTrack} track - The {@link RemoteTrack} that was disabled
+ * @param {RemoteTrackPublication} publication - The {@link RemoteTrackPublication} associated with the disabled track
  * @event RemoteParticipant#trackDisabled
  */
 
 /**
  * A {@link RemoteTrack} was enabled by the {@link RemoteParticipant}.
- * @param {RemoteTrack} track - The {@link RemoteTrack} that was enabled
+ * @param {RemoteTrackPublication} publication - The {@link RemoteTrackPublication} associated with the enabled track
  * @event RemoteParticipant#trackEnabled
  */
 

--- a/lib/remoteparticipant.js
+++ b/lib/remoteparticipant.js
@@ -155,13 +155,13 @@ class RemoteParticipant extends Participant {
 
 /**
  * A {@link RemoteTrack} was disabled by the {@link RemoteParticipant}.
- * @param {RemoteTrackPublication} publication - The {@link RemoteTrackPublication} associated with the disabled track
+ * @param {RemoteTrackPublication} publication - The {@link RemoteTrackPublication} associated with the disabled {@link RemoteTrack}
  * @event RemoteParticipant#trackDisabled
  */
 
 /**
  * A {@link RemoteTrack} was enabled by the {@link RemoteParticipant}.
- * @param {RemoteTrackPublication} publication - The {@link RemoteTrackPublication} associated with the enabled track
+ * @param {RemoteTrackPublication} publication - The {@link RemoteTrackPublication} associated with the enabled {@link RemoteTrack}
  * @event RemoteParticipant#trackEnabled
  */
 

--- a/lib/room.js
+++ b/lib/room.js
@@ -297,7 +297,7 @@ function rewriteLocalTrackIds(room, trackStats) {
 
 /**
  * A {@link RemoteTrack} was disabled by a {@link RemoteParticipant} in the {@link Room}.
- * @param {RemoteTrack} track - The {@link RemoteTrack} that was disabled
+ * @param {RemoteTrackPublication} publication - The {@link RemoteTrackPublication} that represents disabled track
  * @param {RemoteParticipant} participant - The {@link RemoteParticipant} who
  *   disabled the {@link RemoteTrack}
  * @event Room#trackDisabled
@@ -305,7 +305,7 @@ function rewriteLocalTrackIds(room, trackStats) {
 
 /**
  * A {@link RemoteTrack} was enabled by a {@link RemoteParticipant} in the {@link Room}.
- * @param {RemoteTrack} track - The {@link RemoteTrack} that was enabled
+ * @param {RemoteTrackPublication} publication - The {@link RemoteTrackPublication} that represents enabled track
  * @param {RemoteParticipant} participant - The {@link RemoteParticipant} who
  *   enabled the {@link RemoteTrack}
  * @event Room#trackEnabled

--- a/lib/room.js
+++ b/lib/room.js
@@ -297,7 +297,7 @@ function rewriteLocalTrackIds(room, trackStats) {
 
 /**
  * A {@link RemoteTrack} was disabled by a {@link RemoteParticipant} in the {@link Room}.
- * @param {RemoteTrackPublication} publication - The {@link RemoteTrackPublication} that represents disabled track
+ * @param {RemoteTrackPublication} publication - The {@link RemoteTrackPublication} that represents disabled {@link RemoteTrack}
  * @param {RemoteParticipant} participant - The {@link RemoteParticipant} who
  *   disabled the {@link RemoteTrack}
  * @event Room#trackDisabled
@@ -305,7 +305,7 @@ function rewriteLocalTrackIds(room, trackStats) {
 
 /**
  * A {@link RemoteTrack} was enabled by a {@link RemoteParticipant} in the {@link Room}.
- * @param {RemoteTrackPublication} publication - The {@link RemoteTrackPublication} that represents enabled track
+ * @param {RemoteTrackPublication} publication - The {@link RemoteTrackPublication} that represents enabled {@link RemoteTrack}
  * @param {RemoteParticipant} participant - The {@link RemoteParticipant} who
  *   enabled the {@link RemoteTrack}
  * @event Room#trackEnabled


### PR DESCRIPTION
Fixes the type for trackDisabled/trackEnabled events fired on the `Room` and `RemoteParticipant`.
`RemoteTrack` => `RemoteTrackPublication`


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
