### PR TITLE
JSDK-2707 setPriority does not update subscriber track priority for late arrivals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ New Features
 Bug Fixes
 ---------
 
-- Fixed an issue which caused subscriber priority not get updated when calling `setPriority` on `RemoteVideoTrack` on tracks for later joining participants. (JSDK-2707)
+- Fixed an issue which caused subscriber priority changes not take effect when `RemoteVideoTrack.setpriority` was called for tracks on participants that joined later (JSDK-2707)
 
 2.2.0 (February 21, 2020)
 =========================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ New Features
 Bug Fixes
 ---------
 
-- Fixed an issue which caused subscriber priority changes not take effect when `RemoteVideoTrack.setpriority` was called for tracks on participants that joined later (JSDK-2707)
+- Fixed a bug where calling `setPriority` on RemoteVideoTracks of RemoteParticipants that joined after the LocalParticipant had no effect. (JSDK-2707)
 
 2.2.0 (February 21, 2020)
 =========================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ New Features
 - twilio-video.js now raises `connect()` errors due to network disruptions quicker by not retrying after the first connection attempt fails. (JSDK-2682)
 - A LocalParticipant will now have an additional `signalingRegion` property which contains the geographical region of the signaling edge LocalParticipant is connected to. (JSDK-2687)
 
+Bug Fixes
+---------
+
+- Fixed an issue which caused subscriber priority not get updated when calling `setPriority` on `RemoteVideoTrack` on tracks for later joining participants. (JSDK-2707)
+
 2.2.0 (February 21, 2020)
 =========================
 

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -439,9 +439,9 @@ class RoomV2 extends RoomSignaling {
       // to resume sending Track Priority updates.
       receiver.once('close', () => this._teardownTrackPrioritySignaling());
 
-      const trackPrioritySignaling = new this._TrackPrioritySignaling(receiver.toDataTransport());
+      this._trackPrioritySignaling = new this._TrackPrioritySignaling(receiver.toDataTransport());
       [...this.participants.values()].forEach(participant => {
-        participant.setTrackPrioritySignaling(trackPrioritySignaling);
+        participant.setTrackPrioritySignaling(this._trackPrioritySignaling);
       });
     });
     this._trackPriorityPromise = trackPriorityPromise;

--- a/test/integration/spec/remotetracks.js
+++ b/test/integration/spec/remotetracks.js
@@ -181,7 +181,7 @@ describe('RemoteVideoTrack', function() {
   });
 });
 
-(defaults.topology === 'peer-to-peer' ? describe.skip : describe.only)('JSDK-2707', function() {
+(defaults.topology === 'peer-to-peer' ? describe.skip : describe)('JSDK-2707', function() {
   // eslint-disable-next-line no-invalid-this
   this.timeout(60000);
   let aliceRoom;

--- a/test/integration/spec/remotetracks.js
+++ b/test/integration/spec/remotetracks.js
@@ -181,7 +181,7 @@ describe('RemoteVideoTrack', function() {
   });
 });
 
-(defaults.topology === 'peer-to-peer' ? describe.skip : describe.only)('RemoteDataTrack', function() {
+(defaults.topology === 'peer-to-peer' ? describe.skip : describe.only)('JSDK-2707', function() {
   // eslint-disable-next-line no-invalid-this
   this.timeout(60000);
   let aliceRoom;
@@ -192,11 +192,9 @@ describe('RemoteVideoTrack', function() {
   });
 
   ['Alice', 'Bob'].forEach(subscriber => {
-    it(`(JSDK-2707) ${subscriber} can can control subscriber priority`, async () => {
+    it(`${subscriber} can can control subscriber priority`, async () => {
       const [trackA, trackB] = await Promise.all(['trackA', 'trackB'].map(name => createLocalVideoTrack(Object.assign({ name }, smallVideoConstraints))));
-
       const roomName = await createRoom(randomName(), defaults.topology);
-
       const connectOptions = Object.assign({
         name: roomName,
         tracks: [],
@@ -212,7 +210,6 @@ describe('RemoteVideoTrack', function() {
       // JSDK-2707 caused track signaling to not get setup for late RemoteParticipant.
       // to force the repro this wait is needed.
       await waitForSometime(5000);
-
       const roomSid = aliceRoom.sid;
 
       // Bob joins room later.
@@ -220,7 +217,6 @@ describe('RemoteVideoTrack', function() {
 
       const aliceRemote = bobRoom.participants.get(aliceRoom.localParticipant.sid);
       const bobRemote = aliceRoom.participants.get(bobRoom.localParticipant.sid);
-
       const publisherLocal = subscriber === 'Alice' ? bobRoom.localParticipant : aliceRoom.localParticipant;
       const publisherRemote =  subscriber === 'Alice' ? bobRemote : aliceRemote;
 

--- a/test/integration/spec/remotetracks.js
+++ b/test/integration/spec/remotetracks.js
@@ -21,6 +21,7 @@ const {
   tracksSubscribed,
   trackSwitchedOff,
   trackSwitchedOn,
+  waitForSometime,
   waitFor
 } = require('../../lib/util');
 
@@ -177,6 +178,73 @@ describe('RemoteVideoTrack', function() {
         ], `Bob's track to get switched on, and Alice switched off: ${thisRoom.sid}`);
       });
     }
+  });
+});
+
+(defaults.topology === 'peer-to-peer' ? describe.skip : describe.only)('RemoteDataTrack', function() {
+  // eslint-disable-next-line no-invalid-this
+  this.timeout(60000);
+  let aliceRoom;
+  let bobRoom;
+
+  afterEach(() => {
+    [aliceRoom, bobRoom].forEach(room => room && room.disconnect());
+  });
+
+  ['Alice', 'Bob'].forEach(subscriber => {
+    it(`(JSDK-2707) ${subscriber} can can control subscriber priority`, async () => {
+      const [trackA, trackB] = await Promise.all(['trackA', 'trackB'].map(name => createLocalVideoTrack(Object.assign({ name }, smallVideoConstraints))));
+
+      const roomName = await createRoom(randomName(), defaults.topology);
+
+      const connectOptions = Object.assign({
+        name: roomName,
+        tracks: [],
+        logLevel: 'warn',
+        bandwidthProfile: {
+          video: { maxTracks: 1,  dominantSpeakerPriority: 'low' }
+        },
+      }, defaults);
+
+      // Alice joins room first.
+      aliceRoom = await waitFor(connect(getToken('Alice'), connectOptions), 'Alice to connect to room');
+
+      // JSDK-2707 caused track signaling to not get setup for late RemoteParticipant.
+      // to force the repro this wait is needed.
+      await waitForSometime(5000);
+
+      const roomSid = aliceRoom.sid;
+
+      // Bob joins room later.
+      bobRoom = await waitFor(connect(getToken('Bob'), connectOptions), `Bob to join room: ${roomSid}`);
+
+      const aliceRemote = bobRoom.participants.get(aliceRoom.localParticipant.sid);
+      const bobRemote = aliceRoom.participants.get(bobRoom.localParticipant.sid);
+
+      const publisherLocal = subscriber === 'Alice' ? bobRoom.localParticipant : aliceRoom.localParticipant;
+      const publisherRemote =  subscriber === 'Alice' ? bobRemote : aliceRemote;
+
+      // publisher publishes both tracks at standard priority.
+      await waitFor([
+        publisherLocal.publishTrack(trackA, { priority: PRIORITY_STANDARD }),
+        publisherLocal.publishTrack(trackB, { priority: PRIORITY_STANDARD }),
+        tracksSubscribed(publisherRemote, 2),
+      ], 'tracks to get published and subscribed');
+
+      const [remoteTrackA, remoteTrackB] = [trackA, trackB].map(t => [...publisherRemote.videoTracks.values()].find(track => track.trackName === t.name)).map(pub => pub.track);
+
+      remoteTrackA.setPriority(PRIORITY_LOW);
+      await waitFor([
+        waitFor(trackSwitchedOn(remoteTrackB), `track B switched on: ${roomSid}`),
+        waitFor(trackSwitchedOff(remoteTrackA), `track A to get switched off: ${roomSid}`)
+      ], `trackB => On, trackA => Off: ${roomSid}`);
+
+      remoteTrackA.setPriority(PRIORITY_HIGH);
+      await waitFor([
+        waitFor(trackSwitchedOn(remoteTrackA), `track A switched on: ${roomSid}`),
+        waitFor(trackSwitchedOff(remoteTrackB), `track B to get switched off: ${roomSid}`)
+      ], `trackA => On, trackB => Off: ${roomSid}`);
+    });
   });
 });
 

--- a/test/integration/spec/remotetracks.js
+++ b/test/integration/spec/remotetracks.js
@@ -215,6 +215,10 @@ describe('RemoteVideoTrack', function() {
       // Bob joins room later.
       bobRoom = await waitFor(connect(getToken('Bob'), connectOptions), `Bob to join room: ${roomSid}`);
 
+      // wait for Bob and alice to see each other connected.
+      await waitFor(participantsConnected(bobRoom, 1), `Bob to see Alice connected: ${roomSid}`);
+      await waitFor(participantsConnected(aliceRoom, 1), `Alice to see Bob connected: ${roomSid}`);
+
       const aliceRemote = bobRoom.participants.get(aliceRoom.localParticipant.sid);
       const bobRemote = aliceRoom.participants.get(bobRoom.localParticipant.sid);
       const publisherLocal = subscriber === 'Alice' ? bobRoom.localParticipant : aliceRoom.localParticipant;


### PR DESCRIPTION
The issue was caused because we were not caching the `this._trackPrioritySignaling` :(. It made `setPriority` ( the api that sets subscriber priority)  no-op, when called against participants that joined after the MSP object was constructed. Our existing tests did not catch it because they always got MSP objects after all participants were in. 

Added a regression test that fails before the fix.
https://app.circleci.com/pipelines/github/twilio/twilio-video.js/1005/workflows/4fb4088b-d8c7-40c3-889c-ba21cf853d87/jobs/10967/tests

and passes after:
https://app.circleci.com/pipelines/github/twilio/twilio-video.js/1007/workflows/a57b7e97-8f03-4293-a4e6-12818c12bfeb/jobs/10970/tests

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
