### PR TITLE
delay audio.play() 

### DIFF
--- a/lib/media/track/localmediatrack.js
+++ b/lib/media/track/localmediatrack.js
@@ -197,7 +197,7 @@ function restartWhenInadvertentlyStopped(localMediaTrack) {
   mediaStreamTrack.addEventListener('ended', handleTrackStateChange);
   return () => {
     document.removeEventListener('visibilitychange', handleTrackStateChange);
-    mediaStreamTrack.removeEventListener('ended', onended);
+    mediaStreamTrack.removeEventListener('ended', handleTrackStateChange);
   };
 }
 

--- a/lib/media/track/localmediatrack.js
+++ b/lib/media/track/localmediatrack.js
@@ -144,6 +144,7 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
 
 function restartWhenInadvertentlyStopped(localMediaTrack) {
   const { _getUserMedia: getUserMedia, _log: log } = localMediaTrack;
+  let mediaStreamTrack = localMediaTrack.mediaStreamTrack;
   let trackChangeInProgress = false;
 
   function shouldReacquireTrack() {
@@ -168,7 +169,7 @@ function restartWhenInadvertentlyStopped(localMediaTrack) {
 
   function handleTrackStateChange() {
     Promise.race([
-      waitForEvent(localMediaTrack.mediaStreamTrack, 'unmute'),
+      waitForEvent(mediaStreamTrack, 'unmute'),
       waitForSometime(50)
     ]).then(() => {
       if (shouldReacquireTrack()) {
@@ -176,7 +177,13 @@ function restartWhenInadvertentlyStopped(localMediaTrack) {
         reacquireTrack().then(newTrack => {
           log.info('Re-acquired the MediaStreamTrack.');
           log.debug('MediaStreamTrack:', newTrack);
+
           localMediaTrack._setMediaStreamTrack(newTrack);
+
+          // reattach listener on updated mediaStream
+          mediaStreamTrack.removeEventListener('ended', handleTrackStateChange);
+          mediaStreamTrack = localMediaTrack.mediaStreamTrack;
+          mediaStreamTrack.addEventListener('ended', handleTrackStateChange);
         }).catch(err => {
           log.warn('Failed to re-acquire the MediaStreamTrack:', err);
         }).finally(() => {
@@ -187,10 +194,10 @@ function restartWhenInadvertentlyStopped(localMediaTrack) {
   }
 
   document.addEventListener('visibilitychange', handleTrackStateChange);
-  localMediaTrack.on('stopped', handleTrackStateChange);
+  mediaStreamTrack.addEventListener('ended', handleTrackStateChange);
   return () => {
     document.removeEventListener('visibilitychange', handleTrackStateChange);
-    localMediaTrack.removeListener('stopped', handleTrackStateChange);
+    mediaStreamTrack.removeEventListener('ended', onended);
   };
 }
 

--- a/lib/media/track/localmediatrack.js
+++ b/lib/media/track/localmediatrack.js
@@ -179,14 +179,13 @@ function restartWhenInadvertentlyStopped(localMediaTrack) {
           log.debug('MediaStreamTrack:', newTrack);
 
           localMediaTrack._setMediaStreamTrack(newTrack);
-
+        }).catch(err => {
+          log.warn('Failed to re-acquire the MediaStreamTrack:', err);
+        }).finally(() => {
           // reattach listener on updated mediaStream
           mediaStreamTrack.removeEventListener('ended', handleTrackStateChange);
           mediaStreamTrack = localMediaTrack.mediaStreamTrack;
           mediaStreamTrack.addEventListener('ended', handleTrackStateChange);
-        }).catch(err => {
-          log.warn('Failed to re-acquire the MediaStreamTrack:', err);
-        }).finally(() => {
           trackChangeInProgress = false;
         });
       }

--- a/lib/media/track/remotemediatrack.js
+++ b/lib/media/track/remotemediatrack.js
@@ -215,12 +215,11 @@ function playIfPausedWhileInBackground(remoteMediaTrack) {
   function onVisibilityChanged() {
     if (document.visibilityState === 'visible') {
       // NOTE(mpatwardhan): when document regains foreground restore elements that were
-      // unintentionally paused. For audio elements delay 2 seconds to ensure that
-      // if local audio track was being re-acquired it had chance to finish acquiring.
-      const delay = kind === 'audio' ? 2000 : 1;
-      const delayPromise = waitForSometime(delay);
-      delayPromise.then(() => {
-        [...remoteMediaTrack._attachments.values()].forEach(el => {
+      // NOTE(mpatwardhan): On iOS Safari, play inadvertently paused HTMLAudioElements with
+      // a delay to make sure any inadvertently ended LocalMediaTracks are restarted first. Otherwise,
+      // play() will reject with a NotAllowedError.
+      waitForSomeTime(2000).then(() => {
+        remoteMediaTrack._attachments.forEach(el => {
           const shim = shimmedElements.get(el);
           if (el.paused && shim && !shim.isPausedIntentionally()) {
             log.info(`playing paused ${kind} element`);

--- a/lib/media/track/remotemediatrack.js
+++ b/lib/media/track/remotemediatrack.js
@@ -229,7 +229,7 @@ function playIfPausedWhileInBackground(remoteMediaTrack) {
               log.debug('Element:', el);
               log.debug('RemoteMediaTrack:', remoteMediaTrack);
             }).catch(err => {
-              log.warn(`Error while playing inadvertently paused <${kind}> element:`, error, el, remoteMediaTrack);
+              log.warn(`Error while playing inadvertently paused <${kind}> element:`, err, el, remoteMediaTrack);
             });
           }
         });

--- a/lib/media/track/remotemediatrack.js
+++ b/lib/media/track/remotemediatrack.js
@@ -221,11 +221,15 @@ function playIfPausedWhileInBackground(remoteMediaTrack) {
         remoteMediaTrack._attachments.forEach(el => {
           const shim = shimmedElements.get(el);
           if (el.paused && shim && !shim.isPausedIntentionally()) {
-            log.info(`playing paused ${kind} element`);
+            log.info(`Playing inadvertently paused <${kind}> element`);
+            log.debug('Element:', el);
+            log.debug('RemoteMediaTrack:', remoteMediaTrack);
             el.play().then(() => {
-              log.info(`successfully played unintentionally paused ${kind} element`);
+              log.info(`Successfully played inadvertently paused <${kind}> element`);
+              log.debug('Element:', el);
+              log.debug('RemoteMediaTrack:', remoteMediaTrack);
             }).catch(err => {
-              log.warn(`error playing paused ${kind} element`, err);
+              log.warn(`Error while playing inadvertently paused <${kind}> element:`, error, el, remoteMediaTrack);
             });
           }
         });

--- a/lib/media/track/remotemediatrack.js
+++ b/lib/media/track/remotemediatrack.js
@@ -2,6 +2,7 @@
 'use strict';
 const { typeErrors: E, trackPriority } = require('../../util/constants');
 const { guessBrowser } = require('@twilio/webrtc/lib/util');
+const { waitForSometime } = require('../../util');
 
 function mixinRemoteMediaTrack(AudioOrVideoTrack) {
   /**
@@ -210,20 +211,26 @@ function shimMediaElement(mediaElement) {
 }
 
 function playIfPausedWhileInBackground(remoteMediaTrack) {
-  const { _log: log } = remoteMediaTrack;
+  const { _log: log, kind } = remoteMediaTrack;
   function onVisibilityChanged() {
     if (document.visibilityState === 'visible') {
       // NOTE(mpatwardhan): when document regains foreground restore elements that were
-      // unintentionally paused.
-      [...remoteMediaTrack._attachments.values()].forEach(el => {
-        const shim = shimmedElements.get(el);
-        if (el.paused && shim && !shim.isPausedIntentionally()) {
-          el.play().then(() => {
-            log.info('successfully played unintentionally paused element');
-          }).catch(err => {
-            log.warn('error playing paused element', err);
-          });
-        }
+      // unintentionally paused. For audio elements delay 2 seconds to ensure that
+      // if local audio track was being re-acquired it had chance to finish acquiring.
+      const delay = kind === 'audio' ? 2000 : 1;
+      const delayPromise = waitForSometime(delay);
+      delayPromise.then(() => {
+        [...remoteMediaTrack._attachments.values()].forEach(el => {
+          const shim = shimmedElements.get(el);
+          if (el.paused && shim && !shim.isPausedIntentionally()) {
+            log.info(`playing paused ${kind} element`);
+            el.play().then(() => {
+              log.info(`successfully played unintentionally paused ${kind} element`);
+            }).catch(err => {
+              log.warn(`error playing paused ${kind} element`, err);
+            });
+          }
+        });
       });
     }
   }

--- a/lib/media/track/remotemediatrack.js
+++ b/lib/media/track/remotemediatrack.js
@@ -214,11 +214,10 @@ function playIfPausedWhileInBackground(remoteMediaTrack) {
   const { _log: log, kind } = remoteMediaTrack;
   function onVisibilityChanged() {
     if (document.visibilityState === 'visible') {
-      // NOTE(mpatwardhan): when document regains foreground restore elements that were
       // NOTE(mpatwardhan): On iOS Safari, play inadvertently paused HTMLAudioElements with
       // a delay to make sure any inadvertently ended LocalMediaTracks are restarted first. Otherwise,
-      // play() will reject with a NotAllowedError.
-      waitForSomeTime(2000).then(() => {
+      // play() rejects with a NotAllowedError.
+      waitForSometime(2000).then(() => {
         remoteMediaTrack._attachments.forEach(el => {
           const shim = shimmedElements.get(el);
           if (el.paused && shim && !shim.isPausedIntentionally()) {


### PR DESCRIPTION
we workaround safari audio [bug](https://bugs.webkit.org/show_bug.cgi?id=212780) by calling play() on media element that were paused.

This fails if the page was not capturing audio - because of race between media capture and media playback on document getting visible. This delay (although not very elegant) fixes this issue.

also updated local tracks to use mediaStreamTrack `ended` event.
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
