### PR TITLE
JSDK-3021 Document Large Group Rooms behavior.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,24 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 
 **Support for 1.x will cease on December 4th, 2020**. This branch will only receive fixes for critical issues until that date. Check [this guide](https://www.twilio.com/docs/video/migrating-1x-2x) when planning your migration to 2.x. For details on the 1.x changes, go [here](https://github.com/twilio/twilio-video.js/blob/support-1.x/CHANGELOG.md).
 
-2.7.3 (in progress)
+2.8.0 (in progress)
 ===================
 
+New Features
+------------
+
+- You can now connect to a Group Room with Maximum Participants between 50 and 100 (Large Group Rooms).
+  Large Group Rooms are different from the other types of Rooms in the following ways:
+  - "participantConnected" event is raised on the Room when a RemoteParticipant
+    publishes the first LocalTrack.
+  - "participantDisconnected" event is raised on the Room when a RemoteParticipant
+    stops publishing all of LocalTracks.
+  - The total number of published Tracks in the Room cannot exceed 16. Any attempt
+    to publish more Tracks will be rejected with a `ParticipantMaxTracksExceededError`. (JSDK-3021)
+  
+  NOTE: Large Group Rooms is currently in **beta**. It is also backward compatible with all previous
+  2.x versions of wilio-video.js. This version only documents the behavior of Large Group Rooms.
+    
 Bug Fixes
 ---------
 - Fixed a bug where LocalTrack event listeners were not being cleaned up after disconnecting from a room. (JSDK-2985)

--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -333,7 +333,8 @@ class LocalParticipant extends Participant {
    * @returns {Promise<LocalTrackPublication>} - Resolves with the corresponding
    *   {@link LocalTrackPublication} if successful; In a Large Group Room (Maximum
    *   Participants greater than 50), rejects with a {@link ParticipantMaxTracksExceededError}
-   *   if the total number of published Tracks in the Room exceeds 16.
+   *   if either the total number of published Tracks in the Room exceeds 16, or the {@link LocalTrack}
+   *   is part of a set of {@link LocalTrack}s which along with the published Tracks exceeds 16.
    * @throws {TypeError}
    * @throws {RangeError}
    * @example
@@ -366,7 +367,8 @@ class LocalParticipant extends Participant {
    * @returns {Promise<LocalTrackPublication>} - Resolves with the corresponding
    *   {@link LocalTrackPublication} if successful; In a Large Group Room (Maximum
    *   Participants greater than 50), rejects with a {@link ParticipantMaxTracksExceededError}
-   *   if the total number of published Tracks in the Room exceeds 16.
+   *   if the total number of published Tracks in the Room exceeds 16, or the {@link LocalTrack}
+   *   is part of a set of {@link LocalTrack}s which along with the published Tracks exceeds 16.
    * @throws {TypeError}
    * @throws {RangeError}
    * @example
@@ -432,7 +434,10 @@ class LocalParticipant extends Participant {
    *   {@link LocalAudioTrack} or {@link LocalVideoTrack} has not yet been
    *   published, this method will construct one
    * @returns {Promise<Array<LocalTrackPublication>>} - The resulting
-   *   {@link LocalTrackPublication}s
+   *   {@link LocalTrackPublication}s if successful; In a Large Group Room (Maximum
+   *   Participants greater than 50), rejects with a {@link ParticipantMaxTracksExceededError}
+   *   if the total number of published Tracks in the Room exceeds 16, or the {@link LocalTrack}s
+   *   along with the published Tracks exceeds 16.
    * @throws {TypeError}
    */
   publishTracks(tracks) {
@@ -617,9 +622,10 @@ class LocalParticipant extends Participant {
 /**
  * A {@link LocalTrack} failed to publish. Check the error message for more
  * information. In a Large Group Room (Maximum Participants greater than 50),
- * this event is raised with a {@link ParticipantMaxTracksExceededError} when
- * attempting to publish the {@link LocalTrack} will exceed the Maximum Published
- * Tracks limit of 16.
+ * this event is raised with a {@link ParticipantMaxTracksExceededError} either
+ * when attempting to publish the {@link LocalTrack} will exceed the Maximum Published
+ * Tracks limit of 16, or the {@link LocalTrack} is part of a set of {@link LocalTrack}s
+ * which along with the published Tracks exceeds 16.
  * @param {TwilioError} error - A {@link TwilioError} explaining why publication
  *   failed
  * @param {LocalTrack} localTrack - The {@link LocalTrack} that failed to

--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -331,7 +331,9 @@ class LocalParticipant extends Participant {
    * @param {LocalTrackPublishOptions} [options] - The {@link LocalTrackPublishOptions}
    *   for publishing the {@link LocalTrack}
    * @returns {Promise<LocalTrackPublication>} - Resolves with the corresponding
-   *   {@link LocalTrackPublication} if successful
+   *   {@link LocalTrackPublication} if successful; In a Large Group Room (Maximum
+   *   Participants greater than 50), rejects with a {@link ParticipantMaxTracksExceededError}
+   *   if the total number of published Tracks in the Room exceeds 16.
    * @throws {TypeError}
    * @throws {RangeError}
    * @example
@@ -362,7 +364,9 @@ class LocalParticipant extends Participant {
    * @param {MediaStreamTrackPublishOptions} [options] - The options for publishing
    *   the MediaStreamTrack
    * @returns {Promise<LocalTrackPublication>} - Resolves with the corresponding
-   *   {@link LocalTrackPublication} if successful
+   *   {@link LocalTrackPublication} if successful; In a Large Group Room (Maximum
+   *   Participants greater than 50), rejects with a {@link ParticipantMaxTracksExceededError}
+   *   if the total number of published Tracks in the Room exceeds 16.
    * @throws {TypeError}
    * @throws {RangeError}
    * @example
@@ -612,7 +616,10 @@ class LocalParticipant extends Participant {
 
 /**
  * A {@link LocalTrack} failed to publish. Check the error message for more
- * information.
+ * information. In a Large Group Room (Maximum Participants greater than 50),
+ * this event is raised with a {@link ParticipantMaxTracksExceededError} when
+ * attempting to publish the {@link LocalTrack} will exceed the Maximum Published
+ * Tracks limit of 16.
  * @param {TwilioError} error - A {@link TwilioError} explaining why publication
  *   failed
  * @param {LocalTrack} localTrack - The {@link LocalTrack} that failed to

--- a/lib/room.js
+++ b/lib/room.js
@@ -210,7 +210,9 @@ function rewriteLocalTrackIds(room, trackStats) {
  */
 
 /**
- * A {@link RemoteParticipant} joined the {@link Room}.
+ * A {@link RemoteParticipant} joined the {@link Room}. In Large Group Rooms (Maximum
+ * Participants greater than 50), this event is raised only when a {@link RemoteParticipant}
+ * publishes at least one {@link LocalTrack}.
  * @param {RemoteParticipant} participant - The {@link RemoteParticipant} who joined
  * @event Room#participantConnected
  * @example
@@ -220,7 +222,9 @@ function rewriteLocalTrackIds(room, trackStats) {
  */
 
 /**
- * A {@link RemoteParticipant} left the {@link Room}.
+ * A {@link RemoteParticipant} left the {@link Room}. In Large Group Rooms (Maximum
+ * Participants greater than 50), this event is raised only when a {@link RemoteParticipant}
+ * unpublishes all its {@link LocalTrack}s.
  * @param {RemoteParticipant} participant - The {@link RemoteParticipant} who left
  * @event Room#participantDisconnected
  * @example

--- a/lib/util/twilio-video-errors.js
+++ b/lib/util/twilio-video-errors.js
@@ -587,7 +587,7 @@ Object.defineProperty(TwilioErrorByCode, 53202, { value: ParticipantIdentityChar
  */
 class ParticipantMaxTracksExceededError extends TwilioError {
   constructor() {
-    super(53203, 'Participant has too many Tracks');
+    super(53203, 'Published Tracks at maximum capacity');
   }
 }
 


### PR DESCRIPTION
@innerverse @idelgado @ceaglest 

This PR documents the behavior of Large Group Rooms. I will open a separate PR for integration tests.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
