### PR TITLE
JSDK-2762 Reduce publish frequency for insights events.

### DIFF
--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -21,7 +21,7 @@ const {
 
 const { createTwilioError } = require('../../util/twilio-video-errors');
 
-const STATS_PUBLISH_INTERVAL_MS = 1000;
+const STATS_PUBLISH_INTERVAL_MS = 10000;
 
 /**
  * @extends RoomSignaling
@@ -758,7 +758,9 @@ function handleTransportEvents(roomV2, transport) {
  * @param {Number} intervalMs
  */
 function periodicallyPublishStats(roomV2, transport, intervalMs) {
+  let oddPublishCount = 0;
   const interval = setInterval(() => {
+    oddPublishCount = ++oddPublishCount % 2;
     roomV2.getStats().then(stats => {
       stats.forEach((response, id) => {
         // NOTE(mmalavalli): A StatsReport is used to publish a "stats-report"
@@ -774,14 +776,16 @@ function periodicallyPublishStats(roomV2, transport, intervalMs) {
           videoTrackStats: report.remoteVideoTrackStats
         });
 
-        // NOTE(mmalavalli): null properties of the "active-ice-candidate-pair"
-        // payload are assigned default values until the Insights gateway
-        // accepts null values.
-        const activeIceCandidatePair = replaceNullsWithDefaults(
-          response.activeIceCandidatePair,
-          report.peerConnectionId);
+        if (oddPublishCount === 0) {
+          // NOTE(mmalavalli): null properties of the "active-ice-candidate-pair"
+          // payload are assigned default values until the Insights gateway
+          // accepts null values.
+          const activeIceCandidatePair = replaceNullsWithDefaults(
+            response.activeIceCandidatePair,
+            report.peerConnectionId);
 
-        transport.publishEvent('quality', 'active-ice-candidate-pair', activeIceCandidatePair);
+          transport.publishEvent('quality', 'active-ice-candidate-pair', activeIceCandidatePair);
+        }
       });
     }, () => {
       // Do nothing.

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -758,10 +758,10 @@ function handleTransportEvents(roomV2, transport) {
  * @param {Number} intervalMs
  */
 function periodicallyPublishStats(roomV2, transport, intervalMs) {
-  let oddPublishCount = 0;
+  let evenPublishCount = true;
   const interval = setInterval(() => {
-    oddPublishCount = ++oddPublishCount % 2;
     roomV2.getStats().then(stats => {
+      evenPublishCount = !evenPublishCount;
       stats.forEach((response, id) => {
         // NOTE(mmalavalli): A StatsReport is used to publish a "stats-report"
         // event instead of using StandardizedStatsResponse directly because
@@ -776,7 +776,7 @@ function periodicallyPublishStats(roomV2, transport, intervalMs) {
           videoTrackStats: report.remoteVideoTrackStats
         });
 
-        if (oddPublishCount === 0) {
+        if (evenPublishCount) {
           // NOTE(mmalavalli): null properties of the "active-ice-candidate-pair"
           // payload are assigned default values until the Insights gateway
           // accepts null values.

--- a/test/unit/spec/signaling/v2/room.js
+++ b/test/unit/spec/signaling/v2/room.js
@@ -116,14 +116,6 @@ describe('RoomV2', () => {
         ],
         [
           'quality',
-          'active-ice-candidate-pair',
-          {
-            peerConnectionId: 'foo',
-            baz: 'zee'
-          }
-        ],
-        [
-          'quality',
           'stats-report',
           {
             peerConnectionId: 'bar',
@@ -135,6 +127,96 @@ describe('RoomV2', () => {
         ],
         [
           'quality',
+          'stats-report',
+          {
+            peerConnectionId: 'foo',
+            audioTrackStats: reports.foo.remoteAudioTrackStats,
+            localAudioTrackStats: reports.foo.localAudioTrackStats,
+            localVideoTrackStats: reports.foo.localVideoTrackStats,
+            videoTrackStats: reports.foo.remoteVideoTrackStats
+          }
+        ],
+        [
+          'quality',
+          'active-ice-candidate-pair',
+          {
+            peerConnectionId: 'foo',
+            baz: 'zee'
+          }
+        ],
+        [
+          'quality',
+          'stats-report',
+          {
+            peerConnectionId: 'bar',
+            audioTrackStats: reports.foo.remoteAudioTrackStats,
+            localAudioTrackStats: reports.foo.localAudioTrackStats,
+            localVideoTrackStats: reports.foo.localVideoTrackStats,
+            videoTrackStats: reports.foo.remoteVideoTrackStats
+          }
+        ],
+        [
+          'quality',
+          'active-ice-candidate-pair',
+          {
+            peerConnectionId: 'bar',
+            zee: 'foo'
+          }
+        ],
+        [
+          'quality',
+          'stats-report',
+          {
+            peerConnectionId: 'foo',
+            audioTrackStats: reports.foo.remoteAudioTrackStats,
+            localAudioTrackStats: reports.foo.localAudioTrackStats,
+            localVideoTrackStats: reports.foo.localVideoTrackStats,
+            videoTrackStats: reports.foo.remoteVideoTrackStats
+          }
+        ],
+        [
+          'quality',
+          'stats-report',
+          {
+            peerConnectionId: 'bar',
+            audioTrackStats: reports.foo.remoteAudioTrackStats,
+            localAudioTrackStats: reports.foo.localAudioTrackStats,
+            localVideoTrackStats: reports.foo.localVideoTrackStats,
+            videoTrackStats: reports.foo.remoteVideoTrackStats
+          }
+        ],
+        [
+          'quality',
+          'stats-report',
+          {
+            peerConnectionId: 'foo',
+            audioTrackStats: reports.foo.remoteAudioTrackStats,
+            localAudioTrackStats: reports.foo.localAudioTrackStats,
+            localVideoTrackStats: reports.foo.localVideoTrackStats,
+            videoTrackStats: reports.foo.remoteVideoTrackStats
+          }
+        ],
+        [
+          'quality',
+          'active-ice-candidate-pair',
+          {
+            peerConnectionId: 'foo',
+            baz: 'zee'
+          }
+        ],
+        [
+          'quality',
+          'stats-report',
+          {
+            peerConnectionId: 'bar',
+            audioTrackStats: reports.foo.remoteAudioTrackStats,
+            localAudioTrackStats: reports.foo.localAudioTrackStats,
+            localVideoTrackStats: reports.foo.localVideoTrackStats,
+            videoTrackStats: reports.foo.remoteVideoTrackStats
+          }
+        ],
+        [
+          'quality',
           'active-ice-candidate-pair',
           {
             peerConnectionId: 'bar',
@@ -142,8 +224,8 @@ describe('RoomV2', () => {
           }
         ]
       ];
-      await wait(175);
-      test.transport.publishEvent.args.slice(0, 4).forEach(([, name, payload], i) => {
+      await wait(225);
+      test.transport.publishEvent.args.slice(0, expectedArgs.length).forEach(([, name, payload], i) => {
         if (name === 'stats-report') {
           assert.deepEqual(payload, expectedArgs[i][2]);
           return;


### PR DESCRIPTION
@makarandp0 @ceaglest 

With the changes in this PR, the SDK publishes insights events at the following frequency:
* One `stats-report` event every 10 seconds.
* One `active-ice-candidate-pair` every 20 seconds.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
