### PR TITLE
JSDK-2720 - add doc for new properties

### DIFF
--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -28,6 +28,9 @@ const Participant = require('./participant');
  *    The {@link LocalParticipant}'s {@link LocalTrackPublication}s
  * @property {Map<Track.SID, LocalVideoTrackPublication>} videoTracks -
  *    The {@link LocalParticipant}'s {@link LocalVideoTrackPublication}s
+ * @property {string} signalingRegion - The geographical region of the
+ *     signaling edge the {@link LocalParticipant} is connected to.
+ *
  * @emits RemoteParticipant#reconnected
  * @emits RemoteParticipant#reconnecting
  * @emits LocalParticipant#trackDimensionsChanged

--- a/lib/room.js
+++ b/lib/room.js
@@ -20,6 +20,8 @@ let nInstances = 0;
  *   recorded
  * @property {LocalParticipant} localParticipant - Your {@link LocalParticipant}
  *   in the {@link Room}
+ * @property {string} mediaRegion - String indicating geographical region
+ *    where  media is processed for the {@link Room}.
  * @property {string} name - The {@link Room}'s name
  * @property {Map<Participant.SID, RemoteParticipant>} participants -
  *   The {@link RemoteParticipant}s participating in this {@link Room}
@@ -246,7 +248,8 @@ function rewriteLocalTrackIds(room, trackStats) {
  * A {@link RemoteParticipant} is reconnecting to the {@link Room} after a signaling connection disruption.
  * @param {RemoteParticipant} participant - The {@link RemoteParticipant} that is reconnecting.
  * @event Room#participantReconnecting
- * myRoom.on('participantReconnected', participant => {
+ * @example
+ * myRoom.on('participantReconnecting', participant => {
  *   console.log(participant.identity + ' is reconnecting to the Room');
  * });
  */


### PR DESCRIPTION
This fixes 3 doc issues
- added doc for Room.mediaRegion
- added doc for LocalParticipant.signalingRegion
- fixed doc entry for Room.participant.reconnecting.  


LocalParticipant - [Before](http://stage.twiliocdn.com/sdk/js/video/releases/2.3.0-rc1/docs/LocalParticipant.html) and [After](https://11896-46595751-gh.circle-artifacts.com/0/dist/docs/LocalParticipant.html)

Room - [Before](http://stage.twiliocdn.com/sdk/js/video/releases/2.3.0-rc1/docs/Room.html) and [After](https://11896-46595751-gh.circle-artifacts.com/0/dist/docs/Room.html)

page does not include new mediaRegion property
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
