### PR TITLE
JSDK-3095 Removing video-product email from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,7 @@ twilio-video.js allows you to add real-time voice and video to your web apps.
 * [Quickstart and Examples](//github.com/twilio/video-quickstart-js/tree/master)
 * [React-based Multi-party Video App](https://github.com/twilio/twilio-video-app-react)
 
-**We want your feedback!** Email
-[video-product@twilio.com](mailto:video-product@twilio.com) with suggested
-improvements, feature requests and general feedback, or feel free to open a
-GitHub issue. If you need technical support, contact
-[help@twilio.com](mailto:help@twilio.com).
+Feel free to open a GitHub issue for suggested improvements or feature requests. If you need technical support, contact [help@twilio.com](mailto:help@twilio.com).
 
 Browser Support
 ---------------

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -303,9 +303,6 @@ function connect(token, options) {
     isNonArrayObject(options.networkQuality) ? options.networkQuality : {}
   );
 
-  // Convert options.networkQuality to boolean to configure Media Signaling
-  options.networkQuality = isNonArrayObject(options.networkQuality) || options.networkQuality;
-
   // Create a CancelableRoomPromise<Room> that resolves after these steps:
   // 1 - Get the LocalTracks.
   // 2 - Create the LocalParticipant using options.tracks.

--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -14,7 +14,8 @@ const {
   createBandwidthProfilePayload,
   createMediaSignalingPayload,
   createSubscribePayload,
-  getUserAgent
+  getUserAgent,
+  isNonArrayObject
 } = require('../../util');
 
 const {
@@ -140,7 +141,7 @@ class TwilioConnectionTransport extends StateMachine {
         value: name,
       },
       _networkQuality: {
-        value: options.networkQuality
+        value: isNonArrayObject(options.networkQuality) || options.networkQuality
       },
       _options: {
         value: options

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -586,10 +586,24 @@ function createRoomConnectEventPayload(connectOptions) {
     }
   });
 
+  if ('networkQuality' in connectOptions) {
+    payload.networkQualityConfiguration = {};
+    if (isNonArrayObject(connectOptions.networkQuality)) {
+      ['local', 'remote'].forEach(prop => {
+        if (typeof connectOptions.networkQuality[prop] === 'number') {
+          payload.networkQualityConfiguration[prop] = connectOptions.networkQuality[prop];
+        }
+      });
+    } else {
+      payload.networkQualityConfiguration.remote = 0;
+      payload.networkQualityConfiguration.local = connectOptions.networkQuality ? 1 : 0;
+    }
+  }
+
   if (connectOptions.bandwidthProfile && connectOptions.bandwidthProfile.video) {
     const videoBPOptions = connectOptions.bandwidthProfile.video || {};
     payload.bandwidthProfileOptions = {};
-    ['mode', 'maxTracks', 'trackSwitchOffMode', 'dominantSpeakerPriority'].forEach(prop => {
+    ['mode', 'maxTracks', 'trackSwitchOffMode', 'dominantSpeakerPriority', 'maxSubscriptionBitrate'].forEach(prop => {
       if (typeof videoBPOptions[prop] === 'number' || typeof videoBPOptions[prop] === 'string') {
         if (prop in videoBPOptions) {
           payload.bandwidthProfileOptions[prop] = videoBPOptions[prop];

--- a/test/unit/spec/util/index.js
+++ b/test/unit/spec/util/index.js
@@ -93,6 +93,26 @@ describe('util', () => {
         expectedPayload: { maxAudioBitrate: 100 },
       },
       {
+        testCase: 'networkQuality true',
+        connectOptions: { networkQuality: true },
+        expectedPayload: { networkQualityConfiguration: { local: 1, remote: 0 } },
+      },
+      {
+        testCase: 'networkQuality false',
+        connectOptions: { networkQuality: false },
+        expectedPayload: { networkQualityConfiguration: { local: 0, remote: 0 } },
+      },
+      {
+        testCase: 'networkQuality custom',
+        connectOptions: { networkQuality: { local: 2, remote: 2 } },
+        expectedPayload: { networkQualityConfiguration: { local: 2, remote: 2 } },
+      },
+      {
+        testCase: 'networkQuality invalid local',
+        connectOptions: { networkQuality: { local: 'foo', remote: 2 } },
+        expectedPayload: { networkQualityConfiguration: { remote: 2 } },
+      },
+      {
         testCase: 'bandwidthProfile specified',
         connectOptions: {
           bandwidthProfile: {
@@ -101,6 +121,7 @@ describe('util', () => {
               maxTracks: 1,
               trackSwitchOffMode: 'detected',
               dominantSpeakerPriority: 'high',
+              maxSubscriptionBitrate: 500,
               renderDimensions: {
                 high: { width: 100, height: 200 }
               }
@@ -113,6 +134,7 @@ describe('util', () => {
             maxTracks: 1,
             trackSwitchOffMode: 'detected',
             dominantSpeakerPriority: 'high',
+            maxSubscriptionBitrate: 500,
             renderDimensions: JSON.stringify({
               high: { width: 100, height: 200 }
             })


### PR DESCRIPTION
Replaced the old text in the README with new text that removes the video-product email.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
