### PR TITLE
JSDK-2880 - do not use EventEmitter.off

### DIFF
--- a/lib/media/track/localmediatrack.js
+++ b/lib/media/track/localmediatrack.js
@@ -187,7 +187,7 @@ function restartWhenInadvertentlyStopped(localMediaTrack) {
   }
 
   document.addEventListener('visibilitychange', handleTrackStateChange);
-  localMediaTrack.addListener('stopped', handleTrackStateChange);
+  localMediaTrack.on('stopped', handleTrackStateChange);
   return () => {
     document.removeEventListener('visibilitychange', handleTrackStateChange);
     localMediaTrack.removeListener('stopped', handleTrackStateChange);

--- a/lib/media/track/localmediatrack.js
+++ b/lib/media/track/localmediatrack.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 'use strict';
 
 const MediaTrackSender = require('./sender');

--- a/lib/media/track/localmediatrack.js
+++ b/lib/media/track/localmediatrack.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 'use strict';
 
 const MediaTrackSender = require('./sender');
@@ -187,10 +188,10 @@ function restartWhenInadvertentlyStopped(localMediaTrack) {
   }
 
   document.addEventListener('visibilitychange', handleTrackStateChange);
-  localMediaTrack.on('stopped', handleTrackStateChange);
+  localMediaTrack.addListener('stopped', handleTrackStateChange);
   return () => {
     document.removeEventListener('visibilitychange', handleTrackStateChange);
-    localMediaTrack.off('stopped', handleTrackStateChange);
+    localMediaTrack.removeListener('stopped', handleTrackStateChange);
   };
 }
 


### PR DESCRIPTION
This addresses JSDK-2880 found by QA - which is caused by usage of `off` on EventEmitter which was missing in EventEmitter prototype generated by Simpler Signaling. The same function does exist in code generated by VBT or AhoyApp.

For unblocking testing on the safari workaround - I am fixing this usage. But we do need to investigate further to see which part of the Simpler-Singaling Build is causing this issue, and if there are any other functio usages that need to be fixed.

  

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
