### PR TITLE
JSDK-2912 | LocalMediaTrack.restart() logs a warning about PeerConnec…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ New Features
 Bug Fixes
 ---------
 
-- Fixed a bug where calling `LocalMediaTrack.restart()` logs a warning about PeerConnection being closed in Peer to Peer Rooms. (JSDK-2912)
+- Fixed a bug where calling `LocalMediaTrack.restart()` logged a warning about PeerConnection being closed in Peer to Peer Rooms. (JSDK-2912)
 
 2.11.0 (January 26, 2021)
 =========================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ New Features
 
   NOTE: Large Group Rooms is currently in **beta**.
 
+Bug Fixes
+---------
+
+- Fixed a bug where calling `LocalMediaTrack.restart()` logs a warning about PeerConnection being closed in Peer to Peer Rooms. (JSDK-2912)
+
 2.11.0 (January 26, 2021)
 =========================
 

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1366,11 +1366,13 @@ class PeerConnectionV2 extends StateMachine {
    * @returns {void}
    */
   removeMediaTrackSender(mediaTrackSender) {
-    if (this._peerConnection.signalingState === 'closed' || !this._rtpSenders.has(mediaTrackSender)) {
+    const sender = this._rtpSenders.get(mediaTrackSender);
+    if (!sender) {
       return;
     }
-    const sender = this._rtpSenders.get(mediaTrackSender);
-    this._peerConnection.removeTrack(sender);
+    if (this._peerConnection.signalingState !== 'closed') {
+      this._peerConnection.removeTrack(sender);
+    }
     if (this._localMediaStream) {
       this._localMediaStream.removeTrack(mediaTrackSender.track);
     }

--- a/lib/signaling/v2/peerconnectionmanager.js
+++ b/lib/signaling/v2/peerconnectionmanager.js
@@ -188,8 +188,8 @@ class PeerConnectionManager extends QueueingEventEmitter {
       peerConnection.on('stateChanged', function stateChanged(state) {
         if (state === 'closed') {
           peerConnection.removeListener('stateChanged', stateChanged);
-          self._dataTrackSenders.forEach(peerConnection.removeDataTrackSender, peerConnection);
-          self._mediaTrackSenders.forEach(peerConnection.removeMediaTrackSender, peerConnection);
+          self._dataTrackSenders.forEach(sender => peerConnection.removeDataTrackSender(sender));
+          self._mediaTrackSenders.forEach(sender => peerConnection.removeMediaTrackSender(sender));
           self._peerConnections.delete(peerConnection.id);
           self._closedPeerConnectionIds.add(peerConnection.id);
           updateConnectionState(self);

--- a/lib/signaling/v2/peerconnectionmanager.js
+++ b/lib/signaling/v2/peerconnectionmanager.js
@@ -188,6 +188,8 @@ class PeerConnectionManager extends QueueingEventEmitter {
       peerConnection.on('stateChanged', function stateChanged(state) {
         if (state === 'closed') {
           peerConnection.removeListener('stateChanged', stateChanged);
+          self._dataTrackSenders.forEach(peerConnection.removeDataTrackSender, peerConnection);
+          self._mediaTrackSenders.forEach(peerConnection.removeMediaTrackSender, peerConnection);
           self._peerConnections.delete(peerConnection.id);
           self._closedPeerConnectionIds.add(peerConnection.id);
           updateConnectionState(self);


### PR DESCRIPTION
…tion being closed in p2p Rooms.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

We are keeping references of rtcrtpsender objects even after closing their peerconnections. This PR is to make sure we remove the rtcrtpsender references when their peerconnections are closed.