### PR TITLE
fix for bwp options not getting recorded in connect message

### DIFF
--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -586,18 +586,19 @@ function createRoomConnectEventPayload(connectOptions) {
     }
   });
 
-  if (connectOptions.bandwidthProfile) {
+  if (connectOptions.bandwidthProfile && connectOptions.bandwidthProfile.video) {
+    const videoBPOptions = connectOptions.bandwidthProfile.video;
     payload.bandwidthProfileOptions = {};
     ['mode', 'maxTracks', 'trackSwitchOffMode', 'dominantSpeakerPriority'].forEach(prop => {
-      if (typeof connectOptions.bandwidthProfile[prop] === 'number' || typeof connectOptions.bandwidthProfile[prop] === 'string') {
-        if (prop in connectOptions.bandwidthProfile) {
-          payload.bandwidthProfileOptions[prop] = connectOptions.bandwidthProfile[prop];
+      if (typeof videoBPOptions[prop] === 'number' || typeof videoBPOptions[prop] === 'string') {
+        if (prop in videoBPOptions) {
+          payload.bandwidthProfileOptions[prop] = videoBPOptions[prop];
         }
       }
     });
 
-    if ('renderDimensions' in connectOptions.bandwidthProfile) {
-      payload.bandwidthProfileOptions.renderDimensions = JSON.stringify(connectOptions.bandwidthProfile.renderDimensions);
+    if ('renderDimensions' in videoBPOptions) {
+      payload.bandwidthProfileOptions.renderDimensions = JSON.stringify(videoBPOptions.renderDimensions);
     }
   }
 

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -587,7 +587,7 @@ function createRoomConnectEventPayload(connectOptions) {
   });
 
   if (connectOptions.bandwidthProfile && connectOptions.bandwidthProfile.video) {
-    const videoBPOptions = connectOptions.bandwidthProfile.video;
+    const videoBPOptions = connectOptions.bandwidthProfile.video || {};
     payload.bandwidthProfileOptions = {};
     ['mode', 'maxTracks', 'trackSwitchOffMode', 'dominantSpeakerPriority'].forEach(prop => {
       if (typeof videoBPOptions[prop] === 'number' || typeof videoBPOptions[prop] === 'string') {

--- a/test/unit/spec/util/index.js
+++ b/test/unit/spec/util/index.js
@@ -96,12 +96,14 @@ describe('util', () => {
         testCase: 'bandwidthProfile specified',
         connectOptions: {
           bandwidthProfile: {
-            mode: 'grid',
-            maxTracks: 1,
-            trackSwitchOffMode: 'detected',
-            dominantSpeakerPriority: 'high',
-            renderDimensions: {
-              high: { width: 100, height: 200 }
+            video: {
+              mode: 'grid',
+              maxTracks: 1,
+              trackSwitchOffMode: 'detected',
+              dominantSpeakerPriority: 'high',
+              renderDimensions: {
+                high: { width: 100, height: 200 }
+              }
             }
           }
         },


### PR DESCRIPTION
fixed  `connectOptions.bandwidthProfie.xxx` => `connectOptions.bandwidthProfie.video.xxx`
and verified that now [bandwidth profile options](https://kibana.stage-us1.eak.twilio.com/video/app/kibana#/doc/2c8f6840-4a01-11ea-9012-ad9b36c07d10/video-insights-2020.11.24?id=d382516d-8768-4c44-a0d7-e7590807383b&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))) do get recorded

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
