### PR TITLE
JSDK-2784: fix data channel usage example

### DIFF
--- a/lib/media/track/localdatatrack.js
+++ b/lib/media/track/localdatatrack.js
@@ -27,10 +27,10 @@ const DefaultDataTrackSender = require('../../data/sender');
  *
  * var localDataTrack = new Video.LocalDataTrack();
  * window.addEventListener('mousemove', function(event) {
- *   localDataTrack.send({
+ *   localDataTrack.send(JSON.stringify({
  *     x: e.clientX,
  *     y: e.clientY
- *   });
+ *   }));
  * });
  *
  * var token1 = getAccessToken();
@@ -46,7 +46,7 @@ const DefaultDataTrackSender = require('../../data/sender');
  * }).then(function(room) {
  *   room.on('trackSubscribed', function(track) {
  *     track.on('message', function(message) {
- *       console.log(message); // { x: <number>, y: <number> }
+ *       console.log(JSON.parse(message)); // { x: <number>, y: <number> }
  *     });
  *   });
  * });

--- a/test/integration/spec/remotetracks.js
+++ b/test/integration/spec/remotetracks.js
@@ -315,11 +315,15 @@ describe('RemoteVideoTrack', function() {
       assert.equal(tracks.length, 1);
       const remoteDataTrack = tracks[0];
 
-      dataTrack.send('one');
+      const message = {
+        x: 4,
+        y: 5
+      };
+      dataTrack.send(JSON.stringify(message));
 
       const messagePromise = new Promise(resolve =>  remoteDataTrack.on('message', resolve));
       const messageReceived = await waitFor(messagePromise, `to receive 1st message: ${roomSid}`);
-      assert.equal(messageReceived, 'one');
+      assert.deepEqual(JSON.parse(messageReceived), message);
     });
   });
 });


### PR DESCRIPTION
Fixes the documentation issue was reported by customer as https://github.com/twilio/twilio-video.js/issues/980

LocalDataTrack doc [Before](https://media.twiliocdn.com/sdk/js/video/releases/2.3.0/docs/LocalDataTrack.html) and [After](https://14780-46595751-gh.circle-artifacts.com/0/dist/docs/LocalDataTrack.html)
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
