### PR TITLE
JSDK-3063 Don't send the local SDP with DTX enabled over the wire.

### DIFF
--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1025,16 +1025,20 @@ class PeerConnectionV2 extends StateMachine {
    * @returns {Promise<void>}
    */
   _setLocalDescription(description) {
-    if (description.type !== 'rollback' && this._shouldApplyDtx) {
-      description = new this._RTCSessionDescription({
-        sdp: enableDtxForOpus(description.sdp),
-        type: description.type
-      });
-    }
-    return this._peerConnection.setLocalDescription(description).catch(error => {
-      this._log.warn(`Calling setLocalDescription with an RTCSessionDescription of type "${description.type}" failed with the error "${error.message}".`);
-      if (description.sdp) {
-        this._log.warn(`The SDP was ${description.sdp}`);
+    // NOTE(mmalavalli): In order for this feature to be backward compatible with older
+    // SDK versions which to not support opus DTX, we append "usedtx=1" to the local SDP
+    // only while applying it. We will not send it over the wire to prevent inadvertent
+    // enabling of opus DTX in older SDKs. Newer SDKs will append "usedtx=1" by themselves
+    // if the developer has requested opus DTX to be enabled. (JSDK-3063)
+    const descriptionToApply = description.type !== 'rollback' && this._shouldApplyDtx ? new this._RTCSessionDescription({
+      sdp: enableDtxForOpus(description.sdp),
+      type: description.type
+    }) : description;
+
+    return this._peerConnection.setLocalDescription(descriptionToApply).catch(error => {
+      this._log.warn(`Calling setLocalDescription with an RTCSessionDescription of type "${descriptionToApply.type}" failed with the error "${error.message}".`);
+      if (descriptionToApply.sdp) {
+        this._log.warn(`The SDP was ${descriptionToApply.sdp}`);
       }
       throw new MediaClientLocalDescFailedError();
     }).then(() => {


### PR DESCRIPTION
@makarandp0 @PikaJoyce 

This PR ensures that the local SDP with `usedtx=1` is not sent over the wire, only the original SDP is sent over.
This makes sure that older SDKs do not enable DTX even though the feature is not supported. Newer SDKs add this flag by themselves if DTX is enabled, so it should not affect them.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
