### PR TITLE
JSDK-2832 Stop supporting prefixed WebRTC APIs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 For 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/support-1.x/CHANGELOG.md).
 
+2.6.0 (in progress)
+===================
+
+Changes
+-------
+
+- Removed support for versions of Chrome (23 - 55) and Firefox (22 - 43) that support prefixed
+  versions of the WebRTC APIs that have been deprecated. `isSupported` will now return `false`
+  for these browser versions. (JSDK-2832)
+
 2.5.0 (May 27, 2020)
 ====================
 

--- a/lib/stats/peerconnectionreportfactory.js
+++ b/lib/stats/peerconnectionreportfactory.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { guessBrowser } = require('@twilio/webrtc/lib/util');
+
 const IceReportFactory = require('./icereportfactory');
 const PeerConnectionReport = require('./peerconnectionreport');
 const ReceiverReportFactory = require('./receiverreportfactory');
@@ -86,7 +88,7 @@ class PeerConnectionReportFactory {
    * @returns {Promise<PeerConnectionReport>}
    */
   next() {
-    const updatePromise = typeof mozRTCPeerConnection !== 'undefined'
+    const updatePromise = guessBrowser() === 'firefox'
       ? updateFirefox(this)
       : updateChrome(this);
 
@@ -242,7 +244,7 @@ function getReceiverReportFactoryIdsByMediaType(factory) {
 function updateSenderReports(factory, report, senderReportFactoryIdsToDeleteByMediaType, trackId) {
   for (const stats of report.values()) {
     if (stats.type === 'outbound-rtp' && !stats.isRemote) {
-      if (typeof mozRTCPeerConnection === 'undefined' && !stats.trackId) {
+      if (guessBrowser() !== 'firefox' && !stats.trackId) {
         continue;
       }
       const senderReportFactoryIdsToDelete = senderReportFactoryIdsToDeleteByMediaType[stats.mediaType];
@@ -320,7 +322,7 @@ function updateIceReport(ice, report) {
 
 /**
  * @param {PeerConnectionReportFactory} factory
- * @returns {PeerConnectionReport}
+ * @returns {Promise<PeerConnectionReport>}
  */
 function updateFirefox(factory) {
   const senders = factory.pc.getTransceivers()
@@ -352,7 +354,7 @@ function updateFirefox(factory) {
 
 /**
  * @param {PeerConnectionReportFactory} factory
- * @returns {PeerConnectionReport}
+ * @returns {Promise<PeerConnectionReport>}
  */
 function updateChrome(factory) {
   return factory.pc.getStats().then(report => {

--- a/lib/util/support.js
+++ b/lib/util/support.js
@@ -1,4 +1,4 @@
-/* globals RTCPeerConnection, webkitRTCPeerConnection, mozRTCPeerConnection, chrome, navigator */
+/* globals chrome, navigator, RTCPeerConnection */
 'use strict';
 
 const { guessBrowser } = require('@twilio/webrtc/lib/util');
@@ -11,24 +11,14 @@ const SUPPORTED_CHROME_BASED_BROWSERS = [
 ];
 
 /**
- * Check whether PeerConnection API is supported.
+ * Check whether WebRTC APIs are supported.
  * @returns {boolean}
  */
-function isRTCPeerConnectionSupported() {
-  return typeof RTCPeerConnection !== 'undefined'
-    || typeof webkitRTCPeerConnection !== 'undefined'
-    || typeof mozRTCPeerConnection !== 'undefined';
-}
-
-/**
- * Check whether GetUserMedia API is supported.
- * @returns {boolean}
- */
-function isGetUserMediaSupported() {
-  return !!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia)
-    || !!(navigator.getUserMedia)
-    || !!(navigator.webkitGetUserMedia)
-    || !!(navigator.mozGetUserMedia);
+function isWebRTCSupported() {
+  return typeof navigator === 'object'
+    && typeof navigator.mediaDevices === 'object'
+    && typeof navigator.mediaDevices.getUserMedia === 'function'
+    && typeof RTCPeerConnection === 'function';
 }
 
 /**
@@ -88,8 +78,7 @@ function isSupported() {
   const browser = guessBrowser();
   const rebrandedChrome = rebrandedChromeBrowser(browser);
   return !!browser
-    && isGetUserMediaSupported()
-    && isRTCPeerConnectionSupported()
+    && isWebRTCSupported()
     && (!rebrandedChrome || SUPPORTED_CHROME_BASED_BROWSERS.includes(rebrandedChrome))
     && !isNonChromiumEdge(browser);
 }

--- a/lib/util/support.js
+++ b/lib/util/support.js
@@ -1,7 +1,7 @@
-/* globals chrome, navigator, RTCPeerConnection */
+/* globals chrome, navigator */
 'use strict';
 
-const { guessBrowser } = require('@twilio/webrtc/lib/util');
+const { guessBrowser, support: isWebRTCSupported } = require('@twilio/webrtc/lib/util');
 
 const SUPPORTED_CHROME_BASED_BROWSERS = [
   'edg',
@@ -9,17 +9,6 @@ const SUPPORTED_CHROME_BASED_BROWSERS = [
   'electron',
   'headlesschrome'
 ];
-
-/**
- * Check whether WebRTC APIs are supported.
- * @returns {boolean}
- */
-function isWebRTCSupported() {
-  return typeof navigator === 'object'
-    && typeof navigator.mediaDevices === 'object'
-    && typeof navigator.mediaDevices.getUserMedia === 'function'
-    && typeof RTCPeerConnection === 'function';
-}
 
 /**
  * Check whether the current browser is non-Chromium Edge.

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- ./test/unit/index.js"
   },
   "dependencies": {
-    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#JSDK-2832",
+    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#4962c5dae6d3a36fdad4e0c55eaeef262283c8a5",
     "backoff": "^2.5.0",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- ./test/unit/index.js"
   },
   "dependencies": {
-    "@twilio/webrtc": "4.2.1",
+    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#JSDK-2832",
     "backoff": "^2.5.0",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"

--- a/test/lib/mockwebrtc.js
+++ b/test/lib/mockwebrtc.js
@@ -52,12 +52,11 @@ const navigator = {
   userAgent: 'Node'
 };
 
-function getUserMedia(constraints, successCallback) {
-  const mediaStream = new MediaStream();
-  setTimeout(() => successCallback(mediaStream));
+function getUserMedia() {
+  return Promise.resolve(new MediaStream());
 }
 
-navigator.webkitGetUserMedia = getUserMedia;
+navigator.mediaDevices = { getUserMedia };
 
 class RTCDataChannel {
   constructor(label) {


### PR DESCRIPTION
@makarandp0

This PR makes sure we stop supporting Chrome (23 - 55) and Firefox (22 - 43) versions that support only the prefixed webkit and moz WebRTC APIs that are now deprecated.

consumes: https://github.com/twilio/twilio-webrtc.js/pull/123
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
