### PR TITLE
JSDK-2899 Detect silent video upon unmute and restart the LocalVideoTrack.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 Bug Fixes
 ---------
 
-- Fixed a bug where iOS Safari Participants stopped sending video frames after denying
-  an incoming phone call. (JSDK-2899)
+- Fixed a bug where iOS Safari Participants in a Room stopped sending video frames
+  after denying an incoming phone call. (JSDK-2899)
 - Fixed a bug where audio only Firefox 79+ and Chrome Participants could not hear
   each other in a Peer to Peer Room due to this [Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1106157). (JSDK-2914)
 - Fixed a bug where `isSupported` returned `false` for Android Chrome browser on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 Bug Fixes
 ---------
 
+- Fixed a bug where iOS Safari Participants stopped sending video frames after denying
+  an incoming phone call. (JSDK-2899)
 - Fixed a bug where audio only Firefox 79+ and Chrome Participants could not hear
   each other in a Peer to Peer Room due to this [Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1106157). (JSDK-2914)
 - Fixed a bug where `isSupported` returned `false` for Android Chrome browser on

--- a/lib/media/track/localmediatrack.js
+++ b/lib/media/track/localmediatrack.js
@@ -144,7 +144,6 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
         : getUserMedia(gUMConstraints);
 
       return gUMPromise.then(mediaStream => {
-        this._constraints = Object.assign({}, constraints);
         return mediaStream.getTracks()[0];
       });
     }
@@ -161,6 +160,7 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
       }).then(newMediaStreamTrack => {
         log.info('Re-acquired the MediaStreamTrack');
         log.debug('MediaStreamTrack:', newMediaStreamTrack);
+        this._constraints = Object.assign({}, constraints);
         return this._setMediaStreamTrack(newMediaStreamTrack);
       });
     }

--- a/lib/media/track/localmediatrack.js
+++ b/lib/media/track/localmediatrack.js
@@ -10,8 +10,6 @@ const documentVisibilityMonitor = require('../../util/documentvisibilitymonitor.
 const gUMSilentTrackWorkaround = require('../../webaudio/workaround180748');
 const MediaTrackSender = require('./sender');
 
-const guess = guessBrowser();
-
 function mixinLocalMediaTrack(AudioOrVideoTrack) {
   /**
    * A {@link LocalMediaTrack} represents audio or video that your
@@ -31,7 +29,7 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
       // NOTE(mpatwardhan): by default workaround for WebKitBug1208516 will be enabled on Safari browsers
       // although the bug is seen  mainly on iOS devices, we do not have a reliable way to tell iOS from MacOs
       // userAgent on iOS pretends its macOs if Safari is set to request desktop pages.
-      const workaroundWebKitBug1208516 = guess === 'safari'
+      const workaroundWebKitBug1208516 = guessBrowser() === 'safari'
         && typeof document === 'object'
         && typeof document.addEventListener === 'function'
         && typeof document.visibilityState === 'string';
@@ -44,9 +42,17 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
       }, options);
 
       const mediaTrackSender = new MediaTrackSender(mediaStreamTrack);
+      const { kind } = mediaTrackSender;
+
       super(mediaTrackSender, options);
 
       Object.defineProperties(this, {
+        _constraints: {
+          value: typeof options[kind] === 'object'
+            ? options[kind]
+            : {},
+          writable: true
+        },
         _getUserMedia: {
           value: options.getUserMedia
         },
@@ -138,6 +144,7 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
         : getUserMedia(gUMConstraints);
 
       return gUMPromise.then(mediaStream => {
+        this._constraints = Object.assign({}, constraints);
         return mediaStream.getTracks()[0];
       });
     }
@@ -146,14 +153,8 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
      * @private
      */
     _restart(constraints) {
-      const { _log: log, mediaStreamTrack } = this;
-
-      // NOTE(mmalavalli): Safari does not save the constraints passed by the
-      // developer in getConstraints(). So we use getSettings() instead.
-      constraints = constraints || (guess === 'safari'
-        ? mediaStreamTrack.getSettings()
-        : mediaStreamTrack.getConstraints());
-
+      const { _log: log } = this;
+      constraints = constraints || this._constraints;
       return this._reacquireTrack(constraints).catch(error => {
         log.error('Failed to re-acquire the MediaStreamTrack:', error, constraints);
         throw error;

--- a/lib/media/track/localmediatrack.js
+++ b/lib/media/track/localmediatrack.js
@@ -10,6 +10,8 @@ const documentVisibilityMonitor = require('../../util/documentvisibilitymonitor.
 const gUMSilentTrackWorkaround = require('../../webaudio/workaround180748');
 const MediaTrackSender = require('./sender');
 
+const guess = guessBrowser();
+
 function mixinLocalMediaTrack(AudioOrVideoTrack) {
   /**
    * A {@link LocalMediaTrack} represents audio or video that your
@@ -29,7 +31,7 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
       // NOTE(mpatwardhan): by default workaround for WebKitBug1208516 will be enabled on Safari browsers
       // although the bug is seen  mainly on iOS devices, we do not have a reliable way to tell iOS from MacOs
       // userAgent on iOS pretends its macOs if Safari is set to request desktop pages.
-      const workaroundWebKitBug1208516 = guessBrowser() === 'safari'
+      const workaroundWebKitBug1208516 = guess === 'safari'
         && typeof document === 'object'
         && typeof document.addEventListener === 'function'
         && typeof document.visibilityState === 'string';
@@ -145,7 +147,13 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
      */
     _restart(constraints) {
       const { _log: log, mediaStreamTrack } = this;
-      constraints = constraints || mediaStreamTrack.getConstraints();
+
+      // NOTE(mmalavalli): Safari does not save the constraints passed by the
+      // developer in getConstraints(). So we use getSettings() instead.
+      constraints = constraints || (guess === 'safari'
+        ? mediaStreamTrack.getSettings()
+        : mediaStreamTrack.getConstraints());
+
       return this._reacquireTrack(constraints).catch(error => {
         log.error('Failed to re-acquire the MediaStreamTrack:', error, constraints);
         throw error;

--- a/lib/media/track/localvideotrack.js
+++ b/lib/media/track/localvideotrack.js
@@ -30,13 +30,31 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
    * @param {LocalTrackOptions} [options] - {@link LocalTrack} options
    */
   constructor(mediaStreamTrack, options) {
+    options = Object.assign({
+      workAroundSilentLocalVideo: guessBrowser() === 'safari'
+        && typeof document !== 'undefined'
+        && typeof document.createElement === 'function'
+    }, options);
+
     super(mediaStreamTrack, options);
+
+    Object.defineProperties(this, {
+      _workAroundSilentLocalVideo: {
+        value: options.workAroundSilentLocalVideo
+          ? workAroundSilentLocalVideo
+          : null
+      },
+      _workAroundSilentLocalVideoCleanup: {
+        value: null,
+        writable: true
+      }
+    });
 
     // NOTE(mmalavalli): In iOS Safari, we work around a bug where local video
     // MediaStreamTracks are silent (even though they are enabled, live and unmuted)
     // after accepting/rejecting a phone call.
-    if (guessBrowser() === 'safari') {
-      workAroundSilentLocalVideo(this);
+    if (this._workAroundSilentLocalVideo) {
+      this._workAroundSilentLocalVideoCleanup = this._workAroundSilentLocalVideo(this, document);
     }
   }
 
@@ -112,7 +130,17 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
    * });
    */
   restart() {
-    return super.restart.apply(this, arguments);
+    if (this._workAroundSilentLocalVideoCleanup) {
+      this._workAroundSilentLocalVideoCleanup();
+    }
+    const promise = super.restart.apply(this, arguments);
+
+    if (this._workAroundSilentLocalVideo) {
+      promise.finally(() => {
+        this._workAroundSilentLocalVideoCleanup = this._workAroundSilentLocalVideo(this, document);
+      });
+    }
+    return promise;
   }
 
   /**
@@ -122,6 +150,10 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
    * @fires LocalVideoTrack#stopped
    */
   stop() {
+    if (this._workAroundSilentLocalVideoCleanup) {
+      this._workAroundSilentLocalVideoCleanup();
+      this._workAroundSilentLocalVideoCleanup = null;
+    }
     return super.stop.apply(this, arguments);
   }
 }
@@ -131,22 +163,21 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
  * they are enabled, live and unmuted) after accepting/rejecting a phone call.
  * @private
  * @param {LocalVideoTrack} localVideoTrack
+ * @param {HTMLDocument} doc
+ * @returns {function} Cleans up listeners attached by the workaround
  */
-function workAroundSilentLocalVideo(localVideoTrack) {
+function workAroundSilentLocalVideo(localVideoTrack, doc) {
   const { _log: log } = localVideoTrack;
   let { _dummyEl: el, mediaStreamTrack } = localVideoTrack;
 
-  mediaStreamTrack.addEventListener('unmute', function onUnmute() {
+  function onUnmute() {
     if (!localVideoTrack.isEnabled) {
       return;
     }
     log.info('Unmuted, checking silence');
 
     // The dummy element is paused, so play it and then detect silence.
-    el.play().then(() => detectSilentVideo(el)).then(isSilent => {
-      // Pause the dummy element again after detecting silence.
-      el.pause();
-
+    el.play().then(() => detectSilentVideo(el, doc)).then(isSilent => {
       if (!isSilent) {
         log.info('Non-silent frames detected, so no need to restart');
         return;
@@ -158,16 +189,30 @@ function workAroundSilentLocalVideo(localVideoTrack) {
       // we stop the MediaStreamTrack here.
       localVideoTrack._stop();
 
-      localVideoTrack._restart().finally(() => {
-        el = localVideoTrack._dummyEl;
-        mediaStreamTrack.removeEventListener('unmute', onUnmute);
-        mediaStreamTrack = localVideoTrack.mediaStreamTrack;
-        mediaStreamTrack.addEventListener('unmute', onUnmute);
-      });
+      // Restart the LocalVideoTrack.
+      return localVideoTrack._restart();
     }).catch(error => {
       log.warn('Failed to detect silence and restart:', error);
+    }).finally(() => {
+      // If silent frames were not detected, then pause the dummy element again.
+      el = localVideoTrack._dummyEl;
+      if (!el.paused) {
+        el.pause();
+      }
+
+      // Reset the unmute handler.
+      mediaStreamTrack.removeEventListener('unmute', onUnmute);
+      mediaStreamTrack = localVideoTrack.mediaStreamTrack;
+      mediaStreamTrack.addEventListener('unmute', onUnmute);
     });
-  });
+  }
+
+  // Set the unmute handler.
+  mediaStreamTrack.addEventListener('unmute', onUnmute);
+
+  return () => {
+    mediaStreamTrack.removeEventListener('unmute', onUnmute);
+  };
 }
 
 /**

--- a/lib/media/track/localvideotrack.js
+++ b/lib/media/track/localvideotrack.js
@@ -31,7 +31,7 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
    */
   constructor(mediaStreamTrack, options) {
     options = Object.assign({
-      workAroundSilentLocalVideo: guessBrowser() === 'safari'
+      workaroundSilentLocalVideo: guessBrowser() === 'safari'
         && typeof document !== 'undefined'
         && typeof document.createElement === 'function'
     }, options);
@@ -39,12 +39,12 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
     super(mediaStreamTrack, options);
 
     Object.defineProperties(this, {
-      _workAroundSilentLocalVideo: {
-        value: options.workAroundSilentLocalVideo
-          ? workAroundSilentLocalVideo
+      _workaroundSilentLocalVideo: {
+        value: options.workaroundSilentLocalVideo
+          ? workaroundSilentLocalVideo
           : null
       },
-      _workAroundSilentLocalVideoCleanup: {
+      _workaroundSilentLocalVideoCleanup: {
         value: null,
         writable: true
       }
@@ -53,8 +53,8 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
     // NOTE(mmalavalli): In iOS Safari, we work around a bug where local video
     // MediaStreamTracks are silent (even though they are enabled, live and unmuted)
     // after accepting/rejecting a phone call.
-    if (this._workAroundSilentLocalVideo) {
-      this._workAroundSilentLocalVideoCleanup = this._workAroundSilentLocalVideo(this, document);
+    if (this._workaroundSilentLocalVideo) {
+      this._workaroundSilentLocalVideoCleanup = this._workaroundSilentLocalVideo(this, document);
     }
   }
 
@@ -130,14 +130,15 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
    * });
    */
   restart() {
-    if (this._workAroundSilentLocalVideoCleanup) {
-      this._workAroundSilentLocalVideoCleanup();
+    if (this._workaroundSilentLocalVideoCleanup) {
+      this._workaroundSilentLocalVideoCleanup();
+      this._workaroundSilentLocalVideoCleanup = null;
     }
     const promise = super.restart.apply(this, arguments);
 
-    if (this._workAroundSilentLocalVideo) {
+    if (this._workaroundSilentLocalVideo) {
       promise.finally(() => {
-        this._workAroundSilentLocalVideoCleanup = this._workAroundSilentLocalVideo(this, document);
+        this._workaroundSilentLocalVideoCleanup = this._workaroundSilentLocalVideo(this, document);
       });
     }
     return promise;
@@ -150,23 +151,23 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
    * @fires LocalVideoTrack#stopped
    */
   stop() {
-    if (this._workAroundSilentLocalVideoCleanup) {
-      this._workAroundSilentLocalVideoCleanup();
-      this._workAroundSilentLocalVideoCleanup = null;
+    if (this._workaroundSilentLocalVideoCleanup) {
+      this._workaroundSilentLocalVideoCleanup();
+      this._workaroundSilentLocalVideoCleanup = null;
     }
     return super.stop.apply(this, arguments);
   }
 }
 
 /**
- * work around a bug where local video MediaStreamTracks are silent (even though
+ * Work around a bug where local video MediaStreamTracks are silent (even though
  * they are enabled, live and unmuted) after accepting/rejecting a phone call.
  * @private
  * @param {LocalVideoTrack} localVideoTrack
  * @param {HTMLDocument} doc
  * @returns {function} Cleans up listeners attached by the workaround
  */
-function workAroundSilentLocalVideo(localVideoTrack, doc) {
+function workaroundSilentLocalVideo(localVideoTrack, doc) {
   const { _log: log } = localVideoTrack;
   let { _dummyEl: el, mediaStreamTrack } = localVideoTrack;
 

--- a/lib/media/track/localvideotrack.js
+++ b/lib/media/track/localvideotrack.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const { guessBrowser } = require('@twilio/webrtc/lib/util');
+
+const detectSilentVideo = require('../../util/detectsilentvideo');
 const mixinLocalMediaTrack = require('./localmediatrack');
 const VideoTrack = require('./videotrack');
 
@@ -28,6 +31,13 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
    */
   constructor(mediaStreamTrack, options) {
     super(mediaStreamTrack, options);
+
+    // NOTE(mmalavalli): In iOS Safari, we work around a bug where local video
+    // MediaStreamTracks are silent (even though they are enabled, live and unmuted)
+    // after accepting/rejecting a phone call.
+    if (guessBrowser() === 'safari') {
+      workAroundSilentLocalVideo(this);
+    }
   }
 
   toString() {
@@ -114,6 +124,50 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
   stop() {
     return super.stop.apply(this, arguments);
   }
+}
+
+/**
+ * work around a bug where local video MediaStreamTracks are silent (even though
+ * they are enabled, live and unmuted) after accepting/rejecting a phone call.
+ * @private
+ * @param {LocalVideoTrack} localVideoTrack
+ */
+function workAroundSilentLocalVideo(localVideoTrack) {
+  const { _log: log } = localVideoTrack;
+  let { _dummyEl: el, mediaStreamTrack } = localVideoTrack;
+
+  mediaStreamTrack.addEventListener('unmute', function onUnmute() {
+    if (!localVideoTrack.isEnabled) {
+      return;
+    }
+    log.info('Unmuted, checking silence');
+
+    // The dummy element is paused, so play it and then detect silence.
+    el.play().then(() => detectSilentVideo(el)).then(isSilent => {
+      // Pause the dummy element again after detecting silence.
+      el.pause();
+
+      if (!isSilent) {
+        log.info('Non-silent frames detected, so no need to restart');
+        return;
+      }
+      log.warn('Silence detected, restarting');
+
+      // NOTE(mmalavalli): If we try and restart a silent MediaStreamTrack
+      // without stopping it first, then a NotReadableError is raised. Hence,
+      // we stop the MediaStreamTrack here.
+      localVideoTrack._stop();
+
+      localVideoTrack._restart().finally(() => {
+        el = localVideoTrack._dummyEl;
+        mediaStreamTrack.removeEventListener('unmute', onUnmute);
+        mediaStreamTrack = localVideoTrack.mediaStreamTrack;
+        mediaStreamTrack.addEventListener('unmute', onUnmute);
+      });
+    }).catch(error => {
+      log.warn('Failed to detect silence and restart:', error);
+    });
+  });
 }
 
 /**

--- a/lib/util/detectsilentvideo.js
+++ b/lib/util/detectsilentvideo.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const canvas = typeof document !== 'undefined' && typeof document.createElement === 'function'
+  ? document.createElement('canvas')
+  : null;
+
+const N_SAMPLES = 3;
+const SAMPLE_HEIGHT = 50;
+const SAMPLE_INTERVAL_MS = 500;
+const SAMPLE_WIDTH = 50;
+
+/**
+ * Check whether the current video frame is silent by selecting a 50x50
+ * sample and calculating the max value of the pixel data. If it is 0, then
+ * the frame is considered to be silent.
+ * @private
+ * @param {HTMLVideoElement} el
+ * @returns {boolean} true if silent, false if not
+ */
+function checkSilence(el) {
+  const context = canvas.getContext('2d');
+  context.drawImage(el, 0, 0, SAMPLE_WIDTH, SAMPLE_HEIGHT);
+  const frame = context.getImageData(0, 0, SAMPLE_WIDTH, SAMPLE_HEIGHT);
+  const frameDataWithoutAlpha = frame.data.filter((item, i) => (i + 1) % 4);
+  const max = Math.max.apply(Math, frameDataWithoutAlpha);
+  return max === 0;
+}
+
+/**
+ * Detect whether the video stream rendered by the given
+ * HTMLVideoElement is silent.
+ * @param {HTMLVideoElement} el
+ * @returns {Promise<boolean>} true if silent, false if not.
+ */
+function detectSilentVideo(el) {
+  return canvas ? new Promise(resolve => {
+    let samplesLeft = N_SAMPLES;
+    setTimeout(function doCheckSilence() {
+      samplesLeft--;
+      if (!checkSilence(el)) {
+        return resolve(false);
+      }
+      if (samplesLeft > 0) {
+        return setTimeout(doCheckSilence, SAMPLE_INTERVAL_MS);
+      }
+      return resolve(true);
+    }, SAMPLE_INTERVAL_MS);
+  }) : Promise.resolve(false);
+}
+
+module.exports = detectSilentVideo;

--- a/lib/util/detectsilentvideo.js
+++ b/lib/util/detectsilentvideo.js
@@ -1,8 +1,7 @@
 'use strict';
 
-const canvas = typeof document !== 'undefined' && typeof document.createElement === 'function'
-  ? document.createElement('canvas')
-  : null;
+// Cached copy of the <canvas> used to check silent video frames.
+let canvas = null;
 
 const N_SAMPLES = 3;
 const SAMPLE_HEIGHT = 50;
@@ -30,10 +29,18 @@ function checkSilence(el) {
  * Detect whether the video stream rendered by the given
  * HTMLVideoElement is silent.
  * @param {HTMLVideoElement} el
+ * @param {HTMLDocument} doc
  * @returns {Promise<boolean>} true if silent, false if not.
  */
-function detectSilentVideo(el) {
-  return canvas ? new Promise(resolve => {
+function detectSilentVideo(el, doc) {
+  // Create the canvas when detectSilentVideo() is called for the
+  // first time.
+  canvas = canvas || doc.createElement('canvas');
+
+  // Resolve the returned Promise with true if 3 consecutive sample
+  // frames from the video being played by the HTMLVideoElement are
+  // silent.
+  return new Promise(resolve => {
     let samplesLeft = N_SAMPLES;
     setTimeout(function doCheckSilence() {
       samplesLeft--;
@@ -45,7 +52,7 @@ function detectSilentVideo(el) {
       }
       return resolve(true);
     }, SAMPLE_INTERVAL_MS);
-  }) : Promise.resolve(false);
+  });
 }
 
 module.exports = detectSilentVideo;

--- a/test/lib/fakemediastream.js
+++ b/test/lib/fakemediastream.js
@@ -57,12 +57,9 @@ class FakeMediaStream extends EventTarget {
 }
 
 class FakeMediaStreamTrack extends EventTarget {
-  constructor(kind, constraints = {}) {
+  constructor(kind) {
     super();
     Object.defineProperties(this, {
-      _constraints: {
-        value: typeof constraints === 'boolean' ? {} : constraints
-      },
       id: {
         value: randomName(),
         enumerable: true
@@ -94,10 +91,6 @@ class FakeMediaStreamTrack extends EventTarget {
     return clone;
   }
 
-  getConstraints() {
-    return this._constraints;
-  }
-
   stop() {
     this.readyState = 'ended';
     this.dispatchEvent({
@@ -110,10 +103,10 @@ class FakeMediaStreamTrack extends EventTarget {
 function fakeGetUserMedia(constraints) {
   const fakeMediaStream = new FakeMediaStream();
   if (constraints.audio) {
-    fakeMediaStream.addTrack(new FakeMediaStreamTrack('audio'), constraints.audio);
+    fakeMediaStream.addTrack(new FakeMediaStreamTrack('audio'));
   }
   if (constraints.video) {
-    fakeMediaStream.addTrack(new FakeMediaStreamTrack('video'), constraints.video);
+    fakeMediaStream.addTrack(new FakeMediaStreamTrack('video'));
   }
 
   return Promise.resolve(fakeMediaStream);

--- a/test/unit/spec/media/track/localmediatrack.js
+++ b/test/unit/spec/media/track/localmediatrack.js
@@ -559,8 +559,9 @@ const { defer } = require('../../../../../lib/util');
 });
 
 function createLocalMediaTrack(LocalMediaTrack, kind, options = {}, constraints = {}) {
-  const mediaStreamTrack = new MediaStreamTrack(kind, constraints);
+  const mediaStreamTrack = new MediaStreamTrack(kind);
   options = Object.assign({
+    [kind]: constraints,
     log,
     getUserMedia: fakeGetUserMedia,
     gUMSilentTrackWorkaround: (_log, gum, constraints) => gum(constraints)


### PR DESCRIPTION
@makarandp0 

This PR fixes a bug in iOS Safari where sometimes its video is black after denying a phone call. This happens because even though the video is unmuted after denying the call, we only see black frames. This PR fixes it by detecting these silent frames and restarting the video track.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
