### PR TITLE
JSDK-2951 Adding in tests for localAudioTrack methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,18 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 New Features
 ------------
 
-- You can now import type definitions for the SDK APIs to your project as shown below. Twilio-Video types will take priority when installed at the same time as the Definitely Typed type definitions. (JSDK-3007)
+- You can now import type definitions for the SDK APIs to your project. Previously, typescript developers relied on [definitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1a7a99db8ec25d48f3dfec146af742e5bc40a5f7/types/twilio-video/index.d.ts) for these definitions. We would like to thank the folks at DefinitelyTyped for maintaining these definitions. Going forward, the definitions will be included in the library and will take precedence over any other type definitions that you may be using. (JSDK-3007)
 
+  You can access the types of the public API classes from the `Video` namespace as shown below:
   ```ts
   import * as Video from 'twilio-video';
 
-  let room: Video.Room | null = null;
-
-  async function connectToRoom() {
-    room = await Video.connect('$TOKEN', { name: 'room-name' });
-    console.log('Connected to Room "%s"', room.name);
-    return room;
-  }
+  Video.connect('token', { name: 'my-cool-room' }).then((room: Video.Room) => {
+    console.log('Connected to Room:', room.name);
+    room.on('participantConnected', (participant: Video.RemoteParticipant) => {
+      console.log('RemoteParticipant joined:', participant.identity);
+    });
+  });
   ```
 
 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,18 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 New Features
 ------------
 
-- You can now import type definitions for the SDK APIs to your project as shown below. (JSDK-3007)
+- You can now import type definitions for the SDK APIs to your project as shown below. Twilio-Video types will take priority when installed at the same time as the Definitely Typed type definitions. (JSDK-3007)
 
   ```ts
-    import * as Video from 'twilio-video';
+  import * as Video from 'twilio-video';
+
+  let room: Video.Room | null = null;
+
+  async function connectToRoom() {
+    room = await Video.connect('$TOKEN', { name: 'room-name' });
+    console.log('Connected to Room "%s"', room.name);
+    return room;
+  }
   ```
 
 2.10.0 (December 10, 2020)

--- a/lib/room.js
+++ b/lib/room.js
@@ -322,7 +322,7 @@ function rewriteLocalTrackIds(room, trackStats) {
  * A message was received over one of the {@link RemoteParticipant}'s
  * {@link RemoteDataTrack}'s.
  * @param {string|ArrayBuffer} data
- * @param {RemoteVideoTrack} track - The {@link RemoteDataTrack} over which the
+ * @param {RemoteDataTrack} track - The {@link RemoteDataTrack} over which the
  *   message was received
  * @param {RemoteParticipant} participant - The {@link RemoteParticipant} whose
  *   {@link RemoteDataTrack} received the message

--- a/tsdef/Room.d.ts
+++ b/tsdef/Room.d.ts
@@ -2,6 +2,7 @@ import { RemoteTrack, StatsReport } from './types';
 import { EventEmitter } from 'events';
 import { LocalParticipant } from './LocalParticipant';
 import { Participant } from './Participant';
+import { RemoteDataTrack } from './RemoteDataTrack';
 import { RemoteParticipant } from './RemoteParticipant';
 import { RemoteTrackPublication } from './RemoteTrackPublication';
 import { RemoteVideoTrack } from './RemoteVideoTrack';
@@ -38,7 +39,7 @@ export class Room extends EventEmitter {
   on(event: 'trackDimensionsChanged', listener: (track: RemoteVideoTrack, participant: RemoteParticipant) => void): this;
   on(event: 'trackDisabled', listener: (publication: RemoteTrackPublication, participant: RemoteParticipant) => void): this;
   on(event: 'trackEnabled', listener: (publication: RemoteTrackPublication, participant: RemoteParticipant) => void): this;
-  on(event: 'trackMessage', listener: (data: string | ArrayBuffer, track: RemoteVideoTrack, participant: RemoteParticipant) => void): this;
+  on(event: 'trackMessage', listener: (data: string | ArrayBuffer, track: RemoteDataTrack, participant: RemoteParticipant) => void): this;
   on(event: 'trackPublished', listener: (publication: RemoteTrackPublication, participant: RemoteParticipant) => void): this;
   on(event: 'trackPublishPriorityChanged', listener: (priority: Track.Priority, publication: RemoteTrackPublication, participant: RemoteParticipant) => void): this;
   on(event: 'trackStarted', listener: (track: RemoteTrack, participant: RemoteParticipant) => void): this;

--- a/tsdef/twilio-video-tests.ts
+++ b/tsdef/twilio-video-tests.ts
@@ -19,6 +19,9 @@ function getAudioTrack(track: Video.LocalAudioTrack) {
   const localAudioTrack = track;
   localAudioTrack.attach();
   localAudioTrack.detach();
+  localAudioTrack.disable();
+  localAudioTrack.enable();
+  localAudioTrack.stop();
 
   localAudioTrack.attach('someEl');
   localAudioTrack.detach('someEl');

--- a/tsdef/twilio-video-tests.ts
+++ b/tsdef/twilio-video-tests.ts
@@ -16,15 +16,13 @@ function customLogging() {
 }
 
 function getAudioTrack(track: Video.LocalAudioTrack) {
-  const localAudioTrack = track;
-  localAudioTrack.attach();
-  localAudioTrack.detach();
-  localAudioTrack.disable();
-  localAudioTrack.enable();
-  localAudioTrack.stop();
+  let localAudioTrack: Video.LocalAudioTrack = track;
 
   localAudioTrack.attach('someEl');
   localAudioTrack.detach('someEl');
+
+  localAudioTrack = localAudioTrack.disable().enable().stop();
+  return localAudioTrack;
 }
 
 function getDataTrack(track: Video.LocalDataTrack) {


### PR DESCRIPTION
Adding in some quick tests and updating changelog to prepare for TS definition release
- [x] Adding in addition compilation tests for `LocalAudioTrack`
- [x] Beef up CHANGELOG.md entry to include examples of how to import TS definitions into projects, and a note about definitely typed
- [x] Added in fixes for [JSDK-3131](https://issues.corp.twilio.com/browse/JSDK-3131)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
