### PR TITLE
JSDK-3066: note mobile track limitation for createLocalTracks and createVideoTrack docs

### DIFF
--- a/lib/createlocaltrack.js
+++ b/lib/createlocaltrack.js
@@ -58,7 +58,10 @@ function createLocalAudioTrack(options) {
 }
 
 /**
- * Request a {@link LocalVideoTrack}.
+ * Request a {@link LocalVideoTrack}. Note that on mobile browsers,
+ * the camera can be reserved by only one {@link LocalVideoTrack} at any given
+ * time. If you attempt to create a second {@link LocalVideoTrack}, video frames
+ * will no longer be supplied to the first {@link LocalVideoTrack}.
  * @alias module:twilio-video.createLocalVideoTrack
  * @param {CreateLocalTrackOptions} [options] - Options for requesting a {@link LocalVideoTrack}
  * @returns {Promise<LocalVideoTrack>}

--- a/lib/createlocaltracks.js
+++ b/lib/createlocaltracks.js
@@ -60,8 +60,6 @@ let createLocalTrackCalls = 0;
  * });
  *
  * @example
- * // If you want to display your camera preview, pre-acquire media using
- * // createLocalTracks. You can then pass these LocalTracks to connect.
  * var Video = require('twilio-video');
  * var localTracks;
  *

--- a/lib/createlocaltracks.js
+++ b/lib/createlocaltracks.js
@@ -23,6 +23,9 @@ let createLocalTrackCalls = 0;
 /**
  * Request {@link LocalTrack}s. By default, it requests a
  * {@link LocalAudioTrack} and a {@link LocalVideoTrack}.
+ * Note that on mobile browsers, the camera can be reserved by only one {@link LocalVideoTrack}
+ * at any given time. If you attempt to create a second {@link LocalVideoTrack}, video frames
+ * will no longer be supplied to the first {@link LocalVideoTrack}.
  * @alias module:twilio-video.createLocalTracks
  * @param {CreateLocalTracksOptions} [options]
  * @returns {Promise<Array<LocalTrack>>}
@@ -57,12 +60,8 @@ let createLocalTrackCalls = 0;
  * });
  *
  * @example
- * // On mobile browsers, the camera can be reserved by only one {@link LocalVideoTrack}
- * // at any given time. If you attempt to create a second {@link LocalVideoTrack},
- * // video frames will no longer be supplied to the first {@link LocalVideoTrack}.
- * // So, it is recommended that If you want to display your camera preview,
- * // pre-acquire media using createLocalTracks. You can then pass these LocalTracks
- * // to connect.
+ * // If you want to display your camera preview, pre-acquire media using
+ * // createLocalTracks. You can then pass these LocalTracks to connect.
  * var Video = require('twilio-video');
  * var localTracks;
  *

--- a/lib/createlocaltracks.js
+++ b/lib/createlocaltracks.js
@@ -55,6 +55,30 @@ let createLocalTrackCalls = 0;
  *     console.log(localTrack.name);
  *   });
  * });
+ *
+ * @example
+ * // On mobile browsers, the camera can be reserved by only one {@link LocalVideoTrack}
+ * // at any given time. If you attempt to create a second {@link LocalVideoTrack},
+ * // video frames will no longer be supplied to the first {@link LocalVideoTrack}.
+ * // So, it is recommended that If you want to display your camera preview,
+ * // pre-acquire media using createLocalTracks. You can then pass these LocalTracks
+ * // to connect.
+ * var Video = require('twilio-video');
+ * var localTracks;
+ *
+ * // Pre-acquire tracks to display camera preview.
+ * Video.createLocalTracks().then(function(tracks) {
+ *  localTracks = tracks;
+ *  var localVideoTrack = localTracks.find(track => track.kind === 'video');
+ *  divContainer.appendChild(localVideoTrack.attach());
+ * })
+ *
+ * // Later, join the Room with the pre-acquired LocalTracks.
+ * Video.connect('token', {
+ *   name: 'my-cool-room',
+ *   tracks: localTracks
+ * });
+ *
  */
 function createLocalTracks(options) {
   const isAudioVideoAbsent =


### PR DESCRIPTION
updated the documentation to note that only one video track can be used on mobile browsers.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
