### PR TITLE
JSDK-2756 isSupported returns false for Chrome based browsers that are not Electron or Edge.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/support-1.x/CHANGELOG.md).
 
+2.4.0 (in progress)
+===================
+
+Bug Fixes
+---------
+
+- Fixed a bug where `Video.isSupported` was returning `true` for some browsers that
+  are not officially supported by twilio-video.js. (JSDK-2756)
+
 2.3.0 (March 19, 2020)
 ======================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,10 +10,8 @@ const {
  * @module twilio-video
  * @property {boolean} isSupported - true if the current browser is officially
  *   supported by twilio-video.js; In this context, "supported" means that
- *   twilio-video.js has been extensively tested with this browser; You are free
- *   to use twilio-video.js in any unsupported browser that nonetheless supports
- *   the <code>getUserMedia</code> and <code>RTCPeerConnection</code> APIs at your
- *   own risk. This <a href='https://www.twilio.com/docs/video/javascript#supported-browsers'>table</a>
+ *   twilio-video.js has been extensively tested with this browser; This
+ *   <a href='https://www.twilio.com/docs/video/javascript#supported-browsers target="_blank">table</a>
  *   specifies the list of officially supported browsers.
  *
  * @property {string} version - current version of twilio-video.js.

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,14 @@ const {
 
 /**
  * @module twilio-video
- * @property {boolean} isSupported - true if the current browser is officially supported by twilio-video.js.
+ * @property {boolean} isSupported - true if the current browser is officially
+ *   supported by twilio-video.js; In this context, "supported" means that
+ *   twilio-video.js has been extensively tested with this browser; You are free
+ *   to use twilio-video.js in any unsupported browser that nonetheless supports
+ *   the <code>getUserMedia</code> and <code>RTCPeerConnection</code> APIs at your
+ *   own risk. This <a href='https://www.twilio.com/docs/video/javascript#supported-browsers'>table</a>
+ *   specifies the list of officially supported browsers.
+ *
  * @property {string} version - current version of twilio-video.js.
  */
 const version = require('../package.json').version;

--- a/lib/util/support.js
+++ b/lib/util/support.js
@@ -3,6 +3,13 @@
 
 const { guessBrowser } = require('@twilio/webrtc/lib/util');
 
+const SUPPORTED_CHROME_BASED_BROWSERS = [
+  'edg',
+  'edge',
+  'electron',
+  'headlesschrome'
+];
+
 /**
  * Check whether PeerConnection API is supported.
  * @returns {boolean}
@@ -78,7 +85,7 @@ function isSupported() {
   return isGetUserMediaSupported()
     && isRTCPeerConnectionSupported()
     && !!browser
-    && (!rebrandedChrome || ['edg', 'edge', 'electron'].includes(rebrandedChrome))
+    && (!rebrandedChrome || SUPPORTED_CHROME_BASED_BROWSERS.includes(rebrandedChrome))
     && !isNonChromiumEdge(browser);
 }
 

--- a/lib/util/support.js
+++ b/lib/util/support.js
@@ -70,13 +70,13 @@ function rebrandedChromeBrowser(browser) {
   // Extract the <name> that is not expected to be present in the vanilla Chrome
   // browser, which indicates the rebranded name (ex: "edg[e]", "electron"). If null,
   // then this is a vanilla Chrome browser.
-  return browserNames.find(candidate => {
-    return !['chrome', 'mobile', 'safari'].includes(candidate);
+  return browserNames.find(name => {
+    return !['chrome', 'mobile', 'safari'].includes(name);
   }) || null;
 }
 
 /**
- * Check if the current environment is supported by the SDK.
+ * Check if the current browser is officially supported by twilio-video.js.
  * @returns {boolean}
  */
 function isSupported() {

--- a/lib/util/support.js
+++ b/lib/util/support.js
@@ -36,15 +36,50 @@ function isNonChromiumEdge(browser) {
 }
 
 /**
+ * Get the name of the rebranded Chromium browser, if any. Re-branded Chrome's user
+ * agent has the following format:
+ * <source>/<version> (<os>) <engine>/<version> (<engine_name>) Chrome/<version> [Mobile] Safari/<version>
+ * @param browser
+ * @returns {?string} Name of the rebranded Chrome browser, or null if the browser
+ *   is either not Chrome or vanilla Chrome.
+ */
+function rebrandedChromeBrowser(browser) {
+  // If the browser is not Chrome based, then it is not a rebranded Chrome browser.
+  if (browser !== 'chrome') {
+    return null;
+  }
+
+  // Remove the "(.+)" entries from the user agent thereby retaining only the
+  // <name>[/<version>] entries.
+  const nameAndVersions = navigator.userAgent.replace(/\([^)]+\)(\s)?/g, '');
+
+  // Extract the potential browser <name>s by ignoring the first two names, which
+  // point to <source> and <engine>.
+  const matches = nameAndVersions.match(/[^\s]+/g) || [];
+  const [/* source */, /* engine */, ...browserNames] = matches.map(nameAndVersion => {
+    return nameAndVersion.split('/')[0].toLowerCase();
+  });
+
+  // Extract the <name> that is not expected to be present in the vanilla Chrome
+  // browser, which indicates the rebranded name (ex: "edg[e]", "electron"). If null,
+  // then this is a vanilla Chrome browser.
+  return browserNames.find(candidate => {
+    return !['chrome', 'mobile', 'safari'].includes(candidate);
+  }) || null;
+}
+
+/**
  * Check if the current environment is supported by the SDK.
  * @returns {boolean}
  */
 function isSupported() {
   const browser = guessBrowser();
-  return !!browser
-    && !isNonChromiumEdge(browser)
-    && isGetUserMediaSupported()
-    && isRTCPeerConnectionSupported();
+  const rebrandedChrome = rebrandedChromeBrowser(browser);
+  return isGetUserMediaSupported()
+    && isRTCPeerConnectionSupported()
+    && !!browser
+    && (!rebrandedChrome || ['edg', 'edge', 'electron'].includes(rebrandedChrome))
+    && !isNonChromiumEdge(browser);
 }
 
 module.exports = isSupported;

--- a/test/unit/spec/util/support.js
+++ b/test/unit/spec/util/support.js
@@ -52,6 +52,10 @@ describe('isSupported', () => {
       'Edge (Chromium)',
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64; Xbox; Xbox One) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edg/15.15063',
       { runtime: {} }
+    ],
+    [
+      'Electron',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Electron/3.1.12 Safari/537.36'
     ]
   ].forEach(([browser, useragent, chrome]) => {
     it('returns true for supported browser: ' + browser, () => {
@@ -78,6 +82,22 @@ describe('isSupported', () => {
       'Another Edge',
       'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0',
       {}
+    ],
+    [
+      'Brave',
+      'Mozilla/5.0 (Linux; Android 9; ONEPLUS A6013) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36 Brave/74'
+    ],
+    [
+      'Another Brave',
+      'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Brave Chrome/78.0.3904.108 Safari/537.36'
+    ],
+    [
+      'Opera',
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36 OPR/56.0.3051.52'
+    ],
+    [
+      'Samsung Browser',
+      'Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G950U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Mobile Safari/537.36'
     ]
   ].forEach(([browser, useragent, chrome]) => {
     it('returns false for unsupported browser: ' + browser, () => {

--- a/test/unit/spec/util/support.js
+++ b/test/unit/spec/util/support.js
@@ -25,6 +25,11 @@ describe('isSupported', () => {
       { runtime: {} }
     ],
     [
+      'Headless Chrome',
+      'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/81.0.4044.0 Safari/537.36',
+      { runtime: {} }
+    ],
+    [
       'Safari on Mac',
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13 Safari/605.1.15'
     ],


### PR DESCRIPTION
@makarandp0 

With this change, `isSupported` should return `false` for all Chrome-based browsers that are not Electron or Edge (ex: Brave, Samsung, Opera).

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
