### PR TITLE
VIDEO-2800 publish signaling events to kibana

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
-The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.org/). Twilio supports version N-1 for 12 months after the first GA release of version N. We recommend you upgrade to the latest version as soon as possible to avoid any breaking changes. Version 2.x is the lastest Video JavaScript SDK. 
+The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.org/). Twilio supports version N-1 for 12 months after the first GA release of version N. We recommend you upgrade to the latest version as soon as possible to avoid any breaking changes. Version 2.x is the lastest Video JavaScript SDK.
 
 **Support for 1.x will cease on December 4th, 2020**. This branch will only receive fixes for critical issues until that date. Check [this guide](https://www.twilio.com/docs/video/migrating-1x-2x) when planning your migration to 2.x. For details on the 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/support-1.x/CHANGELOG.md).
+
+2.7.2 (In Progress)
+===================
+
+Changes
+-------
+- Added metrics about signaling server connections. This is internal change, and has no effect on the SDK API.
+
+
+Bug Fixes
+---------
 
 2.7.1 (July 28, 2020)
 =====================
@@ -13,7 +24,7 @@ Bug Fixes
 - In version [2.6.0](#260-june-26-2020), we had introduced a workaround for this iOS Safari
   [bug](https://bugs.webkit.org/show_bug.cgi?id=208516) which causes your application to lose
   the microphone when another application (Siri, YouTube, FaceTime, etc.) reserves the microphone.
-  This release refactors the workaround to work for **iOS versions 13.6 and above**. (JSDK-2928) 
+  This release refactors the workaround to work for **iOS versions 13.6 and above**. (JSDK-2928)
 - Fixed a bug where, sometimes an iOS Safari Participant's `<audio>` and `<video>`
   elements were paused after handling an incoming phone call. Because of this,
   RemoteParticipants could not be seen and/or heard. (JSDK-2899)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,9 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 
 Changes
 -------
+
 - Added metrics about signaling server connections. This is internal change, and has no effect on the SDK API.
 
-
-Bug Fixes
----------
 
 2.7.1 (July 28, 2020)
 =====================

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -602,6 +602,32 @@ const BandwidthProfileMode = {
   presentation: 'presentation'
 };
 
+
+/**
+ * Names of the supported levels for {@link EventListenerEvent}s.
+ * @enum {string}
+ */
+// eslint-disable-next-line
+const EventListenerLevel = {
+  debug: 'debug',
+  error: 'error',
+  info: 'info',
+  warning: 'warning'
+};
+
+/**
+ * Names of the supported groups for {@link EventListenerEvent}s.
+ * more groups may be added later.
+ * @enum {string}
+ */
+// eslint-disable-next-line
+const EventListenerGroup = {
+  /**
+   * events associated with connection with signaling server
+   */
+  signaling: 'signaling'
+};
+
 /**
  * An {@link EventListener} allows you to listen to fine-grained {@link EventListenerEvent}s related
  * to signaling and media that are not available in the public APIs, which might be useful for your own
@@ -645,8 +671,8 @@ const BandwidthProfileMode = {
  *  * {@link EventListenerWaitingEvent}
  * @typedef {object} EventListenerEvent
  * @property {number} elapsedTime - The time elapsed in milliseconds since connect() was called
- * @property {string} group - The group under which the event is classified
- * @property {string} level - The verbosity level of the event, which can be one of "debug", "error", "info", "warning"
+ * @property {EventListenerGroup} group - The group under which the event is classified
+ * @property {EventListenerLevel} level - The verbosity level of the event, which can be one of "debug", "error", "info", "warning"
  * @property {string} name - The name of the event
  * @property {*} [payload] - Optional event-specific data
  * @property {number} timestamp - The time in milliseconds relative to the Unix Epoch when the event was raised
@@ -655,8 +681,8 @@ const BandwidthProfileMode = {
 /**
  * The connection to Twilio's signaling server was closed.
  * @typedef {EventListenerEvent} EventListenerClosedEvent
- * @property {string} group='signaling'
- * @property {string} level - 'info' if the connection was closed by the client, 'error' otherwise
+ * @property {EventListenerGroup} group='signaling'
+ * @property {EventListenerLevel} level - 'info' if the connection was closed by the client, 'error' otherwise
  * @property {string} name='closed'
  * @property {{reason: string}} payload - Reason for the connection being closed. It can be one of
  *   'busy', 'failed', 'local', 'remote' or 'timeout'
@@ -665,24 +691,24 @@ const BandwidthProfileMode = {
 /**
  * The SDK is connecting to Twilio's signaling server.
  * @typedef {EventListenerEvent} EventListenerConnectingEvent
- * @property {string} group='signaling'
- * @property {string} level='info'
+ * @property {EventListenerGroup} group='signaling'
+ * @property {EventListenerLevel} level='info'
  * @property {string} name='connecting'
  */
 
 /**
  * The SDK is about to connect to Twilio's signaling server.
  * @typedef {EventListenerEvent} EventListenerEarlyEvent
- * @property {string} group='signaling'
- * @property {string} level='info'
+ * @property {EventListenerGroup} group='signaling'
+ * @property {EventListenerLevel} level='info'
  * @property {string} name='early'
  */
 
 /**
  * The SDK has established a signaling connection to Twilio's signaling server.
  * @typedef {EventListenerEvent} EventListenerOpenEvent
- * @property {string} group='signaling'
- * @property {string} level='info'
+ * @property {EventListenerGroup} group='signaling'
+ * @property {EventListenerLevel} level='info'
  * @property {string} name='open'
  */
 
@@ -690,8 +716,8 @@ const BandwidthProfileMode = {
  * The SDK is waiting to retry connecting th Twilio's signaling server. This can
  * happen if the server is busy with too many connection requests.
  * @typedef {EventListenerEvent} EventListenerWaitingEvent
- * @property {string} group='signaling'
- * @property {string} level='warning'
+ * @property {EventListenerGroup} group='signaling'
+ * @property {EventListenerLevel} level='warning'
  * @property {string} name='waiting'
  */
 

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -617,13 +617,12 @@ const EventListenerLevel = {
 
 /**
  * Names of the supported groups for {@link EventListenerEvent}s.
- * more groups may be added later.
  * @enum {string}
  */
 // eslint-disable-next-line
 const EventListenerGroup = {
   /**
-   * events associated with connection with signaling server
+   * Events associated with the connection to Twilio's signaling server
    */
   signaling: 'signaling'
 };

--- a/lib/signaling/v2/cancelableroomsignalingpromise.js
+++ b/lib/signaling/v2/cancelableroomsignalingpromise.js
@@ -105,7 +105,7 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
       wsServer,
       transportOptions);
 
-    eventObserver.setTransport(transport);
+    // eventObserver.setTransport(transport);
 
     transport.once('connected', initialState => {
       log.debug('Transport connected:', initialState);

--- a/lib/signaling/v2/cancelableroomsignalingpromise.js
+++ b/lib/signaling/v2/cancelableroomsignalingpromise.js
@@ -105,8 +105,6 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
       wsServer,
       transportOptions);
 
-    // eventObserver.setTransport(transport);
-
     transport.once('connected', initialState => {
       log.debug('Transport connected:', initialState);
       if (isCanceled()) {

--- a/lib/signaling/v2/cancelableroomsignalingpromise.js
+++ b/lib/signaling/v2/cancelableroomsignalingpromise.js
@@ -105,6 +105,8 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
       wsServer,
       transportOptions);
 
+    eventObserver.setTransport(transport);
+
     transport.once('connected', initialState => {
       log.debug('Transport connected:', initialState);
       if (isCanceled()) {

--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -186,6 +186,11 @@ class TwilioConnectionTransport extends StateMachine {
         value: wsServer
       }
     });
+
+    if (options.eventObserver) {
+      options.eventObserver.setPublisher(this._eventPublisher);
+    }
+
     setupTransport(this);
 
     this.once('connected', ({ sid, participant }) => {

--- a/lib/twilioconnection.js
+++ b/lib/twilioconnection.js
@@ -181,7 +181,7 @@ class TwilioConnection extends StateMachine {
       }
     });
 
-    const eventToLevel = {
+    const eventsToLevels = {
       connecting: 'info',
       early: 'info',
       open: 'info',
@@ -193,7 +193,7 @@ class TwilioConnection extends StateMachine {
       if (state in events) {
         this.emit(events[state], ...args);
       }
-      const event = { name: state, group: 'signaling', level: eventToLevel[this.state] };
+      const event = { name: state, group: 'signaling', level: eventsToLevels[this.state] };
       if (state === 'closed') {
         const [reason] = args;
         event.payload = { reason };

--- a/lib/twilioconnection.js
+++ b/lib/twilioconnection.js
@@ -202,7 +202,7 @@ class TwilioConnection extends StateMachine {
       this._eventObserver.emit('event', event);
     });
 
-    this._eventObserver.emit('event', { name: this.state, group: 'signaling', level: eventToLevel[this.state] });
+    this._eventObserver.emit('event', { name: this.state, group: 'signaling', level: eventsToLevels[this.state] });
     this._connect();
   }
 

--- a/lib/twilioconnection.js
+++ b/lib/twilioconnection.js
@@ -181,19 +181,28 @@ class TwilioConnection extends StateMachine {
       }
     });
 
+    const eventToLevel = {
+      connecting: 'info',
+      early: 'info',
+      open: 'info',
+      waiting: 'warning',
+      closed: 'info'
+    };
+
     this.on('stateChanged', (state, ...args) => {
       if (state in events) {
         this.emit(events[state], ...args);
       }
-      const event = { name: state };
+      const event = { name: state, group: 'signaling', level: eventToLevel[this.state] };
       if (state === 'closed') {
         const [reason] = args;
         event.payload = { reason };
+        event.level = reason === CloseReason.LOCAL ? 'info' : 'error';
       }
       this._eventObserver.emit('event', event);
     });
 
-    this._eventObserver.emit('event', { name: this.state });
+    this._eventObserver.emit('event', { name: this.state, group: 'signaling', level: eventToLevel[this.state] });
     this._connect();
   }
 

--- a/lib/util/eventobserver.js
+++ b/lib/util/eventobserver.js
@@ -54,7 +54,7 @@ class EventObserver extends EventEmitter {
 
       if (this._publisher) {
         const publisherPayload = Object.assign(payload ? payload : {}, { elapsedTime, level });
-        this._publisher.publishEvent(group, name, publisherPayload);
+        this._publisher.publish(group, name, publisherPayload);
       }
 
       if (eventListener) {

--- a/lib/util/eventobserver.js
+++ b/lib/util/eventobserver.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 'use strict';
 
 const { EventEmitter } = require('events');
@@ -48,27 +49,41 @@ class EventObserver extends EventEmitter {
   constructor(connectTimestamp, eventListener = null) {
     super();
 
-    if (eventListener) {
-      this.on('event', ({ name, payload }) => {
-        const timestamp = Date.now();
-        const elapsedTime = timestamp - connectTimestamp;
-        const group = eventNamesToGroups[name];
+    Object.defineProperties(this, {
+      _transport: {
+        value: null,
+        writable: true
+      }
+    });
 
-        const level = typeof eventNamesToLevels[name] === 'function'
-          ? eventNamesToLevels[name](payload)
-          : eventNamesToLevels[name];
+    this.on('event', ({ name, payload }) => {
+      const timestamp = Date.now();
+      const elapsedTime = timestamp - connectTimestamp;
+      const group = eventNamesToGroups[name];
 
-        const event = Object.assign(payload ? { payload } : {}, {
-          elapsedTime,
-          group,
-          level,
-          name,
-          timestamp
-        });
+      const level = typeof eventNamesToLevels[name] === 'function'
+        ? eventNamesToLevels[name](payload)
+        : eventNamesToLevels[name];
 
-        eventListener.emit('event', event);
-      });
-    }
+      const event = Object.assign(payload ? { payload } : { elapsedTime, level });
+
+      if (this._transport) {
+        console.log('makarand: publishing event', group, name, event);
+        this._transport.publishEvent(group, name, event);
+      }
+
+      const eventForListener = Object.assign({}, event, { group, name, timestamp });
+
+      if (eventListener) {
+        eventListener.emit('event', eventForListener);
+      }
+
+    });
+  }
+
+  setTransport(transport) {
+    // transport is set.
+    this._transport = transport;
   }
 }
 

--- a/lib/util/eventobserver.js
+++ b/lib/util/eventobserver.js
@@ -14,7 +14,6 @@ const VALID_LEVELS = [
   'warning'
 ];
 
-
 /**
  * EventObserver listens to SDK events and re-emits them on the
  * @link EventListener} with some additional information.
@@ -72,7 +71,6 @@ class EventObserver extends EventEmitter {
   }
 
   setPublisher(publisher) {
-    // transport is set.
     this._publisher = publisher;
   }
 }

--- a/lib/util/eventobserver.js
+++ b/lib/util/eventobserver.js
@@ -70,6 +70,10 @@ class EventObserver extends EventEmitter {
     });
   }
 
+  /**
+   * sets the publisher object. Once set events will be send to publisher.
+   * @param {InsightsPublisher} publisher
+  */
   setPublisher(publisher) {
     this._publisher = publisher;
   }

--- a/lib/util/eventobserver.js
+++ b/lib/util/eventobserver.js
@@ -3,36 +3,17 @@
 
 const { EventEmitter } = require('events');
 
-const { CloseReason: { LOCAL } } = require('../twilioconnection');
+const VALID_GROUPS = [
+  'signaling'
+];
 
-const GROUPS = {
-  SIGNALING: 'signaling'
-};
+const VALID_LEVELS = [
+  'debug',
+  'error',
+  'info',
+  'warning'
+];
 
-const LEVELS = {
-  DEBUG: 'debug',
-  ERROR: 'error',
-  INFO: 'info',
-  WARNING: 'warning'
-};
-
-const eventNamesToGroups = {
-  closed: GROUPS.SIGNALING,
-  connecting: GROUPS.SIGNALING,
-  early: GROUPS.SIGNALING,
-  open: GROUPS.SIGNALING,
-  waiting: GROUPS.SIGNALING
-};
-
-const eventNamesToLevels = {
-  closed(payload) {
-    return payload.reason === LOCAL ? LEVELS.INFO : LEVELS.ERROR;
-  },
-  connecting: LEVELS.INFO,
-  early: LEVELS.INFO,
-  open: LEVELS.INFO,
-  waiting: LEVELS.WARNING
-};
 
 /**
  * EventObserver listens to SDK events and re-emits them on the
@@ -50,40 +31,49 @@ class EventObserver extends EventEmitter {
     super();
 
     Object.defineProperties(this, {
-      _transport: {
+      _publisher: {
         value: null,
         writable: true
       }
     });
 
-    this.on('event', ({ name, payload }) => {
+    this.on('event', ({ name, group, level, payload }) => {
+      if (typeof name !== 'string') {
+        throw new Error('Unexpected name: ', name);
+      }
+
+      if (!VALID_GROUPS.includes(group)) {
+        throw new Error('Unexpected group: ', group);
+      }
+
+      if (!VALID_LEVELS.includes(level)) {
+        throw new Error('Unexpected level: ', level);
+      }
+
       const timestamp = Date.now();
       const elapsedTime = timestamp - connectTimestamp;
-      const group = eventNamesToGroups[name];
 
-      const level = typeof eventNamesToLevels[name] === 'function'
-        ? eventNamesToLevels[name](payload)
-        : eventNamesToLevels[name];
-
-      const event = Object.assign(payload ? { payload } : { elapsedTime, level });
-
-      if (this._transport) {
-        console.log('makarand: publishing event', group, name, event);
-        this._transport.publishEvent(group, name, event);
+      if (this._publisher) {
+        const publisherPayload = Object.assign(payload ? payload : {}, { elapsedTime, level });
+        this._publisher.publishEvent(group, name, publisherPayload);
       }
-
-      const eventForListener = Object.assign({}, event, { group, name, timestamp });
 
       if (eventListener) {
-        eventListener.emit('event', eventForListener);
+        const event = Object.assign(payload ? { payload } : {}, {
+          elapsedTime,
+          group,
+          level,
+          name,
+          timestamp
+        });
+        eventListener.emit('event', event);
       }
-
     });
   }
 
-  setTransport(transport) {
+  setPublisher(publisher) {
     // transport is set.
-    this._transport = transport;
+    this._publisher = publisher;
   }
 }
 

--- a/test/unit/spec/twilioconnection.js
+++ b/test/unit/spec/twilioconnection.js
@@ -95,7 +95,7 @@ describe('TwilioConnection', function() {
     });
 
     it('should emit "event" on the EventObserver', () => {
-      sinon.assert.calledWith(eventObserver.emit, 'event', { name: 'early' });
+      sinon.assert.calledWith(eventObserver.emit, 'event', { name: 'early', group: 'signaling', level: 'info' });
     });
   });
 
@@ -105,30 +105,30 @@ describe('TwilioConnection', function() {
 
       const expectedEvents = {
         closed: [
-          { name: 'early' },
-          { name: 'connecting' },
-          { name: 'closed', payload: { reason: 'local' } }
+          { name: 'early', group: 'signaling', level: 'info' },
+          { name: 'connecting', group: 'signaling', level: 'info' },
+          { name: 'closed', group: 'signaling', level: 'info', payload: { reason: 'local' } }
         ],
         connecting: [
-          { name: 'early' },
-          { name: 'connecting' },
-          { name: 'closed', payload: { reason: 'local' } }
+          { name: 'early', group: 'signaling', level: 'info' },
+          { name: 'connecting', group: 'signaling', level: 'info' },
+          { name: 'closed', group: 'signaling', level: 'info', payload: { reason: 'local' } }
         ],
         early: [
-          { name: 'early' },
-          { name: 'closed', payload: { reason: 'local' } }
+          { name: 'early', group: 'signaling', level: 'info' },
+          { name: 'closed', group: 'signaling', level: 'info', payload: { reason: 'local' } }
         ],
         open: [
-          { name: 'early' },
-          { name: 'connecting' },
-          { name: 'open' },
-          { name: 'closed', payload: { reason: 'local' } }
+          { name: 'early', group: 'signaling', level: 'info' },
+          { name: 'connecting', group: 'signaling', level: 'info' },
+          { name: 'open', group: 'signaling', level: 'info' },
+          { name: 'closed', group: 'signaling', level: 'info', payload: { reason: 'local' } }
         ],
         waiting: [
-          { name: 'early' },
-          { name: 'connecting' },
-          { name: 'waiting' },
-          { name: 'closed', payload: { reason: 'local' } }
+          { name: 'early', group: 'signaling', level: 'info' },
+          { name: 'connecting', group: 'signaling', level: 'info' },
+          { name: 'waiting', group: 'signaling', level: 'warning' },
+          { name: 'closed', group: 'signaling', level: 'info', payload: { reason: 'local' } }
         ]
       }[state];
 
@@ -327,8 +327,8 @@ describe('TwilioConnection', function() {
           });
 
           testEventObserverEvents(() => eventObserver, [
-            { name: 'early' },
-            { name: 'closed', payload: { reason: 'timeout' } }
+            { name: 'early', group: 'signaling', level: 'info' },
+            { name: 'closed', group: 'signaling', level: 'error', payload: { reason: 'timeout' } }
           ]);
         });
 
@@ -353,8 +353,8 @@ describe('TwilioConnection', function() {
           });
 
           testEventObserverEvents(() => eventObserver, [
-            { name: 'early' },
-            { name: 'connecting' }
+            { name: 'early', group: 'signaling', level: 'info' },
+            { name: 'connecting', group: 'signaling', level: 'info' }
           ]);
 
           context('when a "welcome" message is received within the "welcome" timeout', () => {
@@ -401,9 +401,9 @@ describe('TwilioConnection', function() {
             });
 
             testEventObserverEvents(() => eventObserver, [
-              { name: 'early' },
-              { name: 'connecting' },
-              { name: 'open' }
+              { name: 'early', group: 'signaling', level: 'info' },
+              { name: 'connecting', group: 'signaling', level: 'info' },
+              { name: 'open', group: 'signaling', level: 'info' }
             ]);
 
             context('when the TwilioConnection fails to receive any "heartbeat" messages', () => {
@@ -430,10 +430,10 @@ describe('TwilioConnection', function() {
               });
 
               testEventObserverEvents(() => eventObserver, [
-                { name: 'early' },
-                { name: 'connecting' },
-                { name: 'open' },
-                { name: 'closed', payload: { reason: 'timeout' } }
+                { name: 'early', group: 'signaling', level: 'info' },
+                { name: 'connecting', group: 'signaling', level: 'info' },
+                { name: 'open', group: 'signaling', level: 'info' },
+                { name: 'closed', group: 'signaling', level: 'error', payload: { reason: 'timeout' } }
               ]);
             });
 
@@ -522,9 +522,9 @@ describe('TwilioConnection', function() {
             });
 
             testEventObserverEvents(() => eventObserver, [
-              { name: 'early' },
-              { name: 'connecting' },
-              { name: 'closed', payload: { reason: 'failed' } }
+              { name: 'early', group: 'signaling', level: 'info' },
+              { name: 'connecting', group: 'signaling', level: 'info' },
+              { name: 'closed', group: 'signaling', level: 'error', payload: { reason: 'failed' } }
             ]);
           });
 
@@ -589,9 +589,9 @@ describe('TwilioConnection', function() {
                 });
 
                 testEventObserverEvents(() => eventObserver, [
-                  { name: 'early' },
-                  { name: 'connecting' },
-                  { name: 'closed', payload: { reason: 'busy' } }
+                  { name: 'early', group: 'signaling', level: 'info' },
+                  { name: 'connecting', group: 'signaling', level: 'info' },
+                  { name: 'closed', group: 'signaling', level: 'error', payload: { reason: 'busy' } }
                 ]);
               } else {
                 it('should set the TwilioConnection\'s .state to "waiting"', () => {
@@ -607,9 +607,9 @@ describe('TwilioConnection', function() {
                 });
 
                 testEventObserverEvents(() => eventObserver, [
-                  { name: 'early' },
-                  { name: 'connecting' },
-                  { name: 'waiting' }
+                  { name: 'early', group: 'signaling', level: 'info' },
+                  { name: 'connecting', group: 'signaling', level: 'info' },
+                  { name: 'waiting', group: 'signaling', level: 'warning' }
                 ]);
 
                 if (keepAlive) {
@@ -657,10 +657,10 @@ describe('TwilioConnection', function() {
                     });
 
                     testEventObserverEvents(() => eventObserver, [
-                      { name: 'early' },
-                      { name: 'connecting' },
-                      { name: 'waiting' },
-                      { name: 'open' }
+                      { name: 'early', group: 'signaling', level: 'info' },
+                      { name: 'connecting', group: 'signaling', level: 'info' },
+                      { name: 'waiting', group: 'signaling', level: 'warning' },
+                      { name: 'open', group: 'signaling', level: 'info' }
                     ]);
                   });
 
@@ -692,10 +692,10 @@ describe('TwilioConnection', function() {
                     });
 
                     testEventObserverEvents(() => eventObserver, [
-                      { name: 'early' },
-                      { name: 'connecting' },
-                      { name: 'waiting' },
-                      { name: 'connecting' }
+                      { name: 'early', group: 'signaling', level: 'info' },
+                      { name: 'connecting', group: 'signaling', level: 'info' },
+                      { name: 'waiting', group: 'signaling', level: 'warning' },
+                      { name: 'connecting', group: 'signaling', level: 'info' }
                     ]);
                   });
                 } else {
@@ -733,11 +733,11 @@ describe('TwilioConnection', function() {
                     });
 
                     testEventObserverEvents(() => eventObserver, [
-                      { name: 'early' },
-                      { name: 'connecting' },
-                      { name: 'waiting' },
-                      { name: 'early' },
-                      { name: 'connecting' }
+                      { name: 'early', group: 'signaling', level: 'info' },
+                      { name: 'connecting', group: 'signaling', level: 'info' },
+                      { name: 'waiting', group: 'signaling', level: 'warning' },
+                      { name: 'early', group: 'signaling', level: 'info' },
+                      { name: 'connecting', group: 'signaling', level: 'info' }
                     ]);
                   });
                 }
@@ -770,9 +770,9 @@ describe('TwilioConnection', function() {
               });
 
               testEventObserverEvents(() => eventObserver, [
-                { name: 'early' },
-                { name: 'connecting' },
-                { name: 'closed', payload: { reason: 'timeout' } }
+                { name: 'early', group: 'signaling', level: 'info' },
+                { name: 'connecting', group: 'signaling', level: 'info' },
+                { name: 'closed', group: 'signaling', level: 'error', payload: { reason: 'timeout' } }
               ]);
             });
 
@@ -816,9 +816,9 @@ describe('TwilioConnection', function() {
               });
 
               testEventObserverEvents(() => eventObserver, [
-                { name: 'early' },
-                { name: 'connecting' },
-                { name: 'open' }
+                { name: 'early', group: 'signaling', level: 'info' },
+                { name: 'connecting', group: 'signaling', level: 'info' },
+                { name: 'open', group: 'signaling', level: 'info' }
               ]);
             });
           });


### PR DESCRIPTION
This changes updates eventObserver to publish events to kibana. This change needs to go in following sequence 

Step 1: [x] [Update the schema](https://code.hq.twilio.com/client/rtc-insights-spec/pull/59) 
Step 2: [x] [update the backend](https://code.hq.twilio.com/ra/sdki-ws-gateway/pull/88) to handle new events
Step 3: [ ] cut rc with this change + push backend to stage for QA tests.
 
 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
