### PR TITLE
JSDK-2804: firefox disconnects when running localtrackpublication.js

### DIFF
--- a/karma/makeconf.js
+++ b/karma/makeconf.js
@@ -40,8 +40,7 @@ function generateReportName(files) {
 }
 
 function makeConf(defaultFile, browserNoActivityTimeout, requires) {
-  const browserDisconnectTimeout = 10000;
-  browserNoActivityTimeout = browserNoActivityTimeout || 30000;
+  browserNoActivityTimeout = browserNoActivityTimeout || 60000;
   if (isDocker) {
     // things go slow in docker for network tests
     browserNoActivityTimeout = 4 * 60 * 10000;
@@ -137,7 +136,9 @@ function makeConf(defaultFile, browserNoActivityTimeout, requires) {
       singleRun: !process.env.DEBUG,
       concurrency: 1,
       browserNoActivityTimeout,
-      browserDisconnectTimeout,
+      captureTimeout: 60000,
+      browserDisconnectTolerance: 2,
+      browserDisconnectTimeout: 60000,
       customLaunchers: {
         ChromeInDocker: {
           base: 'ChromeHeadless',

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -43,7 +43,7 @@ const {
   waitOnceForRoomEvent
 } = require('../../lib/util');
 
-describe(`LocalTrackPublication ${isFirefox ? '(@unstable: JSDK-2804)' : ''}`, function() {
+describe('LocalTrackPublication', function() {
   // eslint-disable-next-line no-invalid-this
   this.timeout(60000);
 
@@ -108,7 +108,6 @@ describe(`LocalTrackPublication ${isFirefox ? '(@unstable: JSDK-2804)' : ''}`, f
 
     aliceLocalAudioTrack.disable();
     await waitOnceForRoomEvent(thisRoom, 'trackDisabled');
-
     [thisRoom, ...thoseRooms].forEach(room => room && room.disconnect());
   });
 


### PR DESCRIPTION
these relaxed settings for browser reconnect/capture/disconnect configs for karma fixes disconnect issues with firefox.
I also found these issues at much lower frequency in newer stable firefox (v79) 


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
