### PR TITLE
JSDK 2920: simulcast getstats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,17 @@ Bug Fixes
 ---------
 - Fixed a bug where a Participant in a large Group Room sometimes gets inadvertently disconnected with a [MediaServerRemoteDescFailedError](https://media.twiliocdn.com/sdk/js/video/releases/2.7.2/docs/MediaServerRemoteDescFailedError.html). (JSDK-2893)
 
-- Fixed a bug where `getStats()` returned stats for only one of the temporal layers of a VP8 simulcast MediaStreamTrack. With simulcast enabled, to get information about local tracks you should look at all matching track sids returned by `getStats` (JSDK-2920). For example following function returns bytes sent on a given video track:
+- Fixed a bug where `Room.getStats()` returned stats for only one of the temporal layers of a VP8 simulcast VideoTrack. Now, you will have a `LocalVideoTrackStats` object for each temporal layer, which you can recognize by the `trackId` and `trackSid` properties. (JSDK-2920)
 ```js
   async function getBytesSentOnLocalVideoTrack(room, trackSid) {
     const stats = await room.getStats();
-    let bytesSent = 0;
+    let totalBytesSent = 0;
     stats.forEach(stat => {
-      bytesSent += stat.localVideoTrackStats
+      totalBytesSent += stat.localVideoTrackStats
         .filter(localVideoTrackStats => trackSid === localVideoTrackStats.trackSid)
         .reduce((bytesSent, localVideoTrackStats) => bytesSent + localVideoTrackStats.bytesSent, 0);
     });
-    return bytesSent;
+    return totalBytesSent;
   }
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Bug Fixes
 ---------
 - Fixed a bug where a Participant in a large Group Room sometimes gets inadvertently disconnected with a [MediaServerRemoteDescFailedError](https://media.twiliocdn.com/sdk/js/video/releases/2.7.2/docs/MediaServerRemoteDescFailedError.html). (JSDK-2893)
 
-- Fixed a bug where `getStats()` returned stats for only one of the temporal layers of a VP8 simulcast MediaStreamTrack. This means you should look at all matching track sids returned by `getStats` to consolidate local track stats (JSDK-2920). For example following function returns bytes sent on a given video track:
+- Fixed a bug where `getStats()` returned stats for only one of the temporal layers of a VP8 simulcast MediaStreamTrack. With simulcast enabled, to get information about local tracks you should look at all matching track sids returned by `getStats` (JSDK-2920). For example following function returns bytes sent on a given video track:
 ```js
   async function getBytesSentOnLocalVideoTrack(room, trackSid) {
     const stats = await room.getStats();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Bug Fixes
 ---------
 - Fixed a bug where a Participant in a large Group Room sometimes gets inadvertently disconnected with a [MediaServerRemoteDescFailedError](https://media.twiliocdn.com/sdk/js/video/releases/2.7.2/docs/MediaServerRemoteDescFailedError.html). (JSDK-2893)
 
+- Fixed a bug where `getStats()` returned stats for only one of the temporal layers of a VP8 simulcast MediaStreamTrack. This means you should look at all matching track sids returned by `getStats` to consolidate local track stats (JSDK-2920). For example following function returns bytes sent on a given video track:
+```js
+  async function getBytesSentOnLocalVideoTrack(room, trackSid) {
+    const stats = await room.getStats();
+    let bytesSent = 0;
+    stats.forEach(stat => {
+      bytesSent += stat.localVideoTrackStats
+        .filter(localVideoTrackStats => trackSid === localVideoTrackStats.trackSid)
+        .reduce((bytesSent, localVideoTrackStats) => bytesSent + localVideoTrackStats.bytesSent, 0);
+    });
+    return bytesSent;
+  }
+```
+
 Changes
 -------
 

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- ./test/unit/index.js"
   },
   "dependencies": {
-    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#0469bcd2e72213c8f6c4c916724e751596c22ced",
+    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#jsdk_2920_simulcast_getstats",
     "backoff": "^2.5.0",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- ./test/unit/index.js"
   },
   "dependencies": {
-    "@twilio/webrtc": "4.3.1",
+    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#0469bcd2e72213c8f6c4c916724e751596c22ced",
     "backoff": "^2.5.0",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- ./test/unit/index.js"
   },
   "dependencies": {
-    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#jsdk_2920_simulcast_getstats",
+    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#11db8bdfcfcc2edf59db933e8131b9e32e34be3a",
     "backoff": "^2.5.0",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"

--- a/test/integration/spec/room.js
+++ b/test/integration/spec/room.js
@@ -159,7 +159,7 @@ describe('Room', function() {
   });
 
   [true, false].forEach(simulcastEnabled => {
-    (isChrome ? describe.only : describe.skip)(`getStats with VP8 Simulcast ${simulcastEnabled ? 'enabled' : 'not enabled'}`, function() {
+    (isChrome ? describe : describe.skip)(`getStats with VP8 Simulcast ${simulcastEnabled ? 'enabled' : 'not enabled'}`, function() {
       it(`returns ${simulcastEnabled ? 'multiple' : 'single'} LocalVideoTrackStats corresponding to the LocalVideoTrack`, async () => {
         const vp8SimulcastOptions = { preferredVideoCodecs: [{ codec: 'VP8', simulcast: true }] };
         const aliceLocalTracks = await createLocalTracks();

--- a/test/integration/spec/room.js
+++ b/test/integration/spec/room.js
@@ -12,7 +12,7 @@ const {
   RoomCompletedError
 } = require('../../../lib/util/twilio-video-errors');
 
-const { isFirefox, isChrome } = require('../../lib/guessbrowser');
+const { isFirefox, isChrome, isSafari } = require('../../lib/guessbrowser');
 const { video: createLocalVideoTrack } = require('../../../lib/createlocaltrack');
 const RemoteParticipant = require('../../../lib/remoteparticipant');
 const { flatMap, smallVideoConstraints } = require('../../../lib/util');
@@ -159,7 +159,7 @@ describe('Room', function() {
   });
 
   [true, false].forEach(simulcastEnabled => {
-    (isChrome ? describe : describe.skip)(`getStats with VP8 Simulcast ${simulcastEnabled ? 'enabled' : 'not enabled'}`, function() {
+    ((isChrome || isSafari) ? describe : describe.skip)(`getStats with VP8 Simulcast ${simulcastEnabled ? 'enabled' : 'not enabled'}`, function() {
       it(`returns ${simulcastEnabled ? 'multiple' : 'single'} LocalVideoTrackStats corresponding to the LocalVideoTrack`, async () => {
         const vp8SimulcastOptions = { preferredVideoCodecs: [{ codec: 'VP8', simulcast: true }] };
         const aliceLocalTracks = await createLocalTracks();


### PR DESCRIPTION
This change updates webrtc dependency to use [fix for simulcast getStats](https://github.com/twilio/twilio-webrtc.js/commit/0469bcd2e72213c8f6c4c916724e751596c22ced) + added an integration test and changelog entry

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
