### PR TITLE
JSDK-2742 start media monitor earlier

### DIFF
--- a/lib/signaling/v2/iceconnectionmonitor.js
+++ b/lib/signaling/v2/iceconnectionmonitor.js
@@ -36,19 +36,11 @@ class IceConnectionMonitor {
         value: null,
         writable: true,
       },
-      _wasInactive: {
-        value: false,
+      _onIceConnectionStateChanged: {
+        value: null,
         writable: true
       }
     });
-  }
-
-  /**
-   * returns true if monitor reported activity when it was last started.
-   * @returns {boolean}
-   */
-  wasInactive() {
-    return this._wasInactive;
   }
 
   _getActivePairStat(stats) {
@@ -56,7 +48,7 @@ class IceConnectionMonitor {
     const hasInBoundTracks = statsArray.find(stat => stat.type === 'inbound-rtp');
     if (!hasInBoundTracks) {
       // NOTE(mpatwardhan): when there are no tracks shared on a peerConnection
-      // on chrome we see inactivity on bytesReceived. but that is not real inactivity,
+      // we may see inactivity on bytesReceived - but that is not real inactivity,
       // ignore it.
       return null;
     }
@@ -81,27 +73,53 @@ class IceConnectionMonitor {
   }
 
   /**
+   * schedules/un-schedules inactivity callback.
+   */
+  _scheduleInactivityCallback(callback) {
+    if (callback && this._onIceConnectionStateChanged === null) {
+      // schedule callback
+      this._onIceConnectionStateChanged = () => {
+        if (this._peerConnection.iceConnectionState === 'disconnected') {
+          // eslint-disable-next-line callback-return
+          callback();
+        }
+      };
+      this._peerConnection.addEventListener('iceconnectionstatechange', this._onIceConnectionStateChanged);
+    } else if (!callback && this._onIceConnectionStateChanged) {
+      // unschedule callback
+      this._peerConnection.removeEventListener('iceconnectionstatechange', this._onIceConnectionStateChanged);
+      this._onIceConnectionStateChanged = null;
+    }
+  }
+
+  /**
    * Start monitoring the ICE connection.
    * Monitors bytes received on active ice connection pair,
    * invokes onIceConnectionInactive when inactivity is detected.
    * @param {function} onIceConnectionInactive
    */
   start(onIceConnectionInactive) {
-    this.clear();
+    this.stop();
+
     this._timer = setInterval(() => {
       this._getIceConnectionStats().then(iceStats => {
         if (!iceStats) {
           return;
         }
 
-        // console.log('makarand: iceStats.bytesReceived:', iceStats.bytesReceived);
         if (!this._lastActivity || this._lastActivity.bytesReceived !== iceStats.bytesReceived) {
           this._lastActivity = iceStats;
+          // detected activity, canceled scheduled callback if any.
+          this._scheduleInactivityCallback(null);
         }
 
         if (iceStats.timestamp - this._lastActivity.timestamp >= this._inactivityThresholdMs) {
-          this._wasInactive = true;
-          onIceConnectionInactive();
+          // detected inactivity.
+          if (this._peerConnection.iceConnectionState === 'disconnected') {
+            onIceConnectionInactive();
+          } else if (this._onIceConnectionStateChanged === null) {
+            this._scheduleInactivityCallback(onIceConnectionInactive);
+          }
         }
       });
     }, this._activityCheckPeriodMs);
@@ -112,21 +130,12 @@ class IceConnectionMonitor {
    * @returns {void}
    */
   stop() {
+    this._scheduleInactivityCallback(null);
     if (this._timer !== null) {
       clearInterval(this._timer);
       this._timer = null;
       this._lastActivity = null;
     }
-  }
-
-  /**
-   * Stop monitoring the ICE connection state.
-   * and clears _wasInactive state
-   * @returns {void}
-   */
-  clear() {
-    this._wasInactive = false;
-    this.stop();
   }
 }
 

--- a/lib/signaling/v2/iceconnectionmonitor.js
+++ b/lib/signaling/v2/iceconnectionmonitor.js
@@ -109,7 +109,7 @@ class IceConnectionMonitor {
 
         if (!this._lastActivity || this._lastActivity.bytesReceived !== iceStats.bytesReceived) {
           this._lastActivity = iceStats;
-          // detected activity, canceled scheduled callback if any.
+          // detected activity, cancel scheduled callback if any.
           this._scheduleInactivityCallback(null);
         }
 

--- a/lib/signaling/v2/iceconnectionmonitor.js
+++ b/lib/signaling/v2/iceconnectionmonitor.js
@@ -25,7 +25,7 @@ class IceConnectionMonitor {
       _inactivityThresholdMs: {
         value: options.inactivityThresholdMs
       },
-      _lastActiveStats: {
+      _lastActivity: {
         value: null,
         writable: true
       },
@@ -35,8 +35,39 @@ class IceConnectionMonitor {
       _timer: {
         value: null,
         writable: true,
+      },
+      _wasInactive: {
+        value: false,
+        writable: true
       }
     });
+  }
+
+  /**
+   * returns true if monitor reported activity when it was last started.
+   * @returns {boolean}
+   */
+  wasInactive() {
+    return this._wasInactive;
+  }
+
+  _getActivePairStat(stats) {
+    const statsArray = Array.from(stats.values());
+    const hasInBoundTracks = statsArray.find(stat => stat.type === 'inbound-rtp');
+    if (!hasInBoundTracks) {
+      // NOTE(mpatwardhan): when there are no tracks shared on a peerConnection
+      // on chrome we see inactivity on bytesReceived. but that is not real inactivity,
+      // ignore it.
+      return null;
+    }
+
+    const activePairStats = statsArray.find(stat => stat.type === 'candidate-pair' && stat.nominated);
+    // NOTE(mpatwardhan): sometimes (JSDK-2667) after getting disconnected while switching network
+    // we may not find active pair. Treat this as 0 bytesReceived so that we count it towards inactivity.
+    return activePairStats || {
+      bytesReceived: 0,
+      timestamp: Math.round((new Date()).getTime())
+    };
   }
 
   /**
@@ -44,16 +75,7 @@ class IceConnectionMonitor {
    * @returns Promise<?RTCIceCandidatePairStats>
    */
   _getIceConnectionStats() {
-    return this._peerConnection.getStats().then(stats => Array.from(stats.values()).find(stat => {
-      return stat.type === 'candidate-pair' && stat.nominated;
-    })).then(activePairStat => {
-      // NOTE(mpatwardhan): sometimes (JSDK-2667) after getting disconnected while switching network
-      // we may not find active pair. Treat this as 0 bytesReceived so that we count it towards inactivity.
-      return activePairStat || {
-        bytesReceived: 0,
-        timestamp: Math.round((new Date()).getTime())
-      };
-    }).catch(() => {
+    return this._peerConnection.getStats().then(stats => this._getActivePairStat(stats)).catch(() => {
       return null;
     });
   }
@@ -65,18 +87,20 @@ class IceConnectionMonitor {
    * @param {function} onIceConnectionInactive
    */
   start(onIceConnectionInactive) {
-    this.stop();
+    this.clear();
     this._timer = setInterval(() => {
       this._getIceConnectionStats().then(iceStats => {
         if (!iceStats) {
           return;
         }
 
+        // console.log('makarand: iceStats.bytesReceived:', iceStats.bytesReceived);
         if (!this._lastActivity || this._lastActivity.bytesReceived !== iceStats.bytesReceived) {
           this._lastActivity = iceStats;
         }
 
         if (iceStats.timestamp - this._lastActivity.timestamp >= this._inactivityThresholdMs) {
+          this._wasInactive = true;
           onIceConnectionInactive();
         }
       });
@@ -93,6 +117,16 @@ class IceConnectionMonitor {
       this._timer = null;
       this._lastActivity = null;
     }
+  }
+
+  /**
+   * Stop monitoring the ICE connection state.
+   * and clears _wasInactive state
+   * @returns {void}
+   */
+  clear() {
+    this._wasInactive = false;
+    this.stop();
   }
 }
 

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -679,7 +679,7 @@ class PeerConnectionV2 extends StateMachine {
    */
   _handleIceConnectionStateChange() {
     const { iceConnectionState } = this._peerConnection;
-    const isIceConnectedOrComplete = ['connected', 'complete'].includes(iceConnectionState);
+    const isIceConnectedOrComplete = ['connected', 'completed'].includes(iceConnectionState);
     const log = this._log;
 
     log.debug(`ICE connection state is "${iceConnectionState}"`);
@@ -712,7 +712,7 @@ class PeerConnectionV2 extends StateMachine {
           this.emit('connectionStateChanged');
         }
       });
-    } else if (!['disconnected', 'complete'].includes(iceConnectionState)) { // don't stop monitoring for disconnected or completed.
+    } else if (!['disconnected', 'completed'].includes(iceConnectionState)) { // don't stop monitoring for disconnected or completed.
       this._iceConnectionMonitor.stop();
       this._isIceConnectionInactive = false;
     }

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1367,7 +1367,7 @@ class PeerConnectionV2 extends StateMachine {
    * Get the {@link PeerConnectionV2}'s media statistics.
    * @returns {Promise<StandardizedStatsResponse>}
    */
-  getStats(withinTime) {
+  getStats() {
     return getStatistics(this._peerConnection).then(response => rewriteTrackIds(this, response));
   }
 }

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -583,6 +583,7 @@ class PeerConnectionV2 extends StateMachine {
    * @returns {boolean}
    */
   _close() {
+    this._iceConnectionMonitor.stop();
     if (this._peerConnection.signalingState !== 'closed') {
       this._peerConnection.close();
       this.preempt('closed');
@@ -672,8 +673,7 @@ class PeerConnectionV2 extends StateMachine {
   }
 
   _handleIceConnectionInactivity() {
-    // console.warn(`makarand: _handleIceConnectionInactivity ${this._lastIceConnectionState}`);
-    this._iceConnectionMonitor.clear();
+    this._iceConnectionMonitor.stop();
     if (!this._shouldRestartIce && !this._isRestartingIce) {
       this._log.warn('ICE Connection Monitor detected inactivity');
       this._isIceConnectionInactive = true;
@@ -693,8 +693,6 @@ class PeerConnectionV2 extends StateMachine {
     const isIceConnectedOrComplete = ['connected', 'complete'].includes(iceConnectionState);
     const log = this._log;
 
-    // console.warn(`makarand: _handleIceConnectionStateChange ${this._lastIceConnectionState} => ${iceConnectionState}`);
-
     log.debug(`ICE connection state is "${iceConnectionState}"`);
     if (isIceConnectedOrComplete) {
       this._iceReconnectTimeout.clear();
@@ -712,23 +710,23 @@ class PeerConnectionV2 extends StateMachine {
 
     // monitor media flow while state is completed.
     // stop the monitor when the state goes to anything else.
-    this._isIceConnectionInactive = false;
     if (iceConnectionState === 'connected') {
+      this._isIceConnectionInactive = false;
       this._iceConnectionMonitor.start(() => {
-        // console.warn(`makarand: iceConnection detected inactivity at ${this._lastIceConnectionState}`);
+        // note: iceConnection monitor waits for iceConnectionState=disconnected for
+        // detecting inactivity. Its possible that it may know about disconnected before _handleIceConnectionStateChange
         this._iceConnectionMonitor.stop();
-        if (this._lastIceConnectionState === 'disconnected') {
-          this._handleIceConnectionInactivity();
+        if (!this._shouldRestartIce && !this._isRestartingIce) {
+          log.warn('ICE Connection Monitor detected inactivity');
+          this._isIceConnectionInactive = true;
+          this._initiateIceRestartBackoff();
+          this.emit('iceConnectionStateChanged');
+          this.emit('connectionStateChanged');
         }
       });
-    } else if ('disconnected' === iceConnectionState) {
-      // did _iceConnectionMonitor previously indicated no-activity?
-      if (this._iceConnectionMonitor.wasInactive()) {
-        // console.warn(`makarand: there as previous inactivity at ${this._lastIceConnectionState}`);
-        this._handleIceConnectionInactivity();
-      }
-    } else {
-      this._iceConnectionMonitor.clear();
+    } else if (!['disconnected', 'complete'].includes(iceConnectionState)) { // don't stop monitoring for disconnected or completed.
+      this._iceConnectionMonitor.stop();
+      this._isIceConnectionInactive = false;
     }
 
     this._lastIceConnectionState = iceConnectionState;

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -423,7 +423,7 @@ class PeerConnectionV2 extends StateMachine {
    * @property {RTCIceConnectionState}
    */
   get iceConnectionState() {
-    return ((this._isIceConnectionInactive && this._peerConnection.iceConnectionState === 'disconnected') || this._iceGatheringFailed)
+    return (this._isIceConnectionInactive  || this._iceGatheringFailed)
       ? 'failed' : this._peerConnection.iceConnectionState;
   }
 
@@ -696,8 +696,10 @@ class PeerConnectionV2 extends StateMachine {
       log.debug('ICE reconnected');
     }
 
+    // monitor media flow while state is completed.
+    // stop the monitor when the state goes to anything else.
     this._isIceConnectionInactive = false;
-    if (iceConnectionState === 'disconnected') {
+    if (iceConnectionState === 'connected') {
       this._iceConnectionMonitor.start(() => {
         this._iceConnectionMonitor.stop();
         if (!this._shouldRestartIce && !this._isRestartingIce) {
@@ -708,7 +710,7 @@ class PeerConnectionV2 extends StateMachine {
           this.emit('connectionStateChanged');
         }
       });
-    } else {
+    } else if (!['disconnected', 'completed'].includes(iceConnectionState)) { // do not stop media monitor for disconnected or completed states.
       this._iceConnectionMonitor.stop();
     }
 
@@ -1365,7 +1367,7 @@ class PeerConnectionV2 extends StateMachine {
    * Get the {@link PeerConnectionV2}'s media statistics.
    * @returns {Promise<StandardizedStatsResponse>}
    */
-  getStats() {
+  getStats(withinTime) {
     return getStatistics(this._peerConnection).then(response => rewriteTrackIds(this, response));
   }
 }

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -671,6 +671,18 @@ class PeerConnectionV2 extends StateMachine {
     }
   }
 
+  _handleIceConnectionInactivity() {
+    // console.warn(`makarand: _handleIceConnectionInactivity ${this._lastIceConnectionState}`);
+    this._iceConnectionMonitor.clear();
+    if (!this._shouldRestartIce && !this._isRestartingIce) {
+      this._log.warn('ICE Connection Monitor detected inactivity');
+      this._isIceConnectionInactive = true;
+      this._initiateIceRestartBackoff();
+      this.emit('iceConnectionStateChanged');
+      this.emit('connectionStateChanged');
+    }
+  }
+
   /**
    * Handle an ICE connection state change event.
    * @private
@@ -680,6 +692,8 @@ class PeerConnectionV2 extends StateMachine {
     const { iceConnectionState } = this._peerConnection;
     const isIceConnectedOrComplete = ['connected', 'complete'].includes(iceConnectionState);
     const log = this._log;
+
+    // console.warn(`makarand: _handleIceConnectionStateChange ${this._lastIceConnectionState} => ${iceConnectionState}`);
 
     log.debug(`ICE connection state is "${iceConnectionState}"`);
     if (isIceConnectedOrComplete) {
@@ -701,17 +715,20 @@ class PeerConnectionV2 extends StateMachine {
     this._isIceConnectionInactive = false;
     if (iceConnectionState === 'connected') {
       this._iceConnectionMonitor.start(() => {
+        // console.warn(`makarand: iceConnection detected inactivity at ${this._lastIceConnectionState}`);
         this._iceConnectionMonitor.stop();
-        if (!this._shouldRestartIce && !this._isRestartingIce) {
-          log.warn('ICE Connection Monitor detected inactivity');
-          this._isIceConnectionInactive = true;
-          this._initiateIceRestartBackoff();
-          this.emit('iceConnectionStateChanged');
-          this.emit('connectionStateChanged');
+        if (this._lastIceConnectionState === 'disconnected') {
+          this._handleIceConnectionInactivity();
         }
       });
-    } else if (!['disconnected', 'completed'].includes(iceConnectionState)) { // do not stop media monitor for disconnected or completed states.
-      this._iceConnectionMonitor.stop();
+    } else if ('disconnected' === iceConnectionState) {
+      // did _iceConnectionMonitor previously indicated no-activity?
+      if (this._iceConnectionMonitor.wasInactive()) {
+        // console.warn(`makarand: there as previous inactivity at ${this._lastIceConnectionState}`);
+        this._handleIceConnectionInactivity();
+      }
+    } else {
+      this._iceConnectionMonitor.clear();
     }
 
     this._lastIceConnectionState = iceConnectionState;

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -423,7 +423,7 @@ class PeerConnectionV2 extends StateMachine {
    * @property {RTCIceConnectionState}
    */
   get iceConnectionState() {
-    return (this._isIceConnectionInactive  || this._iceGatheringFailed)
+    return ((this._isIceConnectionInactive && this._peerConnection.iceConnectionState === 'disconnected') || this._iceGatheringFailed)
       ? 'failed' : this._peerConnection.iceConnectionState;
   }
 

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -672,17 +672,6 @@ class PeerConnectionV2 extends StateMachine {
     }
   }
 
-  _handleIceConnectionInactivity() {
-    this._iceConnectionMonitor.stop();
-    if (!this._shouldRestartIce && !this._isRestartingIce) {
-      this._log.warn('ICE Connection Monitor detected inactivity');
-      this._isIceConnectionInactive = true;
-      this._initiateIceRestartBackoff();
-      this.emit('iceConnectionStateChanged');
-      this.emit('connectionStateChanged');
-    }
-  }
-
   /**
    * Handle an ICE connection state change event.
    * @private
@@ -708,8 +697,7 @@ class PeerConnectionV2 extends StateMachine {
       log.debug('ICE reconnected');
     }
 
-    // monitor media flow while state is completed.
-    // stop the monitor when the state goes to anything else.
+    // start monitor media when connected, and continue to monitor while state is complete-disconnected-connected.
     if (iceConnectionState === 'connected') {
       this._isIceConnectionInactive = false;
       this._iceConnectionMonitor.start(() => {

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -57,9 +57,9 @@ describe('PeerConnectionV2', () => {
     it('equals "failed" when IceConnectionMonitor detects failures, also emits "connectionStateChanged"', async () => {
       const test = makeTest();
 
-      // simulate disconnect.
-      test.pc.connectionState = 'disconnected';
-      test.pc.iceConnectionState = 'disconnected';
+      // simulate connect
+      test.pc.connectionState = 'connected';
+      test.pc.iceConnectionState = 'connected';
       test.pc.emit('iceconnectionstatechange');
       test.pc.emit('connectionstatechange');
 
@@ -89,8 +89,8 @@ describe('PeerConnectionV2', () => {
       const test = makeTest();
       assert.equal(test.pcv2.iceConnectionState, test.pc.iceConnectionState);
 
-      // simulate disconnect.
-      test.pc.iceConnectionState = 'disconnected';
+      // simulate connect.
+      test.pc.iceConnectionState = 'connected';
       test.pc.emit('iceconnectionstatechange');
 
       await oneTick();
@@ -150,21 +150,23 @@ describe('PeerConnectionV2', () => {
       assert(didEmit);
     });
 
-    it('starts IceConnectionMonitor on disconnect', () => {
+    it('starts IceConnectionMonitor on connected', () => {
       const test = makeTest();
       assert(!didStartMonitor);
       assert(!didStopMonitor);
       assert(inactiveCallback === null);
 
-      // simulate disconnect.
-      test.pc.iceConnectionState = 'disconnected';
+      // simulate connection.
+      test.pc.iceConnectionState = 'connected';
       test.pc.emit('iceconnectionstatechange');
       assert(didStartMonitor);
       assert(!didStopMonitor);
       assert(typeof inactiveCallback === 'function');
 
-      // simulate connection.
-      test.pc.iceConnectionState = 'connected';
+
+
+      // simulate failed.
+      test.pc.iceConnectionState = 'failed';
       test.pc.emit('iceconnectionstatechange');
       assert(didStartMonitor);
       assert(didStopMonitor);
@@ -175,14 +177,15 @@ describe('PeerConnectionV2', () => {
       assert(!didStartMonitor);
       assert(!didStopMonitor);
 
-      // simulate disconnect.
-      test.pc.iceConnectionState = 'disconnected';
+      // simulate connection.
+      test.pc.iceConnectionState = 'connected';
       test.pc.emit('iceconnectionstatechange');
       assert(didStartMonitor);
       assert(!didStopMonitor);
+      assert(typeof inactiveCallback === 'function');
 
-      // simulate connection.
-      test.pc.iceConnectionState = 'connected';
+      // simulate failed.
+      test.pc.iceConnectionState = 'failed';
       test.pc.emit('iceconnectionstatechange');
       assert(didStartMonitor);
       assert(didStopMonitor);
@@ -1805,8 +1808,8 @@ describe('PeerConnectionV2', () => {
 
         assert(inactiveCallback === null);
 
-        // Then, cause an ICE disconnect.
-        test.pc.iceConnectionState = 'disconnected';
+        // simulate ice connected
+        test.pc.iceConnectionState = 'connected';
         test.pc.emit('iceconnectionstatechange');
 
         assert(typeof inactiveCallback === 'function');

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -163,8 +163,6 @@ describe('PeerConnectionV2', () => {
       assert(!didStopMonitor);
       assert(typeof inactiveCallback === 'function');
 
-
-
       // simulate failed.
       test.pc.iceConnectionState = 'failed';
       test.pc.emit('iceconnectionstatechange');

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -17,40 +17,23 @@ describe('PeerConnectionV2', () => {
   let didStartMonitor;
   let didStopMonitor;
   let inactiveCallback;
-  let wasInactive;
   beforeEach(() => {
     // stub out IceConnectionMonitor to not have any side effects
     didStartMonitor = false;
     didStopMonitor = false;
     inactiveCallback = null;
-    wasInactive = false;
     sinon.stub(IceConnectionMonitor.prototype, 'start').callsFake(callback => {
-      inactiveCallback = () => {
-        wasInactive = true;
-        callback();
-      };
+      inactiveCallback = callback;
       didStartMonitor = true;
     });
 
     sinon.stub(IceConnectionMonitor.prototype, 'stop').callsFake(() => {
       didStopMonitor = true;
     });
-
-    sinon.stub(IceConnectionMonitor.prototype, 'clear').callsFake(() => {
-      didStopMonitor = true;
-      wasInactive = false;
-    });
-
-    sinon.stub(IceConnectionMonitor.prototype, 'wasInactive').callsFake(() => {
-      return wasInactive;
-    });
-
   });
   afterEach(() => {
     IceConnectionMonitor.prototype.start.restore();
     IceConnectionMonitor.prototype.stop.restore();
-    IceConnectionMonitor.prototype.clear.restore();
-    IceConnectionMonitor.prototype.wasInactive.restore();
   });
 
   describe('constructor', () => {
@@ -83,17 +66,15 @@ describe('PeerConnectionV2', () => {
 
       await oneTick();
 
-      inactiveCallback(); // invoke inactive call back.
-
       let didEmit = false;
       test.pcv2.once('connectionStateChanged', () => { didEmit = true; });
+      inactiveCallback(); // invoke inactive call back.
+      assert.equal(didEmit, true);
 
+      await oneTick();
       // simulate disconnect
       test.pc.iceConnectionState = 'disconnected';
       test.pc.emit('iceconnectionstatechange');
-
-      assert.equal(didEmit, true);
-      await oneTick();
       assert.equal(test.pcv2.connectionState, 'failed');
     });
   });
@@ -1840,41 +1821,33 @@ describe('PeerConnectionV2', () => {
         await oneTick();
         inactiveCallback(); // invoke inactive call back.
         await oneTick();
+
+        // simulate ice disconnected
+        test.pc.iceConnectionState = 'disconnected';
+        test.pc.emit('iceconnectionstatechange');
+        await oneTick();
       });
 
-      it('the PeerConnectionV2 does not restart ice while in connected state', () => {
-        sinon.assert.notCalled(test.pc.createOffer);
+      it('it initiates iceRestart', () => {
+        assert(test.pc.createOffer.calledWith({
+          iceRestart: true
+        }));
       });
 
-      context('once disconnected',  () => {
-        beforeEach(async () => {
-          // simulate ice disconnected
-          test.pc.iceConnectionState = 'disconnected';
-          test.pc.emit('iceconnectionstatechange');
-          await oneTick();
-        });
+      it('closes the PeerConnectionV2 after the ICE reconnection timeout expires', async () => {
+        await new Promise(resolve => test.pcv2.once('stateChanged', resolve));
+        assert.equal(test.pcv2.state, 'closed');
+      });
 
-        it('it initiates iceRestart', () => {
-          assert(test.pc.createOffer.calledWith({
-            iceRestart: true
-          }));
-        });
+      it('does not close the PeerConnectionV2 when the underlying RTCPeerConnection\'s .iceConnectionState transitions to "connected"', async () => {
+        // Cause an ICE reconnect.
+        test.pc.iceConnectionState = 'connected';
+        test.pc.emit('iceconnectionstatechange');
 
-        it('closes the PeerConnectionV2 after the ICE reconnection timeout expires', async () => {
-          await new Promise(resolve => test.pcv2.once('stateChanged', resolve));
-          assert.equal(test.pcv2.state, 'closed');
-        });
+        // Wait for the session timeout period.
+        await waitForSometime(test.sessionTimeout);
 
-        it('does not close the PeerConnectionV2 when the underlying RTCPeerConnection\'s .iceConnectionState transitions to "connected"', async () => {
-          // Cause an ICE reconnect.
-          test.pc.iceConnectionState = 'connected';
-          test.pc.emit('iceconnectionstatechange');
-
-          // Wait for the session timeout period.
-          await waitForSometime(test.sessionTimeout);
-
-          assert.equal(test.pcv2.state, 'open');
-        });
+        assert.equal(test.pcv2.state, 'open');
       });
     });
 


### PR DESCRIPTION
This change updates our media monitor to start when ice connection state goes to `connected` instead of `disconnected`. it will make this behavior consistent with native sdk, and will kick off the ice restart quicker when connection loses.  

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
