### PR TITLE
Use circleci for releasing a build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,9 +41,9 @@ parameters:
     type: enum
     enum: ["all", "stable", "unstable"]
     default: "all"
-  releaseCommand:
+  release_command:
     type: string
-    default: "" # the command to execute to release the build.
+    default: "echo no release command was specified" # release-tool specifies the real command.
 
 defaultEnv: &defaultEnv
   ENVIRONMENT: << pipeline.parameters.environment >>
@@ -233,13 +233,20 @@ jobs:
   ExecuteRelease:
     executor: docker-with-browser
     parameters:
-      releaseCommand:
-        type: string
-        default: ""
+      dryRun:
+        type: boolean
+        default: true
     steps:
-      - checkout # release command builds as part of the flow.
-      - run: echo <<pipeline.parameters.releaseCommand>>
-      - run: <<parameters.releaseCommand>>
+      - build
+      - when:
+          condition: << parameters.dryRun >>
+          steps:
+            - run: echo Wait for other jobs in the workflow to finish
+            - run: echo Release will execute "<< pipeline.parameters.release_command >>"
+      - unless:
+          condition: << parameters.dryRun >>
+          steps:
+            - run: << pipeline.parameters.release_command >>
 
   trigger-qe-tests:
     docker:
@@ -350,13 +357,18 @@ workflows:
               browser: ["chrome", "firefox"]
               bver: ["stable", "unstable", "beta"]
               topology: ["group", "peer-to-peer"]
-              test_stability: ["stable", "unstable"]
+              test_stability: ["stable"]
+          requires: [Build, UnitTests]
+      - ExecuteRelease:
+          dryRun: true
+          name: Release dry run
           requires: [Build, UnitTests]
       - hold:
           type: approval
-          requires: [Build, UnitTests]
-      - ExecuteRelease: # this job has conditional steps, no-ops when pipeline.parameters.releaseCommand not specified
-          releaseCommand: << pipeline.parameters.releaseCommand >>
+          requires: [Release dry run]
+      - ExecuteRelease:
+          dryRun: false
+          context: sdk_js
           requires: [hold]
 
   Release-candidate:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ parameters:
   pr_workflow:    # runs for every pull request.
     type: boolean
     default: true # by default pr workflow will get executed.
+  release_workflow:
+    type: boolean
+    default: false # this will also need parameter.releaseCommand
   custom_workflow: # runs just one custom config.
     type: boolean
     default: false
@@ -38,6 +41,9 @@ parameters:
     type: enum
     enum: ["all", "stable", "unstable"]
     default: "all"
+  releaseCommand:
+    type: string
+    default: "" # the command to execute to release the build.
 
 defaultEnv: &defaultEnv
   ENVIRONMENT: << pipeline.parameters.environment >>
@@ -223,6 +229,18 @@ jobs:
     environment:
       BROWSER: << parameters.browser >>
       BVER: << parameters.bver >>
+
+  ExecuteRelease:
+    executor: docker-with-browser
+    parameters:
+      releaseCommand:
+        type: string
+        default: ""
+    steps:
+      - checkout # release command builds as part of the flow.
+      - run: echo <<pipeline.parameters.releaseCommand>>
+      - run: <<parameters.releaseCommand>>
+
   trigger-qe-tests:
     docker:
       - image: circleci/node:latest
@@ -284,6 +302,7 @@ workflows:
               browser: ["chrome", "firefox"]
               topology: ["group", "peer-to-peer"]
               test_stability: ["stable"]
+
   Pull_Request_Workflow:
     when: << pipeline.parameters.pr_workflow >>
     jobs:
@@ -318,6 +337,28 @@ workflows:
       - Framework-tests:
           name: "framework tests"
           requires: [Build, UnitTests]
+
+  Release_Workflow:
+    when: << pipeline.parameters.release_workflow >>
+    jobs:
+      - Build
+      - UnitTests
+      - run-integration-tests:
+          name: << matrix.test_stability >> integration << matrix.topology >> tests on << matrix.browser >>(<< matrix.bver >>)
+          matrix:
+            parameters:
+              browser: ["chrome", "firefox"]
+              bver: ["stable", "unstable", "beta"]
+              topology: ["group", "peer-to-peer"]
+              test_stability: ["stable", "unstable"]
+          requires: [Build, UnitTests]
+      - hold:
+          type: approval
+          requires: [Build, UnitTests]
+      - ExecuteRelease: # this job has conditional steps, no-ops when pipeline.parameters.releaseCommand not specified
+          releaseCommand: << pipeline.parameters.releaseCommand >>
+          requires: [hold]
+
   Release-candidate:
     jobs:
       - trigger-qe-tests:

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "karma-spec-reporter": "0.0.32",
     "mocha": "^3.2.0",
     "npm-run-all": "^4.0.2",
-    "release-tool": "^0.2.2",
+    "twilio-release-tool": "^1.0.0",
     "requirejs": "^2.3.3",
     "rimraf": "^2.6.1",
     "selenium-webdriver": "3.3.0",


### PR DESCRIPTION
This PR works with twilio/release-tool#2 to allow release_tool to release builds using circleci

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
