### PR TITLE
JSDK-2683  use RSP session timeout for reconnect attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ New Features
 
 - `reconnecting` and `reconnected` events on Room and LocalParticipant are now fired asynchronously. (JSDK-2696)
 - twilio-video.js now raises `connect()` errors due to network disruptions quicker by not retrying after the first connection attempt fails. (JSDK-2682)
-- twilio-video.js attempts to reconnect to a Room only while the Participant's session is valid (typically 30 seconds after the `reconnecting` event) instead of using a fixed number of retries.
+- twilio-video.js attempts to reconnect to a Room only while the Participant's session is valid (typically 30 seconds after the `reconnecting` event) instead of using a fixed number of retries. (JSDK-2683)
 - A LocalParticipant will now have an additional `signalingRegion` property which contains the geographical region of the signaling edge LocalParticipant is connected to. (JSDK-2687)
 
 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ New Features
 
 - `reconnecting` and `reconnected` events on Room and LocalParticipant are now fired asynchronously. (JSDK-2696)
 - twilio-video.js now raises `connect()` errors due to network disruptions quicker by not retrying after the first connection attempt fails. (JSDK-2682)
+- twilio-video.js now uses server supplied timeout value to determine reconnect attempts in case of loss of signaling connection.
 - A LocalParticipant will now have an additional `signalingRegion` property which contains the geographical region of the signaling edge LocalParticipant is connected to. (JSDK-2687)
 
 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ New Features
 
 - `reconnecting` and `reconnected` events on Room and LocalParticipant are now fired asynchronously. (JSDK-2696)
 - twilio-video.js now raises `connect()` errors due to network disruptions quicker by not retrying after the first connection attempt fails. (JSDK-2682)
-- twilio-video.js now uses server supplied timeout value to determine reconnect attempts in case of loss of signaling connection.
+- twilio-video.js attempts to reconnect to a Room only while the Participant's session is valid (typically 30 seconds after the `reconnecting` event) instead of using a fixed number of retries.
 - A LocalParticipant will now have an additional `signalingRegion` property which contains the geographical region of the signaling edge LocalParticipant is connected to. (JSDK-2687)
 
 Bug Fixes

--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -89,7 +89,6 @@ class TwilioConnectionTransport extends StateMachine {
       InsightsPublisher,
       NullInsightsPublisher,
       TwilioConnection,
-      // maxReconnectAttempts: MAX_RECONNECT_ATTEMPTS,
       reconnectBackOffJitter: RECONNECT_BACKOFF_JITTER,
       reconnectBackOffMs: RECONNECT_BACKOFF_MS,
       sdpFormat: getSdpFormat(options.sdpSemantics),
@@ -340,11 +339,10 @@ class TwilioConnectionTransport extends StateMachine {
     this._sessionTimeoutMS = sessionTimeout * 1000;
   }
 
-
   /**
-   * Determines if its okay to attempt reconnect.
-   * if so return a Promise to wait on before attempting to
-   * otherwise returns null
+   * Determines if we should attempt reconnect.
+   * returns a Promise to wait on before attempting to
+   * reconnect. returns null if its not okay to reconnect.
    * @private
    * @returns {Promise<void>}
    */
@@ -362,7 +360,7 @@ class TwilioConnectionTransport extends StateMachine {
         // ensure that _clearReconnectTimer wasn't
         // called while we were waiting.
         if (this._sessionTimer) {
-          // do not make any more connect attempts.
+          // do not allow any more reconnect attempts.
           this._sessionTimeoutMS = 0;
         }
       }, this._sessionTimeoutMS);

--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -8,6 +8,7 @@ const StateMachine = require('../../statemachine');
 const TwilioConnection = require('../../twilioconnection');
 const DefaultBackoff = require('backoff');
 const { reconnectBackoffConfig } = require('../../util/constants');
+const Timeout = require('../../util/timeout');
 
 const {
   createBandwidthProfilePayload,
@@ -347,7 +348,7 @@ class TwilioConnectionTransport extends StateMachine {
 
     // start session timer
     if (!this._sessionTimer) {
-      this._sessionTimer = setTimeout(() => {
+      this._sessionTimer = new Timeout(() => {
         // ensure that _clearReconnectTimer wasn't
         // called while we were waiting.
         if (this._sessionTimer) {
@@ -373,7 +374,7 @@ class TwilioConnectionTransport extends StateMachine {
   _clearReconnectTimer() {
     this._reconnectBackoff.reset();
     if (this._sessionTimer) {
-      clearTimeout(this._sessionTimer);
+      this._sessionTimer.clear();
       this._sessionTimer = null;
     }
   }

--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -21,7 +21,6 @@ const {
   SignalingConnectionError
 } = require('../../util/twilio-video-errors');
 
-const MAX_RECONNECT_ATTEMPTS = 5;
 const RECONNECT_BACKOFF_JITTER = 100;
 const RECONNECT_BACKOFF_MS = 100;
 const RSP_VERSION = 2;
@@ -90,7 +89,7 @@ class TwilioConnectionTransport extends StateMachine {
       InsightsPublisher,
       NullInsightsPublisher,
       TwilioConnection,
-      maxReconnectAttempts: MAX_RECONNECT_ATTEMPTS,
+      // maxReconnectAttempts: MAX_RECONNECT_ATTEMPTS,
       reconnectBackOffJitter: RECONNECT_BACKOFF_JITTER,
       reconnectBackOffMs: RECONNECT_BACKOFF_MS,
       sdpFormat: getSdpFormat(options.sdpSemantics),
@@ -146,8 +145,16 @@ class TwilioConnectionTransport extends StateMachine {
       _peerConnectionManager: {
         value: peerConnectionManager
       },
-      _reconnectAttemptsLeft: {
+      _sessionTimer: {
+        value: null,
+        writable: true
+      },
+      _sessionTimeoutMS: {
         value: 0, // initially 0, set only after 1st successful connection.
+        writable: true
+      },
+      _reconnectAttempt: {
+        value: 0,
         writable: true
       },
       _reconnectBackOffJitter: {
@@ -324,6 +331,62 @@ class TwilioConnectionTransport extends StateMachine {
     }
     return false;
   }
+
+  /**
+   * @returns {void}
+   */
+  _setSession(session, sessionTimeout) {
+    this._session = session;
+    this._sessionTimeoutMS = sessionTimeout * 1000;
+  }
+
+
+  /**
+   * Determines if its okay to attempt reconnect.
+   * if so return a Promise to wait on before attempting to
+   * otherwise returns null
+   * @private
+   * @returns {Promise<void>}
+   */
+  _getReconnectTimer() {
+    if (this._sessionTimeoutMS === 0) {
+      // this means either we have never connected.
+      // or we timed out while trying to reconnect
+      // In either case we do not want to reconnect.
+      return null;
+    }
+
+    // start session timer
+    if (!this._sessionTimer) {
+      this._sessionTimer = setTimeout(() => {
+        // ensure that _clearReconnectTimer wasn't
+        // called while we were waiting.
+        if (this._sessionTimer) {
+          // do not make any more connect attempts.
+          this._sessionTimeoutMS = 0;
+        }
+      }, this._sessionTimeoutMS);
+    }
+
+    // return promise that waits with exponential backoff.
+    this._reconnectAttempt++;
+    const backOffMs = (1 << this._reconnectAttempt) * this._reconnectBackOffMs;
+    return new Promise(resolve => setTimeout(resolve, withJitter(backOffMs, this._reconnectBackOffJitter)));
+  }
+
+  /**
+   * clears the session reconnect timer.
+   *
+   * @private
+   * @returns {void}
+   */
+  _clearReconnectTimer() {
+    this._reconnectAttempt = 0;
+    if (this._sessionTimer) {
+      clearTimeout(this._sessionTimer);
+      this._sessionTimer = null;
+    }
+  }
 }
 
 /**
@@ -410,27 +473,18 @@ function setupEventListeners(transport) {
       transport.disconnect();
       return;
     }
-    if (transport._reconnectAttemptsLeft <= 0) {
+
+    const reconnectTimer = transport._getReconnectTimer();
+    if (!reconnectTimer) {
       transport.disconnect(new SignalingConnectionError());
       return;
     }
-    reconnect();
-  }
 
-  function reconnect() {
     if (transport.state === 'connected') {
       transport.preempt('syncing');
     }
-    transport._reconnectAttemptsLeft--;
-    const { maxReconnectAttempts } = transport._options;
-    const reconnectAttempts = maxReconnectAttempts - transport._reconnectAttemptsLeft;
-    const backOffMs = (1 << reconnectAttempts) * transport._reconnectBackOffMs;
-    setTimeout(startConnect, withJitter(backOffMs, transport._reconnectBackOffJitter));
-  }
 
-  function resetReconnectAttemptsLeft() {
-    const { maxReconnectAttempts } = transport._options;
-    transport._reconnectAttemptsLeft = maxReconnectAttempts;
+    reconnectTimer.then(startConnect);
   }
 
   function startConnect() {
@@ -471,8 +525,7 @@ function setupEventListeners(transport) {
       case 'connecting':
         switch (message.type) {
           case 'connected':
-            resetReconnectAttemptsLeft();
-            transport._session = message.session;
+            transport._setSession(message.session, message.options.session_timeout);
             transport.emit('connected', message);
             transport.preempt('connected');
             return;
@@ -496,7 +549,7 @@ function setupEventListeners(transport) {
             transport._updatesReceived.push(message);
             return;
           case 'synced':
-            resetReconnectAttemptsLeft();
+            transport._clearReconnectTimer();
             transport.emit('message', message);
             transport.preempt('connected');
             return;

--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -6,13 +6,14 @@ const InsightsPublisher = require('../../util/insightspublisher');
 const NullInsightsPublisher = require('../../util/insightspublisher/null');
 const StateMachine = require('../../statemachine');
 const TwilioConnection = require('../../twilioconnection');
+const DefaultBackoff = require('backoff');
+const { reconnectBackoffConfig } = require('../../util/constants');
 
 const {
   createBandwidthProfilePayload,
   createMediaSignalingPayload,
   createSubscribePayload,
-  getUserAgent,
-  withJitter
+  getUserAgent
 } = require('../../util');
 
 const {
@@ -21,8 +22,6 @@ const {
   SignalingConnectionError
 } = require('../../util/twilio-video-errors');
 
-const RECONNECT_BACKOFF_JITTER = 100;
-const RECONNECT_BACKOFF_MS = 100;
 const RSP_VERSION = 2;
 const SDK_NAME = `${packageInfo.name}.js`;
 const SDK_VERSION = packageInfo.version;
@@ -86,11 +85,10 @@ class TwilioConnectionTransport extends StateMachine {
    */
   constructor(name, accessToken, localParticipant, peerConnectionManager, wsServer, options) {
     options = Object.assign({
+      Backoff: DefaultBackoff,
       InsightsPublisher,
       NullInsightsPublisher,
       TwilioConnection,
-      reconnectBackOffJitter: RECONNECT_BACKOFF_JITTER,
-      reconnectBackOffMs: RECONNECT_BACKOFF_MS,
       sdpFormat: getSdpFormat(options.sdpSemantics),
       trackPriority: true,
       trackSwitchOff: true,
@@ -152,15 +150,8 @@ class TwilioConnectionTransport extends StateMachine {
         value: 0, // initially 0, set only after 1st successful connection.
         writable: true
       },
-      _reconnectAttempt: {
-        value: 0,
-        writable: true
-      },
-      _reconnectBackOffJitter: {
-        value: options.reconnectBackOffJitter
-      },
-      _reconnectBackOffMs: {
-        value: options.reconnectBackOffMs
+      _reconnectBackoff: {
+        value: options.Backoff.exponential(reconnectBackoffConfig)
       },
       _session: {
         value: null,
@@ -367,9 +358,10 @@ class TwilioConnectionTransport extends StateMachine {
     }
 
     // return promise that waits with exponential backoff.
-    this._reconnectAttempt++;
-    const backOffMs = (1 << this._reconnectAttempt) * this._reconnectBackOffMs;
-    return new Promise(resolve => setTimeout(resolve, withJitter(backOffMs, this._reconnectBackOffJitter)));
+    return new Promise(resolve => {
+      this._reconnectBackoff.once('ready', resolve);
+      this._reconnectBackoff.backoff();
+    });
   }
 
   /**
@@ -379,7 +371,7 @@ class TwilioConnectionTransport extends StateMachine {
    * @returns {void}
    */
   _clearReconnectTimer() {
-    this._reconnectAttempt = 0;
+    this._reconnectBackoff.reset();
     if (this._sessionTimer) {
       clearTimeout(this._sessionTimer);
       this._sessionTimer = null;

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -85,6 +85,12 @@ module.exports.iceRestartBackoffConfig = {
   randomisationFactor: 0.5
 };
 
+module.exports.reconnectBackoffConfig = {
+  factor: 1.1,
+  initialDelay: 1,
+  randomisationFactor: 0.5
+};
+
 module.exports.subscriptionMode = {
   MODE_COLLABORATION: 'collaboration',
   MODE_GRID: 'grid',

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -86,8 +86,8 @@ module.exports.iceRestartBackoffConfig = {
 };
 
 module.exports.reconnectBackoffConfig = {
-  factor: 1.1,
-  initialDelay: 1,
+  factor: 1.5,
+  initialDelay: 80,
   randomisationFactor: 0.5
 };
 

--- a/test/unit/spec/signaling/v2/twilioconnectiontransport.js
+++ b/test/unit/spec/signaling/v2/twilioconnectiontransport.js
@@ -726,6 +726,7 @@ describe('TwilioConnectionTransport', () => {
                 test.transport.on('stateChanged', state => {
                   if ('disconnected' === state) {
                     assert(connectRequests > 2);
+                    test.sendMessageSpy = null;
                     resolve();
                   }
                 });


### PR DESCRIPTION
With this change we use session_timeout specified in RSP connected message. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
