### PR TITLE
JSDK-2828 Play inadvertently paused elements after an ended MediaStreamTrack is re-acquired.

### DIFF
--- a/lib/media/track/localmediatrack.js
+++ b/lib/media/track/localmediatrack.js
@@ -1,11 +1,12 @@
 'use strict';
 
-const MediaTrackSender = require('./sender');
 const { getUserMedia } = require('@twilio/webrtc');
 const { guessBrowser } = require('@twilio/webrtc/lib/util');
-const { waitForSometime, waitForEvent } = require('../../util');
+
+const { defer, waitForSometime, waitForEvent } = require('../../util');
 const documentVisibilityMonitor = require('../../util/documentvisibilitymonitor.js');
 const gUMSilentTrackWorkaround = require('../../webaudio/workaround180748');
+const MediaTrackSender = require('./sender');
 
 function mixinLocalMediaTrack(AudioOrVideoTrack) {
   /**
@@ -151,7 +152,7 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
 function restartWhenInadvertentlyStopped(localMediaTrack) {
   const { _getUserMedia: getUserMedia, _gUMSilentTrackWorkaround: gUMSilentTrackWorkaround, _log: log, kind } = localMediaTrack;
   let mediaStreamTrack = localMediaTrack.mediaStreamTrack;
-  let trackChangeInProgress = false;
+  let trackChangeInProgress = null;
 
   function shouldReacquireTrack() {
     const { _workaroundWebKitBug1208516Cleanup, isStopped, mediaStreamTrack: { muted } } = localMediaTrack;
@@ -183,7 +184,7 @@ function restartWhenInadvertentlyStopped(localMediaTrack) {
       waitForSometime(50)
     ]).then(() => {
       if (shouldReacquireTrack()) {
-        trackChangeInProgress = true;
+        trackChangeInProgress = defer();
         return reacquireTrack().then(newTrack => {
           log.info('Re-acquired the MediaStreamTrack.');
           log.debug('MediaStreamTrack:', newTrack);
@@ -195,10 +196,15 @@ function restartWhenInadvertentlyStopped(localMediaTrack) {
           mediaStreamTrack.removeEventListener('ended', handleTrackStateChange);
           mediaStreamTrack = localMediaTrack.mediaStreamTrack;
           mediaStreamTrack.addEventListener('ended', handleTrackStateChange);
-          trackChangeInProgress = false;
+          trackChangeInProgress.resolve();
+          trackChangeInProgress = null;
         });
       }
-      return null;
+
+      // NOTE(mmalavalli): If the MediaStreamTrack ends before the DOM is visible,
+      // then this makes sure that visibility callback for phase 2 is called only
+      // after the MediaStreamTrack is re-acquired.
+      return trackChangeInProgress && trackChangeInProgress.promise;
     });
   }
 

--- a/test/lib/fakemediastream.js
+++ b/test/lib/fakemediastream.js
@@ -86,6 +86,10 @@ class FakeMediaStreamTrack extends EventTarget {
     return clone;
   }
 
+  getConstraints() {
+    return {};
+  }
+
   stop() {
     this.dispatchEvent({
       type: 'ended',

--- a/test/unit/spec/util/documentvisibilitymonitor.js
+++ b/test/unit/spec/util/documentvisibilitymonitor.js
@@ -4,7 +4,7 @@ const Document = require('../../../lib/document');
 const documentVisibilityMonitor = require('../../../../lib/util/documentvisibilitymonitor');
 const { defer, waitForSometime } = require('../../../../lib/util');
 
-describe.only('DocumentVisibilityMonitor', () => {
+describe('DocumentVisibilityMonitor', () => {
   let addEventListenerStub;
   let removeEventListenerStub;
 


### PR DESCRIPTION
@makarandp0 

This PR makes sure that the document visibility phase 1 callback resolves its Promise only after the ended MediaStreamTrack is re-acquired, even when "ended" is fired first.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
