### PR TITLE
JSDK-3004 Enable DTX in opus for AudioTracks created using createLocalAudioTrack() or createLocalTracks().

### DIFF
--- a/lib/media/track/localmediatrack.js
+++ b/lib/media/track/localmediatrack.js
@@ -44,7 +44,10 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
         gUMSilentTrackWorkaround
       }, options);
 
-      const mediaTrackSender = new MediaTrackSender(mediaStreamTrack);
+      const mediaTrackSender = new MediaTrackSender(mediaStreamTrack, {
+        enableDtxForOpus: options.isCreatedByCreateLocalTracks
+      });
+
       const { kind } = mediaTrackSender;
 
       super(mediaTrackSender, options);

--- a/lib/media/track/sender.js
+++ b/lib/media/track/sender.js
@@ -10,15 +10,28 @@ class MediaTrackSender extends MediaTrackTransceiver {
   /**
    * Construct a {@link MediaTrackSender}.
    * @param {MediaStreamTrack} mediaStreamTrack
+   * @param {*} options
    */
-  constructor(mediaStreamTrack) {
+  constructor(mediaStreamTrack, options) {
+    options = Object.assign({
+      enableDtxForOpus: false
+    }, options);
+
     super(mediaStreamTrack.id, mediaStreamTrack);
+
     Object.defineProperties(this, {
       _clones: {
         value: new Set()
       },
+      _options: {
+        value: options
+      },
       _senders: {
         value: new Set()
+      },
+      enableDtxForOpus: {
+        enumerable: true,
+        value: options.enableDtxForOpus
       }
     });
   }
@@ -29,7 +42,7 @@ class MediaTrackSender extends MediaTrackTransceiver {
    * @returns {MediaTrackSender}
    */
   clone() {
-    const clone = new MediaTrackSender(this.track.clone());
+    const clone = new MediaTrackSender(this.track.clone(), this._options);
     this._clones.add(clone);
     return clone;
   }

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -23,7 +23,9 @@ const {
 const {
   createCodecMapForMediaSection,
   disableRtx,
+  enableDtxForOpus,
   getMediaSections,
+  getMidForMediaSection,
   removeSSRCAttributes,
   revertSimulcastForNonVP8MediaSections,
   setBitrateParameters,
@@ -958,16 +960,64 @@ class PeerConnectionV2 extends StateMachine {
   }
 
   /**
+   * Get the MediaTrackSender associated the given MediaStreamTrack ID.
+   * Since a MediaTrackSender's underlying MediaStreamTrack can be
+   * replaced, the corresponding IDs can mismatch.
+   * @private
+   * @param {Track.ID} trackId
+   * @returns {?MediaTrackSender}
+   */
+  _getMediaTrackSender(trackId) {
+    return Array.from(this._rtpSenders.keys()).find(({ track: { id } }) => {
+      return id === trackId;
+    }) || null;
+  }
+
+  /**
    * Get the MediaTrackSender ID of the given MediaStreamTrack ID.
    * Since a MediaTrackSender's underlying MediaStreamTrack can be
    * replaced, the corresponding IDs can mismatch.
    * @private
-   * @param {Track.ID} id
+   * @param {Track.ID} trackId
    * @returns {Track.ID}
    */
   _getMediaTrackSenderId(trackId) {
-    const mediaTrackSender = Array.from(this._rtpSenders.keys()).find(({ track: { id } }) => id === trackId);
+    const mediaTrackSender = this._getMediaTrackSender(trackId);
     return mediaTrackSender ? mediaTrackSender.id : trackId;
+  }
+
+  /**
+   * Get a list of MIDs by filtering based on its corresponding {@link Track.ID}.
+   * @private
+   * @param {string} sdp
+   * @param {Track.Kind} kind
+   * @param {function} [filterFn]
+   * @returns {Array<string>}
+   */
+  _getFilteredMids(sdp, kind, filterFn = (/* trackId */) => true) {
+    const transceivers = this._peerConnection.getTransceivers();
+
+    const activeTransceivers = transceivers.filter(({ sender, stopped }) => !stopped
+      && sender
+      && sender.track
+      && sender.track.kind === kind);
+
+    const assignedTransceivers = activeTransceivers.filter(({ mid }) => mid);
+    const unassignedTransceivers = activeTransceivers.filter(({ mid }) => !mid);
+
+    const midsToTrackIds = new Map(assignedTransceivers.map(({ mid, sender }) => [
+      mid,
+      sender.track.id
+    ]));
+
+    const newTrackIds = unassignedTransceivers.map(({ sender }) => sender.track.id);
+
+    const newMids = getMediaSections(sdp, kind, 'send(only|recv)')
+      .map(getMidForMediaSection)
+      .filter(mid => !midsToTrackIds.has(mid));
+
+    newMids.forEach((mid, i) => midsToTrackIds.set(mid, newTrackIds[i]));
+    return Array.from(midsToTrackIds).filter(([, trackId]) => filterFn(trackId)).map(([mid]) => mid);
   }
 
   /**
@@ -1020,6 +1070,13 @@ class PeerConnectionV2 extends StateMachine {
    * @returns {Promise<void>}
    */
   _setLocalDescription(description) {
+    if (this._isUnifiedPlan) {
+      description = new this._RTCSessionDescription({
+        sdp: enableDtxForOpus(description.sdp, this._getFilteredMids(description.sdp, 'audio')),
+        type: description.type
+      });
+    }
+
     return this._peerConnection.setLocalDescription(description).catch(error => {
       this._log.warn(`Calling setLocalDescription with an RTCSessionDescription of type "${description.type}" failed with the error "${error.message}".`);
       if (description.sdp) {
@@ -1663,4 +1720,5 @@ function setMaxBitrate(params, maxBitrate) {
     });
   }
 }
+
 module.exports = PeerConnectionV2;

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1070,9 +1070,15 @@ class PeerConnectionV2 extends StateMachine {
    * @returns {Promise<void>}
    */
   _setLocalDescription(description) {
+    // In unified plan, enable Opus DTX for only those audio MediaStreamTracks that
+    // were created using either createLocalAudioTrack() or createLocalTracks().
     if (this._isUnifiedPlan) {
+      const opusDtxMids = this._getFilteredMids(description.sdp, 'audio', trackId => {
+        const mediaTrackSender = this._getMediaTrackSender(trackId);
+        return mediaTrackSender && mediaTrackSender.enableDtxForOpus;
+      });
       description = new this._RTCSessionDescription({
-        sdp: enableDtxForOpus(description.sdp, this._getFilteredMids(description.sdp, 'audio')),
+        sdp: enableDtxForOpus(description.sdp, opusDtxMids),
         type: description.type
       });
     }

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -592,12 +592,6 @@ function enableDtxForOpus(sdp, mids) {
       return section;
     }
 
-    // If the current m= section does not have one of the given mids, do nothing.
-    const mid = getMidForMediaSection(section);
-    if (!mids.includes(mid)) {
-      return section;
-    }
-
     // Build a map codecs to payload types.
     const codecsToPts = createCodecMapForMediaSection(section);
 
@@ -616,7 +610,15 @@ function enableDtxForOpus(sdp, mids) {
     // Add usedtx=1 to the a=fmtp: line for opus.
     const origOpusFmtpLine = generateFmtpLineFromPtAndAttributes(opusPt, opusFmtpAttrs);
     const origOpusFmtpRegex = new RegExp(origOpusFmtpLine);
-    opusFmtpAttrs.usedtx = 1;
+
+    // If the m= section's MID is in the list of MIDs, then enable dtx. Otherwise disable it.
+    const mid = getMidForMediaSection(section);
+    if (mids.includes(mid)) {
+      opusFmtpAttrs.usedtx = 1;
+    } else {
+      delete opusFmtpAttrs.usedtx;
+    }
+
     const opusFmtpLineWithDtx = generateFmtpLineFromPtAndAttributes(opusPt, opusFmtpAttrs);
     return section.replace(origOpusFmtpRegex, opusFmtpLineWithDtx);
   })).join('\r\n');

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -564,10 +564,70 @@ function disableRtx(sdp) {
   })).join('\r\n');
 }
 
+/**
+ * Generate an a=fmtp: line from the given payload type and attributes.
+ * @param {PT} pt
+ * @param {*} fmtpAttrs
+ * @returns {string}
+ */
+function generateFmtpLineFromPtAndAttributes(pt, fmtpAttrs) {
+  const serializedFmtpAttrs = Object.entries(fmtpAttrs).map(([name, value]) => {
+    return `${name}=${value}`;
+  }).join(';');
+  return `a=fmtp:${pt} ${serializedFmtpAttrs}`;
+}
+
+/**
+ * Enable DTX for opus in the m= sections for the given MIDs.`
+ * @param {string} sdp
+ * @param {Array<string>} mids
+ * @returns {string}
+ */
+function enableDtxForOpus(sdp, mids) {
+  const mediaSections = getMediaSections(sdp);
+  const session = sdp.split('\r\nm=')[0];
+  return [session].concat(mediaSections.map(section => {
+    // Do nothing if the m= section is not audio.
+    if (!/^m=audio/.test(section)) {
+      return section;
+    }
+
+    // If the current m= section does not have one of the given mids, do nothing.
+    const mid = getMidForMediaSection(section);
+    if (!mids.includes(mid)) {
+      return section;
+    }
+
+    // Build a map codecs to payload types.
+    const codecsToPts = createCodecMapForMediaSection(section);
+
+    // Do nothing if a payload type for opus does not exist.
+    const opusPt = codecsToPts.get('opus');
+    if (!opusPt) {
+      return section;
+    }
+
+    // If no fmtp attributes are found for opus, do nothing.
+    const opusFmtpAttrs = getFmtpAttributesForPt(opusPt, section);
+    if (!opusFmtpAttrs) {
+      return section;
+    }
+
+    // Add usedtx=1 to the a=fmtp: line for opus.
+    const origOpusFmtpLine = generateFmtpLineFromPtAndAttributes(opusPt, opusFmtpAttrs);
+    const origOpusFmtpRegex = new RegExp(origOpusFmtpLine);
+    opusFmtpAttrs.usedtx = 1;
+    const opusFmtpLineWithDtx = generateFmtpLineFromPtAndAttributes(opusPt, opusFmtpAttrs);
+    return section.replace(origOpusFmtpRegex, opusFmtpLineWithDtx);
+  })).join('\r\n');
+}
+
 exports.createCodecMapForMediaSection = createCodecMapForMediaSection;
 exports.createPtToCodecName = createPtToCodecName;
 exports.disableRtx = disableRtx;
+exports.enableDtxForOpus = enableDtxForOpus;
 exports.getMediaSections = getMediaSections;
+exports.getMidForMediaSection = getMidForMediaSection;
 exports.removeSSRCAttributes = removeSSRCAttributes;
 exports.revertSimulcastForNonVP8MediaSections = revertSimulcastForNonVP8MediaSections;
 exports.setBitrateParameters = setBitrateParameters;


### PR DESCRIPTION
@makarandp0 @idelgado 

This PR enables opus DTX only for microphone AudioTracks, which can be created by the following methods:

1. Passing constraints to ConnectOptions (SDK will create the AudioTrack)
2. Calling createLocalAudioTrack()
3. Calling createLocalTracks()

For other AudioTracks (like music, screenshare audio, etc.), opus DTX will not be enabled.

NOTE: Because we are enabling opus DTX in selective m= sections, this feature is available only for unified plan sdps.

## Checklist

- [x] Implementation
- [ ] Unit tests
- [x] Smoke test with local Simpler Signaling
- [ ] Changelog entry
- [ ] +1 from at least one reviewer

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
