### PR TITLE
mark unstable

### DIFF
--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -700,8 +700,8 @@ describe('LocalTrackPublication', function() {
   });
 
   // note: I have seen firefox getting disconnected after this test.
-  // note: also seen and this test fail (Bob only sends TrackA in SDP) on p2p.
-  it(`JSDK-2573 - race condition when recycling transceiver: ${isFirefox || defaults.topology === 'peer-to-peer' ? '@unstable: JSDK-2807' : ''}`, async () => {
+  // note: also seen and this test fail (Bob only sends TrackA in SDP)
+  it('JSDK-2573 - race condition when recycling transceiver: @unstable: JSDK-2807', async () => {
     // Alice and Bob join without tracks
     const { roomSid, aliceRoom, bobRoom, bobLocal, bobRemote } = await setupAliceAndBob({
       aliceOptions: { tracks: [] },


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/twilio/twilio-video.js/2277/workflows/83574116-c687-430a-b07c-6015f54dde77/jobs/25182/parallel-runs/5

This test has been failing once in a while, and it's clear that we do not include trackB sometimes - need to investigate more.
When the test fails I noticed following log lines:

```
 WARN LOG: '2020-09-04', '11:26:36.505Z', '|', 'WARN', 'in', '[PeerConnectionV2 #11: df846b6c-2866-4c5c-96d1-2f222b6636a4]:', 'Reusing transceiver: 1] 29b12900-9884-4641-8564-cbd6898de798 => 963f08e7-cf21-4c27-9ce8-7d781026cf9c'
 WARN LOG: 'xxxx [118] Timed out waiting for : wait for alice to subscribe to Bobs tracks: RMe4f4be6aeef6c6d843ab579e43d7839b [30.014 seconds]'
 ✗ JSDK-2573 - race condition when recycling transceiver: 
 Error: Timed out waiting for : wait for alice to subscribe to Bobs tracks: RMe4f4be6aeef6c6d843ab579e43d7839b
 at /tmp/94cdbc341b1e1257e24fcff5dbd4a055.browserify.js:140895:14
```
and noticed that new offer sent does not contain trackB

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
