### PR TITLE
JSDK-2878 Alternate way of filtering parenthesized substrings in the user agent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 Bug Fixes
 ---------
 
-- Fixed a bug where audio only Firefox 79+ and Chrome Participants could not hear each
-  other in a Peer to Peer Room due to this [Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1106157). (JSDK-2914)
+- Fixed a bug where audio only Firefox 79+ and Chrome Participants could not hear
+  each other in a Peer to Peer Room due to this [Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1106157). (JSDK-2914)
+- Fixed a bug where `isSupported` returned `false` for Android Chrome browser on
+  Motorola phones. (JSDK-2878)
 
 2.7.0 (July 8, 2020)
 ====================

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -730,7 +730,6 @@ function waitForEvent(eventTarget, event) {
   });
 }
 
-
 exports.constants = constants;
 exports.createBandwidthProfilePayload = createBandwidthProfilePayload;
 exports.createMediaSignalingPayload = createMediaSignalingPayload;

--- a/lib/util/support.js
+++ b/lib/util/support.js
@@ -11,6 +11,28 @@ const SUPPORTED_CHROME_BASED_BROWSERS = [
 ];
 
 /**
+ * Get the top level parenthesized substrings within a given string.
+ * Ex: "abc (def) gh(ij) (kl (mn)o)" => [""(def)", "(ij)", "(kl (mn)o)"]
+ * @param {string} string
+ * @returns {string[]}
+ */
+function getParenthesizedSubstrings(string) {
+  const openParenthesisPositions = [];
+  const substrings = [];
+  for (let i = 0; i < string.length; i++) {
+    if (string[i] === '(') {
+      openParenthesisPositions.push(i);
+    } else if (string[i] === ')' && openParenthesisPositions.length > 0) {
+      const openParenthesisPosition = openParenthesisPositions.pop();
+      if (openParenthesisPositions.length === 0) {
+        substrings.push(string.substring(openParenthesisPosition, i + 1));
+      }
+    }
+  }
+  return substrings;
+}
+
+/**
  * Check whether the current browser is non-Chromium Edge.
  * @param {string} browser
  * @returns {boolean}
@@ -42,7 +64,11 @@ function rebrandedChromeBrowser(browser) {
 
   // Remove the "(.+)" entries from the user agent thereby retaining only the
   // <name>[/<version>] entries.
-  const nameAndVersions = navigator.userAgent.replace(/\([^)]+\)(\s)?/g, '');
+  const parenthesizedSubstrings = getParenthesizedSubstrings(navigator.userAgent);
+  const nameAndVersions = parenthesizedSubstrings.reduce(
+    (userAgent, substring) => userAgent.replace(substring, ''),
+    navigator.userAgent
+  );
 
   // Extract the potential browser <name>s by ignoring the first two names, which
   // point to <source> and <engine>.

--- a/lib/util/support.js
+++ b/lib/util/support.js
@@ -11,8 +11,9 @@ const SUPPORTED_CHROME_BASED_BROWSERS = [
 ];
 
 /**
- * Get the top level parenthesized substrings within a given string.
- * Ex: "abc (def) gh(ij) (kl (mn)o)" => [""(def)", "(ij)", "(kl (mn)o)"]
+ * Get the top level parenthesized substrings within a given string. Unmatched
+ * parentheses are ignored.
+ * Ex: "abc) (def) gh(ij) (kl (mn)o) (pqr" => ["(def)", "(ij)", "(kl (mn)o)"]
  * @param {string} string
  * @returns {string[]}
  */

--- a/test/unit/spec/util/support.js
+++ b/test/unit/spec/util/support.js
@@ -61,6 +61,14 @@ describe('isSupported', () => {
     [
       'Electron',
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Electron/3.1.12 Safari/537.36'
+    ],
+    [
+      'Moto G4 Android Chrome',
+      'Mozilla/5.0 (Linux; Android 6.0.1; Moto G (4)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Mobile Safari/537.36'
+    ],
+    [
+      'Moto G7 Android Chrome',
+      'Mozilla/5.0 (Linux; Android 9; moto g(7) power) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.96 Mobile Safari/537.36'
     ]
   ].forEach(([browser, useragent, chrome]) => {
     it('returns true for supported browser: ' + browser, () => {


### PR DESCRIPTION
@makarandp0 

This fixes a bug in the logic for filtering out parenthesized substrings in the user agent, which resulted in `isSupported` returning `false` for Android Chrome in Motorola phones.

Ex. user agent: `Mozilla/5.0 (Linux; Android 6.0.1; Moto G (4)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Mobile Safari/537.36`

Now, substrings like `(Linux; Android 6.0.1; Moto G (4))` that contain nested parentheses are handled correctly.
 
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
