### PR TITLE
JSDK-2914 Work around Chromium bug 1106157 by disabling RTX for Firefox 79+.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 
 **Support for 1.x will cease on December 4th, 2020**. This branch will only receive fixes for critical issues until that date. Check [this guide](https://www.twilio.com/docs/video/migrating-1x-2x) when planning your migration to 2.x. For details on the 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/support-1.x/CHANGELOG.md).
 
+2.7.1 (in progress)
+===================
+
+Bug Fixes
+---------
+
+- Fixed a bug where audio only Firefox 79+ and Chrome Participants could not hear each
+  other in a Peer to Peer Room due to this [Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1106157). (JSDK-2914)
+
 2.7.0 (July 8, 2020)
 ====================
 

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -538,9 +538,7 @@ class PeerConnectionV2 extends StateMachine {
     }).then(() => {
       return this._peerConnection.createAnswer();
     }).then(answer => {
-      if (!isFirefox) {
-        answer = workaroundIssue8329(answer);
-      } else {
+      if (isFirefox) {
         // NOTE(mmalavalli): We work around Chromium bug 1106157 by disabling
         // RTX in Firefox 79+. For more details about the bug, please go here:
         // https://bugs.chromium.org/p/chromium/issues/detail?id=1106157
@@ -548,6 +546,8 @@ class PeerConnectionV2 extends StateMachine {
           sdp: disableRtx(answer.sdp),
           type: answer.type
         });
+      } else {
+        answer = workaroundIssue8329(answer);
       }
 
       // NOTE(mpatwardhan): Upcoming chrome versions are going to remove ssrc attributes
@@ -911,9 +911,7 @@ class PeerConnectionV2 extends StateMachine {
     }).catch(() => {
       throw new MediaClientLocalDescFailedError();
     }).then(offer => {
-      if (!isFirefox) {
-        offer = workaroundIssue8329(offer);
-      } else {
+      if (isFirefox) {
         // NOTE(mmalavalli): We work around Chromium bug 1106157 by disabling
         // RTX in Firefox 79+. For more details about the bug, please go here:
         // https://bugs.chromium.org/p/chromium/issues/detail?id=1106157
@@ -921,6 +919,8 @@ class PeerConnectionV2 extends StateMachine {
           sdp: disableRtx(offer.sdp),
           type: offer.type
         });
+      } else {
+        offer = workaroundIssue8329(offer);
       }
 
       // NOTE(mpatwardhan): upcoming chrome versions are going to remove ssrc attributes

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -22,6 +22,7 @@ const {
 
 const {
   createCodecMapForMediaSection,
+  disableRtx,
   getMediaSections,
   removeSSRCAttributes,
   revertSimulcastForNonVP8MediaSections,
@@ -539,6 +540,14 @@ class PeerConnectionV2 extends StateMachine {
     }).then(answer => {
       if (!isFirefox) {
         answer = workaroundIssue8329(answer);
+      } else {
+        // NOTE(mmalavalli): We work around Chromium bug 1106157 by disabling
+        // RTX in Firefox 79+. For more details about the bug, please go here:
+        // https://bugs.chromium.org/p/chromium/issues/detail?id=1106157
+        answer = new this._RTCSessionDescription({
+          sdp: disableRtx(answer.sdp),
+          type: answer.type
+        });
       }
 
       // NOTE(mpatwardhan): Upcoming chrome versions are going to remove ssrc attributes
@@ -904,6 +913,14 @@ class PeerConnectionV2 extends StateMachine {
     }).then(offer => {
       if (!isFirefox) {
         offer = workaroundIssue8329(offer);
+      } else {
+        // NOTE(mmalavalli): We work around Chromium bug 1106157 by disabling
+        // RTX in Firefox 79+. For more details about the bug, please go here:
+        // https://bugs.chromium.org/p/chromium/issues/detail?id=1106157
+        offer = new this._RTCSessionDescription({
+          sdp: disableRtx(offer.sdp),
+          type: offer.type
+        });
       }
 
       // NOTE(mpatwardhan): upcoming chrome versions are going to remove ssrc attributes

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -501,7 +501,7 @@ function unifiedPlanAddOrRewriteTrackIds(sdp, midsToTrackIds) {
 /**
  * removes specified ssrc attributes from given sdp
  * @param {string} sdp
- * @returns {Array<string>} ssrcAttributesToRemove
+ * @param {Array<string>} ssrcAttributesToRemove
  * @returns {string}
  */
 function removeSSRCAttributes(sdp, ssrcAttributesToRemove) {
@@ -510,9 +510,65 @@ function removeSSRCAttributes(sdp, ssrcAttributesToRemove) {
   ).join('\r\n');
 }
 
+/**
+ * Disable RTX in a given sdp.
+ * @param {string} sdp
+ * @returns {string} sdp without RTX
+ */
+function disableRtx(sdp) {
+  const mediaSections = getMediaSections(sdp);
+  const session = sdp.split('\r\nm=')[0];
+  return [session].concat(mediaSections.map(mediaSection => {
+    // Do nothing if the m= section does not represent a video track.
+    if (!/^m=video/.test(mediaSection)) {
+      return mediaSection;
+    }
+
+    // Create a map of codecs to payload types.
+    const codecsToPts = createCodecMapForMediaSection(mediaSection);
+    // Get the RTX payload types.
+    const rtxPts = codecsToPts.get('rtx');
+
+    // Do nothing if there are no RTX payload types.
+    if (!rtxPts) {
+      return mediaSection;
+    }
+
+    // Remove the RTX payload types.
+    const pts = new Set(getPayloadTypesInMediaSection(mediaSection));
+    rtxPts.forEach(rtxPt => pts.delete(rtxPt));
+
+    // Get the RTX SSRC.
+    const rtxSSRCMatches = mediaSection.match(/a=ssrc-group:FID [0-9]+ ([0-9]+)/);
+    const rtxSSRC = rtxSSRCMatches && rtxSSRCMatches[1];
+
+    // Remove the following lines associated with the RTX payload types:
+    // 1. "a=fmtp:<rtxPt> apt=<pt>"
+    // 2. "a=rtpmap:<rtxPt> rtx/..."
+    // 3. "a=ssrc:<rtxSSRC> cname:..."
+    // 4. "a=ssrc-group:FID <SSRC> <rtxSSRC>"
+    const filterRegexes = [
+      /^a=fmtp:.+ apt=.+$/,
+      /^a=rtpmap:.+ rtx\/.+$/,
+      /^a=ssrc-group:.+$/
+    ].concat(rtxSSRC
+      ? [new RegExp(`^a=ssrc:${rtxSSRC} .+$`)]
+      : []);
+
+    mediaSection = mediaSection.split('\r\n')
+      .filter(line => filterRegexes.every(regex => !regex.test(line)))
+      .join('\r\n');
+
+    // Reconstruct the m= section without the RTX payload types.
+    return setPayloadTypesInMediaSection(Array.from(pts), mediaSection);
+  })).join('\r\n');
+}
+
 exports.createCodecMapForMediaSection = createCodecMapForMediaSection;
 exports.createPtToCodecName = createPtToCodecName;
+exports.disableRtx = disableRtx;
 exports.getMediaSections = getMediaSections;
+exports.removeSSRCAttributes = removeSSRCAttributes;
 exports.revertSimulcastForNonVP8MediaSections = revertSimulcastForNonVP8MediaSections;
 exports.setBitrateParameters = setBitrateParameters;
 exports.setCodecPreferences = setCodecPreferences;
@@ -520,5 +576,4 @@ exports.setSimulcast = setSimulcast;
 exports.unifiedPlanFilterLocalCodecs = unifiedPlanFilterLocalCodecs;
 exports.unifiedPlanAddOrRewriteNewTrackIds = unifiedPlanAddOrRewriteNewTrackIds;
 exports.unifiedPlanAddOrRewriteTrackIds = unifiedPlanAddOrRewriteTrackIds;
-exports.removeSSRCAttributes = removeSSRCAttributes;
 

--- a/test/unit/spec/util/sdp/index.js
+++ b/test/unit/spec/util/sdp/index.js
@@ -5,6 +5,7 @@ const assert = require('assert');
 const { flatMap } = require('../../../../../lib/util');
 
 const {
+  disableRtx,
   getMediaSections,
   setBitrateParameters,
   setCodecPreferences,
@@ -979,6 +980,189 @@ describe('removeSSRCAttributes', () => {
   tests.forEach(test => {
     it(test.name, () => {
       assert.equal(removeSSRCAttributes(test.before, test.remove), test.after);
+    });
+  });
+});
+
+describe('disableRtx', () => {
+  const sdpWithoutRtx = `v=0\r
+o=mozilla...THIS_IS_SDPARTA-78.0.1 914717455470386583 0 IN IP4 0.0.0.0\r
+s=-\r
+t=0 0\r
+a=fingerprint:sha-256 64:C5:43:F0:DE:63:49:1C:80:85:98:98:48:EA:50:38:DF:1E:95:28:5A:F2:5B:22:A3:9D:6E:C7:F5:66:A4:73\r
+a=group:BUNDLE 0 1\r
+a=ice-options:trickle\r
+a=msid-semantic:WMS *\r
+m=audio 9 UDP/TLS/RTP/SAVPF 111 9 0 8 126\r
+c=IN IP4 0.0.0.0\r
+a=sendrecv\r
+a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r
+a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:mid\r
+a=fmtp:111 maxplaybackrate=48000;stereo=1;useinbandfec=1\r
+a=fmtp:126 0-15\r
+a=ice-pwd:87bc3b58d14e6e747ec7607495db1e36\r
+a=ice-ufrag:73f379bf\r
+a=mid:0\r
+a=msid:{7c81c628-2293-d24f-b6a6-612725ade021} {c04b41b9-0284-c549-bb2b-ba0d430f18d2}\r
+a=rtcp-mux\r
+a=rtpmap:111 opus/48000/2\r
+a=rtpmap:9 G722/8000/1\r
+a=rtpmap:0 PCMU/8000\r
+a=rtpmap:8 PCMA/8000\r
+a=rtpmap:126 telephone-event/8000/1\r
+a=setup:active\r
+a=ssrc:599948313 cname:{69b8d6b0-3ec4-004c-98e0-543de2b8e22f}\r
+m=video 9 UDP/TLS/RTP/SAVPF 96 98 125 108\r
+c=IN IP4 0.0.0.0\r
+a=inactive\r
+a=extmap:14 urn:ietf:params:rtp-hdrext:toffset\r
+a=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r
+a=extmap:12 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay\r
+a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:mid\r
+a=fmtp:125 profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1\r
+a=fmtp:108 profile-level-id=42e01f;level-asymmetry-allowed=1\r
+a=fmtp:96 max-fs=12288;max-fr=60\r
+a=fmtp:98 max-fs=12288;max-fr=60\r
+a=ice-pwd:87bc3b58d14e6e747ec7607495db1e36\r
+a=ice-ufrag:73f379bf\r
+a=mid:1\r
+a=rtcp-fb:96 nack\r
+a=rtcp-fb:96 nack pli\r
+a=rtcp-fb:96 ccm fir\r
+a=rtcp-fb:96 goog-remb\r
+a=rtcp-fb:98 nack\r
+a=rtcp-fb:98 nack pli\r
+a=rtcp-fb:98 ccm fir\r
+a=rtcp-fb:98 goog-remb\r
+a=rtcp-fb:125 nack\r
+a=rtcp-fb:125 nack pli\r
+a=rtcp-fb:125 ccm fir\r
+a=rtcp-fb:125 goog-remb\r
+a=rtcp-fb:108 nack\r
+a=rtcp-fb:108 nack pli\r
+a=rtcp-fb:108 ccm fir\r
+a=rtcp-fb:108 goog-remb\r
+a=rtcp-mux\r
+a=rtpmap:96 VP8/90000\r
+a=rtpmap:98 VP9/90000\r
+a=rtpmap:125 H264/90000\r
+a=rtpmap:108 H264/90000\r
+a=setup:active\r
+a=ssrc:123182331 cname:{69b8d6b0-3ec4-004c-98e0-543de2b8e22f}`;
+
+  const sdpWithRtx = `v=0\r
+o=mozilla...THIS_IS_SDPARTA-79.0 182335824049326962 0 IN IP4 0.0.0.0\r
+s=-\r
+t=0 0\r
+a=fingerprint:sha-256 24:B0:F9:5C:CD:C4:88:C2:9B:DE:CC:B1:D7:9C:41:7B:1D:94:C8:2A:87:8C:A3:F6:94:83:AC:30:64:00:4C:E5\r
+a=group:BUNDLE 0 1\r
+a=ice-options:trickle\r
+a=msid-semantic:WMS *\r
+m=audio 9 UDP/TLS/RTP/SAVPF 111 9 0 8 126\r
+c=IN IP4 0.0.0.0\r
+a=sendrecv\r
+a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r
+a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:mid\r
+a=fmtp:111 maxplaybackrate=48000;stereo=1;useinbandfec=1\r
+a=fmtp:126 0-15\r
+a=ice-pwd:00887f6cd54bbbdde038834c933f944e\r
+a=ice-ufrag:3914f648\r
+a=mid:0\r
+a=msid:{ecaa60a2-3118-3d43-a5c8-0793a8a5b0cc} {dae6631b-a5f7-c047-a11f-22b467ccb280}\r
+a=rtcp-mux\r
+a=rtpmap:111 opus/48000/2\r
+a=rtpmap:9 G722/8000/1\r
+a=rtpmap:0 PCMU/8000\r
+a=rtpmap:8 PCMA/8000\r
+a=rtpmap:126 telephone-event/8000/1\r
+a=setup:active\r
+a=ssrc:3010114044 cname:{fd6b9593-e05a-f34f-b91a-389a1874c13c}\r
+m=video 9 UDP/TLS/RTP/SAVPF 96 97 99 107 109 98 125 108\r
+c=IN IP4 0.0.0.0\r
+a=inactive\r
+a=extmap:14 urn:ietf:params:rtp-hdrext:toffset\r
+a=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r
+a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01\r
+a=extmap:12 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay\r
+a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:mid\r
+a=fmtp:125 profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1\r
+a=fmtp:108 profile-level-id=42e01f;level-asymmetry-allowed=1\r
+a=fmtp:96 max-fs=12288;max-fr=60\r
+a=fmtp:97 apt=96\r
+a=fmtp:98 max-fs=12288;max-fr=60\r
+a=fmtp:99 apt=98\r
+a=fmtp:107 apt=125\r
+a=fmtp:109 apt=108\r
+a=ice-pwd:00887f6cd54bbbdde038834c933f944e\r
+a=ice-ufrag:3914f648\r
+a=mid:1\r
+a=rtcp-fb:96 nack\r
+a=rtcp-fb:96 nack pli\r
+a=rtcp-fb:96 ccm fir\r
+a=rtcp-fb:96 goog-remb\r
+a=rtcp-fb:96 transport-cc\r
+a=rtcp-fb:98 nack\r
+a=rtcp-fb:98 nack pli\r
+a=rtcp-fb:98 ccm fir\r
+a=rtcp-fb:98 goog-remb\r
+a=rtcp-fb:98 transport-cc\r
+a=rtcp-fb:125 nack\r
+a=rtcp-fb:125 nack pli\r
+a=rtcp-fb:125 ccm fir\r
+a=rtcp-fb:125 goog-remb\r
+a=rtcp-fb:125 transport-cc\r
+a=rtcp-fb:108 nack\r
+a=rtcp-fb:108 nack pli\r
+a=rtcp-fb:108 ccm fir\r
+a=rtcp-fb:108 goog-remb\r
+a=rtcp-fb:108 transport-cc\r
+a=rtcp-mux\r
+a=rtpmap:96 VP8/90000\r
+a=rtpmap:97 rtx/90000\r
+a=rtpmap:98 VP9/90000\r
+a=rtpmap:99 rtx/90000\r
+a=rtpmap:125 H264/90000\r
+a=rtpmap:107 rtx/90000\r
+a=rtpmap:108 H264/90000\r
+a=rtpmap:109 rtx/90000\r
+a=setup:active\r
+a=ssrc:2476366320 cname:{fd6b9593-e05a-f34f-b91a-389a1874c13c}\r
+a=ssrc:3143435575 cname:{fd6b9593-e05a-f34f-b91a-389a1874c13c}\r
+a=ssrc-group:FID 2476366320 3143435575`;
+
+  [sdpWithoutRtx, sdpWithRtx].forEach(sdp => {
+    const rtxFmtpRegex = /^a=fmtp:.+ apt=.+$/gm;
+    const rtxPts = [97, 99, 107, 109];
+    const rtxRtpmapRegex = /^a=rtpmap:.+ rtx\/.+$/gm;
+    const rtxSSRCAttrRegex = /^a=ssrc:3143435575 .+$/gm;
+    const shouldRemoveRtx = sdp === sdpWithRtx;
+    const ssrcGroupRegex = /^a=ssrc-group:FID .+ .+$/gm;
+
+    it(`should ${shouldRemoveRtx ? 'disable RTX' : 'do nothing'}`, () => {
+      const sdp1 = disableRtx(sdp);
+      if (shouldRemoveRtx) {
+        const mediaSections = getMediaSections(sdp);
+        const mediaSections1 = getMediaSections(sdp1);
+        mediaSections.forEach((mediaSection, i) => {
+          if (!/^m=video/.test(mediaSections1[i])) {
+            assert.equal(mediaSections1[i], mediaSection);
+          } else {
+            // The RTX payload types should not be present.
+            const lines = mediaSections1[i].split('\r\n');
+            const pts = lines[0].match(/(\d+)/g).slice(1);
+            rtxPts.forEach(rtxPt => assert(!pts.includes(rtxPt)));
+
+            // SDP lines related to RTX should not be present.
+            const rtxLines = lines.filter(line => rtxFmtpRegex.test(line)
+             || rtxRtpmapRegex.test(line)
+             || rtxSSRCAttrRegex.test(line)
+             || ssrcGroupRegex.test(line));
+            assert.equal(rtxLines.length, 0);
+          }
+        });
+      } else {
+        assert.equal(sdp1, sdp);
+      }
     });
   });
 });


### PR DESCRIPTION
@makarandp0 

This PR fixes Firefox 79+ <-> Chrome interop issue in audio only Peer-to-Peer Participants. I have filed a [Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1106157) for this issue.

### Changes

- [x] Implementation
- [x] Unit test
- [x] Verify interop fix locally
- [x] CHANGELOG.md entry

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
