### PR TITLE
JSDK-3076 Removing the list of disconnected Participant SIDs.

### DIFF
--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -62,8 +62,8 @@ class RoomV2 extends RoomSignaling {
         value: null,
         writable: true
       },
-      _disconnectedParticipantSids: {
-        value: new Set()
+      _disconnectedParticipantRevisions: {
+        value: new Map()
       },
       _NetworkQualityMonitor: {
         value: options.NetworkQualityMonitor
@@ -267,7 +267,7 @@ class RoomV2 extends RoomSignaling {
         if (state === 'disconnected') {
           participant.removeListener('stateChanged', stateChanged);
           self.participants.delete(participant.sid);
-          self._disconnectedParticipantSids.add(participant.sid);
+          self._disconnectedParticipantRevisions.set(participant.sid, participant.revision);
         }
       });
       this.connectParticipant(participant);
@@ -346,9 +346,21 @@ class RoomV2 extends RoomSignaling {
     // eslint-disable-next-line no-warning-comments
     // TODO(mroberts): Remove me once the Server is fixed.
     (roomState.participants || []).forEach(participantState => {
-      if (participantState.sid === this.localParticipant.sid ||
-          this._disconnectedParticipantSids.has(participantState.sid)) {
+      if (participantState.sid === this.localParticipant.sid) {
         return;
+      }
+
+      // NOTE(mmalavalli): If the incoming revision for a disconnected Participant is less than or
+      // equal to the revision when it was disconnected, then the state is old and can be ignored.
+      // Otherwise, the Participant was most likely disconnected in a Large Group Room when it
+      // stopped publishing media, and hence needs to be re-added.
+      const disconnectedParticipantRevision = this._disconnectedParticipantRevisions.get(participantState.sid);
+      if (disconnectedParticipantRevision && participantState.revision <= disconnectedParticipantRevision) {
+        return;
+      }
+
+      if (disconnectedParticipantRevision) {
+        this._disconnectedParticipantRevisions.delete(participantState.sid);
       }
       const participant = this._getOrCreateRemoteParticipant(participantState);
       participant.update(participantState);


### PR DESCRIPTION
@makarandp0 @ramapal 

This PR makes sure that we allow disconnected Participants to be connected again if the new Participant state has a higher revision number than the previous disconnected state. Now, a Participant in a large group Room that was marked as disconnected when he/she stopped publishing media, can be considered connected again when they start publishing media.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
