### PR TITLE
JSDK-2999 safari media popup shows up during preflight

### DIFF
--- a/lib/preflight/preflighttest.js
+++ b/lib/preflight/preflighttest.js
@@ -4,6 +4,8 @@ const connect  = require('../connect');
 const TimeMeasurement = require('../util/timemeasurement');
 const makeStat = require('../stats/makestat.js');
 const { createAudioTrack, createVideoTrack } = require('./synthetic');
+const LocalAudioTrack = require('../media/track/es5/localaudiotrack');
+const LocalVideoTrack = require('../media/track/es5/localvideotrack');
 const SECOND = 1000;
 const DEFAULT_TEST_DURATION = 10 * SECOND;
 
@@ -314,7 +316,10 @@ function runPreflightTest(publisherToken, subscriberToken, options, preflightTes
   return Promise.resolve()
     .then(() => {
       return executePreflightStep('acquire media', () => {
-        return [createAudioTrack(), createVideoTrack()];
+        return [
+          new LocalAudioTrack(createAudioTrack(), { workaroundWebKitBug1208516: false, workaroundWebKitBug180748: false }),
+          new LocalVideoTrack(createVideoTrack(), { workaroundWebKitBug1208516: false, workaroundSilentLocalVideo: false })
+        ];
       });
     }).then(tracks => {
       return executePreflightStep('connect publisher', () => {


### PR DESCRIPTION
This disables various workarounds for iOS safari when running preflight test. They are not applicable as preflight test works on synthetic tracks. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
