### PR TITLE
JSDK-3129 | Fixing loglevel module to work with browserify and requirejs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,16 @@ commands:
       - run:
           name: Running Framework Tests
           command: npm run test:framework
+      - save-test-results
+  umd-tests:
+    steps:
+      - build
+      - run:
+          name: Installing dependencies
+          command: npm install
+      - run:
+          name: Installing UMD test dependencies
+          command: npm run test:umd:install
       - run:
           name: Running UMD Tests
           command: npm run test:umd
@@ -222,6 +232,11 @@ jobs:
       BROWSER: "chrome"
     executor: docker-with-browser
     steps: [framework-tests]
+  UMD-tests:
+    environment:
+      BROWSER: "chrome"
+    executor: docker-with-browser
+    steps: [umd-tests]
   Build-Docker-Test-Image:
     executor: machine-executor
     parameters:
@@ -375,6 +390,9 @@ workflows:
           requires: [Build, UnitTests]
       - Framework-tests:
           name: "framework tests"
+          requires: [Build, UnitTests]
+      - UMD-tests:
+          name: "umd tests"
           requires: [Build, UnitTests]
 
   Release_Workflow:

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,7 @@ Object.defineProperties(Video, {
   },
   Logger: {
     enumerable: true,
-    value: require('loglevel')
+    value: require('./vendor/loglevel')
   },
   version: {
     enumerable: true,

--- a/lib/util/log.js
+++ b/lib/util/log.js
@@ -1,7 +1,7 @@
 /* eslint new-cap:0 */
 'use strict';
 
-const defaultGetLogger = require('loglevel').getLogger;
+const defaultGetLogger = require('../vendor/loglevel').getLogger;
 const constants = require('./constants');
 const { DEFAULT_LOG_LEVEL, DEFAULT_LOGGER_NAME } = constants;
 const E = require('./constants').typeErrors;

--- a/lib/vendor/loglevel.js
+++ b/lib/vendor/loglevel.js
@@ -1,0 +1,268 @@
+/**
+ * Copyright (c) 2013 Tim Perry
+ * Licensed under the MIT license.
+ *
+ * Copied from https://github.com/pimterry/loglevel (1.7.0)
+ * and modified to remove browser and AMD module support, while keeping CommonJS.
+ * It was causing a conflict when this is bundled using CommonJS, and then loaded via RequireJS.
+ * The proper way to fix this module is to have a build that outputs CommonJS and AMD separately
+ * which needs to be submitted to the original module's repo.
+ */
+
+/* istanbul ignore file */
+/* eslint-disable */
+// Slightly dubious tricks to cut down minimized file size
+var noop = function() {};
+var undefinedType = "undefined";
+var isIE = (typeof window !== undefinedType) && (typeof window.navigator !== undefinedType) && (
+    /Trident\/|MSIE /.test(window.navigator.userAgent)
+);
+
+var logMethods = [
+    "trace",
+    "debug",
+    "info",
+    "warn",
+    "error"
+];
+
+// Cross-browser bind equivalent that works at least back to IE6
+function bindMethod(obj, methodName) {
+    var method = obj[methodName];
+    if (typeof method.bind === 'function') {
+        return method.bind(obj);
+    } else {
+        try {
+            return Function.prototype.bind.call(method, obj);
+        } catch (e) {
+            // Missing bind shim or IE8 + Modernizr, fallback to wrapping
+            return function() {
+                return Function.prototype.apply.apply(method, [obj, arguments]);
+            };
+        }
+    }
+}
+
+// Trace() doesn't print the message in IE, so for that case we need to wrap it
+function traceForIE() {
+    if (console.log) {
+        if (console.log.apply) {
+            console.log.apply(console, arguments);
+        } else {
+            // In old IE, native console methods themselves don't have apply().
+            Function.prototype.apply.apply(console.log, [console, arguments]);
+        }
+    }
+    if (console.trace) console.trace();
+}
+
+// Build the best logging method possible for this env
+// Wherever possible we want to bind, not wrap, to preserve stack traces
+function realMethod(methodName) {
+    if (methodName === 'debug') {
+        methodName = 'log';
+    }
+
+    if (typeof console === undefinedType) {
+        return false; // No method possible, for now - fixed later by enableLoggingWhenConsoleArrives
+    } else if (methodName === 'trace' && isIE) {
+        return traceForIE;
+    } else if (console[methodName] !== undefined) {
+        return bindMethod(console, methodName);
+    } else if (console.log !== undefined) {
+        return bindMethod(console, 'log');
+    } else {
+        return noop;
+    }
+}
+
+// These private functions always need `this` to be set properly
+
+function replaceLoggingMethods(level, loggerName) {
+    /*jshint validthis:true */
+    for (var i = 0; i < logMethods.length; i++) {
+        var methodName = logMethods[i];
+        this[methodName] = (i < level) ?
+            noop :
+            this.methodFactory(methodName, level, loggerName);
+    }
+
+    // Define log.log as an alias for log.debug
+    this.log = this.debug;
+}
+
+// In old IE versions, the console isn't present until you first open it.
+// We build realMethod() replacements here that regenerate logging methods
+function enableLoggingWhenConsoleArrives(methodName, level, loggerName) {
+    return function () {
+        if (typeof console !== undefinedType) {
+            replaceLoggingMethods.call(this, level, loggerName);
+            this[methodName].apply(this, arguments);
+        }
+    };
+}
+
+// By default, we use closely bound real methods wherever possible, and
+// otherwise we wait for a console to appear, and then try again.
+function defaultMethodFactory(methodName, level, loggerName) {
+    /*jshint validthis:true */
+    return realMethod(methodName) ||
+           enableLoggingWhenConsoleArrives.apply(this, arguments);
+}
+
+function Logger(name, defaultLevel, factory) {
+  var self = this;
+  var currentLevel;
+
+  var storageKey = "loglevel";
+  if (typeof name === "string") {
+    storageKey += ":" + name;
+  } else if (typeof name === "symbol") {
+    storageKey = undefined;
+  }
+
+  function persistLevelIfPossible(levelNum) {
+      var levelName = (logMethods[levelNum] || 'silent').toUpperCase();
+
+      if (typeof window === undefinedType || !storageKey) return;
+
+      // Use localStorage if available
+      try {
+          window.localStorage[storageKey] = levelName;
+          return;
+      } catch (ignore) {}
+
+      // Use session cookie as fallback
+      try {
+          window.document.cookie =
+            encodeURIComponent(storageKey) + "=" + levelName + ";";
+      } catch (ignore) {}
+  }
+
+  function getPersistedLevel() {
+      var storedLevel;
+
+      if (typeof window === undefinedType || !storageKey) return;
+
+      try {
+          storedLevel = window.localStorage[storageKey];
+      } catch (ignore) {}
+
+      // Fallback to cookies if local storage gives us nothing
+      if (typeof storedLevel === undefinedType) {
+          try {
+              var cookie = window.document.cookie;
+              var location = cookie.indexOf(
+                  encodeURIComponent(storageKey) + "=");
+              if (location !== -1) {
+                  storedLevel = /^([^;]+)/.exec(cookie.slice(location))[1];
+              }
+          } catch (ignore) {}
+      }
+
+      // If the stored level is not valid, treat it as if nothing was stored.
+      if (self.levels[storedLevel] === undefined) {
+          storedLevel = undefined;
+      }
+
+      return storedLevel;
+  }
+
+  /*
+   *
+   * Public logger API - see https://github.com/pimterry/loglevel for details
+   *
+   */
+
+  self.name = name;
+
+  self.levels = { "TRACE": 0, "DEBUG": 1, "INFO": 2, "WARN": 3,
+      "ERROR": 4, "SILENT": 5};
+
+  self.methodFactory = factory || defaultMethodFactory;
+
+  self.getLevel = function () {
+      return currentLevel;
+  };
+
+  self.setLevel = function (level, persist) {
+      if (typeof level === "string" && self.levels[level.toUpperCase()] !== undefined) {
+          level = self.levels[level.toUpperCase()];
+      }
+      if (typeof level === "number" && level >= 0 && level <= self.levels.SILENT) {
+          currentLevel = level;
+          if (persist !== false) {  // defaults to true
+              persistLevelIfPossible(level);
+          }
+          replaceLoggingMethods.call(self, level, name);
+          if (typeof console === undefinedType && level < self.levels.SILENT) {
+              return "No console available for logging";
+          }
+      } else {
+          throw "log.setLevel() called with invalid level: " + level;
+      }
+  };
+
+  self.setDefaultLevel = function (level) {
+      if (!getPersistedLevel()) {
+          self.setLevel(level, false);
+      }
+  };
+
+  self.enableAll = function(persist) {
+      self.setLevel(self.levels.TRACE, persist);
+  };
+
+  self.disableAll = function(persist) {
+      self.setLevel(self.levels.SILENT, persist);
+  };
+
+  // Initialize with the right level
+  var initialLevel = getPersistedLevel();
+  if (initialLevel == null) {
+      initialLevel = defaultLevel == null ? "WARN" : defaultLevel;
+  }
+  self.setLevel(initialLevel, false);
+}
+
+/*
+ *
+ * Top-level API
+ *
+ */
+
+var defaultLogger = new Logger();
+
+var _loggersByName = {};
+defaultLogger.getLogger = function getLogger(name) {
+    if ((typeof name !== "symbol" && typeof name !== "string") || name === "") {
+      throw new TypeError("You must supply a name when creating a logger.");
+    }
+
+    var logger = _loggersByName[name];
+    if (!logger) {
+      logger = _loggersByName[name] = new Logger(
+        name, defaultLogger.getLevel(), defaultLogger.methodFactory);
+    }
+    return logger;
+};
+
+// Grab the current global log variable in case of overwrite
+var _log = (typeof window !== undefinedType) ? window.log : undefined;
+defaultLogger.noConflict = function() {
+    if (typeof window !== undefinedType &&
+           window.log === defaultLogger) {
+        window.log = _log;
+    }
+
+    return defaultLogger;
+};
+
+defaultLogger.getLoggers = function getLoggers() {
+    return _loggersByName;
+};
+
+// ES6 default export, for compatibility
+defaultLogger['default'] = defaultLogger;
+
+module.exports = defaultLogger;

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "test:unit": "mocha ./test/unit/index.js",
     "test:integration:adapter": "node ./scripts/karma.js karma/integration.adapter.conf.js",
     "test:integration": "node ./scripts/karma.js karma/integration.conf.js",
+    "test:umd:install": "npm install puppeteer",
     "test:umd": "mocha ./test/umd/index.js",
     "test:crossbrowser:build:clean": "rimraf ./test/crossbrowser/lib ./test/crossbrowser/src/browser/index.js",
     "test:crossbrowser:build:lint": "cd ./test/crossbrowser && tslint --project tsconfig.json",
@@ -135,7 +136,6 @@
   "dependencies": {
     "@twilio/webrtc": "4.3.2",
     "backoff": "^2.5.0",
-    "loglevel": "^1.7.0",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"
   },

--- a/test/umd/index.js
+++ b/test/umd/index.js
@@ -12,7 +12,8 @@ const publicVars = [
   'isSupported',
   'LocalAudioTrack',
   'LocalDataTrack',
-  'LocalVideoTrack'
+  'LocalVideoTrack',
+  'Logger'
 ];
 
 describe('UMD', function() {

--- a/test/umd/require-browser/index.html
+++ b/test/umd/require-browser/index.html
@@ -13,7 +13,8 @@
         'isSupported',
         'LocalAudioTrack',
         'LocalDataTrack',
-        'LocalVideoTrack'
+        'LocalVideoTrack',
+        'Logger'
       ];
       require(['../../../../dist/twilio-video'], function(video) {
         try {

--- a/test/umd/require-browser/min.html
+++ b/test/umd/require-browser/min.html
@@ -13,7 +13,8 @@
         'isSupported',
         'LocalAudioTrack',
         'LocalDataTrack',
-        'LocalVideoTrack'
+        'LocalVideoTrack',
+        'Logger'
       ];
       require(['../../../../dist/twilio-video.min'], function(video) {
         try {

--- a/tsdef/index.d.ts
+++ b/tsdef/index.d.ts
@@ -1,12 +1,12 @@
 import { ConnectOptions, CreateLocalTrackOptions, CreateLocalTracksOptions, LocalTrack } from './types';
 import { LocalAudioTrack } from './LocalAudioTrack';
 import { LocalVideoTrack } from './LocalVideoTrack';
-import Log from 'loglevel';
+import { Log } from './loglevel';
 import { Room } from './Room';
 
 export const isSupported: boolean;
 export const version:string;
-export const Logger: typeof Log;
+export const Logger: Log.RootLogger;
 export function connect(token: string, options?: ConnectOptions): Promise<Room>;
 export function createLocalAudioTrack(options?: CreateLocalTrackOptions): Promise<LocalAudioTrack>;
 export function createLocalTracks(options?: CreateLocalTracksOptions): Promise<LocalTrack[]>;
@@ -21,6 +21,7 @@ export { LocalParticipant } from './LocalParticipant';
 export { LocalTrackPublication } from './LocalTrackPublication';
 export { LocalVideoTrack } from './LocalVideoTrack';
 export { LocalVideoTrackPublication } from './LocalVideoTrackPublication';
+export { Log } from './loglevel';
 export { Participant } from './Participant';
 export { RemoteAudioTrack } from './RemoteAudioTrack';
 export { RemoteAudioTrackPublication } from './RemoteAudioTrackPublication';

--- a/tsdef/loglevel.d.ts
+++ b/tsdef/loglevel.d.ts
@@ -1,0 +1,187 @@
+// Originally from Definitely Typed, see:
+// https://github.com/DefinitelyTyped/DefinitelyTyped/blob/b4683d7/types/loglevel/index.d.ts
+// Original definitions by: Stefan Profanter <https://github.com/Pro>
+//                          Gabor Szmetanko <https://github.com/szmeti>
+//                          Christian Rackerseder <https://github.com/screendriver>
+// Copied from https://github.com/pimterry/loglevel (1.7.0)
+// See lib/vendor/loglevel.js for details
+
+export namespace Log {
+    /**
+     * Log levels
+     */
+    interface LogLevel {
+        TRACE: 0;
+        DEBUG: 1;
+        INFO: 2;
+        WARN: 3;
+        ERROR: 4;
+        SILENT: 5;
+    }
+
+    /**
+     * Possible log level numbers.
+     */
+    type LogLevelNumbers = LogLevel[keyof LogLevel];
+
+    /**
+     * Possible log level descriptors, may be string, lower or upper case, or number.
+     */
+    type LogLevelDesc = LogLevelNumbers
+        | 'trace'
+        | 'debug'
+        | 'info'
+        | 'warn'
+        | 'error'
+        | 'silent'
+        | keyof LogLevel;
+
+    type LoggingMethod = (...message: any[]) => void;
+
+    type MethodFactory = (methodName: string, level: LogLevelNumbers, loggerName: string | symbol) => LoggingMethod;
+
+    interface RootLogger extends Logger {
+        /**
+         * If you're using another JavaScript library that exposes a 'log' global, you can run into conflicts with loglevel.
+         * Similarly to jQuery, you can solve this by putting loglevel into no-conflict mode immediately after it is loaded
+         * onto the page. This resets to 'log' global to its value before loglevel was loaded (typically undefined), and
+         * returns the loglevel object, which you can then bind to another name yourself.
+         */
+        noConflict(): any;
+
+        /**
+         * This gets you a new logger object that works exactly like the root log object, but can have its level and
+         * logging methods set independently. All loggers must have a name (which is a non-empty string or a symbol)
+         * Calling * getLogger() multiple times with the same name will return an identical logger object.
+         * In large applications, it can be incredibly useful to turn logging on and off for particular modules as you are
+         * working with them. Using the getLogger() method lets you create a separate logger for each part of your
+         * application with its own logging level. Likewise, for small, independent modules, using a named logger instead
+         * of the default root logger allows developers using your module to selectively turn on deep, trace-level logging
+         * when trying to debug problems, while logging only errors or silencing logging altogether under normal
+         * circumstances.
+         * @param name The name of the produced logger
+         */
+        getLogger(name: string | symbol): Logger;
+
+        /**
+         * This will return you the dictionary of all loggers created with getLogger, keyed off of their names.
+         */
+        getLoggers(): { [name: string]: Logger };
+
+        /**
+         * A .default property for ES6 default import compatibility
+         */
+        default: RootLogger;
+    }
+
+    interface Logger {
+        /**
+         * Available log levels.
+         */
+        readonly levels: LogLevel;
+
+        /**
+         * Plugin API entry point. This will be called for each enabled method each time the level is set
+         * (including initially), and should return a MethodFactory to be used for the given log method, at the given level,
+         * for a logger with the given name. If you'd like to retain all the reliability and features of loglevel, it's
+         * recommended that this wraps the initially provided value of log.methodFactory
+         */
+        methodFactory: MethodFactory;
+
+        /**
+         * Output trace message to console.
+         * This will also include a full stack trace
+         *
+         * @param msg any data to log to the console
+         */
+        trace(...msg: any[]): void;
+
+        /**
+         * Output debug message to console including appropriate icons
+         *
+         * @param msg any data to log to the console
+         */
+        debug(...msg: any[]): void;
+
+        /**
+         * Output debug message to console including appropriate icons
+         *
+         * @param msg any data to log to the console
+         */
+        log(...msg: any[]): void;
+
+        /**
+         * Output info message to console including appropriate icons
+         *
+         * @param msg any data to log to the console
+         */
+        info(...msg: any[]): void;
+
+        /**
+         * Output warn message to console including appropriate icons
+         *
+         * @param msg any data to log to the console
+         */
+        warn(...msg: any[]): void;
+
+        /**
+         * Output error message to console including appropriate icons
+         *
+         * @param msg any data to log to the console
+         */
+        error(...msg: any[]): void;
+
+        /**
+         * This disables all logging below the given level, so that after a log.setLevel("warn") call log.warn("something")
+         * or log.error("something") will output messages, but log.info("something") will not.
+         *
+         * @param level as a string, like 'error' (case-insensitive) or as a number from 0 to 5 (or as log.levels. values)
+         * @param persist Where possible the log level will be persisted. LocalStorage will be used if available, falling
+         *     back to cookies if not. If neither is available in the current environment (i.e. in Node), or if you pass
+         *     false as the optional 'persist' second argument, persistence will be skipped.
+         */
+        setLevel(level: LogLevelDesc, persist?: boolean): void;
+
+        /**
+         * Returns the current logging level, as a value from LogLevel.
+         * It's very unlikely you'll need to use this for normal application logging; it's provided partly to help plugin
+         * development, and partly to let you optimize logging code as below, where debug data is only generated if the
+         * level is set such that it'll actually be logged. This probably doesn't affect you, unless you've run profiling
+         * on your code and you have hard numbers telling you that your log data generation is a real performance problem.
+         */
+        getLevel(): LogLevel[keyof LogLevel];
+
+        /**
+         * This sets the current log level only if one has not been persisted and can’t be loaded. This is useful when
+         * initializing scripts; if a developer or user has previously called setLevel(), this won’t alter their settings.
+         * For example, your application might set the log level to error in a production environment, but when debugging
+         * an issue, you might call setLevel("trace") on the console to see all the logs. If that error setting was set
+         * using setDefaultLevel(), it will still say as trace on subsequent page loads and refreshes instead of resetting
+         * to error.
+         *
+         * The level argument takes is the same values that you might pass to setLevel(). Levels set using
+         * setDefaultLevel() never persist to subsequent page loads.
+         *
+         * @param level as a string, like 'error' (case-insensitive) or as a number from 0 to 5 (or as log.levels. values)
+         */
+        setDefaultLevel(level: LogLevelDesc): void;
+
+        /**
+         * This enables all log messages, and is equivalent to log.setLevel("trace").
+         *
+         * @param persist Where possible the log level will be persisted. LocalStorage will be used if available, falling
+         *     back to cookies if not. If neither is available in the current environment (i.e. in Node), or if you pass
+         *     false as the optional 'persist' second argument, persistence will be skipped.
+         */
+        enableAll(persist?: boolean): void;
+
+        /**
+         * This disables all log messages, and is equivalent to log.setLevel("silent").
+         *
+         * @param persist Where possible the log level will be persisted. LocalStorage will be used if available, falling
+         *     back to cookies if not. If neither is available in the current environment (i.e. in Node), or if you pass
+         *     false as the optional 'persist' second argument, persistence will be skipped.
+         */
+        disableAll(persist?: boolean): void;
+    }
+}


### PR DESCRIPTION
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

The loglevel npm module is handling CommonJS, AMD, and browser environments all in the same file. Which doesn't work if the module is bundled with browserify, and then later used with RequireJS. To fix this issue, the loglevel module should update its build process to output AMD/Browser and CommonJS files separately. Unfortunately, this is a common mistake by some developers. See this discussion and some links to requirejs docs [here](https://stackoverflow.com/questions/15371918/mismatched-anonymous-define-module.). Summary: If using requirejs, all files should be included using requirejs. If using CommonJS, building should only include CommonJS (this is the one that needs to be publish to npm). If you need to support both, you should build for both.

To address this issue on our side, I included the loglevel file directly and only added CommonJS support since that's the only scenario we need it for. The browser/AMD use case is handled by our SDK's build process already.