### PR TITLE
tests that force differen m-line order

### DIFF
--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -633,10 +633,10 @@ async function getRegionalizedIceServers(token, region) {
   return iceServers;
 }
 
-function getTotalBytesReceived(statReports) {
+function getTotalBytesReceived(statReports, trackTypes = ['remoteVideoTrackStats', 'remoteAudioTrackStats']) {
   let totalBytesReceived = 0;
   statReports.forEach(statReport => {
-    ['remoteVideoTrackStats', 'remoteAudioTrackStats'].forEach(trackType => {
+    trackTypes.forEach(trackType => {
       statReport[trackType].forEach(trackStats => {
         totalBytesReceived += trackStats.bytesReceived;
       });
@@ -651,20 +651,20 @@ function getTotalBytesReceived(statReports) {
  * @param {number} testTimeMS
  * @returns {Promise<>}
  */
-async function validateMediaFlow(room, testTimeMS = 6000) {
+async function validateMediaFlow(room, testTimeMS = 6000, trackTypes = ['remoteVideoTrackStats', 'remoteAudioTrackStats']) {
   // wait for some time.
   await new Promise(resolve => setTimeout(resolve, testTimeMS));
 
   // get StatsReports.
   const statsBefore = await room.getStats();
-  const bytesReceivedBefore = getTotalBytesReceived(statsBefore);
+  const bytesReceivedBefore = getTotalBytesReceived(statsBefore, trackTypes);
 
   // wait for some more time.
   await new Promise(resolve => setTimeout(resolve, testTimeMS));
 
   // get StatsReports again.
   const statsAfter = await room.getStats();
-  const bytesReceivedAfter = getTotalBytesReceived(statsAfter);
+  const bytesReceivedAfter = getTotalBytesReceived(statsAfter, trackTypes);
 
   console.log(`'BytesReceived Before =  ${bytesReceivedBefore}, After = ${bytesReceivedAfter}`);
   if (bytesReceivedAfter <= bytesReceivedBefore) {


### PR DESCRIPTION
These tests forces different order or audio and video m-lines for participants. These would help catch bugs like [VMS-2812](https://issues.corp.twilio.com/browse/VMS-2812)  which turned into [incident](https://twilioincidents.appspot.com/incident/5087283968475136/view) on chrome 85.

verified that test failed and [rollbar entry was captured](https://rollbar.com/Twilio/VIDEO-rtc-sfu-service/items/1987/occurrences/135997201632/) in dev when the [buggy SFU was deployed](https://twilio.slack.com/archives/C01A979A68Z/p1600363354354800).
 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
