### PR TITLE
JSDK-2801: not unstable anymore

### DIFF
--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -864,11 +864,6 @@ describe('connect', function() {
             }
           ],
           ({ source }) => `when Tracks are pre-created using ${source}`
-        ],
-        [
-          [true],
-          // eslint-disable-next-line no-unused-vars
-          _x => defaults.topology === 'peer-to-peer' ? '(@unstable: JSDK-2801)' : ''
         ]
       ], ([names, { source, getTracks }]) => {
         if (source === 'MediaStreamTracks from getUserMedia()' && !!names) {


### PR DESCRIPTION
this this test has been passing consistently lately. removing `unstable` tag

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
