### PR TITLE
do not emit public events with statemachine locked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/suppor
 New Features
 ------------
 
+- `reconnecting` and `reconnected` events on Room and LocalParticipant are now fired asynchronously. (JSDK-2696)
 - twilio-video.js now raises `connect()` errors due to network disruptions quicker by not retrying after the first connection attempt fails. (JSDK-2682)
 - A LocalParticipant will now have an additional `signalingRegion` property which contains the geographical region of the signaling edge LocalParticipant is connected to. (JSDK-2687)
 

--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -223,7 +223,10 @@ class LocalParticipant extends Participant {
         // successful signaling reconnection, and not a first-time establishment
         // of the signaling connection.
         log.info('reconnected');
-        self.emit('reconnected');
+
+        // NOTE(mpatwardhan): `stateChanged` can get emitted with StateMachine locked.
+        // Do not signal  public events synchronously with lock held.
+        setTimeout(() => self.emit('reconnected'), 0);
       }
     });
   }

--- a/lib/participant.js
+++ b/lib/participant.js
@@ -364,6 +364,7 @@ class Participant extends EventEmitter {
         // successful signaling reconnection, and not a first-time establishment
         // of the signaling connection.
         log.info('reconnected');
+
         // NOTE(mpatwardhan): `stateChanged` can get emitted with StateMachine locked.
         // Do not signal  public events synchronously with lock held.
         setTimeout(() => self.emit('reconnected'), 0);

--- a/lib/participant.js
+++ b/lib/participant.js
@@ -364,7 +364,10 @@ class Participant extends EventEmitter {
         // successful signaling reconnection, and not a first-time establishment
         // of the signaling connection.
         log.info('reconnected');
-        self.emit('reconnected');
+        // NOTE(mpatwardhan): `stateChanged` can get emitted with StateMachine locked.
+        // Do not signal  public events synchronously with lock held.
+        setTimeout(() => self.emit('reconnected'), 0);
+
       }
     });
   }

--- a/lib/room.js
+++ b/lib/room.js
@@ -528,7 +528,7 @@ function handleSignalingEvents(room, signaling) {
 
         // NOTE(mpatwardhan): `stateChanged` can get emitted with StateMachine locked.
         // Do not signal  public events synchronously with lock held.
-        setTimeout(() => room.emit('reconnecting'), 0);
+        setTimeout(() => room.emit('reconnecting', error), 0);
 
         break;
       default:

--- a/lib/room.js
+++ b/lib/room.js
@@ -525,10 +525,17 @@ function handleSignalingEvents(room, signaling) {
         signaling.removeListener('stateChanged', stateChanged);
         break;
       case 'reconnecting':
-        room.emit('reconnecting', error);
+
+        // NOTE(mpatwardhan): `stateChanged` can get emitted with StateMachine locked.
+        // Do not signal  public events synchronously with lock held.
+        setTimeout(() => room.emit('reconnecting'), 0);
+
         break;
       default:
-        room.emit('reconnected');
+
+        // NOTE(mpatwardhan): `stateChanged` can get emitted with StateMachine locked.
+        // Do not signal  public events synchronously with lock held.
+        setTimeout(() => room.emit('reconnected'), 0);
     }
   });
 }

--- a/test/unit/spec/localparticipant.js
+++ b/test/unit/spec/localparticipant.js
@@ -1057,10 +1057,9 @@ describe('LocalParticipant', () => {
       context('when the LocalParticipant .state is "reconnecting"', () => {
         it('should emit "reconnected" on the LocalParticipant', () => {
           const test = makeTest({ state: 'reconnecting' });
-          let emitted;
-          test.participant.once('reconnected', () => { emitted = true; });
+          const reconnectingPromise = new Promise(resolve => test.participant.once('reconnected', resolve));
           test.signaling.emit('stateChanged', 'connected');
-          assert(emitted);
+          return reconnectingPromise;
         });
       });
 

--- a/test/unit/spec/remoteparticipant.js
+++ b/test/unit/spec/remoteparticipant.js
@@ -614,10 +614,9 @@ describe('RemoteParticipant', () => {
 
         it(`should emit "${participantEvent}" on the Participant`, () => {
           const test = makeTest({ state });
-          let eventEmitted;
-          test.participant.once(participantEvent, () => { eventEmitted = true; });
+          const eventPromise = new Promise(resolve => test.participant.once(participantEvent, resolve));
           test.signaling.emit('stateChanged', newState);
-          assert(eventEmitted);
+          return eventPromise;
         });
       });
     });


### PR DESCRIPTION
With this fix, we fire some events (`reconnecting`, `reconnected`) asynchronously - ensuring that our StateMachine lock is not held, so that there would be no side effects by caller synchronously calling into state machine again.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
