### PR TITLE
JSDK-2893: Fixes incorrect answer revision in sync messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 2.7.2 (In Progress)
 ===================
 
+Bug Fixes
+---------
+- Fixed a race condition that causes the sdk to return stale answer SDP when it loses connection momentarily, which leads to an error: 'Error setting remote description` (JSDK-2893)
+
 Changes
 -------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 
 Bug Fixes
 ---------
-- Fixed a race condition that causes the sdk to return stale answer SDP when it loses connection momentarily, which leads to an error: 'Error setting remote description` (JSDK-2893)
+- Fixed a bug where a Participant in a large Group Room sometimes gets inadvertently disconnected with a [MediaServerRemoteDescFailedError](https://media.twiliocdn.com/sdk/js/video/releases/2.7.2/docs/MediaServerRemoteDescFailedError.html). (JSDK-2893)
 
 Changes
 -------

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1274,7 +1274,6 @@ class PeerConnectionV2 extends StateMachine {
     // we need to send the most recent stable description revision instead of the current description revision,
     // which is supposed to be for the next local answer.
     const localDescriptionRevision = this._localDescription.type === 'answer' ? this._lastStableDescriptionRevision : this._descriptionRevision;
-    // const localDescriptionRevision = this._descriptionRevision;
     const localDescription = {
       type: this._localDescription.type,
       revision: localDescriptionRevision

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1268,9 +1268,14 @@ class PeerConnectionV2 extends StateMachine {
     if (!this._localDescription) {
       return null;
     }
+
+    // return the last revision that is set in the local description.
+    // not the one that we are in processing. they would be different if this function gets called for
+    // sending 'sync' message, while we were processing a new offer (but not yet sent the answer for it.)
+    const localDescriptionRevision = this._localDescription.type === 'answer' ? this._lastStableDescriptionRevision : this._descriptionRevision;
     const localDescription = {
       type: this._localDescription.type,
-      revision: this._descriptionRevision
+      revision: localDescriptionRevision
     };
     if (this._localDescription.sdp) {
       localDescription.sdp = this._localDescription.sdp;

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1269,10 +1269,12 @@ class PeerConnectionV2 extends StateMachine {
       return null;
     }
 
-    // return the last revision that is set in the local description.
-    // not the one that we are in processing. they would be different if this function gets called for
-    // sending 'sync' message, while we were processing a new offer (but not yet sent the answer for it.)
+    // NOTE(mpatwardhan): Return most recent localDescription. If the most recent local description is an
+    // answer, and this method is called for sending a "sync" message while the next remote offer is being processed,
+    // we need to send the most recent stable description revision instead of the current description revision,
+    // which is supposed to be for the next local answer.
     const localDescriptionRevision = this._localDescription.type === 'answer' ? this._lastStableDescriptionRevision : this._descriptionRevision;
+    // const localDescriptionRevision = this._descriptionRevision;
     const localDescription = {
       type: this._localDescription.type,
       revision: localDescriptionRevision


### PR DESCRIPTION
In a sequence where:

Step 1. Peer A => sends offer1, revision 1
Step 2. Peer B => returns answer1, revision 1

Step 3. Peer A => sends offer2, revision 2
Step 4. Peer B => sends sync with answer1 but marks it as revision 2

This is what I see in https://issues.corp.twilio.com/browse/JSDK-2893 looking at participant logs. And I see the possibility in code of this if a sync message was sent after step 3 before PeerB set the new answer ( answer2, revision 2) as the local description.

This change ensures that sync message will always set the revision of the local description that is set, not the one that is in process of setting. 


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
