### PR TITLE
JSDK-2928 Restart silent LocalAudioTrack on unmute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 Bug Fixes
 ---------
 
+- In version [2.6.0](#260-june-26-2020), we had introduced a workaround for this iOS Safari
+  [bug](https://bugs.webkit.org/show_bug.cgi?id=208516) which causes your application to lose
+  the microphone when another application (Siri, YouTube, FaceTime, etc.) reserves the microphone.
+  This release refactors the workaround to work for **iOS versions 13.6 and above**. (JSDK-2928) 
 - Fixed a bug where, sometimes an iOS Safari Participant's `<audio>` and `<video>`
   elements were paused after handling an incoming phone call. Because of this,
   RemoteParticipants could not be seen and/or heard. (JSDK-2899)

--- a/lib/media/track/localmediatrack.js
+++ b/lib/media/track/localmediatrack.js
@@ -6,9 +6,13 @@ const { guessBrowser } = require('@twilio/webrtc/lib/util');
 
 const { capitalize, defer, waitForSometime, waitForEvent } = require('../../util');
 const { typeErrors: { ILLEGAL_INVOKE } } = require('../../util/constants');
+const detectSilentAudio = require('../../util/detectsilentaudio');
+const detectSilentVideo = require('../../util/detectsilentvideo');
 const documentVisibilityMonitor = require('../../util/documentvisibilitymonitor.js');
 const gUMSilentTrackWorkaround = require('../../webaudio/workaround180748');
 const MediaTrackSender = require('./sender');
+
+const isSafari = guessBrowser() === 'safari';
 
 function mixinLocalMediaTrack(AudioOrVideoTrack) {
   /**
@@ -26,10 +30,18 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
      * @param {LocalTrackOptions} [options] - {@link LocalTrack} options
      */
     constructor(mediaStreamTrack, options) {
+      // NOTE(mmalavalli): By default, this workaround will be enabled on Safari browsers
+      // although the bug is seen mainly on iOS devices, we do not have a reliable way to
+      // tell iOS from MacOs userAgent on iOS pretends its macOs if Safari is set to request
+      // desktop pages.
+      const workaroundSilenceOnUnmute = isSafari
+        && typeof document === 'object'
+        && typeof document.createElement === 'function';
+
       // NOTE(mpatwardhan): by default workaround for WebKitBug1208516 will be enabled on Safari browsers
       // although the bug is seen  mainly on iOS devices, we do not have a reliable way to tell iOS from MacOs
       // userAgent on iOS pretends its macOs if Safari is set to request desktop pages.
-      const workaroundWebKitBug1208516 = guessBrowser() === 'safari'
+      const workaroundWebKitBug1208516 = isSafari
         && typeof document === 'object'
         && typeof document.addEventListener === 'function'
         && typeof document.visibilityState === 'string';
@@ -37,6 +49,7 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
       options = Object.assign({
         getUserMedia,
         isCreatedByCreateLocalTracks: false,
+        workaroundSilenceOnUnmute,
         workaroundWebKitBug1208516,
         gUMSilentTrackWorkaround
       }, options);
@@ -58,6 +71,16 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
         },
         _gUMSilentTrackWorkaround: {
           value: options.gUMSilentTrackWorkaround
+        },
+        _workaroundSilenceOnUnmute: {
+          value: options.workaroundSilenceOnUnmute
+        },
+        _workaroundWebKitBug1208516: {
+          value: options.workaroundWebKitBug1208516
+        },
+        _workaroundSilenceOnUnmuteCleanup: {
+          value: null,
+          writable: true
         },
         _workaroundWebKitBug1208516Cleanup: {
           value: null,
@@ -91,9 +114,15 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
         }
       });
 
+      // NOTE(mmalavalli): In iOS Safari, we work around a bug where sometimes,
+      // local MediaStreamTracks are silent after they are unmuted.
+      if (this._workaroundSilenceOnUnmute) {
+        this._workaroundSilenceOnUnmuteCleanup = restartWhenSilentOnUnmute(this);
+      }
+
       // NOTE(mpatwardhan): As a workaround for WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=208516,
       // upon foregrounding, re-acquire new MediaStreamTrack if the existing one is ended or muted.
-      if (options.workaroundWebKitBug1208516) {
+      if (this._workaroundWebKitBug1208516) {
         this._workaroundWebKitBug1208516Cleanup = restartWhenInadvertentlyStopped(this);
       }
     }
@@ -214,11 +243,37 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
           + ` Local${capitalize(kind)}Track that is created using createLocalTracks`
           + ` or createLocal${capitalize(kind)}Track.`));
       }
-      return this._restart(constraints);
+
+      if (this._workaroundSilenceOnUnmuteCleanup) {
+        this._workaroundSilenceOnUnmuteCleanup();
+        this._workaroundSilenceOnUnmuteCleanup = null;
+      }
+      if (this._workaroundWebKitBug1208516Cleanup) {
+        this._workaroundWebKitBug1208516Cleanup();
+        this._workaroundWebKitBug1208516Cleanup = null;
+      }
+      const promise = this._restart(constraints);
+
+      if (this._workaroundSilenceOnUnmute) {
+        promise.finally(() => {
+          this._workaroundWebKitBug1208516Cleanup = restartWhenSilentOnUnmute(this);
+        });
+      }
+      if (this._workaroundWebKitBug1208516) {
+        promise.finally(() => {
+          this._workaroundWebKitBug1208516Cleanup = restartWhenInadvertentlyStopped(this);
+        });
+      }
+
+      return promise;
     }
 
     stop() {
       this._log.info('Stopping');
+      if (this._workaroundSilenceOnUnmuteCleanup) {
+        this._workaroundSilenceOnUnmuteCleanup();
+        this._workaroundSilenceOnUnmuteCleanup = null;
+      }
       if (this._workaroundWebKitBug1208516Cleanup) {
         this._workaroundWebKitBug1208516Cleanup();
         this._workaroundWebKitBug1208516Cleanup = null;
@@ -270,6 +325,68 @@ function restartWhenInadvertentlyStopped(localMediaTrack) {
   return () => {
     documentVisibilityMonitor.offVisible(1, handleTrackStateChange);
     mediaStreamTrack.removeEventListener('ended', handleTrackStateChange);
+  };
+}
+
+/**
+ * Restart a {@link LocalMediaTrack} that is silent upon unmute.
+ * @private
+ * @param {LocalAudioTrack|LocalVideoTrack} localMediaTrack
+ * @returns {function} Cleans up listeners attached by the workaround
+ */
+function restartWhenSilentOnUnmute(localMediaTrack) {
+  const { _log: log, kind } = localMediaTrack;
+
+  const detectSilence = {
+    audio: detectSilentAudio,
+    video: detectSilentVideo
+  }[kind];
+
+  let { _dummyEl: el, mediaStreamTrack } = localMediaTrack;
+
+  function onUnmute() {
+    if (!localMediaTrack.isEnabled) {
+      return;
+    }
+    log.info('Unmuted, checking silence');
+
+    // The dummy element is paused, so play it and then detect silence.
+    el.play().then(() => detectSilence(el)).then(isSilent => {
+      if (!isSilent) {
+        log.info('Non-silence detected, no need to restart');
+        return;
+      }
+      log.warn('Silence detected, restarting');
+
+      // NOTE(mmalavalli): If we try and restart a silent MediaStreamTrack
+      // without stopping it first, then a NotReadableError is raised in case of
+      // video, or the restarted audio will still be silent. Hence, we stop the
+      // MediaStreamTrack here.
+      localMediaTrack._stop();
+
+      // Restart the LocalMediaTrack.
+      return localMediaTrack._restart();
+    }).catch(error => {
+      log.warn('Failed to detect silence and restart:', error);
+    }).finally(() => {
+      // If silence was not detected, then pause the dummy element again.
+      el = localMediaTrack._dummyEl;
+      if (!el.paused) {
+        el.pause();
+      }
+
+      // Reset the unmute handler.
+      mediaStreamTrack.removeEventListener('unmute', onUnmute);
+      mediaStreamTrack = localMediaTrack.mediaStreamTrack;
+      mediaStreamTrack.addEventListener('unmute', onUnmute);
+    });
+  }
+
+  // Set the unmute handler.
+  mediaStreamTrack.addEventListener('unmute', onUnmute);
+
+  return () => {
+    mediaStreamTrack.removeEventListener('unmute', onUnmute);
   };
 }
 

--- a/lib/media/track/localmediatrack.js
+++ b/lib/media/track/localmediatrack.js
@@ -275,8 +275,18 @@ function restartWhenInadvertentlyStopped(localMediaTrack) {
   }
 
   function shouldReacquireTrack() {
-    const { _workaroundWebKitBug1208516Cleanup, isStopped, mediaStreamTrack: { muted } } = localMediaTrack;
+    const {
+      _workaroundWebKitBug1208516Cleanup,
+      isStopped,
+      mediaStreamTrack: { muted }
+    } = localMediaTrack;
+
     const isInadvertentlyStopped = isStopped && !!_workaroundWebKitBug1208516Cleanup;
+
+    // NOTE(mmalavalli): Restart the LocalMediaTrack if:
+    // 1. The app is foregrounded, and
+    // 2. A restart is not already in progress, and
+    // 3. The LocalMediaTrack is either muted, inadvertently stopped or silent
     return Promise.resolve().then(() => {
       return document.visibilityState === 'visible'
         && !trackChangeInProgress

--- a/lib/media/track/localmediatrack.js
+++ b/lib/media/track/localmediatrack.js
@@ -12,8 +12,6 @@ const documentVisibilityMonitor = require('../../util/documentvisibilitymonitor.
 const gUMSilentTrackWorkaround = require('../../webaudio/workaround180748');
 const MediaTrackSender = require('./sender');
 
-const isSafari = guessBrowser() === 'safari';
-
 function mixinLocalMediaTrack(AudioOrVideoTrack) {
   /**
    * A {@link LocalMediaTrack} represents audio or video that your
@@ -30,18 +28,10 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
      * @param {LocalTrackOptions} [options] - {@link LocalTrack} options
      */
     constructor(mediaStreamTrack, options) {
-      // NOTE(mmalavalli): By default, this workaround will be enabled on Safari browsers
-      // although the bug is seen mainly on iOS devices, we do not have a reliable way to
-      // tell iOS from MacOs userAgent on iOS pretends its macOs if Safari is set to request
-      // desktop pages.
-      const workaroundSilenceOnUnmute = isSafari
-        && typeof document === 'object'
-        && typeof document.createElement === 'function';
-
       // NOTE(mpatwardhan): by default workaround for WebKitBug1208516 will be enabled on Safari browsers
       // although the bug is seen  mainly on iOS devices, we do not have a reliable way to tell iOS from MacOs
       // userAgent on iOS pretends its macOs if Safari is set to request desktop pages.
-      const workaroundWebKitBug1208516 = isSafari
+      const workaroundWebKitBug1208516 = guessBrowser() === 'safari'
         && typeof document === 'object'
         && typeof document.addEventListener === 'function'
         && typeof document.visibilityState === 'string';
@@ -49,7 +39,6 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
       options = Object.assign({
         getUserMedia,
         isCreatedByCreateLocalTracks: false,
-        workaroundSilenceOnUnmute,
         workaroundWebKitBug1208516,
         gUMSilentTrackWorkaround
       }, options);
@@ -72,15 +61,8 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
         _gUMSilentTrackWorkaround: {
           value: options.gUMSilentTrackWorkaround
         },
-        _workaroundSilenceOnUnmute: {
-          value: options.workaroundSilenceOnUnmute
-        },
         _workaroundWebKitBug1208516: {
           value: options.workaroundWebKitBug1208516
-        },
-        _workaroundSilenceOnUnmuteCleanup: {
-          value: null,
-          writable: true
         },
         _workaroundWebKitBug1208516Cleanup: {
           value: null,
@@ -113,12 +95,6 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
           }
         }
       });
-
-      // NOTE(mmalavalli): In iOS Safari, we work around a bug where sometimes,
-      // local MediaStreamTracks are silent after they are unmuted.
-      if (this._workaroundSilenceOnUnmute) {
-        this._workaroundSilenceOnUnmuteCleanup = restartWhenSilentOnUnmute(this);
-      }
 
       // NOTE(mpatwardhan): As a workaround for WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=208516,
       // upon foregrounding, re-acquire new MediaStreamTrack if the existing one is ended or muted.
@@ -243,37 +219,22 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
           + ` Local${capitalize(kind)}Track that is created using createLocalTracks`
           + ` or createLocal${capitalize(kind)}Track.`));
       }
-
-      if (this._workaroundSilenceOnUnmuteCleanup) {
-        this._workaroundSilenceOnUnmuteCleanup();
-        this._workaroundSilenceOnUnmuteCleanup = null;
-      }
       if (this._workaroundWebKitBug1208516Cleanup) {
         this._workaroundWebKitBug1208516Cleanup();
         this._workaroundWebKitBug1208516Cleanup = null;
       }
-      const promise = this._restart(constraints);
+      let promise = this._restart(constraints);
 
-      if (this._workaroundSilenceOnUnmute) {
-        promise.finally(() => {
-          this._workaroundWebKitBug1208516Cleanup = restartWhenSilentOnUnmute(this);
-        });
-      }
       if (this._workaroundWebKitBug1208516) {
-        promise.finally(() => {
+        promise = promise.finally(() => {
           this._workaroundWebKitBug1208516Cleanup = restartWhenInadvertentlyStopped(this);
         });
       }
-
       return promise;
     }
 
     stop() {
       this._log.info('Stopping');
-      if (this._workaroundSilenceOnUnmuteCleanup) {
-        this._workaroundSilenceOnUnmuteCleanup();
-        this._workaroundSilenceOnUnmuteCleanup = null;
-      }
       if (this._workaroundWebKitBug1208516Cleanup) {
         this._workaroundWebKitBug1208516Cleanup();
         this._workaroundWebKitBug1208516Cleanup = null;
@@ -283,24 +244,62 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
   };
 }
 
+/**
+ * Restart the given {@link LocalMediaTrack} if it has been inadvertently stopped.
+ * @private
+ * @param {LocalAudioTrack|LocalVideoTrack} localMediaTrack
+ * @returns {function} Clean up listeners attached by the workaround
+ */
 function restartWhenInadvertentlyStopped(localMediaTrack) {
-  let { mediaStreamTrack } = localMediaTrack;
+  const { _log: log, kind } = localMediaTrack;
+  const detectSilence = { audio: detectSilentAudio, video: detectSilentVideo }[kind];
+
+  let { _dummyEl: el, mediaStreamTrack } = localMediaTrack;
   let trackChangeInProgress = null;
+
+  function checkSilence() {
+    // The dummy element is paused, so play it and then detect silence.
+    return el.play().then(() => detectSilence(el)).then(isSilent => {
+      if (isSilent) {
+        log.warn('Silence detected');
+      } else {
+        log.info('Non-silence detected');
+      }
+      return isSilent;
+    }).catch(error => {
+      log.warn('Failed to detect silence:', error);
+    }).finally(() => {
+      // Pause the dummy element again.
+      el.pause();
+    });
+  }
 
   function shouldReacquireTrack() {
     const { _workaroundWebKitBug1208516Cleanup, isStopped, mediaStreamTrack: { muted } } = localMediaTrack;
     const isInadvertentlyStopped = isStopped && !!_workaroundWebKitBug1208516Cleanup;
-    return document.visibilityState === 'visible' && (muted || isInadvertentlyStopped) && !trackChangeInProgress;
+    return Promise.resolve().then(() => {
+      return document.visibilityState === 'visible'
+        && !trackChangeInProgress
+        && (muted || isInadvertentlyStopped || checkSilence());
+    });
   }
 
   function handleTrackStateChange() {
     return Promise.race([
       waitForEvent(mediaStreamTrack, 'unmute'),
       waitForSometime(50)
-    ]).then(() => {
-      if (shouldReacquireTrack()) {
+    ]).then(() => shouldReacquireTrack()).then(shouldReacquire => {
+      if (shouldReacquire && !trackChangeInProgress) {
         trackChangeInProgress = defer();
+
+        // NOTE(mmalavalli): If we try and restart a silent MediaStreamTrack
+        // without stopping it first, then a NotReadableError is raised in case of
+        // video, or the restarted audio will still be silent. Hence, we stop the
+        // MediaStreamTrack here.
+        localMediaTrack._stop();
+
         localMediaTrack._restart().finally(() => {
+          el = localMediaTrack._dummyEl;
           mediaStreamTrack.removeEventListener('ended', handleTrackStateChange);
           mediaStreamTrack = localMediaTrack.mediaStreamTrack;
           mediaStreamTrack.addEventListener('ended', handleTrackStateChange);
@@ -322,71 +321,12 @@ function restartWhenInadvertentlyStopped(localMediaTrack) {
   // play can fail on safari if audio is not being captured.
   documentVisibilityMonitor.onVisible(1, handleTrackStateChange);
   mediaStreamTrack.addEventListener('ended', handleTrackStateChange);
+  mediaStreamTrack.addEventListener('unmute', handleTrackStateChange);
+
   return () => {
     documentVisibilityMonitor.offVisible(1, handleTrackStateChange);
     mediaStreamTrack.removeEventListener('ended', handleTrackStateChange);
-  };
-}
-
-/**
- * Restart a {@link LocalMediaTrack} that is silent upon unmute.
- * @private
- * @param {LocalAudioTrack|LocalVideoTrack} localMediaTrack
- * @returns {function} Cleans up listeners attached by the workaround
- */
-function restartWhenSilentOnUnmute(localMediaTrack) {
-  const { _log: log, kind } = localMediaTrack;
-
-  const detectSilence = {
-    audio: detectSilentAudio,
-    video: detectSilentVideo
-  }[kind];
-
-  let { _dummyEl: el, mediaStreamTrack } = localMediaTrack;
-
-  function onUnmute() {
-    if (!localMediaTrack.isEnabled) {
-      return;
-    }
-    log.info('Unmuted, checking silence');
-
-    // The dummy element is paused, so play it and then detect silence.
-    el.play().then(() => detectSilence(el)).then(isSilent => {
-      if (!isSilent) {
-        log.info('Non-silence detected, no need to restart');
-        return;
-      }
-      log.warn('Silence detected, restarting');
-
-      // NOTE(mmalavalli): If we try and restart a silent MediaStreamTrack
-      // without stopping it first, then a NotReadableError is raised in case of
-      // video, or the restarted audio will still be silent. Hence, we stop the
-      // MediaStreamTrack here.
-      localMediaTrack._stop();
-
-      // Restart the LocalMediaTrack.
-      return localMediaTrack._restart();
-    }).catch(error => {
-      log.warn('Failed to detect silence and restart:', error);
-    }).finally(() => {
-      // If silence was not detected, then pause the dummy element again.
-      el = localMediaTrack._dummyEl;
-      if (!el.paused) {
-        el.pause();
-      }
-
-      // Reset the unmute handler.
-      mediaStreamTrack.removeEventListener('unmute', onUnmute);
-      mediaStreamTrack = localMediaTrack.mediaStreamTrack;
-      mediaStreamTrack.addEventListener('unmute', onUnmute);
-    });
-  }
-
-  // Set the unmute handler.
-  mediaStreamTrack.addEventListener('unmute', onUnmute);
-
-  return () => {
-    mediaStreamTrack.removeEventListener('unmute', onUnmute);
+    mediaStreamTrack.removeEventListener('unmute', handleTrackStateChange);
   };
 }
 

--- a/lib/util/detectsilentaudio.js
+++ b/lib/util/detectsilentaudio.js
@@ -38,12 +38,8 @@ function detectSilentAudio(el) {
 
   // Resolve the returned Promise with true if 3 consecutive attempts
   // to detect silent audio are successful.
-  return doCheckSilence().then(isSilent => {
+  return doCheckSilence().finally(() => {
     AudioContextFactory.release(holder);
-    return isSilent;
-  }).catch(error => {
-    AudioContextFactory.release(holder);
-    throw error;
   });
 }
 

--- a/lib/util/detectsilentaudio.js
+++ b/lib/util/detectsilentaudio.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const detectSilence = require('../webaudio/detectsilence');
+
+const N_ATTEMPTS = 3;
+const ATTEMPT_DURATION_MS = 250;
+
+/**
+ * Detect whether the audio stream rendered by the given HTMLVideoElement is silent.
+ * @param {HTMLAudioElement} el
+ * @returns {Promise<boolean>} true if silent, false if not.
+ */
+function detectSilentAudio(el) {
+  // NOTE(mmalavalli): We have to delay require-ing AudioContextFactory, because
+  // it exports a default instance whose constructor calls Object.assign.
+  const AudioContextFactory = require('../webaudio/audiocontext');
+  const holder = {};
+  const audioContext = AudioContextFactory.getOrCreate(holder);
+
+  let attemptsLeft = N_ATTEMPTS;
+
+  function doCheckSilence() {
+    attemptsLeft--;
+    return detectSilence(audioContext, el.srcObject, ATTEMPT_DURATION_MS).then(isSilent => {
+      if (!isSilent) {
+        return false;
+      }
+      if (attemptsLeft > 0) {
+        return doCheckSilence();
+      }
+      return true;
+    }).catch(() => {
+      // NOTE(mmalavalli): If an error is thrown while detect silence, the audio
+      // stream is assumed to be silent.
+      return true;
+    });
+  }
+
+  // Resolve the returned Promise with true if 3 consecutive attempts
+  // to detect silent audio are successful.
+  return doCheckSilence().then(isSilent => {
+    AudioContextFactory.release(holder);
+    return isSilent;
+  }).catch(error => {
+    AudioContextFactory.release(holder);
+    throw error;
+  });
+}
+
+module.exports = detectSilentAudio;

--- a/lib/util/detectsilentvideo.js
+++ b/lib/util/detectsilentvideo.js
@@ -5,7 +5,7 @@ let canvas = null;
 
 const N_SAMPLES = 3;
 const SAMPLE_HEIGHT = 50;
-const SAMPLE_INTERVAL_MS = 500;
+const SAMPLE_INTERVAL_MS = 250;
 const SAMPLE_WIDTH = 50;
 
 /**
@@ -26,16 +26,14 @@ function checkSilence(el) {
 }
 
 /**
- * Detect whether the video stream rendered by the given
- * HTMLVideoElement is silent.
+ * Detect whether the video stream rendered by the given HTMLVideoElement is silent.
  * @param {HTMLVideoElement} el
- * @param {HTMLDocument} doc
  * @returns {Promise<boolean>} true if silent, false if not.
  */
-function detectSilentVideo(el, doc) {
+function detectSilentVideo(el) {
   // Create the canvas when detectSilentVideo() is called for the
   // first time.
-  canvas = canvas || doc.createElement('canvas');
+  canvas = canvas || document.createElement('canvas');
 
   // Resolve the returned Promise with true if 3 consecutive sample
   // frames from the video being played by the HTMLVideoElement are

--- a/test/unit/spec/media/track/localmediatrack.js
+++ b/test/unit/spec/media/track/localmediatrack.js
@@ -420,11 +420,25 @@ const { defer } = require('../../../../../lib/util');
 
     describe('constructor', () => {
       context('when called without workaroundWebKitBug1208516', () => {
-        it('does not register for document visibility change', () => {
+        let track;
+
+        before(() => {
           document.visibilityState = 'visible';
-          const track = createLocalMediaTrack(LocalMediaTrack, kind[description]);
-          assert(track instanceof LocalMediaTrack);
-          sinon.assert.callCount(document.addEventListener, 0);
+          track = createLocalMediaTrack(LocalMediaTrack, kind[description], {}, {}, [
+            'addEventListener',
+            'removeEventListener'
+          ]);
+        });
+
+        it('does not register for document visibility change', () => {
+          sinon.assert.notCalled(document.addEventListener);
+        });
+
+        it('should not listen to "ended" and "unmute" events on the underlying MediaStreamTrack', () => {
+          sinon.assert.callCount(track.mediaStreamTrack.addEventListener, 1);
+          sinon.assert.neverCalledWith(track.mediaStreamTrack.addEventListener, 'unmute');
+          assert.equal(track.mediaStreamTrack.addEventListener.args[0][0], 'ended');
+          assert.equal(track.mediaStreamTrack.addEventListener.args[0][1].name, 'onended');
         });
       });
 
@@ -433,8 +447,12 @@ const { defer } = require('../../../../../lib/util');
 
         before(() => {
           document.visibilityState = 'visible';
-          localMediaTrack = createLocalMediaTrack(LocalMediaTrack, kind[description], { workaroundWebKitBug1208516: true });
-          assert(localMediaTrack instanceof LocalMediaTrack);
+          localMediaTrack = createLocalMediaTrack(LocalMediaTrack, kind[description], {
+            workaroundWebKitBug1208516: true
+          }, {}, [
+            'addEventListener',
+            'removeEventListener'
+          ]);
         });
 
         after(() => {
@@ -446,6 +464,12 @@ const { defer } = require('../../../../../lib/util');
           sinon.assert.callCount(document.addEventListener, 1);
           sinon.assert.calledWith(document.addEventListener, 'visibilitychange');
           sinon.assert.callCount(document.removeEventListener, 0);
+        });
+
+        it('should listen to "ended" and "unmute" events on the underlying MediaStreamTrack', () => {
+          ['ended', 'unmute'].forEach(event => {
+            sinon.assert.calledWith(localMediaTrack.mediaStreamTrack.addEventListener, event);
+          });
         });
 
         it('should call setMediaStreamTrack on all senders when document is visible and MediaStreamTrack has ended', async () => {
@@ -543,7 +567,7 @@ const { defer } = require('../../../../../lib/util');
           return phase2Promise;
         });
 
-        it('un-registers for document visibility change when track is stopped', () => {
+        it('un-registers for document visibility change and "ended" and "unmute" events when track is stopped', () => {
           sinon.assert.callCount(document.addEventListener, 1);
           sinon.assert.calledWith(document.addEventListener, 'visibilitychange');
           sinon.assert.callCount(document.removeEventListener, 0);
@@ -551,82 +575,10 @@ const { defer } = require('../../../../../lib/util');
           localMediaTrack.stop();
           sinon.assert.callCount(document.removeEventListener, 1);
           sinon.assert.calledWith(document.removeEventListener, 'visibilitychange');
-        });
-      });
-    });
-  });
 
-  [
-    { workaroundSilenceOnUnmute: true },
-    { workaroundSilenceOnUnmute: false },
-    {}
-  ].forEach(options => {
-    describe(`when created with${'workaroundSilenceOnUnmute' in options
-      ? ` workaroundSilenceOnUnmute = ${options.workaroundSilenceOnUnmute}`
-      : 'out workaroundSilenceOnUnmute'}`, () => {
-      const { workaroundSilenceOnUnmute } = options;
-      let localMediaTrack;
-
-      beforeEach(() => {
-        global.document = global.document || new Document();
-        localMediaTrack = createLocalMediaTrack(LocalMediaTrack, kind[description], Object.assign({
-          isCreatedByCreateLocalTracks: true
-        }, options), {}, [
-          'addEventListener',
-          'removeEventListener'
-        ]);
-      });
-
-      afterEach(() => {
-        if (global.document instanceof Document) {
-          delete global.document;
-        }
-      });
-
-      it(`should${workaroundSilenceOnUnmute ? '' : ' not'} call addEventListener on the underlying MediaStreamTrack for the "unmute" event`, () => {
-        if (workaroundSilenceOnUnmute) {
-          sinon.assert.calledWith(localMediaTrack.mediaStreamTrack.addEventListener, 'unmute');
-        } else {
-          sinon.assert.neverCalledWith(localMediaTrack.mediaStreamTrack.addEventListener, 'unmute');
-        }
-      });
-
-      context('when #stop is called', () => {
-        beforeEach(() => {
-          localMediaTrack.stop();
-        });
-
-        it(`should${workaroundSilenceOnUnmute ? '' : ' not'} call removeEventListener on the underlying MediaStreamTrack for the "unmute" event`, () => {
-          if (workaroundSilenceOnUnmute) {
-            sinon.assert.calledWith(localMediaTrack.mediaStreamTrack.removeEventListener, 'unmute');
-          } else {
-            sinon.assert.neverCalledWith(localMediaTrack.mediaStreamTrack.removeEventListener, 'unmute');
-          }
-        });
-      });
-
-      context('when #restart is called', () => {
-        let mediaStreamTrack;
-
-        beforeEach(() => {
-          mediaStreamTrack = localMediaTrack.mediaStreamTrack;
-          return localMediaTrack.restart();
-        });
-
-        it(`should${workaroundSilenceOnUnmute ? '' : ' not'} call removeEventListener on the old MediaStreamTrack for the "unmute" event`, () => {
-          if (workaroundSilenceOnUnmute) {
-            sinon.assert.calledWith(mediaStreamTrack.removeEventListener, 'unmute');
-          } else {
-            sinon.assert.neverCalledWith(mediaStreamTrack.removeEventListener, 'unmute');
-          }
-        });
-
-        it(`should${workaroundSilenceOnUnmute ? '' : ' not'} call addEventListener on the new MediaStreamTrack for the "unmute" event`, () => {
-          if (workaroundSilenceOnUnmute) {
-            sinon.assert.calledWith(localMediaTrack.mediaStreamTrack.addEventListener, 'unmute');
-          } else {
-            sinon.assert.neverCalledWith(localMediaTrack.mediaStreamTrack.addEventListener, 'unmute');
-          }
+          ['ended', 'unmute'].forEach(event => {
+            sinon.assert.calledWith(localMediaTrack.mediaStreamTrack.removeEventListener, event);
+          });
         });
       });
     });
@@ -655,6 +607,7 @@ function createLocalMediaTrack(LocalMediaTrack, kind, options = {}, constraints 
 
 function stubMethods(instance, methods) {
   methods.forEach(method => {
-    instance[method] = sinon.spy();
+    const fn = instance[method];
+    instance[method] = sinon.spy((...args) => fn.apply(instance, args));
   });
 }


### PR DESCRIPTION
@makarandp0 

This PR fixes the silent local audio issue (after playing youtube, etc) for iOS 13.6+, where the track does not go to ended state like before. Rather, it gets unmuted. Now, we detect silence after unmuted and reacquire the track.

This PR also merges the workaround for the local video silent issue (after a phone call) with the workaround for the local audio silent issue into a common workaround function.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
