### PR TITLE
add missing dependencies for browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
   "dependencies": {
     "@twilio/webrtc": "4.3.2",
     "backoff": "^2.5.0",
+    "util": "^0.12.3",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },


### PR DESCRIPTION
If this package is intended to be used in browsers it should not require node builtins.

Instead it should use browser compatible dependencies, e.g.:

- https://www.npmjs.com/package/util
- https://www.npmjs.com/package/events

If you try to use this package with a bundler (e.g. some Rollup setups, and Vite) that is strict about this sort of thing you will be forced to workaround this issue.

I've also opened [a PR on `twilio-webrct.js`](https://github.com/twilio/twilio-webrtc.js/pull/131).

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
