### PR TITLE
JSDK-2802 Stabilizing unstable LocalParticipant tests.

### DIFF
--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -419,11 +419,6 @@ describe('LocalParticipant', function() {
       [
         ['never', 'previously'],
         x => `that has ${x} been published`
-      ],
-      [
-        [true],
-        // eslint-disable-next-line no-unused-vars
-        _x => defaults.topology === 'peer-to-peer' ? '(@unstable: JSDK-2802)' : ''
       ]
     ], ([isEnabled, kind, withName, priority, when]) => {
       // eslint-disable-next-line no-warning-comments
@@ -715,11 +710,6 @@ describe('LocalParticipant', function() {
       [
         ['published', 'published, unpublished, and then published again'],
         x => 'that was ' + x
-      ],
-      [
-        [true],
-        // eslint-disable-next-line no-unused-vars
-        _x => defaults.topology === 'peer-to-peer' ? '(@unstable: JSDK-2803)' : ''
       ]
     ], ([isEnabled, kind, when]) => {
       // eslint-disable-next-line no-warning-comments


### PR DESCRIPTION
@makarandp0 

This PR unmarks the unstable LocalParticipant integration tests. I did so because these tests now pass consistently, and one of them is skipped because the implementation that it tests is not yet scheduled to be worked on.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
