### PR TITLE
JSDK-3118 - TSDef setPriority

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/node": "^8.5.1",
     "@types/selenium-webdriver": "^3.0.8",
     "@types/ws": "^3.2.1",
-    "@typescript-eslint/eslint-plugin": "^4.9.1",
+    "@typescript-eslint/eslint-plugin": "^4.13.0",
     "@typescript-eslint/parser": "^3.10.1",
     "babel-cli": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",

--- a/tsdef/RemoteAudioTrack.d.ts
+++ b/tsdef/RemoteAudioTrack.d.ts
@@ -7,6 +7,8 @@ export class RemoteAudioTrack extends AudioTrack {
   isSwitchedOff: boolean;
   isEnabled: boolean;
 
+  setPriority(priority: Track.Priority | null): this;
+
   on(event: 'disabled', listener: (track: this) => void): this;
   on(event: 'enabled', listener: (track: this) => void): this;
   on(event: 'started', listener: (track: this) => void): this;

--- a/tsdef/RemoteDataTrack.d.ts
+++ b/tsdef/RemoteDataTrack.d.ts
@@ -7,6 +7,7 @@ export class RemoteDataTrack extends Track {
   maxPacketLifeTime: number | null;
   maxRetransmits: number | null;
   ordered: boolean;
+  priority: Track.Priority | null;
   reliable: boolean;
   sid: Track.SID;
 

--- a/tsdef/RemoteDataTrack.d.ts
+++ b/tsdef/RemoteDataTrack.d.ts
@@ -10,7 +10,7 @@ export class RemoteDataTrack extends Track {
   reliable: boolean;
   sid: Track.SID;
 
-  setPriority(priority: Track.Priority | null): RemoteDataTrack;
+  setPriority(priority: Track.Priority | null): this;
 
   on(event: 'message', listener: (data: string | ArrayBuffer, track: RemoteDataTrack) => void): this;
   on(event: 'switchedOff', listener: (track: this) => void): this;

--- a/tsdef/twilio-video-tests.ts
+++ b/tsdef/twilio-video-tests.ts
@@ -69,6 +69,7 @@ function remoteAudioTrackPublication(publication: Video.RemoteAudioTrackPublicat
   });
   publication.on('subscribed', track => {
     track.attach('someOtherEl');
+    track.setPriority('high');
   });
   publication.on('trackDisabled', () => {
     if (track) {
@@ -86,6 +87,7 @@ function remoteAudioTrackPublication(publication: Video.RemoteAudioTrackPublicat
 function remoteDataTrackPublication(publication: Video.RemoteDataTrackPublication) {
   const chatLog = document.getElementById('someElementChat');
   publication.on('subscribed', track => {
+    track.setPriority('high');
     track.on('message', msg => {
       const textElement = document.createElement('p');
       if (chatLog) {
@@ -277,12 +279,10 @@ function unpublishTracks() {
 }
 
 function participantConnected(participant: Video.Participant) {
-  type TrackPublications = Video.LocalTrackPublication | Video.RemoteTrackPublication;
-
   participant.on('trackSubscribed', trackSubscribed);
   participant.on('trackUnsubscribed', trackUnsubscribed);
 
-  participant.tracks.forEach((publication: TrackPublications) => {
+  participant.tracks.forEach(publication => {
     const remotePublication = publication as Video.RemoteTrackPublication;
     if (remotePublication.isSubscribed) {
       trackSubscribed(remotePublication.track as Video.VideoTrack | Video.AudioTrack);
@@ -291,9 +291,7 @@ function participantConnected(participant: Video.Participant) {
 }
 
 function participantDisconnected(participant: Video.Participant) {
-  type TrackPublications = Video.LocalTrackPublication | Video.RemoteTrackPublication;
-
-  participant.tracks.forEach((publication: TrackPublications) => {
+  participant.tracks.forEach(publication => {
     const remotePublication = publication as Video.RemoteTrackPublication;
     if (remotePublication.isSubscribed) {
       const { track } = remotePublication;


### PR DESCRIPTION
JIRA Ticket : [JSDK-3118](https://issues.corp.twilio.com/browse/JSDK-3118)

PR contains:
- [x] setPriority on the `RemoteDataTrack` and `RemoteAudioTrack`.
- [x] "Tests" to check for any compiling errors. 
- [x] Another typescript-eslint update otherwise the linting will fail.

I also remembered that I had added a `CHANGELOG.md` entry before we cut the RC. Let me know if there is anything else I should add to the entry since it currently just says:

```
2.11.0 (In Progress)
====================

New Features
------------

- You can now import type definitions for the SDK APIs to your project as shown below. (JSDK-3007)

  ```ts
    import * as Video from 'twilio-video';
  ```

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
