### PR TITLE
JSDK-2687 Add signalingRegion Property on LocalParticipant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/suppor
 
 New Features
 ------------
-- A LocalParticipant will now have an additional `signalingRegion` property which contains the signaling region the local participant is connected to. (JSDK-2687)
+- A LocalParticipant will now have an additional `signalingRegion` property which contains the geographical region of the signaling edge LocalParticipant is connected to. (JSDK-2687)
 
 
 2.2.0 (February 21, 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/support-1.x/CHANGELOG.md).
 
+2.3.0 (In Progress)
+=========================
+
+New Features
+------------
+- A LocalParticipant will now have an additional `signalingRegion` property which contains the signaling region the local participant is connected to. (JSDK-2687)
+
+
 2.2.0 (February 21, 2020)
 =========================
 

--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -88,6 +88,12 @@ class LocalParticipant extends Participant {
       },
       _tracksToStop: {
         value: tracksToStop
+      },
+      signalingRegion: {
+        enumerable: true,
+        get() {
+          return signaling.signalingRegion;
+        }
       }
     });
 

--- a/lib/signaling/v2/cancelableroomsignalingpromise.js
+++ b/lib/signaling/v2/cancelableroomsignalingpromise.js
@@ -89,13 +89,13 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
             reject(cancelationError);
             return;
           }
-
           const localParticipantState = initialState.participant;
           if (!localParticipantState) {
             reject(new SignalingIncomingMessageInvalidError());
             return;
           }
 
+          localParticipant.setSignalingRegion(initialState.options.signaling_region);
           resolve(new RoomV2(localParticipant, initialState, transport, peerConnectionManager, options));
         });
 

--- a/lib/signaling/v2/localparticipant.js
+++ b/lib/signaling/v2/localparticipant.js
@@ -86,11 +86,11 @@ class LocalParticipantV2 extends LocalParticipantSignaling {
   }
 
   /**
-   * Set the {@link signalingRegion}.
-   * @param {signalingRegion} signalingRegion.
+   * Set the signalingRegion.
+   * @param {string} signalingRegion.
    */
   setSignalingRegion(signalingRegion) {
-    if (!isDeepEqual(this._signalingRegion, signalingRegion)) {
+    if (!this._signalingRegion) {
       this._signalingRegion = signalingRegion;
     }
   }

--- a/lib/signaling/v2/localparticipant.js
+++ b/lib/signaling/v2/localparticipant.js
@@ -50,6 +50,10 @@ class LocalParticipantV2 extends LocalParticipantSignaling {
         writable: true,
         value: 1
       },
+      _signalingRegion: {
+        value: null,
+        writable: true
+      },
       bandwidthProfile: {
         enumerable: true,
         get() {
@@ -71,8 +75,24 @@ class LocalParticipantV2 extends LocalParticipantSignaling {
         get() {
           return this._revision;
         }
+      },
+      signalingRegion: {
+        enumerable: true,
+        get() {
+          return this._signalingRegion;
+        }
       }
     });
+  }
+
+  /**
+   * Set the {@link signalingRegion}.
+   * @param {signalingRegion} signalingRegion.
+   */
+  setSignalingRegion(signalingRegion) {
+    if (!isDeepEqual(this._signalingRegion, signalingRegion)) {
+      this._signalingRegion = signalingRegion;
+    }
   }
 
   /**

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -250,68 +250,13 @@ describe('connect', function() {
               assert(error instanceof SignalingConnectionError);
             } else {
               assert.equal(error, null);
+              assert.equal(typeof room.localParticipant.signalingRegion, 'string');
+              assert('signalingRegion' in room.localParticipant);
               assert(room instanceof Room);
             }
           }
         });
       });
-    });
-  });
-
-  describe('default(gll) signaling region on LocalParticipant', () => {
-    let cancelablePromise;
-    beforeEach(() => {
-      const identity = randomName();
-      const token = getToken(identity);
-      cancelablePromise = connect(token);
-    });
-
-    it('signalingRegion key should exist on the LocalParticipant and value is a string', async () => {
-      let room;
-      let roomRegion;
-      try {
-        room = await cancelablePromise;
-        roomRegion = room.localParticipant;
-        assert('signalingRegion' in roomRegion);
-        assert.equal(typeof roomRegion.signalingRegion, 'string');
-      } catch (error) {
-        assert.throws(assert.equal(error, roomRegion));
-        room.disconnect();
-      } finally {
-        if (room) {
-          room.disconnect();
-        }
-      }
-    });
-  });
-
-  describe('signaling region on LocalParticipant with region as argument', () => {
-    const regions = ['au1', 'br1', 'de1', 'ie1', 'in1', 'jp1', 'sg1', 'us1', 'us2'];
-    const randomRegion = regions[Math.floor(Math.random() * regions.length)];
-    let cancelablePromise;
-
-    beforeEach(() => {
-      const identity = randomName();
-      const token = getToken(identity);
-      cancelablePromise = connect(token, Object.assign({ region: randomRegion }));
-    });
-
-    it('signalingRegion property should match the signaling region passed in', async () => {
-      let room;
-      let roomRegion;
-      try {
-        room = await cancelablePromise;
-        roomRegion = room.localParticipant.signalingRegion;
-        assert.equal(roomRegion, randomRegion);
-      } catch (error) {
-        roomRegion = room.localParticipant.signalingRegion;
-        assert.throws(assert.equal(error, roomRegion));
-        room.disconnect();
-      } finally {
-        if (room) {
-          room.disconnect();
-        }
-      }
     });
   });
 

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -250,7 +250,11 @@ describe('connect', function() {
               assert(error instanceof SignalingConnectionError);
             } else {
               assert.equal(error, null);
-              assert.equal(typeof room.localParticipant.signalingRegion, 'string');
+              if (typeof region !== 'string' || region === 'gll') {
+                assert.equal(typeof room.localParticipant.signalingRegion, 'string');
+              } else {
+                assert.equal(room.localParticipant.signalingRegion, region);
+              }
               assert('signalingRegion' in room.localParticipant);
               assert(room instanceof Room);
             }

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -266,16 +266,16 @@ describe('connect', function() {
       cancelablePromise = connect(token);
     });
 
-    it('signalingRegion property should exist on the LocalParticipant and value is a string', async () => {
+    it('signalingRegion key should exist on the LocalParticipant and value is a string', async () => {
       let room;
       let roomRegion;
       try {
         room = await cancelablePromise;
         roomRegion = room.localParticipant.signalingRegion;
-        await assert.isString(roomRegion);
+        assert('signalingRegion' in roomRegion);
+        assert.equal(typeof roomRegion.signalingRegion, 'string');
       } catch (error) {
-        roomRegion = room.localParticipant.signalingRegion;
-        await assert.equal(error, roomRegion);
+        assert.throws(assert.equal(error, roomRegion));
         room.disconnect();
       } finally {
         if (room) {
@@ -302,10 +302,10 @@ describe('connect', function() {
       try {
         room = await cancelablePromise;
         roomRegion = room.localParticipant.signalingRegion;
-        await assert.equal(roomRegion, randomRegion);
+        assert.equal(roomRegion, randomRegion);
       } catch (error) {
         roomRegion = room.localParticipant.signalingRegion;
-        await assert.equal(error, roomRegion);
+        assert.throws(assert.equal(error, roomRegion));
         room.disconnect();
       } finally {
         if (room) {

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -258,7 +258,7 @@ describe('connect', function() {
     });
   });
 
-  describe.only('default(gll) signaling region on LocalParticipant', () => {
+  describe('default(gll) signaling region on LocalParticipant', () => {
     let cancelablePromise;
     beforeEach(() => {
       const identity = randomName();
@@ -271,7 +271,7 @@ describe('connect', function() {
       let roomRegion;
       try {
         room = await cancelablePromise;
-        roomRegion = room.localParticipant.signalingRegion;
+        roomRegion = room.localParticipant;
         assert('signalingRegion' in roomRegion);
         assert.equal(typeof roomRegion.signalingRegion, 'string');
       } catch (error) {
@@ -285,7 +285,7 @@ describe('connect', function() {
     });
   });
 
-  describe.only('signaling region on LocalParticipant with region as argument', () => {
+  describe('signaling region on LocalParticipant with region as argument', () => {
     const regions = ['au1', 'br1', 'de1', 'ie1', 'in1', 'jp1', 'sg1', 'us1', 'us2'];
     const randomRegion = regions[Math.floor(Math.random() * regions.length)];
     let cancelablePromise;

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -258,7 +258,7 @@ describe('connect', function() {
     });
   });
 
-  describe('default(gll) signaling region on LocalParticipant', () => {
+  describe.only('default(gll) signaling region on LocalParticipant', () => {
     let cancelablePromise;
     beforeEach(() => {
       const identity = randomName();
@@ -268,17 +268,24 @@ describe('connect', function() {
 
     it('signalingRegion property should exist on the LocalParticipant and value is a string', async () => {
       let room;
+      let roomRegion;
       try {
         room = await cancelablePromise;
-        const roomRegion = room.localParticipant.signalingRegion;
-        assert.equal(typeof roomRegion, 'string');
+        roomRegion = room.localParticipant.signalingRegion;
+        await assert.isString(roomRegion);
       } catch (error) {
+        roomRegion = room.localParticipant.signalingRegion;
+        await assert.equal(error, roomRegion);
         room.disconnect();
+      } finally {
+        if (room) {
+          room.disconnect();
+        }
       }
     });
   });
 
-  describe('signaling region on LocalParticipant with region as argument', () => {
+  describe.only('signaling region on LocalParticipant with region as argument', () => {
     const regions = ['au1', 'br1', 'de1', 'ie1', 'in1', 'jp1', 'sg1', 'us1', 'us2'];
     const randomRegion = regions[Math.floor(Math.random() * regions.length)];
     let cancelablePromise;
@@ -291,12 +298,19 @@ describe('connect', function() {
 
     it('signalingRegion property should match the signaling region passed in', async () => {
       let room;
+      let roomRegion;
       try {
         room = await cancelablePromise;
-        const roomRegion = room.localParticipant.signalingRegion;
-        assert.equal(roomRegion, randomRegion);
+        roomRegion = room.localParticipant.signalingRegion;
+        await assert.equal(roomRegion, randomRegion);
       } catch (error) {
+        roomRegion = room.localParticipant.signalingRegion;
+        await assert.equal(error, roomRegion);
         room.disconnect();
+      } finally {
+        if (room) {
+          room.disconnect();
+        }
       }
     });
   });

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -204,7 +204,7 @@ describe('connect', function() {
   });
 
   // eslint-disable-next-line require-await
-  describe.only('signaling region', async () => {
+  describe('signaling region', async () => {
     let sid;
     let token;
     beforeEach(async () => {

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -204,7 +204,7 @@ describe('connect', function() {
   });
 
   // eslint-disable-next-line require-await
-  describe('signaling region', async () => {
+  describe.only('signaling region', async () => {
     let sid;
     let token;
     beforeEach(async () => {
@@ -250,12 +250,11 @@ describe('connect', function() {
               assert(error instanceof SignalingConnectionError);
             } else {
               assert.equal(error, null);
-              if (typeof region !== 'string' || region === 'gll') {
+              if (['without', 'gll'].includes(region)) {
                 assert.equal(typeof room.localParticipant.signalingRegion, 'string');
               } else {
                 assert.equal(room.localParticipant.signalingRegion, region);
               }
-              assert('signalingRegion' in room.localParticipant);
               assert(room instanceof Room);
             }
           }

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -258,6 +258,49 @@ describe('connect', function() {
     });
   });
 
+  describe('default(gll) signaling region on LocalParticipant', () => {
+    let cancelablePromise;
+    beforeEach(() => {
+      const identity = randomName();
+      const token = getToken(identity);
+      cancelablePromise = connect(token);
+    });
+
+    it('signalingRegion property should exist on the LocalParticipant and value is a string', async () => {
+      let room;
+      try {
+        room = await cancelablePromise;
+        const roomRegion = room.localParticipant.signalingRegion;
+        assert.equal(typeof roomRegion, 'string');
+      } catch (error) {
+        room.disconnect();
+      }
+    });
+  });
+
+  describe('signaling region on LocalParticipant with region as argument', () => {
+    const regions = ['au1', 'br1', 'de1', 'ie1', 'in1', 'jp1', 'sg1', 'us1', 'us2'];
+    const randomRegion = regions[Math.floor(Math.random() * regions.length)];
+    let cancelablePromise;
+
+    beforeEach(() => {
+      const identity = randomName();
+      const token = getToken(identity);
+      cancelablePromise = connect(token, Object.assign({ region: randomRegion }));
+    });
+
+    it('signalingRegion property should match the signaling region passed in', async () => {
+      let room;
+      try {
+        room = await cancelablePromise;
+        const roomRegion = room.localParticipant.signalingRegion;
+        assert.equal(roomRegion, randomRegion);
+      } catch (error) {
+        room.disconnect();
+      }
+    });
+  });
+
   describe('called with an incorrect RTCIceServer url', () => {
     let cancelablePromise;
 

--- a/test/unit/spec/localparticipant.js
+++ b/test/unit/spec/localparticipant.js
@@ -1095,6 +1095,7 @@ describe('LocalParticipant', () => {
         'state',
         'tracks',
         'videoTracks',
+        'signalingRegion'
       ]);
     });
   });
@@ -1114,6 +1115,7 @@ describe('LocalParticipant', () => {
         networkQualityLevel: participant.networkQualityLevel,
         networkQualityStats: participant.networkQualityStats,
         sid: participant.sid,
+        signalingRegion: participant.signalingRegion,
         state: participant.state,
         tracks: {},
         videoTracks: {}

--- a/test/unit/spec/signaling/v2/cancelableroomsignalingpromise.js
+++ b/test/unit/spec/signaling/v2/cancelableroomsignalingpromise.js
@@ -187,6 +187,10 @@ describe('createCancelableRoomSignalingPromise', () => {
               participant: {
                 sid: sid,
                 identity: identity
+              },
+              options: {
+                // eslint-disable-next-line camelcase
+                signaling_region: 'foo'
               }
             });
             assert(test.RoomV2.calledOnce);
@@ -204,6 +208,10 @@ describe('createCancelableRoomSignalingPromise', () => {
                 participant: {
                   sid: sid,
                   identity: identity
+                },
+                options: {
+                  // eslint-disable-next-line camelcase
+                  signaling_region: 'foo'
                 }
               });
             });
@@ -224,6 +232,10 @@ describe('createCancelableRoomSignalingPromise', () => {
                 participant: {
                   sid: sid,
                   identity: identity
+                },
+                options: {
+                  // eslint-disable-next-line camelcase
+                  signaling_region: 'foo'
                 }
               });
               test.cancelableRoomSignalingPromise.cancel();
@@ -247,6 +259,10 @@ describe('createCancelableRoomSignalingPromise', () => {
                 participant: {
                   sid: sid,
                   identity: identity
+                },
+                options: {
+                  // eslint-disable-next-line camelcase
+                  signaling_region: 'foo'
                 }
               });
               test.cancelableRoomSignalingPromise.cancel();
@@ -268,6 +284,10 @@ describe('createCancelableRoomSignalingPromise', () => {
                 participant: {
                   sid: sid,
                   identity: identity
+                },
+                options: {
+                  // eslint-disable-next-line camelcase
+                  signaling_region: 'foo'
                 }
               });
               test.cancelableRoomSignalingPromise.cancel();
@@ -289,6 +309,10 @@ describe('createCancelableRoomSignalingPromise', () => {
                 participant: {
                   sid: sid,
                   identity: identity
+                },
+                options: {
+                  // eslint-disable-next-line camelcase
+                  signaling_region: 'foo'
                 }
               });
               test.cancelableRoomSignalingPromise.cancel();
@@ -421,6 +445,7 @@ function makeLocalParticipantSignaling(options) {
   localParticipant.update = sinon.spy(() => localParticipant.revision++);
   localParticipant.tracks = options.tracks;
   localParticipant.disconnect = sinon.spy(() => {});
+  localParticipant.setSignalingRegion = sinon.spy(() => {});
   localParticipant.connect = sinon.spy((sid, identity) => {
     localParticipant.sid = sid;
     localParticipant.identity = identity;


### PR DESCRIPTION
Reopening #898 here
 
Added signalingRegion property on the Room.localParticipant object. Implemented integration tests and fixed the LocalParticipantV2 mock for unit testing.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
