### PR TITLE
add preflight field to ice and connect messages

### DIFF
--- a/lib/preflight/preflighttest.js
+++ b/lib/preflight/preflighttest.js
@@ -126,6 +126,7 @@ function runPreflightTest(publisherToken, subscriberToken, options, preflightTes
   options = Object.assign(options, {
     video: false,
     audio: false,
+    preflight: true,
     networkQuality: true
   });
 

--- a/lib/signaling/v2/cancelableroomsignalingpromise.js
+++ b/lib/signaling/v2/cancelableroomsignalingpromise.js
@@ -71,10 +71,12 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
       insights,
       realm,
       sdpSemantics,
-      wsServerInsights
+      wsServerInsights,
+      preflight,
     } = options;
 
     const transportOptions = Object.assign({
+      preflight: !!preflight,
       automaticSubscription,
       dominantSpeaker,
       environment,

--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -110,6 +110,9 @@ class TwilioConnectionTransport extends StateMachine {
       _accessToken: {
         value: accessToken
       },
+      _preflight: {
+        value: !!options.preflight
+      },
       _automaticSubscription: {
         value: options.automaticSubscription
       },
@@ -231,6 +234,7 @@ class TwilioConnectionTransport extends StateMachine {
 
     if (message.type === 'connect') {
       message.ice_servers = this._iceServersStatus;
+      message.preflight = this._preflight;
 
       message.publisher = {
         name: SDK_NAME,
@@ -274,6 +278,7 @@ class TwilioConnectionTransport extends StateMachine {
   _createIceMessage() {
     return {
       edge: 'roaming', // roaming here means use same edge as signaling.
+      preflight: this._preflight,
       token: this._accessToken,
       type: 'ice',
       version: ICE_VERSION

--- a/test/unit/spec/signaling/v2/twilioconnectiontransport.js
+++ b/test/unit/spec/signaling/v2/twilioconnectiontransport.js
@@ -14,6 +14,7 @@ const { combinations, waitForSometime } = require('../../../../lib/util');
 
 describe('TwilioConnectionTransport', () => {
   combinations([
+    [true, false], // preflight
     [true, false], // iceServers
     [true, false], // networkQuality
     [true, false], // dominantSpeaker
@@ -78,8 +79,9 @@ describe('TwilioConnectionTransport', () => {
         }
       ]
     ]
-  ]).forEach(([iceServers, networkQuality, dominantSpeaker, automaticSubscription, trackPriority, trackSwitchOff, bandwidthProfile, expectedRspPayload]) => {
+  ]).forEach(([preflight, iceServers, networkQuality, dominantSpeaker, automaticSubscription, trackPriority, trackSwitchOff, bandwidthProfile, expectedRspPayload]) => {
     describe(`constructor, called with
+      .preflight ${preflight ? '' : 'not '}set
       .iceServers ${iceServers ? '' : 'not '}provided
       .networkQuality flag ${networkQuality ? 'enabled' : 'disabled'},
       .dominantSpeaker flag ${dominantSpeaker ? 'enabled' : 'disabled'},
@@ -97,6 +99,7 @@ describe('TwilioConnectionTransport', () => {
         } : {}, {
           automaticSubscription,
           networkQuality,
+          preflight,
           dominantSpeaker,
           trackPriority,
           trackSwitchOff
@@ -180,6 +183,7 @@ describe('TwilioConnectionTransport', () => {
           assert.deepEqual(message.peer_connections, test.peerConnectionManager.getStates());
           assert.equal(message.token, test.accessToken);
           assert.equal(message.type, 'connect');
+          assert.equal(message.preflight, preflight);
           assert.equal(message.version, 2);
           assert.equal(message.publisher.name, `${name}.js`);
           assert.equal(message.publisher.sdk_version, version);
@@ -193,6 +197,7 @@ describe('TwilioConnectionTransport', () => {
           const message = test.twilioConnection.helloBody;
           assert.deepEqual(message, {
             edge: 'roaming',
+            preflight,
             token: test.accessToken,
             type: 'ice',
             version: 1


### PR DESCRIPTION
This adds a new boolean field `preflight` for `ice` and `connect` messages. This field is set to true from preflight tests.

related rsp pr: https://code.hq.twilio.com/client/room-signaling-protocol/pull/67
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
