### PR TITLE
JSDK-2819 EventListenerCloseEvent contains the TwilioConnection close reason.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,15 +21,28 @@ New Features
   // Listen to events on the EventListener in order to monitor the status
    // of the connection to Twilio's signaling server.
   sdkEvents.on('event', event => {
-    if (event.name === 'wait') {
-      console.log('Twilio\'s signaling server is busy, so we wait a little while before trying again.');
-    } else if (event.name === 'connecting') {
+    const { level, name } = event;
+    if (name === 'wait') {
+      assert.equal(level, 'warning');
+      console.warn('Twilio\'s signaling server is busy, so we wait a little while before trying again.');
+    } else if (name === 'connecting') {
+      assert.equal(level, 'info');
       console.log('Connecting to Twilio\'s signaling server.');
+    } else if (name === 'open') {
+      assert.equal(level, 'info');
+      console.log('Connected to Twilio\'s signaling server, joining the Room now.');
+    } else if (name === 'closed') {
+      if (level === 'error') {
+        const { payload: { reason } } = event;
+        console.error('Connection to Twilio\'s signaling server abruptly closed:', reason);
+      } else {
+        console.log('Connection to Twilio\'s signaling server closed.');
+      }
     }
   });
 
   connect('token', { eventListener: sdkEvents }).then(room => {
-    console.log('Successfully connected to Room:', room.name);
+    console.log('Joined the Room:', room.name);
   }, error => {
     if (error.code === 53006) {
       console.error('Twilio\'s signaling server cannot accept connection requests at this time.');

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -656,9 +656,10 @@ const BandwidthProfileMode = {
  * The connection to Twilio's signaling server was closed.
  * @typedef {EventListenerEvent} EventListenerClosedEvent
  * @property {string} group='signaling'
- * @property {string} level - 'info' if there is no payload, 'error' otherwise
+ * @property {string} level - 'info' if the connection was closed by the client, 'error' otherwise
  * @property {string} name='closed'
- * @property {{code: number, message: string}} [payload] - Optional payload with error code and message
+ * @property {{reason: string}} payload - Reason for the connection being closed. It can be one of
+ *   'busy', 'failed', 'local', 'remote' or 'timeout'
  */
 
 /**

--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -489,7 +489,14 @@ function setupTransport(transport) {
         : transport._createConnectOrSyncOrDisconnectMessage()
     }, _options));
 
-    twilioConnection.once('close', disconnect);
+    twilioConnection.once('close', reason => {
+      if (reason === TwilioConnection.CloseReason.LOCAL) {
+        disconnect();
+      } else {
+        disconnect(new Error(reason));
+      }
+    });
+
     twilioConnection.on('message', handleMessage);
     transport._twilioConnection = twilioConnection;
   }
@@ -505,7 +512,7 @@ function setupTransport(transport) {
 
     const reconnectTimer = transport._getReconnectTimer();
     if (!reconnectTimer) {
-      const twilioError = error.code === TwilioConnection.CloseCode.SERVER_BUSY
+      const twilioError = error.message === TwilioConnection.CloseReason.BUSY
         ? new SignalingServerBusyError()
         : new SignalingConnectionError();
       transport.disconnect(twilioError);

--- a/lib/twilioconnection.js
+++ b/lib/twilioconnection.js
@@ -50,6 +50,7 @@ const DEFAULT_MAX_REQUESTED_HEARTBEAT_TIMEOUT = 5000;
 const DEFAULT_OPEN_TIMEOUT = 15000;
 const DEFAULT_WELCOME_TIMEOUT = 5000;
 const OUTGOING_HEARTBEAT_OFFSET = 200;
+
 const WS_CLOSE_NORMAL = 1000;
 const WS_CLOSE_WELCOME_TIMEOUT = 3000;
 const WS_CLOSE_HEARTBEATS_MISSED = 3001;
@@ -62,6 +63,24 @@ const WS_CLOSE_OPEN_TIMEOUT = 3007;
 
 const toplevel = global.window || global;
 const WebSocket = toplevel.WebSocket ? toplevel.WebSocket : require('ws');
+
+const CloseReason = {
+  BUSY: 'busy',
+  FAILED: 'failed',
+  LOCAL: 'local',
+  REMOTE: 'remote',
+  TIMEOUT: 'timeout'
+};
+
+const wsCloseCodesToCloseReasons = new Map([
+  [WS_CLOSE_WELCOME_TIMEOUT, CloseReason.TIMEOUT],
+  [WS_CLOSE_HEARTBEATS_MISSED, CloseReason.TIMEOUT],
+  [WS_CLOSE_HELLO_FAILED, CloseReason.FAILED],
+  [WS_CLOSE_SEND_FAILED, CloseReason.FAILED],
+  [WS_CLOSE_NETWORK_CHANGED, CloseReason.TIMEOUT],
+  [WS_CLOSE_SERVER_BUSY, CloseReason.BUSY],
+  [WS_CLOSE_OPEN_TIMEOUT, CloseReason.TIMEOUT]
+]);
 
 /**
  * A {@link TwilioConnection} represents a WebSocket connection
@@ -168,11 +187,8 @@ class TwilioConnection extends StateMachine {
       }
       const event = { name: state };
       if (state === 'closed') {
-        const [error] = args;
-        if (error) {
-          const { code, reason } = error;
-          event.payload = { code, message: reason };
-        }
+        const [reason] = args;
+        event.payload = { reason };
       }
       this._eventObserver.emit('event', event);
     });
@@ -217,14 +233,13 @@ class TwilioConnection extends StateMachine {
 
     if (code === WS_CLOSE_NORMAL) {
       log.debug('Closed');
-      this.transition('closed', null, [null]);
+      this.transition('closed', null, [CloseReason.LOCAL]);
     } else {
       log.warn(`Closed: ${code} - ${reason}`);
       if (code !== WS_CLOSE_BUSY_WAIT) {
-        const error = new Error(`WebSocket Error ${code}: ${reason}`);
-        error.code = code;
-        error.reason = reason;
-        this.transition('closed', null, [error]);
+        this.transition('closed', null, [
+          wsCloseCodesToCloseReasons.get(code) || CloseReason.REMOTE
+        ]);
       }
     }
     const { readyState } = this._ws;
@@ -577,23 +592,15 @@ class TwilioConnection extends StateMachine {
 }
 
 /**
- * A unique number depicting the reason for an inadvertent closing of
- * the {@link TwilioConnection}.
- * @enum {number}
+ * A unique string depicting the reason for the {@link TwilioConnection} being closed.
+ * @enum {string}
  */
-TwilioConnection.CloseCode = {
-  WELCOME_TIMEOUT: WS_CLOSE_NORMAL,
-  HEARTBEATS_MISSED: WS_CLOSE_HEARTBEATS_MISSED,
-  HELLO_FAILED: WS_CLOSE_HELLO_FAILED,
-  SEND_FAILED: WS_CLOSE_SEND_FAILED,
-  NETWORK_CHANGED: WS_CLOSE_NETWORK_CHANGED,
-  SERVER_BUSY: WS_CLOSE_SERVER_BUSY
-};
+TwilioConnection.CloseReason = CloseReason;
 
 /**
  * A {@link TwilioConnection} was closed.
  * @event TwilioConnection#close
- * @param {?Error} error - If closed by the client, then this is null
+ * @param {CloseReason} reason - The reason for the {@link TwilioConnection} being closed
  */
 
 /**

--- a/lib/util/eventobserver.js
+++ b/lib/util/eventobserver.js
@@ -2,6 +2,8 @@
 
 const { EventEmitter } = require('events');
 
+const { CloseReason: { LOCAL } } = require('../twilioconnection');
+
 const GROUPS = {
   SIGNALING: 'signaling'
 };
@@ -23,7 +25,7 @@ const eventNamesToGroups = {
 
 const eventNamesToLevels = {
   closed(payload) {
-    return payload ? LEVELS.ERROR : LEVELS.INFO;
+    return payload.reason === LOCAL ? LEVELS.INFO : LEVELS.ERROR;
   },
   connecting: LEVELS.INFO,
   early: LEVELS.INFO,
@@ -56,9 +58,7 @@ class EventObserver extends EventEmitter {
           ? eventNamesToLevels[name](payload)
           : eventNamesToLevels[name];
 
-        // TODO(mmalavalli): Until the TCMP CloseReason is defined, do not send
-        // include the payload for the "closed" event name.
-        const event = Object.assign(name !== 'closed' && payload ? { payload } : {}, {
+        const event = Object.assign(payload ? { payload } : {}, {
           elapsedTime,
           group,
           level,

--- a/test/unit/spec/signaling/v2/twilioconnectiontransport.js
+++ b/test/unit/spec/signaling/v2/twilioconnectiontransport.js
@@ -89,7 +89,7 @@ describe('TwilioConnectionTransport', () => {
       .bandwidthProfile ${JSON.stringify(bandwidthProfile)}`, () => {
       let test;
 
-      beforeEach(() => {
+      beforeEach(async () => {
         test = makeTest(Object.assign(iceServers ? {
           iceServers: [{ urls: 'foo' }]
         } : {}, bandwidthProfile ? {
@@ -102,7 +102,7 @@ describe('TwilioConnectionTransport', () => {
           trackSwitchOff
         }));
         if (iceServers) {
-          return waitForSometime(1);
+          await waitForSometime(1);
         }
       });
 

--- a/test/unit/spec/util/eventobserver.js
+++ b/test/unit/spec/util/eventobserver.js
@@ -11,8 +11,8 @@ describe('EventObserver', () => {
 
   describe('"event", when emitted', () => {
     [
-      ['closed', 'error', { foo: 'bar' }],
-      ['closed', 'info'],
+      ['closed', 'error', { reason: 'failed' }],
+      ['closed', 'info', { reason: 'local' }],
       ['connecting', 'info'],
       ['early', 'info'],
       ['open', 'info'],
@@ -50,13 +50,8 @@ describe('EventObserver', () => {
           assert.equal(eventParams.name, name);
         });
 
-        // TODO(mmalavalli): Remove "closed" check once TCMP CloseReason is defined.
-        it(`.payload ${name !== 'closed' && payload ? 'set to the given payload' : 'not set'}`, () => {
-          if (name !== 'closed' && payload) {
-            assert.deepEqual(eventParams.payload, payload);
-          } else {
-            assert(!('payload' in eventParams));
-          }
+        it('.payload set to the given payload', () => {
+          assert.deepEqual(eventParams.payload, payload);
         });
       });
     });

--- a/test/unit/spec/util/eventobserver.js
+++ b/test/unit/spec/util/eventobserver.js
@@ -11,14 +11,19 @@ describe('EventObserver', () => {
 
   describe('"event", when emitted', () => {
     [
+      ['closed', 'error', { reason: 'busy' }],
       ['closed', 'error', { reason: 'failed' }],
       ['closed', 'info', { reason: 'local' }],
+      ['closed', 'error', { reason: 'remote' }],
+      ['closed', 'error', { reason: 'timeout' }],
       ['connecting', 'info'],
       ['early', 'info'],
       ['open', 'info'],
       ['wait', 'warning']
     ].forEach(([name, level, payload]) => {
-      context(`with .name "${name}"${payload ? ' and a .payload' : ''}, should emit an "event" on the EventListener with`, () => {
+      context(`with .name "${name}"${payload
+        ? ` and .payload ${JSON.stringify(payload)}`
+        : ''}, should emit an "event" on the EventListener with`, () => {
         let connectTimestamp;
         let eventParams;
 


### PR DESCRIPTION
@makarandp0 

This PR implements the TwilioConnection close reason defined [here](https://code.hq.twilio.com/client/rtc-insights-spec/pull/55), which is based on the [TCMP FRD](https://code.hq.twilio.com/client/sdk-frd/pull/36/files#diff-3b6eb58a63e88c51d172c548d9ccf7e0R202).

### TODO

- [x] Expand EventListener example in CHANGELOG.md
- [x] Add EventListener tests.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
