### PR TITLE
instrumentation for insights asserts

### DIFF
--- a/test/integration/spec/util/insightspublisher.js
+++ b/test/integration/spec/util/insightspublisher.js
@@ -51,7 +51,11 @@ describe('InsightsPublisher (@unstable: JSDK-2761)', function() {
             publisher.once('connected', () => reject(new Error('Unexpected connect')));
             publisher.once('disconnected', resolve);
           });
-          assert(error instanceof Error);
+          assert(error instanceof Error, `unexpected error ${error}`);
+          if (!(error instanceof Error)) {
+            // eslint-disable-next-line no-console
+            console.log('Unexpected error:', error);
+          }
         } : () => new Promise((resolve, reject) => {
           publisher.once('connected', resolve);
           publisher.once('disconnected', error => reject(error || new Error('Unexpected disconnect')));


### PR DESCRIPTION
We see an assert failing in insights test @  https://app.circleci.com/pipelines/github/twilio/twilio-video.js/2639/workflows/c7bc4297-cc8a-403b-9c64-0aa0f3baf50f/jobs/28768/steps
with log:
```
InsightsPublisher
    connect
      when attempted with an expired token
        ✗ should disconnect with an Error
	AssertionError: false == true
	    at Context.<anonymous> (/tmp/0e9c83861db80405b8278497249cd6a0.browserify:115256:11)

      when attempted with an invalid token
        ✓ should disconnect with an Error
      when attempted with a valid token
        ✓ should be successful
    disconnect
      ✓ should disconnect without any error
```
This instrumentation would help us find more information next time.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
