### PR TITLE
JSDK-2951 - TS Definition LocalAudioTrack Fix

### DIFF
--- a/tsdef/LocalAudioTrack.d.ts
+++ b/tsdef/LocalAudioTrack.d.ts
@@ -8,10 +8,10 @@ export class LocalAudioTrack extends AudioTrack {
   id: Track.ID;
   isStopped: boolean;
 
-  disable(): LocalAudioTrack;
-  enable(enabled?: boolean): LocalAudioTrack;
+  disable(): this;
+  enable(enabled?: boolean): this;
   restart(constraints?: MediaTrackConstraints): Promise<void>;
-  stop(): LocalAudioTrack;
+  stop(): this;
 
   on(event: 'disabled', listener: (track: this) => void): this;
   on(event: 'enabled', listener: (track: this) => void): this;


### PR DESCRIPTION
Quick fix in regards to [Karina's comment](https://issues.corp.twilio.com/browse/JSDK-2951?focusedCommentId=2786495&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-2786495)

Changing some of the LocalAudioTrack method return types to `this` for consistency.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
