### PR TITLE
Deprecate ConnectOptions.eventlistener property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Additionally  `ConnectOptions`'s `eventListener` property is now deprecated. You
 
       // check for signaling events that previously were
       // emitted on (now deprecated) eventListener
-      if (message === 'event') {
+      if (message === 'event' && data.group === 'signaling') {
         if (data.name === 'waiting') {
           assert.equal(data.level, 'warning');
           console.warn('Twilio\'s signaling server is busy, so we wait a little while before trying again.');
@@ -50,7 +50,7 @@ Additionally  `ConnectOptions`'s `eventListener` property is now deprecated. You
           }
         }
       }
-      // You can send to your own server
+      // You may also send the logs to your own server
       postDataToServer(arguments);
 
     };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ New Features
 
 With this change `ConnectOptions`'s `logLevel` property is now deprecated. You can instead use `logger.setLevel` to set the desired log level.
 
-Additionally  `ConnectOptions`'s `eventListener` property is now deprecated. You can listen for the signaling events by intercepting logger as shown in example below.
+Additionally  `ConnectOptions`'s `eventListener` property is now deprecated. You can listen for the signaling events by intercepting the logger's messages as shown in the example below.
 
   Example:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 New Features
 ------------
 
-- twilio-video now allows customizing logger using [loglevel](https://www.npmjs.com/package/loglevel) module. With this feature, logs can now be intercepted at runtime to allow real-time processing of the logs which include but not limited to inspecting the log data and sending it to your own server.
+- twilio-video now allows customizing logger using [loglevel](https://www.npmjs.com/package/loglevel) module. With this feature, logs can now be intercepted at runtime to allow real-time processing of the logs which include but not limited to inspecting the log data and sending it to your own server. (JSDK-2373)
 
 With this change `ConnectOptions`'s `logLevel` property is now deprecated. You can instead use `logger.setLevel` to set the desired log level.
   ```js
@@ -28,7 +28,7 @@ With this change `ConnectOptions`'s `logLevel` property is now deprecated. You c
   });
   ```
 
-Additionally  `ConnectOptions`'s `eventListener` property is now deprecated. You can listen for the signaling events by intercepting the logger's messages as shown in the example below.
+Additionally  `ConnectOptions`'s `eventListener` property is now deprecated. You can listen for the signaling events by intercepting the logger's messages as shown in the example below. (JSDK-2977)
 
   Example:
 
@@ -79,8 +79,6 @@ Additionally  `ConnectOptions`'s `eventListener` property is now deprecated. You
     console.log('Could not connect to the Room:', error.message);
   });
   ```
-
-
 
 2.9.0 (in progress)
 ===================

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -234,7 +234,7 @@ function connect(token, options) {
 
   /* eslint new-cap:0 */
   const wsServer = WS_SERVER(options.environment, options.region);
-  const eventObserver = new EventObserver(Date.now(), options.eventListener);
+  const eventObserver = new EventObserver(Date.now(), log, options.eventListener);
   options = Object.assign({ eventObserver, wsServer }, options);
 
   options.log = log;
@@ -366,9 +366,10 @@ function connect(token, options) {
  *   sent with DSCP header value set to 0xb8 which corresponds to Expedited Forwarding (EF).
  *   Video packets will be sent with DSCP header value set to 0x88 which corresponds to
  *   Assured Forwarding (AF41).
- * @property {EventListener} [eventListener] - Optionally, you can listen to fine-grained events
- *   related to signaling and media that are not available in the public APIs. These events
- *   might be useful for your own reporting and diagnostics.
+ * @property {EventListener} [eventListener] - <code>(deprecated: use [Video.Logger](module-twilio-video.html)</code>
+ *   you can listen to fine-grained events related to signaling and media that are
+ *   not available in the public APIs. These events might be useful for your own reporting
+ *   and diagnostics.
  * @property {Array<RTCIceServer>} iceServers - Override the STUN and TURN
  *   servers used when connecting to {@link Room}s
  * @property {RTCIceTransportPolicy} [iceTransportPolicy="all"] - Override the
@@ -780,6 +781,7 @@ const deprecatedConnectOptionsProps = new Set([
   { didWarn: false, shouldDelete: true, name: 'abortOnIceServersTimeout' },
   { didWarn: false, shouldDelete: true, name: 'dscpTagging', newName: 'enableDscp' },
   { didWarn: false, shouldDelete: true, name: 'iceServersTimeout' },
+  { didWarn: false, shouldDelete: false, name: 'eventListener', newName: 'Video.Logger' },
   { didWarn: false, shouldDelete: false, name: 'logLevel', newName: 'Video.Logger' },
 ]);
 

--- a/lib/media/track/localvideotrack.js
+++ b/lib/media/track/localvideotrack.js
@@ -191,6 +191,7 @@ function workaroundSilentLocalVideo(localVideoTrack, doc) {
       localVideoTrack._stop();
 
       // Restart the LocalVideoTrack.
+      // eslint-disable-next-line consistent-return
       return localVideoTrack._restart();
     }).catch(error => {
       log.warn('Failed to detect silence and restart:', error);

--- a/lib/util/eventobserver.js
+++ b/lib/util/eventobserver.js
@@ -24,9 +24,10 @@ class EventObserver extends EventEmitter {
   /**
    * Constructor.
    * @param {number} connectTimestamp
+   * @param {log} Log
    * @param {EventListener} eventListener
    */
-  constructor(connectTimestamp, eventListener = null) {
+  constructor(connectTimestamp, log, eventListener = null) {
     super();
 
     Object.defineProperties(this, {
@@ -56,15 +57,16 @@ class EventObserver extends EventEmitter {
         const publisherPayload = Object.assign(payload ? payload : {}, { elapsedTime, level });
         this._publisher.publish(group, name, publisherPayload);
       }
+      const event = Object.assign(payload ? { payload } : {}, {
+        elapsedTime,
+        group,
+        level,
+        name,
+        timestamp
+      });
 
+      log.info('event', event);
       if (eventListener) {
-        const event = Object.assign(payload ? { payload } : {}, {
-          elapsedTime,
-          group,
-          level,
-          name,
-          timestamp
-        });
         eventListener.emit('event', event);
       }
     });

--- a/test/integration/spec/localparticipant.js
+++ b/test/integration/spec/localparticipant.js
@@ -196,6 +196,7 @@ describe('LocalParticipant', function() {
           updatedConfig: { local: 1, remote: 0 }
         }
       ].forEach(testCase => {
+        // eslint-disable-next-line no-warning-comments
         // TODO(mmalavalli): Re-enable once JSDK-2827 is implemented.
         it.skip('setNetworkQualityConfiguration can update the configuration after connect: (@unstable: JSDK-2827)' + testCase.name, async () => {
           let nqConfig = testCase.initialConfig;

--- a/test/integration/spec/logger.js
+++ b/test/integration/spec/logger.js
@@ -130,13 +130,12 @@ describe('logger', function() {
     assert(!!callSpies.length);
 
     // ensure that signaling events were fired for early/connecting/open events.
-    // callSpies.map(callSpy => callSpy.args[0]).filter(arg => arg.message === 'event')
     let early = false;
     let connecting = false;
     let open = false;
     callSpies.forEach(callSpy => {
       const { message, data } = callSpy.args[0];
-      if (message === 'event') {
+      if (message === 'event' && data.group === 'signaling') {
         assert(typeof data.elapsedTime === 'number');
         assert(typeof data.timestamp === 'number');
         assert(typeof data.level === 'string');

--- a/test/integration/spec/logger.js
+++ b/test/integration/spec/logger.js
@@ -124,6 +124,33 @@ describe('logger', function() {
     assert.equal(room.name, loggedRoomName);
   });
 
+  it('should log signaling events', async () => {
+    room = await connect(token, Object.assign({ name: sid }, defaults));
+    const callSpies = loggerCb.getCalls();
+    assert(!!callSpies.length);
+
+    // ensure that signaling events were fired for early/connecting/open events.
+    // callSpies.map(callSpy => callSpy.args[0]).filter(arg => arg.message === 'event')
+    let early = false;
+    let connecting = false;
+    let open = false;
+    callSpies.forEach(callSpy => {
+      const { message, data } = callSpy.args[0];
+      if (message === 'event') {
+        assert(typeof data.elapsedTime === 'number');
+        assert(typeof data.timestamp === 'number');
+        assert(typeof data.level === 'string');
+        assert(typeof data.name === 'string');
+        early = early || data.name === 'early';
+        connecting = connecting || data.name === 'connecting';
+        open = open || data.name === 'open';
+      }
+    });
+    assert(early);
+    assert(connecting);
+    assert(open);
+  });
+
   describe('connectOptions.logLevel', () => {
     beforeEach(() => {
       loadPlugin('my-logger', true);

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -484,6 +484,7 @@ async function setupAliceAndBob({ aliceOptions, bobOptions }) {
   // ICE goes to connected state instead of the expected behavior (both Participants' ICE should go
   // to connected state). So, until we know more, we wait for only one Participant to reach
   // ICE connected state.
+  // eslint-disable-next-line no-warning-comments
   // TODO(mmalavalli): Wait for both Participants to reach ICE connected state.
   await waitFor(Promise.race(peerConnectionManagers.map(pcm => new Promise(resolve => {
     pcm.on('iceConnectionStateChanged', function onIceConnectionStateChanged() {

--- a/test/unit/spec/connect.js
+++ b/test/unit/spec/connect.js
@@ -83,6 +83,12 @@ describe('connect', () => {
       shouldDelete: true
     },
     {
+      name: 'eventListener',
+      newName: 'Video.Logger',
+      value: sinon.spy(),
+      shouldDelete: false
+    },
+    {
       name: 'iceServersTimeout',
       value: 2000,
       shouldDelete: true

--- a/test/unit/spec/util/eventobserver.js
+++ b/test/unit/spec/util/eventobserver.js
@@ -1,11 +1,12 @@
 const assert = require('assert');
 const { EventEmitter } = require('events');
 const EventObserver = require('../../../../lib/util/eventobserver');
+const log = require('../../../lib/fakelog');
 
 describe('EventObserver', () => {
   describe('constructor', () => {
     it('should return an EventObserver', () => {
-      assert(new EventObserver(0, new EventEmitter()) instanceof EventObserver);
+      assert(new EventObserver(0, log, new EventEmitter()) instanceof EventObserver);
     });
   });
 
@@ -30,7 +31,7 @@ describe('EventObserver', () => {
         delete params.reason;
         connectTimestamp = Date.now();
         const eventListener = new EventEmitter();
-        eventObserver = new EventObserver(connectTimestamp, eventListener);
+        eventObserver = new EventObserver(connectTimestamp, log, eventListener);
         eventListener.once('event', event => { eventParams = event; });
       });
 


### PR DESCRIPTION
With the introduction of[ customizable logger](https://github.com/twilio/twilio-video.js/pull/1275). Applications can use the same logger to listen for signaling events that used be fired on 'eventListener'. 

This change deprecates 'eventListener' and logs the event on logger instead.


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
