### PR TITLE
JSDK-3063 Actively remove DTX from local SDPs sent over the wire.

### DIFF
--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1025,25 +1025,34 @@ class PeerConnectionV2 extends StateMachine {
    * @returns {Promise<void>}
    */
   _setLocalDescription(description) {
-    // NOTE(mmalavalli): In order for this feature to be backward compatible with older
-    // SDK versions which to not support opus DTX, we append "usedtx=1" to the local SDP
-    // only while applying it. We will not send it over the wire to prevent inadvertent
-    // enabling of opus DTX in older SDKs. Newer SDKs will append "usedtx=1" by themselves
-    // if the developer has requested opus DTX to be enabled. (JSDK-3063)
-    const descriptionToApply = description.type !== 'rollback' && this._shouldApplyDtx ? new this._RTCSessionDescription({
-      sdp: enableDtxForOpus(description.sdp),
-      type: description.type
-    }) : description;
-
-    return this._peerConnection.setLocalDescription(descriptionToApply).catch(error => {
-      this._log.warn(`Calling setLocalDescription with an RTCSessionDescription of type "${descriptionToApply.type}" failed with the error "${error.message}".`);
-      if (descriptionToApply.sdp) {
-        this._log.warn(`The SDP was ${descriptionToApply.sdp}`);
+    if (description.type !== 'rollback' && this._shouldApplyDtx) {
+      description = new this._RTCSessionDescription({
+        sdp: enableDtxForOpus(description.sdp),
+        type: description.type
+      });
+    }
+    return this._peerConnection.setLocalDescription(description).catch(error => {
+      this._log.warn(`Calling setLocalDescription with an RTCSessionDescription of type "${description.type}" failed with the error "${error.message}".`);
+      if (description.sdp) {
+        this._log.warn(`The SDP was ${description.sdp}`);
       }
       throw new MediaClientLocalDescFailedError();
     }).then(() => {
       if (description.type !== 'rollback') {
         this._localDescription = this._isUnifiedPlan ? this._addOrRewriteLocalTrackIds(description) : description;
+
+        // NOTE(mmalavalli): In order for this feature to be backward compatible with older
+        // SDK versions which to not support opus DTX, we append "usedtx=1" to the local SDP
+        // only while applying it. We will not send it over the wire to prevent inadvertent
+        // enabling of opus DTX in older SDKs. Newer SDKs will append "usedtx=1" by themselves
+        // if the developer has requested opus DTX to be enabled. (JSDK-3063)
+        if (this._shouldApplyDtx) {
+          this._localDescription = new this._RTCSessionDescription({
+            sdp: enableDtxForOpus(this._localDescription.sdp, []),
+            type: this._localDescription.type
+          });
+        }
+
         this._localCandidates = [];
         if (description.type === 'offer') {
           this._descriptionRevision++;


### PR DESCRIPTION
@makarandp0 @dipankadas ,

After we enable DTX once, subsequent SDPs will already have it enabled even before we munge the SDP. So, we need to make sure we actively remove the DTX flag before sending the SDP over the wire.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
