### PR TITLE
JSDK 2998 - preflight safari audiocontext

### DIFF
--- a/lib/preflight/preflight.js
+++ b/lib/preflight/preflight.js
@@ -12,7 +12,9 @@ const PreflightTest = require('./preflighttest');
  * connectivity. Tokens used for this api call should be associated with unique test room,
  * Test will join the room specified in the token. if room does not exist an ad-hoc room will
  * be created of the type specified in your <a href="https://www.twilio.com/console/video/configure"> console settings </a>
- *
+ * This function uses <a href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API"> web audio apis.</a> Browser's
+ * autoplay policies sometimes require user action before accessing these apis. Ensure that this api is called in response to user action
+ * like a button click.
  * @alias module:twilio-video.testPreflight
  * @param {string} publisherToken - The Access Token string for the participant. This participant will publish tracks.
  * @param {string} subscriberToken - The Access Token string for the participant. This participant will subscribe to tracks.

--- a/lib/preflight/preflighttest.js
+++ b/lib/preflight/preflighttest.js
@@ -314,13 +314,18 @@ function runPreflightTest(publisherToken, subscriberToken, options, preflightTes
   }
 
   function acquireMedia() {
-    return [
-      new LocalAudioTrack(createAudioTrack(), { workaroundWebKitBug1208516: false, workaroundWebKitBug180748: false }),
-      new LocalVideoTrack(createVideoTrack(), { workaroundWebKitBug1208516: false, workaroundSilentLocalVideo: false })
-    ];
+    try {
+      const tracks = [
+        new LocalAudioTrack(createAudioTrack(), { workaroundWebKitBug1208516: false, workaroundWebKitBug180748: false }),
+        new LocalVideoTrack(createVideoTrack(), { workaroundWebKitBug1208516: false, workaroundSilentLocalVideo: false })
+      ];
+      return Promise.resolve(tracks);
+    } catch (ex) {
+      return Promise.reject(ex);
+    }
   }
 
-  return Promise.resolve(acquireMedia())
+  return acquireMedia()
     .then(tracks => {
       localTracks = tracks;
     }).then(() => {

--- a/lib/preflight/preflighttest.js
+++ b/lib/preflight/preflighttest.js
@@ -313,17 +313,18 @@ function runPreflightTest(publisherToken, subscriberToken, options, preflightTes
     });
   }
 
-  return Promise.resolve()
-    .then(() => {
-      return executePreflightStep('acquire media', () => {
-        return [
-          new LocalAudioTrack(createAudioTrack(), { workaroundWebKitBug1208516: false, workaroundWebKitBug180748: false }),
-          new LocalVideoTrack(createVideoTrack(), { workaroundWebKitBug1208516: false, workaroundSilentLocalVideo: false })
-        ];
-      });
-    }).then(tracks => {
+  function acquireMedia() {
+    return [
+      new LocalAudioTrack(createAudioTrack(), { workaroundWebKitBug1208516: false, workaroundWebKitBug180748: false }),
+      new LocalVideoTrack(createVideoTrack(), { workaroundWebKitBug1208516: false, workaroundSilentLocalVideo: false })
+    ];
+  }
+
+  return Promise.resolve(acquireMedia())
+    .then(tracks => {
+      localTracks = tracks;
+    }).then(() => {
       return executePreflightStep('connect publisher', () => {
-        localTracks = tracks;
         preflightTest.emit('progress', PreflightProgress.mediaAcquired);
         return connect(publisherToken, options);
       });


### PR DESCRIPTION
preflight uses web audio apis - On safari we do not get any bytes on audio tracks created using these apis if there was a big delay between user action and creating audio context.  here is a demo of this issue (https://makarandp0.github.io/safariAudio/)

This change 1) adds doc to clarify this 2) small code change to ensure we acquire tracks on the same tick

- [ ] todo: fix unit test

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
