### PR TITLE
JSDK-2769 Renegotiate when a Track is added during a current negotiation.

### DIFF
--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -858,20 +858,11 @@ class PeerConnectionV2 extends StateMachine {
     let shouldReoffer = this._shouldOffer;
 
     if (localDescription && localDescription.sdp) {
-      // NOTE(mmalavalli): For "unified-plan" sdps, if the remote RTCPeerConnection sends
-      // an offer with fewer audio m= lines than the number of audio RTCRTPSenders
-      // in the local RTCPeerConnection, then the local RTCPeerConnection creates
-      // an answer with the same number of audio m= lines as in the offer. This
-      // behavior was triggered by the removal of 'offerToReceiveAudio' from the
-      // default RTCOfferOptions. Ideally, the local RTCPeerConnection should create
-      // an answer with the same number of audio m= lines as the number of
-      // RTCRTPSenders. In order to achieve this,the local RTCPeerConnection
-      // initiates renegotiation.
-      //
-      // We can reduce the number of cases where renegotiation is needed by
-      // re-introducing 'offerToReceiveAudio' to the default RTCOfferOptions with a
-      // value > 1.
-      if (this._isUnifiedPlan && localDescription.type === 'answer') {
+      // NOTE(mmalavalli): For "unified-plan" sdps, if the local RTCSessionDescription
+      // has fewer audio and/or video send* m= lines than the corresponding RTCRtpSenders
+      // with non-null MediaStreamTracks, it means that the newly added RTCRtpSenders
+      // require renegotiation.
+      if (this._isUnifiedPlan) {
         const senders = this._peerConnection.getSenders().filter(sender => sender.track);
         shouldReoffer = ['audio', 'video'].reduce((shouldOffer, kind) => {
           const mediaSections = getMediaSections(localDescription.sdp, kind, '(sendrecv|sendonly)');

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -9,8 +9,7 @@ const {
   createLocalAudioTrack,
   createLocalTracks,
   createLocalVideoTrack,
-  LocalDataTrack,
-  LocalVideoTrack
+  LocalDataTrack
 } = require('../../../lib');
 
 const LocalTrackPublication = require('../../../lib/media/track/localtrackpublication');
@@ -1288,18 +1287,19 @@ describe('LocalParticipant', function() {
     });
   });
 
-  describe('#publishTrack and #unpublishTrack, when called in rapid succession', () => {
+  describe('JSDK-2769 - #publishTrack and #unpublishTrack, when called in rapid succession', () => {
     let error;
     let publication;
 
     before(async () => {
       const audioTrack = await createLocalAudioTrack();
       const name = randomName();
+      const tracks = [audioTrack, await createLocalVideoTrack()];
       let videoTrack;
 
-      const rooms = await Promise.all([randomName(), randomName()].map(getToken).map(token => connect(token, Object.assign({
+      const rooms = await Promise.all([randomName(), randomName()].map(getToken).map((token, i) => connect(token, Object.assign({
         name,
-        tracks: [audioTrack]
+        tracks: i === 0 ? [audioTrack] : tracks
       }, defaults))));
 
       await Promise.all(rooms.map(room => participantsConnected(room, 1)));
@@ -1307,9 +1307,10 @@ describe('LocalParticipant', function() {
       try {
         for (let i = 0; i < 10; i++) {
           // eslint-disable-next-line no-await-in-loop
-          videoTrack = videoTrack ? new LocalVideoTrack(videoTrack.mediaStreamTrack.clone()) : await createLocalVideoTrack();
+          videoTrack = await createLocalVideoTrack();
           // eslint-disable-next-line no-await-in-loop
           publication = await rooms[0].localParticipant.publishTrack(videoTrack);
+          videoTrack.stop();
           rooms[0].localParticipant.unpublishTrack(videoTrack);
         }
       } catch (e) {

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -355,8 +355,6 @@ describe('LocalTrackPublication', function() {
     });
   });
 
-  // eslint-disable-next-line no-warning-comments
-  // TODO: enable these tests when track_priority MSP is available in prod
   (defaults.topology === 'peer-to-peer' ? describe.skip : describe)('#setPriority', function() {
     // eslint-disable-next-line no-invalid-this
     describe('three participant tests', () => {

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -49,7 +49,7 @@ describe('LocalTrackPublication', function() {
 
   it('JSDK-2583 late arrivals see stale priority for the tracks', async () => {
     const roomSid = await createRoom(randomName(), defaults.topology);
-    const options = Object.assign({ name: roomSid, logLevel: 'debug' }, defaults);
+    const options = Object.assign({ name: roomSid }, defaults);
 
     // BOB joins a room
     const bobRoom = await connect(getToken('Bob'), Object.assign({ tracks: [] }, options));

--- a/test/integration/spec/room.js
+++ b/test/integration/spec/room.js
@@ -488,6 +488,9 @@ describe('Room', function() {
       bob = bobRoom.localParticipant;
       charlie = charlieRoom.localParticipant;
 
+      // Create a high priority LocalTrack for charlie.
+      hiPriTrack = await createLocalVideoTrack(smallVideoConstraints);
+
       // Let bob publish a LocalTrack with low priority.
       loPriTrack = await createLocalVideoTrack(smallVideoConstraints);
       await waitFor(bob.publishTrack(loPriTrack, { priority: PRIORITY_LOW }), `${bob.sid} to publish LocalTrack: ${aliceRoom.sid}`);
@@ -529,7 +532,6 @@ describe('Room', function() {
       }));
 
       // Induce a track switch off by having charlie publish a track with high priority.
-      hiPriTrack = await createLocalVideoTrack(smallVideoConstraints);
       await waitFor(charlie.publishTrack(hiPriTrack, { priority: PRIORITY_HIGH }), `${charlie.sid} to publish a high priority LocalTrack: ${aliceRoom.sid}`);
       await waitFor(tracksSubscribed(remoteCharlie, 1), `${alice.sid} to subscribe to charlie's RemoteTrack ${hiPriTrack.sid}: ${aliceRoom.sid}`);
 


### PR DESCRIPTION
@makarandp0 

The reason sometimes calling `unpublishTrack` / `publishTrack` multiple times in quick succession resulted in publication not being complete is because a new negotiation was not being triggered after adding the track to the PeerConnection. This was happening because of the following sequence:
```
PeerConnectionV2.offer() -- remove track --> _needsAnswer = true
createOffer1 = PeerConnection.createOffer()
PeerConnectionV2.offer() -- add track --> _shouldOffer = true, before createOffer1 is resolved
await createOffer1 --> _shouldOffer = false
```
Because of this sequence of events, there is no negotiation initiated for the second `offer()` when a new track is added, and therefore the publication is never completed.

This fix makes sure that after the current negotiation is complete, we renegotiate if we notice that the number of send* m= lines in the most recent local offer is less than the number of non-null RTCRtpSenders in the PeerConnection. This now triggers renegotiation for the second `offer()` in the above sequence, thereby completing the publication.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
