### PR TITLE
JSDK-2660 Chrome tab share should be handled similar to screenshare

### DIFF
--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -705,7 +705,7 @@ function isChromeScreenShareTrack(track) {
   // NOTE(mpatwardhan): Chrome creates screen share tracks with label like: "screen:69734272*"
   // we will check for label that starts with "screen:D" where D being a digit.
   const isChrome = util.guessBrowser() === 'chrome';
-  return isChrome && track.kind === 'video' && track.label && /^screen:[0-9]+/.test(track.label) && /^web-contents-media-stream:[0-9/]+/.test(track.label) && /^window:[0-9]+/.test(track.label);
+  return isChrome && track.kind === 'video' && track.label && /^screen:[0-9]+/.test(track.label) || /^web-contents-media-stream:[0-9/]+/.test(track.label) || /^window:[0-9]+/.test(track.label);
 }
 
 exports.constants = constants;

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -705,7 +705,7 @@ function isChromeScreenShareTrack(track) {
   // NOTE(mpatwardhan): Chrome creates screen share tracks with label like: "screen:69734272*"
   // we will check for label that starts with "screen:D" where D being a digit.
   const isChrome = util.guessBrowser() === 'chrome';
-  return isChrome && track.kind === 'video' && track.label && /^screen:[0-9]+/.test(track.label);
+  return isChrome && track.kind === 'video' && track.label && /^screen:[0-9]+/.test(track.label) && /^web-contents-media-stream:[0-9/]+/.test(track.label) && /^window:[0-9]+/.test(track.label);
 }
 
 exports.constants = constants;

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -705,7 +705,7 @@ function isChromeScreenShareTrack(track) {
   // NOTE(mpatwardhan): Chrome creates screen share tracks with label like: "screen:69734272*"
   // we will check for label that starts with "screen:D" where D being a digit.
   const isChrome = util.guessBrowser() === 'chrome';
-  return isChrome && track.kind === 'video' && track.label && /^screen:[0-9]+/.test(track.label) || /^web-contents-media-stream:[0-9/]+/.test(track.label) || /^window:[0-9]+/.test(track.label);
+  return isChrome && track.kind === 'video' && track.label && (/^screen:[0-9]+/.test(track.label) || /^web-contents-media-stream:[0-9/]+/.test(track.label) || /^window:[0-9]+/.test(track.label));
 }
 
 exports.constants = constants;

--- a/test/unit/spec/util/index.js
+++ b/test/unit/spec/util/index.js
@@ -95,7 +95,7 @@ describe('util', () => {
     });
   });
 
-  describe.only('chromeScreenShare', () => {
+  describe('chromeScreenShare', () => {
     const labels = ['web-contents-media-stream://1174:3', 'window:1561:0', 'screen:2077749241:0'];
     const mediaStreamTrack = {
       kind: 'video',
@@ -108,46 +108,25 @@ describe('util', () => {
       onended: null,
       contentHint: ''
     };
-
-    // [['chrome', true], ['firefox', false], ['safari', false]].forEach(([browser, bool]) => {
-    //   describe(`for ${browser}`, () => {
-    //     before(() => {
-    //       stub = sinon.stub(util, 'guessBrowser').returns(browser);
-    //     });
-
-    //     it(`should return ${bool}`, () => {
-    //       labels.forEach(label => {
-    //         mediaStreamTrack.label = label;
-    //         const screenShare = isChromeScreenShareTrack(mediaStreamTrack);
-    //         console.log(screenShare);
-    //         assert.equal(bool, screenShare);
-    //       });
-    //     });
-
-    //     after(() => {
-    //       stub.restore();
-    //     });
-    //   });
-    // });
-
     let stub;
 
-    beforeEach(() => {
-      stub = sinon.stub(util, 'guessBrowser');
-    });
+    [['chrome', true], ['firefox', false], ['safari', false]].forEach(([browser, bool]) => {
+      describe(`for ${browser}`, () => {
+        before(() => {
+          stub = sinon.stub(util, 'guessBrowser');
+        });
 
-    afterEach(() => {
-      stub.restore();
-    });
+        it(`should return ${bool}`, () => {
+          stub.returns(browser);
+          labels.forEach(label => {
+            mediaStreamTrack.label = label;
+            const screenShare = isChromeScreenShareTrack(mediaStreamTrack);
+            assert.equal(bool, screenShare);
+          });
+        });
 
-    [['chrome', true], ['firefox', false], ['safari', false]].forEach(([browser, expectedBool], index) => {
-      it(`should return ${expectedBool} for ${browser}`, () => {
-        stub = stub.returns(browser);
-        labels.forEach(label => {
-          mediaStreamTrack.label = label;
-          const screenShare = isChromeScreenShareTrack(mediaStreamTrack);
-          // assert.equal(expectedBool, screenShare);
-          stub.resetHistory();
+        after(() => {
+          stub.restore();
         });
       });
     });

--- a/test/unit/spec/util/index.js
+++ b/test/unit/spec/util/index.js
@@ -95,8 +95,9 @@ describe('util', () => {
     });
   });
 
-  describe.only('chromeScreenShare', () => {
-    const labels = ['web-contents-media-stream://1174:3', 'window:1561:0', 'screen:2077749241:0'];
+  describe('chromeScreenShare', () => {
+    const validLabels = ['web-contents-media-stream://1174:3', 'window:1561:0', 'screen:2077749241:0'];
+    const invalidLabels = ['foo:bar:12356', 'fizz:123456:78901', 'fakelabel://123456'];
     const mediaStreamTrack = {
       kind: 'video',
       id: '1aaadf6e-6a4f-465b-96bf-1a35a2d3ac2b',
@@ -119,9 +120,21 @@ describe('util', () => {
     });
 
     [['chrome', true], ['firefox', false], ['safari', false]].forEach(([browser, expectedBool]) => {
-      it(`should return ${expectedBool} for ${browser}`, () => {
+      it(`valid labels should return ${expectedBool} for ${browser}`, () => {
         stub = stub.returns(browser);
-        labels.forEach(label => {
+        validLabels.forEach(label => {
+          mediaStreamTrack.label = label;
+          const screenShare = isChromeScreenShareTrack(mediaStreamTrack);
+          assert.equal(expectedBool, screenShare);
+          stub.resetHistory();
+        });
+      });
+    });
+
+    [['chrome', false], ['firefox', false], ['safari', false]].forEach(([browser, expectedBool]) => {
+      it(`invalid labels should return ${expectedBool} for ${browser}`, () => {
+        stub = stub.returns(browser);
+        invalidLabels.forEach(label => {
           mediaStreamTrack.label = label;
           const screenShare = isChromeScreenShareTrack(mediaStreamTrack);
           assert.equal(expectedBool, screenShare);

--- a/test/unit/spec/util/index.js
+++ b/test/unit/spec/util/index.js
@@ -95,7 +95,7 @@ describe('util', () => {
     });
   });
 
-  describe('chromeScreenShare', () => {
+  describe.only('chromeScreenShare', () => {
     const labels = ['web-contents-media-stream://1174:3', 'window:1561:0', 'screen:2077749241:0'];
     const mediaStreamTrack = {
       kind: 'video',
@@ -110,23 +110,22 @@ describe('util', () => {
     };
     let stub;
 
-    [['chrome', true], ['firefox', false], ['safari', false]].forEach(([browser, bool]) => {
-      describe(`for ${browser}`, () => {
-        before(() => {
-          stub = sinon.stub(util, 'guessBrowser');
-        });
+    beforeEach(() => {
+      stub = sinon.stub(util, 'guessBrowser');
+    });
 
-        it(`should return ${bool}`, () => {
-          stub.returns(browser);
-          labels.forEach(label => {
-            mediaStreamTrack.label = label;
-            const screenShare = isChromeScreenShareTrack(mediaStreamTrack);
-            assert.equal(bool, screenShare);
-          });
-        });
+    afterEach(() => {
+      stub.restore();
+    });
 
-        after(() => {
-          stub.restore();
+    [['chrome', true], ['firefox', false], ['safari', false]].forEach(([browser, expectedBool]) => {
+      it(`should return ${expectedBool} for ${browser}`, () => {
+        stub = stub.returns(browser);
+        labels.forEach(label => {
+          mediaStreamTrack.label = label;
+          const screenShare = isChromeScreenShareTrack(mediaStreamTrack);
+          assert.equal(expectedBool, screenShare);
+          stub.resetHistory();
         });
       });
     });

--- a/test/unit/spec/util/index.js
+++ b/test/unit/spec/util/index.js
@@ -3,12 +3,14 @@
 const assert = require('assert');
 const { EventEmitter } = require('events');
 const sinon = require('sinon');
+const util = require('@twilio/webrtc/lib/util');
 
 const {
   hidePrivateProperties,
   hidePrivateAndCertainPublicPropertiesInClass,
   makeUUID,
-  promiseFromEvents
+  promiseFromEvents,
+  isChromeScreenShareTrack
 } = require('../../../../lib/util');
 
 describe('util', () => {
@@ -90,6 +92,64 @@ describe('util', () => {
       promise = promiseFromEvents(spy, emitter, 'foo');
       emitter.emit('foo');
       return promise;
+    });
+  });
+
+  describe.only('chromeScreenShare', () => {
+    const labels = ['web-contents-media-stream://1174:3', 'window:1561:0', 'screen:2077749241:0'];
+    const mediaStreamTrack = {
+      kind: 'video',
+      id: '1aaadf6e-6a4f-465b-96bf-1a35a2d3ac2b',
+      enabled: true,
+      muted: true,
+      onmute: null,
+      onunmute: null,
+      readyState: 'live',
+      onended: null,
+      contentHint: ''
+    };
+
+    // [['chrome', true], ['firefox', false], ['safari', false]].forEach(([browser, bool]) => {
+    //   describe(`for ${browser}`, () => {
+    //     before(() => {
+    //       stub = sinon.stub(util, 'guessBrowser').returns(browser);
+    //     });
+
+    //     it(`should return ${bool}`, () => {
+    //       labels.forEach(label => {
+    //         mediaStreamTrack.label = label;
+    //         const screenShare = isChromeScreenShareTrack(mediaStreamTrack);
+    //         console.log(screenShare);
+    //         assert.equal(bool, screenShare);
+    //       });
+    //     });
+
+    //     after(() => {
+    //       stub.restore();
+    //     });
+    //   });
+    // });
+
+    let stub;
+
+    beforeEach(() => {
+      stub = sinon.stub(util, 'guessBrowser');
+    });
+
+    afterEach(() => {
+      stub.restore();
+    });
+
+    [['chrome', true], ['firefox', false], ['safari', false]].forEach(([browser, expectedBool], index) => {
+      it(`should return ${expectedBool} for ${browser}`, () => {
+        stub = stub.returns(browser);
+        labels.forEach(label => {
+          mediaStreamTrack.label = label;
+          const screenShare = isChromeScreenShareTrack(mediaStreamTrack);
+          // assert.equal(expectedBool, screenShare);
+          stub.resetHistory();
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
Added in extra logic for maxbitrate for chrome tabs as well as application windows to be handled similar to screen share.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
