### PR TITLE
JSDK-3003 - stop track before restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 Bug Fixes
 ---------
 
+- Fixed a bug which caused `restart` method on LocalTrack to fail on some android devices
+  with `Failed to re-acquire MediaStreamTrack`. (JSDK-3003)
+
 - Fixed a bug where an iOS 14 Safari Participant is not heard by others in a Room after
   handling an incoming phone call. (JSDK-3031)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 Bug Fixes
 ---------
 
-- Fixed a bug which caused `restart` method on LocalTrack to fail on some android devices
-  with `Failed to re-acquire MediaStreamTrack`. (JSDK-3003)
+- Fixed a bug where restarting a LocalAudioTrack or LocalVideoTrack failed on some android devices. (JSDK-3003)
 
 - Fixed a bug where an iOS 14 Safari Participant is not heard by others in a Room after
   handling an incoming phone call. (JSDK-3031)

--- a/lib/media/track/localaudiotrack.js
+++ b/lib/media/track/localaudiotrack.js
@@ -111,17 +111,6 @@ class LocalAudioTrack extends LocalMediaAudioTrack {
    * });
    */
   restart() {
-    const constraints = arguments[0] || {};
-
-    // NOTE(mmalavalli): If "deviceId" is present in the constraints, then the developer
-    // is most likely trying to switch audio devices. In Firefox, getUserMedia raises a
-    // NotReadableError when trying to capture from a different audio device while the
-    // existing audio device is still being used. So, we stop the existing MediaStreamTrack
-    // before calling getUserMedia.
-    if (isFirefox && 'deviceId' in constraints) {
-      this._stop();
-    }
-
     return super.restart.apply(this, arguments);
   }
 

--- a/lib/media/track/localaudiotrack.js
+++ b/lib/media/track/localaudiotrack.js
@@ -1,11 +1,8 @@
 'use strict';
 
-const { guessBrowser } = require('@twilio/webrtc/lib/util');
-
 const AudioTrack = require('./audiotrack');
 const mixinLocalMediaTrack = require('./localmediatrack');
 
-const isFirefox = guessBrowser() === 'firefox';
 const LocalMediaAudioTrack = mixinLocalMediaTrack(AudioTrack);
 
 /**

--- a/lib/media/track/localmediatrack.js
+++ b/lib/media/track/localmediatrack.js
@@ -160,6 +160,13 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
     _restart(constraints) {
       const { _log: log } = this;
       constraints = constraints || this._constraints;
+
+      // NOTE(mmalavalli): If we try and restart a silent MediaStreamTrack
+      // without stopping it first, then a NotReadableError is raised in case of
+      // video, or the restarted audio will still be silent. Hence, we stop the
+      // MediaStreamTrack here.
+      this._stop();
+
       return this._reacquireTrack(constraints).catch(error => {
         log.error('Failed to re-acquire the MediaStreamTrack:', error, constraints);
         throw error;
@@ -302,13 +309,6 @@ function restartWhenInadvertentlyStopped(localMediaTrack) {
     ]).then(() => shouldReacquireTrack()).then(shouldReacquire => {
       if (shouldReacquire && !trackChangeInProgress) {
         trackChangeInProgress = defer();
-
-        // NOTE(mmalavalli): If we try and restart a silent MediaStreamTrack
-        // without stopping it first, then a NotReadableError is raised in case of
-        // video, or the restarted audio will still be silent. Hence, we stop the
-        // MediaStreamTrack here.
-        localMediaTrack._stop();
-
         localMediaTrack._restart().finally(() => {
           el = localMediaTrack._dummyEl;
           removeMediaStreamTrackListeners();
@@ -356,7 +356,7 @@ function restartWhenInadvertentlyStopped(localMediaTrack) {
   }
 
   // NOTE(mpatwardhan): listen for document visibility callback on phase 1.
-  // this ensures that any we acquire media tracks before RemoteMediaTrack
+  // this ensures that we acquire media tracks before RemoteMediaTrack
   // tries to `play` them (in phase 2). This order is important because
   // play can fail on safari if audio is not being captured.
   documentVisibilityMonitor.onVisible(1, maybeRestart);

--- a/test/integration/spec/localtracks.js
+++ b/test/integration/spec/localtracks.js
@@ -206,8 +206,15 @@ async function assertMediaFlow(room, mediaFlowExpected,  errorMessage) {
         }
         assert.equal(bobRemoteTrack.track.isEnabled, trackEnabled, `alice was expecting remoteTrack to be ${trackEnabled ? 'enabled' : 'disabled'} in ${roomSid}`);
 
-        // Bob restarts the track.
+        const startedPromise = waitForEvent(bobLocalTrackA, 'started');
+        const stoppedPromise = waitForEvent(bobLocalTrackA, 'stopped');
+
+        // Bob restarts track.
         await bobLocalTrackA.restart();
+
+        // "stopped" and "started" events should fire in order.
+        await waitFor(stoppedPromise, `Bob's LocalTrack to stop: ${roomSid}`);
+        await waitFor(startedPromise, `Bob's LocalTrack to start: ${roomSid}`);
 
         // Charlie joins a room after sometime.
         const charlieRoom = await connect(getToken('Charlie'), Object.assign({ tracks: [], name: roomName }, defaults));


### PR DESCRIPTION
On some android devices track.restart did not work. This was reported on [this github issue](https://github.com/twilio/twilio-video.js/issues/1180) 

The solution is to stop the current track before restarting using different constraints. 
 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
