### PR TITLE
JSDK-2932 Work around WebKit Bug 213853

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 Bug Fixes
 ---------
 
+- Fixed a bug where, sometimes an iOS Safari Participant is not heard by others in
+  a Room after handling an incoming phone call. (JSDK-2932)
 - In version [2.6.0](#260-june-26-2020), we had introduced a workaround for this iOS Safari
   [bug](https://bugs.webkit.org/show_bug.cgi?id=208516) which causes your application to lose
   the microphone when another application (Siri, YouTube, FaceTime, etc.) reserves the microphone.

--- a/lib/media/track/localmediatrack.js
+++ b/lib/media/track/localmediatrack.js
@@ -9,6 +9,7 @@ const { typeErrors: { ILLEGAL_INVOKE } } = require('../../util/constants');
 const detectSilentAudio = require('../../util/detectsilentaudio');
 const detectSilentVideo = require('../../util/detectsilentvideo');
 const documentVisibilityMonitor = require('../../util/documentvisibilitymonitor.js');
+const localMediaRestartDeferreds = require('../../util/localmediarestartdeferreds');
 const gUMSilentTrackWorkaround = require('../../webaudio/workaround180748');
 const MediaTrackSender = require('./sender');
 
@@ -294,7 +295,7 @@ function restartWhenInadvertentlyStopped(localMediaTrack) {
     });
   }
 
-  function handleTrackStateChange() {
+  function maybeRestart() {
     return Promise.race([
       waitForEvent(mediaStreamTrack, 'unmute'),
       waitForSometime(50)
@@ -310,9 +311,9 @@ function restartWhenInadvertentlyStopped(localMediaTrack) {
 
         localMediaTrack._restart().finally(() => {
           el = localMediaTrack._dummyEl;
-          mediaStreamTrack.removeEventListener('ended', handleTrackStateChange);
+          removeMediaStreamTrackListeners();
           mediaStreamTrack = localMediaTrack.mediaStreamTrack;
-          mediaStreamTrack.addEventListener('ended', handleTrackStateChange);
+          addMediaStreamTrackListeners();
           trackChangeInProgress.resolve();
           trackChangeInProgress = null;
         });
@@ -321,22 +322,49 @@ function restartWhenInadvertentlyStopped(localMediaTrack) {
       // NOTE(mmalavalli): If the MediaStreamTrack ends before the DOM is visible,
       // then this makes sure that visibility callback for phase 2 is called only
       // after the MediaStreamTrack is re-acquired.
-      return trackChangeInProgress && trackChangeInProgress.promise;
+      const promise = (trackChangeInProgress && trackChangeInProgress.promise) || Promise.resolve();
+      return promise.finally(() => localMediaRestartDeferreds.resolveDeferred(kind));
     });
+  }
+
+  function onMute() {
+    const { _log: log, kind } = localMediaTrack;
+    log.info('Muted');
+    log.debug('LocalMediaTrack:', localMediaTrack);
+
+    // NOTE(mmalavalli): When a LocalMediaTrack is muted without the app being
+    // backgrounded, and the inadvertently paused elements are played before it
+    // is restarted, it never gets unmuted due to the WebKit Bug 213853. Hence,
+    // setting this Deferred will make sure that the inadvertently paused elements
+    // are played only after the LocalMediaTrack is unmuted.
+    //
+    // Bug: https://bugs.webkit.org/show_bug.cgi?id=213853
+    //
+    localMediaRestartDeferreds.startDeferred(kind);
+  }
+
+  function addMediaStreamTrackListeners() {
+    mediaStreamTrack.addEventListener('ended', maybeRestart);
+    mediaStreamTrack.addEventListener('mute', onMute);
+    mediaStreamTrack.addEventListener('unmute', maybeRestart);
+  }
+
+  function removeMediaStreamTrackListeners() {
+    mediaStreamTrack.removeEventListener('ended', maybeRestart);
+    mediaStreamTrack.removeEventListener('mute', onMute);
+    mediaStreamTrack.removeEventListener('unmute', maybeRestart);
   }
 
   // NOTE(mpatwardhan): listen for document visibility callback on phase 1.
   // this ensures that any we acquire media tracks before RemoteMediaTrack
   // tries to `play` them (in phase 2). This order is important because
   // play can fail on safari if audio is not being captured.
-  documentVisibilityMonitor.onVisible(1, handleTrackStateChange);
-  mediaStreamTrack.addEventListener('ended', handleTrackStateChange);
-  mediaStreamTrack.addEventListener('unmute', handleTrackStateChange);
+  documentVisibilityMonitor.onVisible(1, maybeRestart);
+  addMediaStreamTrackListeners();
 
   return () => {
-    documentVisibilityMonitor.offVisible(1, handleTrackStateChange);
-    mediaStreamTrack.removeEventListener('ended', handleTrackStateChange);
-    mediaStreamTrack.removeEventListener('unmute', handleTrackStateChange);
+    documentVisibilityMonitor.offVisible(1, maybeRestart);
+    removeMediaStreamTrackListeners();
   };
 }
 

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -4,6 +4,7 @@ const { guessBrowser } = require('@twilio/webrtc/lib/util');
 const { MediaStream } = require('@twilio/webrtc');
 
 const { waitForEvent, waitForSometime } = require('../../util');
+const localMediaRestartDeferreds = require('../../util/localmediarestartdeferreds');
 const Track = require('./');
 
 /**
@@ -290,9 +291,16 @@ function playIfPausedAndNotBackgrounded(el, log) {
     waitForSometime(1000)
   ]).then(() => {
     if (document.visibilityState === 'visible') {
-      log.info(`Playing unintentionally paused <${tag}> element`);
-      log.debug('Element:', el);
-      el.play().then(() => {
+      // NOTE(mmalavalli): We play the inadvertently paused elements only after
+      // the LocalAudioTrack is unmuted to work around WebKit Bug 213853.
+      //
+      // Bug: https://bugs.webkit.org/show_bug.cgi?id=213853
+      //
+      localMediaRestartDeferreds.whenResolved(tag).then(() => {
+        log.info(`Playing unintentionally paused <${tag}> element`);
+        log.debug('Element:', el);
+        return el.play();
+      }).then(() => {
         log.info(`Successfully played unintentionally paused <${tag}> element`);
         log.debug('Element:', el);
       }).catch(error => {

--- a/lib/util/localmediarestartdeferreds.js
+++ b/lib/util/localmediarestartdeferreds.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const { defer } = require('./');
+
+/**
+ * This is a pair of Deferreds that are set whenever local media is muted and
+ * resolved whenever local media is unmuted/ended and restarted if necessary.
+ */
+class LocalMediaRestartDeferreds {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    Object.defineProperties(this, {
+      _audio: {
+        value: defer(),
+        writable: true
+      },
+      _video: {
+        value: defer(),
+        writable: true
+      }
+    });
+
+    // Initially, resolve both the Deferreds.
+    this._audio.resolve();
+    this._video.resolve();
+  }
+
+  /**
+   * Resolve the Deferred for audio or video.
+   * @param {'audio'|'video'} kind
+   */
+  resolveDeferred(kind) {
+    if (kind === 'audio') {
+      this._audio.resolve();
+    } else {
+      this._video.resolve();
+    }
+  }
+
+  /**
+   * Start the Deferred for audio or video.
+   * @param {'audio' | 'video'} kind
+   */
+  startDeferred(kind) {
+    if (kind === 'audio') {
+      this._audio = defer();
+    } else {
+      this._video = defer();
+    }
+  }
+
+  /**
+   * Wait until the Deferred for audio or video is resolved.
+   * @param {'audio'|'video'} kind
+   * @returns {Promise<void>}
+   */
+  whenResolved(kind) {
+    return kind === 'audio' ? this._audio.promise : this._video.promise;
+  }
+}
+
+module.exports = new LocalMediaRestartDeferreds();


### PR DESCRIPTION
@makarandp0 
 
This PR works around this WebKit [bug](https://bugs.webkit.org/show_bug.cgi?id=213853) by playing inadvertently paused elements only after the local media is restarted after it has ended or unmuted.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
