### PR TITLE
mark insights test unstable with JSDK-2761

### DIFF
--- a/test/integration/spec/util/insightspublisher.js
+++ b/test/integration/spec/util/insightspublisher.js
@@ -43,7 +43,7 @@ describe('InsightsPublisher', function() {
 
         const description = tokenType !== 'valid'
           ? 'should disconnect with an Error'
-          : 'should be successful';
+          : 'should be successful (@unstable: JSDK-2761)';
 
         const test = tokenType !== 'valid' ? async () => {
           const error = await new Promise((resolve, reject) => {

--- a/test/integration/spec/util/insightspublisher.js
+++ b/test/integration/spec/util/insightspublisher.js
@@ -16,7 +16,7 @@ const tokens = new Map([
 
 const options = Object.assign({
   environment: 'prod'
-}, defaults);
+}, defaults, { insights: true });
 
 if (defaults.wsServerInsights) {
   options.gateway = defaults.wsServerInsights;

--- a/test/lib/defaults.js
+++ b/test/lib/defaults.js
@@ -22,6 +22,7 @@ const defaults = [
 }, {
   dominantSpeaker: true,
   environment: 'prod',
+  insights: env.environment !== 'stage', // disable insights for stage. (JSDK-2761)
   networkQuality: true,
   topology: 'peer-to-peer',
   testStability: 'all' // other choices: 'stable', 'unstable'


### PR DESCRIPTION
we are seeing some consistent failures in our insights connection tests. Its caused by insights server returning '{"type":"error","code":503,"message":"Closed","version":1}'
I have filed: JSDK-2761 to investigate root cause. but marking the test as unstable in the meanwhile. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
