### PR TITLE
remove deprecated attributes from sdp

### DIFF
--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -23,7 +23,7 @@ const {
 const {
   createCodecMapForMediaSection,
   getMediaSections,
-  removeSSRCAttributesMsLabelAndLabel,
+  removeSSRCAttributes,
   revertSimulcastForNonVP8MediaSections,
   setBitrateParameters,
   setCodecPreferences,
@@ -547,7 +547,7 @@ class PeerConnectionV2 extends StateMachine {
       // and PSA: https://groups.google.com/forum/#!searchin/discuss-webrtc/PSA%7Csort:date/discuss-webrtc/jcZO-Wj0Wus/k2XvPCvoAwAJ
       // We are not referencing those attributes, but this changes goes ahead and removes them to see if it works.
       // this also helps reduce bytes on wires
-      let updatedSdp = removeSSRCAttributesMsLabelAndLabel(answer.sdp);
+      let updatedSdp = removeSSRCAttributes(answer.sdp, ['mslabel', 'label']);
       if (this._shouldApplySimulcast) {
         let sdpWithoutSimulcast = updatedSdp;
         updatedSdp = this._setSimulcast(sdpWithoutSimulcast, this._sdpFormat, this._trackIdsToAttributes);
@@ -912,7 +912,7 @@ class PeerConnectionV2 extends StateMachine {
       // and PSA: https://groups.google.com/forum/#!searchin/discuss-webrtc/PSA%7Csort:date/discuss-webrtc/jcZO-Wj0Wus/k2XvPCvoAwAJ
       // Looks like we are not referencing those attributes, but this changes goes ahead and removes them to see if it works.
       // this also helps reduce bytes on wires
-      let sdp = removeSSRCAttributesMsLabelAndLabel(offer.sdp);
+      let sdp = removeSSRCAttributes(offer.sdp, ['mslabel', 'label']);
       sdp = this._isUnifiedPlan && this._peerConnection.remoteDescription
         ? unifiedPlanFilterLocalCodecs(sdp, this._peerConnection.remoteDescription.sdp)
         : sdp;

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1361,12 +1361,6 @@ class PeerConnectionV2 extends StateMachine {
     });
   }
 
-  _removeMsLabel(sdp) {
-    return sdp.split('\r\n').filter(a => {
-      return /a=ssrc:.*label/g.test(a) === false;
-    }).join('\r\n');
-  }
-
   /**
    * Get the {@link PeerConnectionV2}'s media statistics.
    * @returns {Promise<StandardizedStatsResponse>}

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -23,6 +23,7 @@ const {
 const {
   createCodecMapForMediaSection,
   getMediaSections,
+  removeSSRCAttributesMsLabelAndLabel,
   revertSimulcastForNonVP8MediaSections,
   setBitrateParameters,
   setCodecPreferences,
@@ -536,6 +537,13 @@ class PeerConnectionV2 extends StateMachine {
     }).then(() => {
       return this._peerConnection.createAnswer();
     }).then(answer => {
+      // NOTE(mpatwardhan): upcoming chrome versions are going to remove ssrc attributes
+      // mslabel and label. See this bug https://bugs.chromium.org/p/webrtc/issues/detail?id=7110
+      // and PSA: https://groups.google.com/forum/#!searchin/discuss-webrtc/PSA%7Csort:date/discuss-webrtc/jcZO-Wj0Wus/k2XvPCvoAwAJ
+      // Looks like we are not referencing those attributes, but this changes goes ahead and removes them to see if it works.
+      // this also helps reduce bytes on wires
+      answer.sdp = removeSSRCAttributesMsLabelAndLabel(answer.sdp);
+
       if (!isFirefox) {
         answer = workaroundIssue8329(answer);
       }
@@ -898,6 +906,13 @@ class PeerConnectionV2 extends StateMachine {
       if (!isFirefox) {
         offer = workaroundIssue8329(offer);
       }
+
+      // NOTE(mpatwardhan): upcoming chrome versions are going to remove ssrc attributes
+      // mslabel and label. See this bug https://bugs.chromium.org/p/webrtc/issues/detail?id=7110
+      // and PSA: https://groups.google.com/forum/#!searchin/discuss-webrtc/PSA%7Csort:date/discuss-webrtc/jcZO-Wj0Wus/k2XvPCvoAwAJ
+      // Looks like we are not referencing those attributes, but this changes goes ahead and removes them to see if it works.
+      // this also helps reduce bytes on wires
+      offer.sdp = removeSSRCAttributesMsLabelAndLabel(offer.sdp);
 
       const sdp = this._isUnifiedPlan && this._peerConnection.remoteDescription
         ? unifiedPlanFilterLocalCodecs(offer.sdp, this._peerConnection.remoteDescription.sdp)
@@ -1347,6 +1362,12 @@ class PeerConnectionV2 extends StateMachine {
     });
   }
 
+  _removeMsLabel(sdp) {
+    return sdp.split('\r\n').filter(a => {
+      return /a=ssrc:.*label/g.test(a) === false;
+    }).join('\r\n');
+  }
+
   /**
    * Get the {@link PeerConnectionV2}'s media statistics.
    * @returns {Promise<StandardizedStatsResponse>}
@@ -1607,5 +1628,4 @@ function setMaxBitrate(params, maxBitrate) {
     });
   }
 }
-
 module.exports = PeerConnectionV2;

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -537,30 +537,30 @@ class PeerConnectionV2 extends StateMachine {
     }).then(() => {
       return this._peerConnection.createAnswer();
     }).then(answer => {
-      // NOTE(mpatwardhan): upcoming chrome versions are going to remove ssrc attributes
-      // mslabel and label. See this bug https://bugs.chromium.org/p/webrtc/issues/detail?id=7110
-      // and PSA: https://groups.google.com/forum/#!searchin/discuss-webrtc/PSA%7Csort:date/discuss-webrtc/jcZO-Wj0Wus/k2XvPCvoAwAJ
-      // Looks like we are not referencing those attributes, but this changes goes ahead and removes them to see if it works.
-      // this also helps reduce bytes on wires
-      answer.sdp = removeSSRCAttributesMsLabelAndLabel(answer.sdp);
 
       if (!isFirefox) {
         answer = workaroundIssue8329(answer);
       }
 
-      let description = answer;
+      // NOTE(mpatwardhan): upcoming chrome versions are going to remove ssrc attributes
+      // mslabel and label. See this bug https://bugs.chromium.org/p/webrtc/issues/detail?id=7110
+      // and PSA: https://groups.google.com/forum/#!searchin/discuss-webrtc/PSA%7Csort:date/discuss-webrtc/jcZO-Wj0Wus/k2XvPCvoAwAJ
+      // We are not referencing those attributes, but this changes goes ahead and removes them to see if it works.
+      // this also helps reduce bytes on wires
+      let updatedSdp = removeSSRCAttributesMsLabelAndLabel(answer.sdp);
       if (this._shouldApplySimulcast) {
-        let updatedSdp = this._setSimulcast(answer.sdp, this._sdpFormat, this._trackIdsToAttributes);
+        let sdpWithoutSimulcast = updatedSdp;
+        updatedSdp = this._setSimulcast(sdpWithoutSimulcast, this._sdpFormat, this._trackIdsToAttributes);
         // NOTE(syerrapragada): VMS does not support H264 simulcast. So,
         // unset simulcast for sections in local offer where corresponding
         // sections in answer doesn't have vp8 as preferred codec and reapply offer.
-        updatedSdp = this._revertSimulcastForNonVP8MediaSections(updatedSdp, answer.sdp, offer.sdp);
-        description = {
-          type: description.type,
-          sdp: updatedSdp
-        };
+        updatedSdp = this._revertSimulcastForNonVP8MediaSections(updatedSdp, sdpWithoutSimulcast, offer.sdp);
       }
-      return this._setLocalDescription(description);
+
+      return this._setLocalDescription({
+        type: answer.type,
+        sdp: updatedSdp
+      });
     }).then(() => {
       return this._checkIceBox(offer);
     }).then(() => {
@@ -912,11 +912,10 @@ class PeerConnectionV2 extends StateMachine {
       // and PSA: https://groups.google.com/forum/#!searchin/discuss-webrtc/PSA%7Csort:date/discuss-webrtc/jcZO-Wj0Wus/k2XvPCvoAwAJ
       // Looks like we are not referencing those attributes, but this changes goes ahead and removes them to see if it works.
       // this also helps reduce bytes on wires
-      offer.sdp = removeSSRCAttributesMsLabelAndLabel(offer.sdp);
-
-      const sdp = this._isUnifiedPlan && this._peerConnection.remoteDescription
-        ? unifiedPlanFilterLocalCodecs(offer.sdp, this._peerConnection.remoteDescription.sdp)
-        : offer.sdp;
+      let sdp = removeSSRCAttributesMsLabelAndLabel(offer.sdp);
+      sdp = this._isUnifiedPlan && this._peerConnection.remoteDescription
+        ? unifiedPlanFilterLocalCodecs(sdp, this._peerConnection.remoteDescription.sdp)
+        : sdp;
 
       let updatedSdp = this._setCodecPreferences(
         sdp,

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -498,10 +498,16 @@ function unifiedPlanAddOrRewriteTrackIds(sdp, midsToTrackIds) {
   })).join('\r\n');
 }
 
-function removeSSRCAttributesMsLabelAndLabel(sdp) {
-  return sdp.split('\r\n').filter(a => {
-    return /a=ssrc:.*label/g.test(a) === false;
-  }).join('\r\n');
+/**
+ * removes specified ssrc attributes from given sdp
+ * @param {string} sdp
+ * @returns {Array<string>} ssrcAttributesToRemove
+ * @returns {string}
+ */
+function removeSSRCAttributes(sdp, ssrcAttributesToRemove) {
+  return sdp.split('\r\n').filter(line =>
+    !ssrcAttributesToRemove.find(srcAttribute => new RegExp('a=ssrc:.*' + srcAttribute + ':', 'g').test(line))
+  ).join('\r\n');
 }
 
 exports.createCodecMapForMediaSection = createCodecMapForMediaSection;
@@ -514,4 +520,5 @@ exports.setSimulcast = setSimulcast;
 exports.unifiedPlanFilterLocalCodecs = unifiedPlanFilterLocalCodecs;
 exports.unifiedPlanAddOrRewriteNewTrackIds = unifiedPlanAddOrRewriteNewTrackIds;
 exports.unifiedPlanAddOrRewriteTrackIds = unifiedPlanAddOrRewriteTrackIds;
-exports.removeSSRCAttributesMsLabelAndLabel = removeSSRCAttributesMsLabelAndLabel;
+exports.removeSSRCAttributes = removeSSRCAttributes;
+

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -498,6 +498,12 @@ function unifiedPlanAddOrRewriteTrackIds(sdp, midsToTrackIds) {
   })).join('\r\n');
 }
 
+function removeSSRCAttributesMsLabelAndLabel(sdp) {
+  return sdp.split('\r\n').filter(a => {
+    return /a=ssrc:.*label/g.test(a) === false;
+  }).join('\r\n');
+}
+
 exports.createCodecMapForMediaSection = createCodecMapForMediaSection;
 exports.createPtToCodecName = createPtToCodecName;
 exports.getMediaSections = getMediaSections;
@@ -508,3 +514,4 @@ exports.setSimulcast = setSimulcast;
 exports.unifiedPlanFilterLocalCodecs = unifiedPlanFilterLocalCodecs;
 exports.unifiedPlanAddOrRewriteNewTrackIds = unifiedPlanAddOrRewriteNewTrackIds;
 exports.unifiedPlanAddOrRewriteTrackIds = unifiedPlanAddOrRewriteTrackIds;
+exports.removeSSRCAttributesMsLabelAndLabel = removeSSRCAttributesMsLabelAndLabel;


### PR DESCRIPTION
Chrome is soon [going to deprecate](https://groups.google.com/forum/#!searchin/discuss-webrtc/PSA%7Csort:date/discuss-webrtc/jcZO-Wj0Wus/k2XvPCvoAwAJ) SSRC attributes mslabel and label. 

I did not see references to these attributes in our code, but This now removes it from the sdp, to force the condition and ensure that things works - This will help validate that no backend code is referencing these attributes either. This will also help shave off ~250 bytes from the offer/answer messages ( before chrome actually removes those attributes )

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
