### PR TITLE
Update browserify support1x

### DIFF
--- a/.circleci/runbuild.js
+++ b/.circleci/runbuild.js
@@ -177,7 +177,7 @@ const tagPrompt = {
   type: 'input',
   name: 'tag',
   message: 'Tag to use (type branch name if you do not want to use tag):',
-  default: '2.0.0-beta15',
+  default: () => getBranches().then(branches => branches.current),
   validate: (val) => { return typeof val === 'string' && val.length > 5; }
 };
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/ws": "^3.2.1",
     "babel-cli": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
-    "browserify": "^14.3.0",
+    "browserify": "^16.5.0",
     "cheerio": "^0.22.0",
     "chromedriver": "2.28.0",
     "electron": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/ws": "^3.2.1",
     "babel-cli": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
-    "browserify": "^16.5.0",
+    "browserify": "^17.0.0",
     "cheerio": "^0.22.0",
     "chromedriver": "2.28.0",
     "electron": "^5.0.1",


### PR DESCRIPTION
update browserify to fix test failures 

Browserify caused [these failures](https://app.circleci.com/pipelines/github/twilio/twilio-video.js/2694/workflows/057d3b5f-58d8-4262-aa4d-d27bd4610be2/jobs/29408) and with changes we have [green build](https://app.circleci.com/pipelines/github/twilio/twilio-video.js/2719/workflows/11f244ce-dfc2-4da8-ad9d-4c168d51f6d8)




**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
