### PR TITLE
JSDK-2889 Playing unintentionally paused media elements if not backgrounded.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 Bug Fixes
 ---------
 
+- Fixed a bug where, sometimes an iOS Safari Participant's `<audio>` and `<video>`
+  elements were paused after handling an incoming phone call. Because of this,
+  RemoteParticipants could not be seen and/or heard. (JSDK-2899)
 - Fixed a bug where iOS Safari Participants stopped sending video frames after an
   incoming phone call. (JSDK-2915)
 - Fixed a bug where audio only Firefox 79+ and Chrome Participants could not hear

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -1,6 +1,9 @@
 'use strict';
 
-const MediaStream = require('@twilio/webrtc').MediaStream;
+const { guessBrowser } = require('@twilio/webrtc/lib/util');
+const { MediaStream } = require('@twilio/webrtc');
+
+const { waitForEvent, waitForSometime } = require('../../util');
 const Track = require('./');
 
 /**
@@ -27,6 +30,13 @@ class MediaTrack extends Track {
    * @param {{log: Log}} options
    */
   constructor(mediaTrackTransceiver, options) {
+    options = Object.assign({
+      playPausedElementsIfNotBackgrounded: guessBrowser() === 'safari'
+        && typeof document === 'object'
+        && typeof document.addEventListener === 'function'
+        && typeof document.visibilityState === 'string'
+    }, options);
+
     super(mediaTrackTransceiver.id, mediaTrackTransceiver.kind, options);
     let isStarted = false;
 
@@ -43,6 +53,9 @@ class MediaTrack extends Track {
         value: null,
         writable: true
       },
+      _elShims: {
+        value: new WeakMap()
+      },
       _isStarted: {
         get() {
           return isStarted;
@@ -50,6 +63,13 @@ class MediaTrack extends Track {
         set(_isStarted) {
           isStarted = _isStarted;
         }
+      },
+      _playPausedElementsIfNotBackgrounded: {
+        value: options.playPausedElementsIfNotBackgrounded
+      },
+      _shouldShimAttachedElements: {
+        value: options.workaroundWebKitBug212780
+          || options.playPausedElementsIfNotBackgrounded
       },
       _MediaStream: {
         value: options.MediaStream
@@ -158,6 +178,13 @@ class MediaTrack extends Track {
       this._attachments.add(el);
     }
 
+    if (this._shouldShimAttachedElements && !this._elShims.has(el)) {
+      const onUnintentionallyPaused = this._playPausedElementsIfNotBackgrounded
+        ? () => playWhenPausedAndNotBackgrounded(el, this._log)
+        : null;
+      this._elShims.set(el, shimMediaElement(el, onUnintentionallyPaused));
+    }
+
     return el;
   }
 
@@ -220,6 +247,13 @@ class MediaTrack extends Track {
     }
 
     this._attachments.delete(el);
+
+    if (this._shouldShimAttachedElements && this._elShims.has(el)) {
+      const shim = this._elShims.get(el);
+      shim.unShim();
+      this._elShims.delete(el);
+    }
+
     return el;
   }
 
@@ -235,6 +269,84 @@ class MediaTrack extends Track {
 
     return els;
   }
+}
+
+/**
+ * Play an HTMLMediaElement when it is paused and not backgrounded.
+ * @private
+ * @param {HTMLMediaElement} el
+ * @param {Log} log
+ * @returns {void}
+ */
+function playWhenPausedAndNotBackgrounded(el, log) {
+  const tag = el.tagName.toLowerCase();
+  log.warn('Unintentionally paused:', el);
+
+  // NOTE(mmalavalli): When the element is unintentionally paused, we wait one
+  // second for the "onvisibilitychange" event on the HTMLDocument to see if the
+  // app will be backgrounded. If not, then the element can be safely played.
+  Promise.race([
+    waitForEvent(document, 'visibilitychange'),
+    waitForSometime(1000)
+  ]).then(() => {
+    if (document.visibilityState === 'visible') {
+      log.info(`Playing unintentionally paused <${tag}> element`);
+      log.debug('Element:', el);
+      el.play().then(() => {
+        log.info(`Successfully played unintentionally paused <${tag}> element`);
+        log.debug('Element:', el);
+      }).catch(error => {
+        log.warn(`Error while playing unintentionally paused <${tag}> element:`, error, el);
+      });
+    }
+  });
+}
+
+/**
+ * Shim the pause() and play() methods of the given HTMLMediaElement so that
+ * we can detect if it was paused unintentionally.
+ * @param {HTMLMediaElement} el
+ * @param {?function} [onUnintentionallyPaused=null]
+ * @returns {{pausedIntentionally: function, unShim: function}}
+ */
+function shimMediaElement(el, onUnintentionallyPaused = null) {
+  const origPause = el.pause;
+  const origPlay = el.play;
+
+  let pausedIntentionally = false;
+
+  el.pause = () => {
+    pausedIntentionally = true;
+    return origPause.call(el);
+  };
+
+  el.play = () => {
+    pausedIntentionally = false;
+    return origPlay.call(el);
+  };
+
+  const onPause = onUnintentionallyPaused ? () => {
+    if (!pausedIntentionally) {
+      onUnintentionallyPaused();
+    }
+  } : null;
+
+  if (onPause) {
+    el.addEventListener('pause', onPause);
+  }
+
+  return {
+    pausedIntentionally() {
+      return pausedIntentionally;
+    },
+    unShim() {
+      el.pause = origPause;
+      el.play = origPlay;
+      if (onPause) {
+        el.removeEventListener('pause', onPause);
+      }
+    }
+  };
 }
 
 module.exports = MediaTrack;

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -146,6 +146,13 @@ class MediaTrack extends Track {
     this._log.debug('Attempting to attach to element:', el);
     el = this._attach(el);
 
+    if (this._shouldShimAttachedElements && !this._elShims.has(el)) {
+      const onUnintentionallyPaused = this._playPausedElementsIfNotBackgrounded
+        ? () => playIfPausedAndNotBackgrounded(el, this._log)
+        : null;
+      this._elShims.set(el, shimMediaElement(el, onUnintentionallyPaused));
+    }
+
     return el;
   }
 
@@ -176,13 +183,6 @@ class MediaTrack extends Track {
 
     if (!this._attachments.has(el)) {
       this._attachments.add(el);
-    }
-
-    if (this._shouldShimAttachedElements && !this._elShims.has(el)) {
-      const onUnintentionallyPaused = this._playPausedElementsIfNotBackgrounded
-        ? () => playWhenPausedAndNotBackgrounded(el, this._log)
-        : null;
-      this._elShims.set(el, shimMediaElement(el, onUnintentionallyPaused));
     }
 
     return el;
@@ -272,13 +272,13 @@ class MediaTrack extends Track {
 }
 
 /**
- * Play an HTMLMediaElement when it is paused and not backgrounded.
+ * Play an HTMLMediaElement if it is paused and not backgrounded.
  * @private
  * @param {HTMLMediaElement} el
  * @param {Log} log
  * @returns {void}
  */
-function playWhenPausedAndNotBackgrounded(el, log) {
+function playIfPausedAndNotBackgrounded(el, log) {
   const tag = el.tagName.toLowerCase();
   log.warn('Unintentionally paused:', el);
 

--- a/lib/media/track/remotemediatrack.js
+++ b/lib/media/track/remotemediatrack.js
@@ -28,15 +28,17 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
      * @param {{log: Log, name: ?string}} options
      */
     constructor(sid, mediaTrackReceiver, isEnabled, setPriority, options) {
-      super(mediaTrackReceiver, options);
+      options = Object.assign({
+        // NOTE(mpatwardhan): WebKit bug: 212780 sometimes causes the audio/video elements to stay paused when safari
+        // regains foreground. To workaround it, when safari gains foreground - we will play any elements that were
+        // playing before safari lost foreground.
+        workaroundWebKitBug212780: guessBrowser() === 'safari'
+          && typeof document === 'object'
+          && typeof document.addEventListener === 'function'
+          && typeof document.visibilityState === 'string'
+      }, options);
 
-      // NOTE(mpatwardhan): WebKit bug: 212780 sometimes causes the audio/video elements to stay paused when safari
-      // regains foreground. To workaround it, when safari gains foreground - we will play any elements that were
-      // playing before safari lost foreground.
-      const workaroundWebKitBug212780 = guessBrowser() === 'safari'
-        && typeof document === 'object'
-        && typeof document.addEventListener === 'function'
-        && typeof document.visibilityState === 'string';
+      super(mediaTrackReceiver, options);
 
       Object.defineProperties(this, {
         _isEnabled: {
@@ -77,7 +79,7 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
           value: sid
         },
         _workaroundWebKitBug212780: {
-          value: workaroundWebKitBug212780
+          value: options.workaroundWebKitBug212780
         },
         _workaroundWebKitBug212780Cleanup: {
           value: null,
@@ -140,7 +142,6 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
       if (this._workaroundWebKitBug212780) {
         this._workaroundWebKitBug212780Cleanup = this._workaroundWebKitBug212780Cleanup
           || playIfPausedWhileInBackground(this);
-        shimMediaElement(result);
       }
 
       return result;
@@ -148,10 +149,6 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
 
     detach(el) {
       const result = super.detach(el);
-      if (this._workaroundWebKitBug212780) {
-        const elements = Array.isArray(result) ? result : [result];
-        elements.forEach(element => removeShim(element));
-      }
       if (this._attachments.size === 0) {
         // NOTE(mpatwardhan): chrome continues playing webrtc audio
         // track even after audio element is removed from the DOM.
@@ -171,52 +168,13 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
   };
 }
 
-const shimmedElements = new WeakMap();
-
-function removeShim(mediaElement) {
-  const el = shimmedElements.get(mediaElement);
-  if (el) {
-    el.unShim();
-    shimmedElements.delete(mediaElement);
-  }
-}
-
-/**
- * shims given media element to overwrites its play and paused methods.
- * overwritten methods call base method after keeping track of last call in `pausedIntentionally`
- * @param {HTMLAudioElement|HTMLVideoElement} mediaElement
- */
-function shimMediaElement(mediaElement) {
-  const realPlay = mediaElement.play;
-  const realPause = mediaElement.pause;
-  let pausedIntentionally = false;
-
-  mediaElement.play = () => {
-    pausedIntentionally = false;
-    return realPlay.call(mediaElement);
-  };
-
-  mediaElement.pause = () => {
-    pausedIntentionally = true;
-    return realPause.call(mediaElement);
-  };
-
-  const unShim = () => {
-    mediaElement.play = realPlay;
-    mediaElement.pause = realPause;
-  };
-
-  const isPausedIntentionally = () => pausedIntentionally;
-  shimmedElements.set(mediaElement, { unShim, isPausedIntentionally });
-}
-
 function playIfPausedWhileInBackground(remoteMediaTrack) {
   const { _log: log, kind } = remoteMediaTrack;
 
   function onVisibilityChanged() {
     remoteMediaTrack._attachments.forEach(el => {
-      const shim = shimmedElements.get(el);
-      const isInadvertentlyPaused = el.paused && shim && !shim.isPausedIntentionally();
+      const shim = remoteMediaTrack._elShims.get(el);
+      const isInadvertentlyPaused = el.paused && shim && !shim.pausedIntentionally();
       if (isInadvertentlyPaused) {
         log.info(`Playing inadvertently paused <${kind}> element`);
         log.debug('Element:', el);


### PR DESCRIPTION
@makarandp0 This PR makes the following changes:

1. Move the element shimming logic from RemoteMediaTrack to MediaTrack, since local audio/video elements can also be inadvertently paused.
2. Playing unintentionally paused media elements only if not backgrounded. (We have already implemented playing unintentionally paused media elements after backgrounding and foregrounding).

Please take a look and let me know what you think.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
