### PR TITLE
JSDK-2939: 'resetNetwork' timeout failures.

### DIFF
--- a/docker/dockerProxyClient.js
+++ b/docker/dockerProxyClient.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const DOCKER_PROXY_SERVER_URL = 'http://localhost:3032/';
-
+let requestNumber = 0;
 /**
  * Provides interface to communicate with docker via DockerProxyServer
  * via {@link DockerProxyServer}
@@ -152,13 +152,17 @@ class DockerProxyClient {
   }
 
   async _makeRequest(api) {
+    const thisRequestNumber = requestNumber++;
+    const logPrefix = `DockerProxyClient [${thisRequestNumber}]: `;
     try {
+      console.log(logPrefix + 'Requesting: ', api);
       const res = await fetch(this._serverUrl + api);
       const text = await res.text();
       const json = text ? JSON.parse(text) : {};
+      console.log(logPrefix + 'Done: ', api, json);
       return json;
     } catch (err) {
-      console.error(`"fetch ${api} threw  : `, err);
+      console.error(logPrefix + 'Threw  : ', err);
       throw err;
     }
   }

--- a/docker/fetchRequest.js
+++ b/docker/fetchRequest.js
@@ -3,13 +3,15 @@
 const http = require('http');
 
 let requestId = 200;
-function fetchRequest(options, postdata) {
+function fetchRequest(options, postData) {
   const thisRequest = requestId++;
+  const logPrefix = `fetchRequest[${thisRequest}]: `;
+  console.log(logPrefix + 'Processing ', postData);
   return new Promise((resolve, reject) => {
     let clientRequest = http.request(options, res => {
       const requestFailed = res.statusCode !== 200 && res.statusCode !== 201;
       if (requestFailed) {
-        console.warn(`${thisRequest}: request returned:`, res.statusCode, options, postdata);
+        console.warn(logPrefix + 'requestFailed returned:', res.statusCode, options, postData);
       }
       res.setEncoding('utf8');
       let rawData = '';
@@ -23,22 +25,23 @@ function fetchRequest(options, postdata) {
             parsedData = JSON.parse(rawData);
           }
           if (requestFailed) {
-            console.warn(`${thisRequest}: request failed with:`, res.statusCode, parsedData);
+            console.warn(logPrefix + 'requestFailed2 returned:', res.statusCode, postData);
           }
+          console.log(logPrefix + 'resolving');
           resolve(parsedData);
         } catch (e) {
-          console.warn(`${thisRequest}: error parsing data:`, rawData);
+          console.error(logPrefix + 'rejecting:', e);
           reject(e);
         }
       });
     });
     clientRequest.on('error', e => {
-      console.warn(`${thisRequest}: request failed`, e);
+      console.error(logPrefix + 'rejecting:', e);
       reject(e);
     });
 
-    if (postdata) {
-      clientRequest.write(postdata);
+    if (postData) {
+      clientRequest.write(postData);
     }
     clientRequest.end();
   });

--- a/test/integration/spec/docker/reconnection.js
+++ b/test/integration/spec/docker/reconnection.js
@@ -35,6 +35,7 @@ const VALIDATE_MEDIA_FLOW_TIMEOUT = ONE_MINUTE;
 const RECONNECTING_TIMEOUT = 5 * ONE_MINUTE;
 const RECONNECTED_TIMEOUT = 5 * ONE_MINUTE;
 const DISCONNECTED_TIMEOUT = 10 * ONE_MINUTE;
+const RESET_NETWORK_TIMEOUT = 4 * ONE_MINUTE;
 
 const DOCKER_PROXY_TURN_REGIONS = ['au1', 'us1', 'us2'];
 const DOCKER_PROXY_TURN_IP_RANGES = {
@@ -140,7 +141,7 @@ describe('network:', function() {
   });
 
   it('connect rejects when network is down', async () => {
-    await waitFor(dockerAPI.resetNetwork(), 'reset network');
+    await waitFor(dockerAPI.resetNetwork(), 'reset network', RESET_NETWORK_TIMEOUT);
     await waitToGoOnline();
     let currentNetworks = await readCurrentNetworks(dockerAPI);
     const sid = await createRoom(name, defaults.topology);
@@ -168,7 +169,7 @@ describe('network:', function() {
       return;
     } finally {
       console.log('resetting network');
-      await waitFor(dockerAPI.resetNetwork(), 'resetting network');
+      await waitFor(dockerAPI.resetNetwork(), 'resetting network', RESET_NETWORK_TIMEOUT);
     }
     throw new Error(`Unexpectedly succeeded joining a room: ${room.sid}`);
   });
@@ -239,7 +240,7 @@ describe('network:', function() {
           this.skip();
         }
 
-        await waitFor(dockerAPI.resetNetwork(), 'reset network');
+        await waitFor(dockerAPI.resetNetwork(), 'reset network', RESET_NETWORK_TIMEOUT);
         await waitToGoOnline();
         currentNetworks = await readCurrentNetworks(dockerAPI);
         const setupOptions = identities.map(identity => ({ identity }));
@@ -256,7 +257,7 @@ describe('network:', function() {
           }
         });
         rooms = [];
-        await waitFor(dockerAPI.resetNetwork(), 'reset network after each');
+        await waitFor(dockerAPI.resetNetwork(), 'reset network after each', RESET_NETWORK_TIMEOUT);
         if (sid) {
           await completeRoom(sid);
         }


### PR DESCRIPTION
It turns out that `resetNetwork` could take long time (sometimes couple of minutes) on firefox. This change increases the timeout value. Other changes are just to help debug such failures. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
