### PR TITLE
JSDK-2729: fix media region tests for stage

### DIFF
--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -239,7 +239,7 @@ describe('connect', function() {
           }
         });
         it(`should return a CancelablePromise that ${defaults.topology === 'peer-to-peer' ? 'returns null on Room.mediaRegion' : 'resolves with a Room'}`, async () => {
-          const cancelablePromise = connect(token, Object.assign({ name: sid }, { tracks: [] }));
+          const cancelablePromise = connect(token, Object.assign({ name: sid }, defaults, { tracks: [] }));
           assert(cancelablePromise instanceof CancelablePromise);
 
           let error = null;

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -239,7 +239,7 @@ describe('connect', function() {
           }
         });
         it(`should return a CancelablePromise that ${defaults.topology === 'peer-to-peer' ? 'returns null on Room.mediaRegion' : 'resolves with a Room'}`, async () => {
-          const cancelablePromise = connect(token, Object.assign({ name: sid }, defaults, { tracks: [] }));
+          const cancelablePromise = connect(token, Object.assign({ name: sid, tracks: [] }, defaults));
           assert(cancelablePromise instanceof CancelablePromise);
 
           let error = null;


### PR DESCRIPTION
these tests were not passing `environment` option to `connect` causing them to fail on stage.

https://app.circleci.com/pipelines/github/twilio/twilio-video.js/1146/workflows/6ecef648-1013-4138-87e6-bf4e023eb188/jobs/12362

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
