### PR TITLE
JSDK-2909 When restarting a LocalAudioTrack in Firefox, stop existing MediaStreamTrack before calling getUserMedia.

### DIFF
--- a/lib/media/track/localaudiotrack.js
+++ b/lib/media/track/localaudiotrack.js
@@ -1,8 +1,11 @@
 'use strict';
 
+const { guessBrowser } = require('@twilio/webrtc/lib/util');
+
 const AudioTrack = require('./audiotrack');
 const mixinLocalMediaTrack = require('./localmediatrack');
 
+const isFirefox = guessBrowser() === 'firefox';
 const LocalMediaAudioTrack = mixinLocalMediaTrack(AudioTrack);
 
 /**
@@ -108,6 +111,17 @@ class LocalAudioTrack extends LocalMediaAudioTrack {
    * });
    */
   restart() {
+    const constraints = arguments[0] || {};
+
+    // NOTE(mmalavalli): If "deviceId" is present in the constraints, then the developer
+    // is most likely trying to switch audio devices. In Firefox, getUserMedia raises a
+    // NotReadableError when trying to capture from a different audio device while the
+    // existing audio device is still being used. So, we stop the existing MediaStreamTrack
+    // before calling getUserMedia.
+    if (isFirefox && 'deviceId' in constraints) {
+      this._stop();
+    }
+
     return super.restart.apply(this, arguments);
   }
 


### PR DESCRIPTION
@makarandp0 

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
