### PR TITLE
JSDK-3031 Wait until LocalAudioTrack is unmuted before playing inadvertently paused video elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,27 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 
 Bug Fixes
 ---------
-- Fixed a bug where LocalTrack event listeners were not being cleaned up after disconnecting from a room. (JSDK-2985)
 
+- Fixed a bug where an iOS 14 Safari Participant is not heard by others in a Room after
+  handling an incoming phone call. (JSDK-3031)
+- Fixed a bug where LocalTrack event listeners were not being cleaned up after disconnecting
+  from a Room. (JSDK-2985)
 
 2.7.2 (August 12, 2020)
 =======================
 
 Bug Fixes
 ---------
-- Fixed a bug where a Participant in a large Group Room sometimes gets inadvertently disconnected with a [MediaServerRemoteDescFailedError](https://media.twiliocdn.com/sdk/js/video/releases/2.7.2/docs/MediaServerRemoteDescFailedError.html). (JSDK-2893)
 
-- Fixed a bug where `Room.getStats()` returned stats for only one of the temporal layers of a VP8 simulcast VideoTrack. Now, you will have a `LocalVideoTrackStats` object for each temporal layer, which you can recognize by the `trackId` and `trackSid` properties. (JSDK-2920)
-```js
+- Fixed a bug where a Participant in a large Group Room sometimes gets inadvertently
+  disconnected with a [MediaServerRemoteDescFailedError](https://media.twiliocdn.com/sdk/js/video/releases/2.7.2/docs/MediaServerRemoteDescFailedError.html). (JSDK-2893)
+
+- Fixed a bug where `Room.getStats()` returned stats for only one of the temporal
+  layers of a VP8 simulcast VideoTrack. Now, you will have a `LocalVideoTrackStats`
+  object for each temporal layer, which you can recognize by the `trackId` and
+  `trackSid` properties. (JSDK-2920)
+
+  ```js
   async function getBytesSentOnLocalVideoTrack(room, trackSid) {
     const stats = await room.getStats();
     let totalBytesSent = 0;
@@ -29,7 +38,7 @@ Bug Fixes
     });
     return totalBytesSent;
   }
-```
+  ```
 
 2.7.1 (July 28, 2020)
 =====================

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -296,7 +296,7 @@ function playIfPausedAndNotBackgrounded(el, log) {
       //
       // Bug: https://bugs.webkit.org/show_bug.cgi?id=213853
       //
-      localMediaRestartDeferreds.whenResolved(tag).then(() => {
+      localMediaRestartDeferreds.whenResolved('audio').then(() => {
         log.info(`Playing unintentionally paused <${tag}> element`);
         log.debug('Element:', el);
         return el.play();


### PR DESCRIPTION
@makarandp0 @syerrapragada 

Before this change, whenever the user returned to the video app after returning from an incoming phone call, the paused video elements would be played before the LocalAudioTrack was unmuted, resulting it the LocalAudioTrack never being unmuted due to https://bugs.webkit.org/show_bug.cgi?id=213853.

GitHub Issue: #1206 

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
