### PR TITLE
JSDK-2826 wrong state inprogress

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- ./test/unit/index.js"
   },
   "dependencies": {
-    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#signaling_change_is_still_fired_on_close",
+    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#68f190898c17d104f6c9a6212cdc6737c97635a0",
     "backoff": "^2.5.0",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- ./test/unit/index.js"
   },
   "dependencies": {
-    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#1499aa43fb200614103ef8e2556eeb97558ad4b1",
+    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#signaling_change_is_still_fired_on_close",
     "backoff": "^2.5.0",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"


### PR DESCRIPTION
consumes [twilio-webrc change](https://github.com/twilio/twilio-webrtc.js/pull/120) to fix insights issue.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
