### PR TITLE
Check whether environment is a browser before other functions reference navigator

### DIFF
--- a/lib/util/support.js
+++ b/lib/util/support.js
@@ -87,9 +87,9 @@ function rebrandedChromeBrowser(browser) {
 function isSupported() {
   const browser = guessBrowser();
   const rebrandedChrome = rebrandedChromeBrowser(browser);
-  return isGetUserMediaSupported()
+  return !!browser
+    && isGetUserMediaSupported()
     && isRTCPeerConnectionSupported()
-    && !!browser
     && (!rebrandedChrome || SUPPORTED_CHROME_BASED_BROWSERS.includes(rebrandedChrome))
     && !isNonChromiumEdge(browser);
 }


### PR DESCRIPTION
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

The PR https://github.com/twilio/twilio-video.js/pull/955/files changed the order in which `isSupported()` evaluates different browser features. By moving `!!browser` from the beginning, it attempts to access `navigator` and other browser globals before even checking whether it's in a browser environment. This breaks using the library with NodeJS server-side rendering. This fix first checks to see whether it's running in a browser before attempting to use any of the browser globals.

Let me know if you have any questions/comments/concerns. Thanks.