### PR TITLE
JSDK-3135 | addProcessor API

### DIFF
--- a/lib/media/track/localvideotrack.js
+++ b/lib/media/track/localvideotrack.js
@@ -74,7 +74,7 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
     const result = super.addProcessor.apply(this, arguments);
 
     this._log.debug('Updating LocalVideoTrack\'s MediaStreamTrack with the processedTrack', this.processedTrack);
-    this._trackSender.setMediaStreamTrack(this.processedTrack).catch(error => 
+    this._trackSender.setMediaStreamTrack(this.processedTrack).catch(error =>
       this._log.warn('setMediaStreamTrack failed after adding a VideoProcessor:',
         { error, mediaStreamTrack: this.processedTrack }));
 

--- a/lib/media/track/localvideotrack.js
+++ b/lib/media/track/localvideotrack.js
@@ -69,12 +69,27 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
     return super._end.apply(this, arguments);
   }
 
+  addProcessor() {
+    this._log.debug('Adding VideoProcessor to the LocalVideoTrack');
+    const result = super.addProcessor.apply(this, arguments);
+
+    this._log.debug('Updating LocalVideoTrack\'s MediaStreamTrack with the processedTrack', this.processedTrack);
+    this._trackSender.setMediaStreamTrack(this.processedTrack).catch(error => 
+      this._log.warn('setMediaStreamTrack failed after adding a VideoProcessor:',
+        { error, mediaStreamTrack: this.processedTrack }));
+
+    return result;
+  }
+
   /**
    * Disable the {@link LocalVideoTrack}. This is effectively "pause".
    * @returns {this}
    * @fires VideoTrack#disabled
    */
   disable() {
+    if (this.processedTrack) {
+      this.processedTrack.enabled = false;
+    }
     return super.disable.apply(this, arguments);
   }
 
@@ -92,6 +107,9 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
    * @fires VideoTrack#enabled
    */
   enable() {
+    if (this.processedTrack) {
+      this.processedTrack.enabled = true;
+    }
     return super.enable.apply(this, arguments);
   }
 

--- a/lib/media/track/localvideotrack.js
+++ b/lib/media/track/localvideotrack.js
@@ -73,6 +73,10 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
     this._log.debug('Adding VideoProcessor to the LocalVideoTrack');
     const result = super.addProcessor.apply(this, arguments);
 
+    if (!this.processedTrack) {
+      return this._log.warn('Unable to add a VideoProcessor to the LocalVideoTrack');
+    }
+
     this._log.debug('Updating LocalVideoTrack\'s MediaStreamTrack with the processedTrack', this.processedTrack);
     this._trackSender.setMediaStreamTrack(this.processedTrack).catch(error =>
       this._log.warn('setMediaStreamTrack failed after adding a VideoProcessor:',

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -20,6 +20,8 @@ const Track = require('./');
  *   MediaStreamTrack, "audio" or "video"
  * @property {MediaStreamTrack} mediaStreamTrack - The underlying
  *   MediaStreamTrack
+ * @property {MediaStreamTrack} processedTrack - A MediaStreamTrack
+ *   that is the source of the processed frames
  * @emits MediaTrack#disabled
  * @emits MediaTrack#enabled
  * @emits MediaTrack#started
@@ -86,6 +88,11 @@ class MediaTrack extends Track {
         get() {
           return mediaTrackTransceiver.track;
         }
+      },
+      processedTrack: {
+        enumerable: true,
+        value: null,
+        writable: true
       }
     });
 
@@ -166,14 +173,15 @@ class MediaTrack extends Track {
       mediaStream = new this._MediaStream();
     }
 
-    const getTracks = this.mediaStreamTrack.kind === 'audio'
+    const mediaStreamTrack = this.processedTrack || this.mediaStreamTrack;
+    const getTracks = mediaStreamTrack.kind === 'audio'
       ? 'getAudioTracks'
       : 'getVideoTracks';
 
-    mediaStream[getTracks]().forEach(mediaStreamTrack => {
-      mediaStream.removeTrack(mediaStreamTrack);
+    mediaStream[getTracks]().forEach(track => {
+      mediaStream.removeTrack(track);
     });
-    mediaStream.addTrack(this.mediaStreamTrack);
+    mediaStream.addTrack(mediaStreamTrack);
 
     // NOTE(mpatwardhan): resetting `srcObject` here, causes flicker (JSDK-2641), but it lets us
     // to sidestep the a chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1052353
@@ -200,6 +208,14 @@ class MediaTrack extends Track {
     }
 
     return el;
+  }
+
+  /**
+   * @private
+   */
+  _updateElementsMediaStreamTrack() {
+    this._log.debug('Reattaching all elements to update mediaStreamTrack');
+    this._getAllAttachedElements().forEach(el => this._attach(el));
   }
 
   /**

--- a/lib/media/track/videotrack.js
+++ b/lib/media/track/videotrack.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const MediaTrack = require('./mediatrack');
-const { CAPTURE_FRAME_PERIOD_MS } = require('../../util/constants');
 
 /**
  * A {@link VideoTrack} is a {@link Track} representing video.
@@ -80,10 +79,13 @@ class VideoTrack extends MediaTrack {
     this._isCapturing = true;
     this._log.debug('Start capturing frames');
 
+    const { frameRate } = this.mediaStreamTrack.getSettings();
+    const capturePeriodMs = 1000 / frameRate;
+
     this._dummyEl.play().then(() => {
       const captureFrame = this._dummyEl.requestVideoFrameCallback ?
         (cb => this._dummyEl.requestVideoFrameCallback(cb)) :
-        (cb => setTimeout(cb, CAPTURE_FRAME_PERIOD_MS));
+        (cb => setTimeout(cb, capturePeriodMs));
 
       const process = () => {
         this._inputFrame.getContext('2d')

--- a/lib/media/track/videotrack.js
+++ b/lib/media/track/videotrack.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const MediaTrack = require('./mediatrack');
+const { CAPTURE_FRAME_PERIOD_MS } = require('../../util/constants');
 
 /**
  * A {@link VideoTrack} is a {@link Track} representing video.
@@ -14,6 +15,10 @@ const MediaTrack = require('./mediatrack');
  *   {@link VideoTrack.Dimensions}
  * @property {Track.Kind} kind - "video"
  * @property {MediaStreamTrack} mediaStreamTrack - A video MediaStreamTrack
+ * @property {VideoProcessor} processor - A {@link VideoProcessor} that will be used
+ *   to process video frames
+ * @property {MediaStreamTrack} processedTrack - A MediaStreamTrack
+ *   that is the source of the processed frames
  * @emits VideoTrack#dimensionsChanged
  * @emits VideoTrack#disabled
  * @emits VideoTrack#enabled
@@ -28,15 +33,79 @@ class VideoTrack extends MediaTrack {
   constructor(mediaTrackTransceiver, options) {
     super(mediaTrackTransceiver, options);
     Object.defineProperties(this, {
+      _isCapturing: {
+        value: false,
+        writable: true
+      },
+      _inputFrame: {
+        value: null,
+        writable: true
+      },
+      _outputFrame: {
+        value: null,
+        writable: true
+      },
       dimensions: {
         enumerable: true,
         value: {
           width: null,
           height: null
         }
+      },
+      processor: {
+        enumerable: true,
+        value: null,
+        writable: true
       }
     });
+
     return this;
+  }
+
+  /**
+   * @private
+   */
+  _captureFrames() {
+    if (this._isCapturing) {
+      return this._log.debug('Ignoring captureFrames call. Capture is already in progress');
+    }
+    if (!this.processor) {
+      this._isCapturing = false;
+      return this._log.info('VideoProcessor not detected. Stopping capturing frames.');
+    }
+    if (!this._attachments.size) {
+      this._isCapturing = false;
+      return this._log.info('No attached video element. Stopping capturing frames.');
+    }
+    this._isCapturing = true;
+    this._log.debug('Start capturing frames');
+
+    this._dummyEl.play().then(() => {
+      const captureFrame = this._dummyEl.requestVideoFrameCallback ?
+        (cb => this._dummyEl.requestVideoFrameCallback(cb)) :
+        (cb => setTimeout(cb, CAPTURE_FRAME_PERIOD_MS));
+
+      const process = () => {
+        this._inputFrame.getContext('2d')
+          .drawImage(this._dummyEl, 0, 0, this._inputFrame.width, this._inputFrame.height);
+
+        let result = null;
+        try {
+          result = this.processor.processFrame(this._inputFrame);
+        } catch (ex) {
+          this._log.debug('Exception detected after calling processFrame.', ex);
+        }
+        ((result instanceof Promise) ? result : Promise.resolve(result))
+          .then(outputFrame => {
+            if (outputFrame) {
+              this._outputFrame.getContext('2d')
+                .drawImage(outputFrame, 0, 0, this._outputFrame.width, this._outputFrame.height);
+            }
+          })
+          .finally(() => captureFrame(process));
+      };
+      captureFrame(process);
+    });
   }
 
   /**
@@ -73,6 +142,65 @@ class VideoTrack extends MediaTrack {
 
     this._log.debug('Dimensions:', this.dimensions);
     return super._start.call(this, dummyEl);
+  }
+
+  /**
+   * Add a {@link VideoProcessor} to allow for custom processing of video frames belonging to a VideoTrack.
+   * @param {VideoProcessor} processor - The {@link VideoProcessor} to use.
+   * @returns {this}
+   * @example
+   * class Processor {
+   *   constructor() {
+   *     this.outputFrame = document.createElement('canvas');
+   *   }
+   *   processFrame(inputFrame) {
+   *     this.outputFrame.width = inputFrame.width;
+   *     this.outputFrame.height = inputFrame.height;
+   *
+   *     const context = this.outputFrame.getContext('2d');
+   *     context.filter = 'grayscale(100%)';
+   *     context.drawImage(inputFrame, 0, 0, inputFrame.width, inputFrame.height);
+   *     return this.outputFrame;
+   *   }
+   * }
+   *
+   * Video.createLocalVideoTrack().then(function(videoTrack) {
+   *   videoTrack.addProcessor(new Processor());
+   * });
+   */
+  addProcessor(processor) {
+    if (!processor || typeof processor.processFrame !== 'function') {
+      throw new Error('Received an invalid VideoProcessor.');
+    }
+    if (this.processor) {
+      throw new Error('A VideoProcessor has already been added.');
+    }
+    if (!this._dummyEl) {
+      throw new Error('VideoTrack has not been initialized.');
+    }
+    this._log.debug('Adding VideoProcessor to the VideoTrack', processor);
+
+    const { width, height, frameRate } = this.mediaStreamTrack.getSettings();
+    this._inputFrame = document.createElement('canvas');
+    this._inputFrame.width = width;
+    this._inputFrame.height = height;
+
+    this._outputFrame = document.createElement('canvas');
+    this._outputFrame.width = width;
+    this._outputFrame.height = height;
+
+    // Bug https://bugzilla.mozilla.org/show_bug.cgi?id=1572422
+    // Firefox requires calling getContext before calling captureStream or else it throws an error
+    this._inputFrame.getContext('2d');
+    this._outputFrame.getContext('2d');
+
+    this.processedTrack = this._outputFrame.captureStream(frameRate).getTracks()[0];
+    this.processedTrack.enabled = this.mediaStreamTrack.enabled;
+    this.processor = processor;
+
+    this._updateElementsMediaStreamTrack();
+    this._captureFrames();
+    return this;
   }
 
   /**
@@ -138,7 +266,11 @@ class VideoTrack extends MediaTrack {
    * });
    */
   attach() {
-    return super.attach.apply(this, arguments);
+    const result = super.attach.apply(this, arguments);
+    if (this.processor) {
+      this._captureFrames();
+    }
+    return result;
   }
 
   /**
@@ -183,6 +315,17 @@ function dimensionsChanged(track, elem) {
  *   {@link VideoTrack} has not yet started
  * @property {?number} height - The {@link VideoTrack}'s height or null if the
  *   {@link VideoTrack} has not yet started
+ */
+
+/**
+ * A {@link VideoProcessor} is used to process incoming video frames before
+ * sending to the encoder or renderer.
+ * @typedef {object} VideoProcessor
+ * @property {function} processFrame - A callback to receive incoming video frames for processing
+ * and has the following signature:
+ * <code>processFrame(inputFrame: HTMLCanvasElement | OffscreenCanvas)</code><br/>
+ * &nbsp;&nbsp;<code>: Promise<HTMLCanvasElement | OffscreenCanvas | null></code><br/>
+ * &nbsp;&nbsp;<code>| HTMLCanvasElement | OffscreenCanvas | null;</code><br/>
  */
 
 /**

--- a/lib/media/track/videotrack.js
+++ b/lib/media/track/videotrack.js
@@ -107,7 +107,7 @@ class VideoTrack extends MediaTrack {
           .finally(() => captureFrame(process));
       };
       captureFrame(process);
-    });
+    }).catch(error => this._log.error('Video element cannot be played', { error, track: this }));
   }
 
   /**

--- a/lib/media/track/videotrack.js
+++ b/lib/media/track/videotrack.js
@@ -148,6 +148,7 @@ class VideoTrack extends MediaTrack {
 
   /**
    * Add a {@link VideoProcessor} to allow for custom processing of video frames belonging to a VideoTrack.
+   * Only Chrome supports this as of now.
    * @param {VideoProcessor} processor - The {@link VideoProcessor} to use.
    * @returns {this}
    * @example
@@ -171,6 +172,9 @@ class VideoTrack extends MediaTrack {
    * });
    */
   addProcessor(processor) {
+    if (typeof OffscreenCanvas !== 'function') {
+      return this._log.warn('Adding a VideoProcessor is not supported in this browser.');
+    }
     if (!processor || typeof processor.processFrame !== 'function') {
       throw new Error('Received an invalid VideoProcessor.');
     }

--- a/lib/media/track/videotrack.js
+++ b/lib/media/track/videotrack.js
@@ -153,7 +153,7 @@ class VideoTrack extends MediaTrack {
    * @example
    * class Processor {
    *   constructor() {
-   *     this.outputFrame = document.createElement('canvas');
+   *     this.outputFrame = new OffscreenCanvas(0, 0);
    *   }
    *   processFrame(inputFrame) {
    *     this.outputFrame.width = inputFrame.width;
@@ -183,18 +183,10 @@ class VideoTrack extends MediaTrack {
     this._log.debug('Adding VideoProcessor to the VideoTrack', processor);
 
     const { width, height, frameRate } = this.mediaStreamTrack.getSettings();
-    this._inputFrame = document.createElement('canvas');
-    this._inputFrame.width = width;
-    this._inputFrame.height = height;
-
+    this._inputFrame = new OffscreenCanvas(width, height);
     this._outputFrame = document.createElement('canvas');
     this._outputFrame.width = width;
     this._outputFrame.height = height;
-
-    // Bug https://bugzilla.mozilla.org/show_bug.cgi?id=1572422
-    // Firefox requires calling getContext before calling captureStream or else it throws an error
-    this._inputFrame.getContext('2d');
-    this._outputFrame.getContext('2d');
 
     this.processedTrack = this._outputFrame.captureStream(frameRate).getTracks()[0];
     this.processedTrack.enabled = this.mediaStreamTrack.enabled;
@@ -325,9 +317,9 @@ function dimensionsChanged(track, elem) {
  * @typedef {object} VideoProcessor
  * @property {function} processFrame - A callback to receive incoming video frames for processing
  * and has the following signature:
- * <code>processFrame(inputFrame: HTMLCanvasElement | OffscreenCanvas)</code><br/>
- * &nbsp;&nbsp;<code>: Promise<HTMLCanvasElement | OffscreenCanvas | null></code><br/>
- * &nbsp;&nbsp;<code>| HTMLCanvasElement | OffscreenCanvas | null;</code><br/>
+ * <code>processFrame(inputFrame: OffscreenCanvas)</code><br/>
+ * &nbsp;&nbsp;<code>: Promise<OffscreenCanvas | null></code><br/>
+ * &nbsp;&nbsp;<code>| OffscreenCanvas | null;</code><br/>
  */
 
 /**

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -15,6 +15,10 @@ module.exports.PUBLISH_MAX_ATTEMPTS = 5;
 module.exports.PUBLISH_BACKOFF_JITTER = 10;
 module.exports.PUBLISH_BACKOFF_MS = 20;
 
+// How often do we capture frames in the case where requestVideoFrameCallback
+// is not available. This value results to 24fps. (interval = 1000 / 30)
+module.exports.CAPTURE_FRAME_PERIOD_MS = 41;
+
 /**
  * Returns the appropriate indefinite article ("a" | "an").
  * @param {string} word - The word which determines whether "a" | "an" is returned

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -15,10 +15,6 @@ module.exports.PUBLISH_MAX_ATTEMPTS = 5;
 module.exports.PUBLISH_BACKOFF_JITTER = 10;
 module.exports.PUBLISH_BACKOFF_MS = 20;
 
-// How often do we capture frames in the case where requestVideoFrameCallback
-// is not available. This value results to 24fps. (interval = 1000 / 30)
-module.exports.CAPTURE_FRAME_PERIOD_MS = 41;
-
 /**
  * Returns the appropriate indefinite article ("a" | "an").
  * @param {string} word - The word which determines whether "a" | "an" is returned

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "karma-safari-launcher": "^1.0.0",
     "karma-spec-reporter": "0.0.32",
     "mocha": "^3.2.0",
+    "mock-require": "^3.0.3",
     "node-http-server": "^8.1.2",
     "npm-run-all": "^4.0.2",
     "requirejs": "^2.3.3",

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -27,6 +27,7 @@ require('./spec/media/track/mediatrack');
 require('./spec/media/track/localdatatrack');
 require('./spec/media/track/localmediatrack');
 require('./spec/media/track/localaudiotrack');
+require('./spec/media/track/localvideotrack');
 require('./spec/media/track/localtrackpublication');
 require('./spec/media/track/receiver');
 require('./spec/media/track/remotedatatrack');

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -35,6 +35,7 @@ require('./spec/media/track/remotemediatrack');
 require('./spec/media/track/remotetrackpublication');
 require('./spec/media/track/sender');
 require('./spec/media/track/transceiver');
+require('./spec/media/track/videotrack');
 
 require('./spec/signaling/participant');
 require('./spec/signaling/room');

--- a/test/unit/spec/media/track/localmediatrack.js
+++ b/test/unit/spec/media/track/localmediatrack.js
@@ -357,6 +357,7 @@ const { defer } = require('../../../../../lib/util');
             'name',
             'isStarted',
             'mediaStreamTrack',
+            'processedTrack',
             'id',
             'isEnabled',
             'isStopped'
@@ -367,7 +368,9 @@ const { defer } = require('../../../../../lib/util');
             'name',
             'isStarted',
             'mediaStreamTrack',
+            'processedTrack',
             'dimensions',
+            'processor',
             'id',
             'isEnabled',
             'isStopped'
@@ -392,7 +395,8 @@ const { defer } = require('../../../../../lib/util');
             isStopped: track.isStopped,
             kind: track.kind,
             mediaStreamTrack: track.mediaStreamTrack,
-            name: track.name
+            name: track.name,
+            processedTrack: null
           });
         } else {
           assert.deepEqual(track.toJSON(), {
@@ -403,7 +407,9 @@ const { defer } = require('../../../../../lib/util');
             dimensions: track.dimensions,
             kind: track.kind,
             mediaStreamTrack: track.mediaStreamTrack,
-            name: track.name
+            name: track.name,
+            processor: null,
+            processedTrack: null
           });
         }
       });

--- a/test/unit/spec/media/track/localvideotrack.js
+++ b/test/unit/spec/media/track/localvideotrack.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const assert = require('assert');
+const sinon = require('sinon');
+const mock = require('mock-require');
+const { EventEmitter } = require('events');
+const { inherits } = require('util');
+const log = require('../../../../lib/fakelog');
+
+const parentClassContext = {};
+mock('../../../../../lib/media/track/localmediatrack', function() {
+  return class LocalMediaTrack {
+    constructor() {
+      this._log = log;
+    }
+    addProcessor() {
+      parentClassContext.addProcessor(...arguments);
+    }
+    disable() {
+      parentClassContext.disable(...arguments);
+    }
+    enable() {
+      parentClassContext.enable(...arguments);
+    }
+  }
+});
+
+const LocalVideoTrack = require('../../../../../lib/media/track/localvideotrack');
+
+describe('LocalVideoTrack', () => {
+  let localVideoTrack;
+  let mediaStreamTrack;
+
+  beforeEach(() => {
+    parentClassContext.addProcessor = sinon.spy();
+    parentClassContext.disable = sinon.spy();
+    parentClassContext.enable = sinon.spy();
+
+    mediaStreamTrack = new MediaStreamTrack('foo', 'video');
+    localVideoTrack = new LocalVideoTrack(mediaStreamTrack, {});
+    localVideoTrack._trackSender = {
+      setMediaStreamTrack: sinon.stub().resolves({})
+    };
+  });
+
+  after(() => {
+    mock.stopAll();
+  });
+
+  describe('#addProcessor', () => {
+    it('should call parent class method', () => {
+      localVideoTrack.addProcessor('foo');
+      sinon.assert.calledWith(parentClassContext.addProcessor, 'foo');
+    });
+
+    it('should not set RTCRtpSender if processedTrack is not available', () => {
+      localVideoTrack.addProcessor();
+      sinon.assert.notCalled(localVideoTrack._trackSender.setMediaStreamTrack);
+    });
+
+    it('should set RTCRtpSender if processedTrack is available', () => {
+      localVideoTrack.processedTrack = 'foo';
+      localVideoTrack.addProcessor();
+      sinon.assert.calledWith(localVideoTrack._trackSender.setMediaStreamTrack, 'foo');
+    });
+  });
+
+  describe('#enable', () => {
+    it('should call parent class method', () => {
+      localVideoTrack.enable();
+      sinon.assert.calledOnce(parentClassContext.enable);
+    });
+
+    it('should enable processedTrack', () => {
+      localVideoTrack.processedTrack = {};
+      localVideoTrack.enable();
+      assert(localVideoTrack.processedTrack.enabled);
+    });
+  });
+
+  describe('#disable', () => {
+    it('should call parent class method', () => {
+      localVideoTrack.disable();
+      sinon.assert.calledOnce(parentClassContext.disable);
+    });
+
+    it('should disable processedTrack', () => {
+      localVideoTrack.processedTrack = {};
+      localVideoTrack.disable();
+      assert(localVideoTrack.processedTrack.enabled === false);
+    });
+  });
+});
+
+function MediaStreamTrack(id, kind) {
+  EventEmitter.call(this);
+  Object.defineProperties(this, {
+    id: { value: id },
+    kind: { value: kind },
+    enabled: { value: true, writable: true },
+    readyState: { value: 'live', writable: true }
+  });
+}
+inherits(MediaStreamTrack, EventEmitter);
+MediaStreamTrack.prototype.addEventListener = MediaStreamTrack.prototype.addListener;
+MediaStreamTrack.prototype.removeEventListener = MediaStreamTrack.prototype.removeListener;

--- a/test/unit/spec/media/track/localvideotrack.js
+++ b/test/unit/spec/media/track/localvideotrack.js
@@ -22,7 +22,7 @@ mock('../../../../../lib/media/track/localmediatrack', function() {
     enable() {
       parentClassContext.enable(...arguments);
     }
-  }
+  };
 });
 
 const LocalVideoTrack = require('../../../../../lib/media/track/localvideotrack');

--- a/test/unit/spec/media/track/localvideotrack.js
+++ b/test/unit/spec/media/track/localvideotrack.js
@@ -7,29 +7,37 @@ const { EventEmitter } = require('events');
 const { inherits } = require('util');
 const log = require('../../../../lib/fakelog');
 
-const parentClassContext = {};
-mock('../../../../../lib/media/track/localmediatrack', function() {
-  return class LocalMediaTrack {
-    constructor() {
-      this._log = log;
-    }
-    addProcessor() {
-      parentClassContext.addProcessor(...arguments);
-    }
-    disable() {
-      parentClassContext.disable(...arguments);
-    }
-    enable() {
-      parentClassContext.enable(...arguments);
-    }
-  };
-});
-
-const LocalVideoTrack = require('../../../../../lib/media/track/localvideotrack');
-
 describe('LocalVideoTrack', () => {
+  const parentClassContext = {};
   let localVideoTrack;
   let mediaStreamTrack;
+  let LocalVideoTrack;
+
+  before(() => {
+    delete require.cache[require.resolve('../../../../../lib/media/track/localmediatrack')];
+    delete require.cache[require.resolve('../../../../../lib/media/track/localvideotrack')];
+    mock('../../../../../lib/media/track/localmediatrack', function() {
+      return class LocalMediaTrack {
+        constructor() {
+          this._log = log;
+        }
+        addProcessor() {
+          parentClassContext.addProcessor(...arguments);
+        }
+        disable() {
+          parentClassContext.disable(...arguments);
+        }
+        enable() {
+          parentClassContext.enable(...arguments);
+        }
+      };
+    });
+    LocalVideoTrack = require('../../../../../lib/media/track/localvideotrack');
+  });
+
+  after(() => {
+    mock.stopAll();
+  });
 
   beforeEach(() => {
     parentClassContext.addProcessor = sinon.spy();
@@ -41,10 +49,6 @@ describe('LocalVideoTrack', () => {
     localVideoTrack._trackSender = {
       setMediaStreamTrack: sinon.stub().resolves({})
     };
-  });
-
-  after(() => {
-    mock.stopAll();
   });
 
   describe('#addProcessor', () => {

--- a/test/unit/spec/media/track/mediatrack.js
+++ b/test/unit/spec/media/track/mediatrack.js
@@ -383,6 +383,20 @@ describe('MediaTrack', () => {
     });
   });
 
+  describe('_updateElementsMediaStreamTrack', () => {
+    it('should reattach each existing elements', () => {
+      track = createMediaTrack('1', 'video');
+      track._attach = sinon.spy();
+      track._attachments.add('foo');
+      track._attachments.add('bar');
+      track._updateElementsMediaStreamTrack();
+
+      sinon.assert.calledTwice(track._attach);
+      assert.equal(track._attach.firstCall.args[0], 'foo');
+      assert.equal(track._attach.secondCall.args[0], 'bar');
+    });
+  });
+
   describe('_getAllAttachedElements', () => {
     it('should return an array with all elements in ._attachments', () => {
       track = createMediaTrack('1', 'audio');
@@ -449,8 +463,14 @@ describe('MediaTrack', () => {
     let track;
     let mediaStream;
     let MediaStream;
+    let processedTrack;
 
     beforeEach(() => {
+      processedTrack = {
+        getAudioTracks: sinon.stub(),
+        getVideoTracks: sinon.stub(),
+        kind: 'audio'
+      };
       MediaStream = sinon.spy(function MediaStream() {
         // eslint-disable-next-line consistent-this
         mediaStream = this;
@@ -460,6 +480,7 @@ describe('MediaTrack', () => {
       MediaStream.prototype.removeTrack = sinon.spy();
       el = document.createElement('audio');
       track = createMediaTrack(1, 'audio', { MediaStream: MediaStream });
+      track.processedTrack = null;
     });
 
     context('when the .srcObject of the HTMLMediaElement is not a MediaStream', () => {
@@ -478,6 +499,14 @@ describe('MediaTrack', () => {
 
       it('should call .addTrack() with the MediaTrack\'s MediaStreamTrack on the MediaStream', () => {
         assert(MediaStream.prototype.addTrack.calledWith(track.mediaStreamTrack));
+      });
+
+      context('when processedTrack is not null', () => {
+        it('should call .addTrack() with the MediaTrack\'s processedTrack on the MediaStream', () => {
+          track.processedTrack = processedTrack;
+          track._attach(el);
+          assert(MediaStream.prototype.addTrack.calledWith(processedTrack));
+        });
       });
 
       it('should set the .srcObject of the HTMLMediaElement to the MediaStream', () => {
@@ -521,6 +550,14 @@ describe('MediaTrack', () => {
 
       it('should call .addTrack() with the MediaTrack\'s MediaStreamTrack on the MediaStream', () => {
         assert(MediaStream.prototype.addTrack.calledWith(track.mediaStreamTrack));
+      });
+
+      context('when processedTrack is not null', () => {
+        it('should call .addTrack() with the MediaTrack\'s processedTrack on the MediaStream', () => {
+          track.processedTrack = processedTrack;
+          track._attach(el);
+          assert(MediaStream.prototype.addTrack.calledWith(processedTrack));
+        });
       });
 
       it('should set the .srcObject of the HTMLMediaElement to the MediaStream', () => {

--- a/test/unit/spec/media/track/remotemediatrack.js
+++ b/test/unit/spec/media/track/remotemediatrack.js
@@ -219,6 +219,7 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
             'name',
             'isStarted',
             'mediaStreamTrack',
+            'processedTrack',
             'isEnabled',
             'isSwitchedOff',
             'priority',
@@ -230,7 +231,9 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
             'name',
             'isStarted',
             'mediaStreamTrack',
+            'processedTrack',
             'dimensions',
+            'processor',
             'isEnabled',
             'isSwitchedOff',
             'priority',
@@ -315,6 +318,7 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
             mediaStreamTrack: track.mediaStreamTrack,
             name: track.name,
             priority: null,
+            processedTrack: null,
             sid: track.sid
           });
         } else {
@@ -327,6 +331,8 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
             mediaStreamTrack: track.mediaStreamTrack,
             name: track.name,
             priority: null,
+            processedTrack: null,
+            processor: null,
             sid: track.sid
           });
         }

--- a/test/unit/spec/media/track/videotrack.js
+++ b/test/unit/spec/media/track/videotrack.js
@@ -1,0 +1,181 @@
+'use strict';
+
+const assert = require('assert');
+const sinon = require('sinon');
+const { EventEmitter } = require('events');
+const { inherits } = require('util');
+const log = require('../../../../lib/fakelog');
+const Document = require('../../../../lib/document');
+const VideoTrack = require('../../../../../lib/media/track/videotrack');
+const MediaTrackTransceiver = require('../../../../../lib/media/track/transceiver');
+
+const mediaStreamTrackSettings = {
+  width: 1280,
+  height: 720,
+  frameRate: 24,
+  enabled: true
+};
+
+describe('VideoTrack', () => {
+  let captureStream;
+  let videoTrack;
+  let mediaStreamTrack;
+  let processedTrack;
+
+  beforeEach(() => {
+    processedTrack = {};
+    captureStream = sinon.stub().returns({getTracks: () => [processedTrack]});
+    const document = new Document();
+    document.createElement = () => ({captureStream});
+    global.document = document;
+
+    mediaStreamTrack = new MediaStreamTrack('1', 'video');
+    const mediaTrackTransceiver = new MediaTrackTransceiver('1', mediaStreamTrack);
+    videoTrack = new VideoTrack(mediaTrackTransceiver, { log: log });
+    videoTrack._selectElement = sinon.stub();
+    videoTrack._attach = sinon.stub();
+    videoTrack._captureFrames = sinon.stub();
+    videoTrack._updateElementsMediaStreamTrack = sinon.stub();
+  });
+
+  afterEach(() => {
+    delete global.document;
+  });
+
+  describe('#attach', () => {
+    it('should start capturing frames if a VideoProcessor is attached', () => {
+      videoTrack.processor = 'foo';
+      videoTrack.attach('foo');
+      sinon.assert.calledOnce(videoTrack._captureFrames);
+    });
+
+    it('should not start capturing frames if a VideoProcessor is not attached', () => {
+      videoTrack.attach('foo');
+      sinon.assert.notCalled(videoTrack._captureFrames);
+    });
+  });
+
+  describe('#addProcessor', () => {
+    let processor;
+
+    beforeEach(() => {
+      processor = { processFrame: sinon.spy() };
+      videoTrack._dummyEl = 'foo';
+      log.warn = sinon.spy();
+    });
+
+    describe('when OffscreenCanvas is not supported', () => {
+      it('should not add a VideoProcessor', () => {
+        videoTrack.addProcessor(processor);
+        assert(!videoTrack.processor);
+      });
+
+      it('should log a warning', () => {
+        videoTrack.addProcessor(processor);
+        sinon.assert.calledWith(log.warn, 'Adding a VideoProcessor is not supported in this browser.');
+      });
+    });
+
+    describe('when OffscreenCanvas is supported', () => {
+      before(() => {
+        global.OffscreenCanvas = OffscreenCanvas;
+      });
+
+      after(() => {
+        delete global.OffscreenCanvas;
+      });
+
+      describe('when a valid VideoProcessor is provided', () => {
+        beforeEach(() => {
+          videoTrack.addProcessor(processor);
+        });
+
+        it('should add a VideoProcessor', () => {
+          assert.equal(videoTrack.processor, processor);
+        });
+  
+        it('should not log a warning', () => {
+          sinon.assert.notCalled(log.warn);
+        });
+
+        it('should initialize canvases', () => {
+          assert(!!videoTrack._inputFrame);
+          assert(!!videoTrack._outputFrame);
+          assert.equal(videoTrack._inputFrame.width, mediaStreamTrackSettings.width);
+          assert.equal(videoTrack._inputFrame.height, mediaStreamTrackSettings.height);
+          assert.equal(videoTrack._outputFrame.width, mediaStreamTrackSettings.width);
+          assert.equal(videoTrack._outputFrame.height, mediaStreamTrackSettings.height);
+        });
+
+        it('should set processedTrack with the correct settings', () => {
+          sinon.assert.calledWith(captureStream, mediaStreamTrackSettings.frameRate);
+          assert.equal(videoTrack.processedTrack.enabled, mediaStreamTrackSettings.enabled);
+        });
+
+        it('should update the mediaStreamTrack of attached elements', () => {
+          sinon.assert.calledOnce(videoTrack._updateElementsMediaStreamTrack);
+        });
+
+        it('should start capturing frames', () => {
+          sinon.assert.calledOnce(videoTrack._captureFrames);
+        });
+      });
+
+      context('raise an error', () => {
+        [{
+          name: 'processor is null',
+          errorMsg: 'Received an invalid VideoProcessor.',
+          param: null,
+        },{
+          name: 'processor is undefined',
+          errorMsg: 'Received an invalid VideoProcessor.',
+          param: undefined,
+        },{
+          name: 'processFrame is null',
+          errorMsg: 'Received an invalid VideoProcessor.',
+          param: { processFrame: null },
+        },{
+          name: 'processFrame is undefined',
+          errorMsg: 'Received an invalid VideoProcessor.',
+          param: { processFrame: undefined },
+        },{
+          name: 'processor is already set',
+          errorMsg: 'A VideoProcessor has already been added.',
+          param: { processFrame: sinon.spy() },
+          setup: () => videoTrack.processor = { processFrame: sinon.spy() }
+        },{
+          name: 'dummyEl is not set',
+          errorMsg: 'VideoTrack has not been initialized.',
+          param: { processFrame: sinon.spy() },
+          setup: () => videoTrack._dummyEl = null
+        }].forEach(({name, errorMsg, param, setup}) => {
+          it(`when ${name}`, () => {
+            if (setup) {
+              setup();
+            }
+            const regex = new RegExp(errorMsg);
+            assert.throws(() => {videoTrack.addProcessor(param)}, regex);
+          });
+        });
+      });
+    });
+  });
+});
+
+function OffscreenCanvas(width, height){
+  this.width = width;
+  this.height = height;
+}
+
+function MediaStreamTrack(id, kind) {
+  EventEmitter.call(this);
+  Object.defineProperties(this, {
+    id: { value: id },
+    kind: { value: kind },
+    enabled: { value: mediaStreamTrackSettings.enabled },
+    getSettings: { value: () => mediaStreamTrackSettings }
+  });
+}
+inherits(MediaStreamTrack, EventEmitter);
+MediaStreamTrack.prototype.addEventListener = MediaStreamTrack.prototype.addListener;
+MediaStreamTrack.prototype.removeEventListener = MediaStreamTrack.prototype.removeListener;

--- a/test/unit/spec/media/track/videotrack.js
+++ b/test/unit/spec/media/track/videotrack.js
@@ -26,9 +26,9 @@ describe('VideoTrack', () => {
   beforeEach(() => {
     clock = sinon.useFakeTimers();
     processedTrack = {};
-    captureStream = sinon.stub().returns({getTracks: () => [processedTrack]});
+    captureStream = sinon.stub().returns({ getTracks: () => [processedTrack] });
     const document = new Document();
-    document.createElement = () => ({captureStream});
+    document.createElement = () => ({ captureStream });
     global.document = document;
 
     mediaStreamTrack = new MediaStreamTrack('1', 'video');
@@ -101,7 +101,7 @@ describe('VideoTrack', () => {
         it('should add a VideoProcessor', () => {
           assert.equal(videoTrack.processor, processor);
         });
-  
+
         it('should not log a warning', () => {
           sinon.assert.notCalled(log.warn);
         });
@@ -134,35 +134,35 @@ describe('VideoTrack', () => {
           name: 'processor is null',
           errorMsg: 'Received an invalid VideoProcessor.',
           param: null,
-        },{
+        }, {
           name: 'processor is undefined',
           errorMsg: 'Received an invalid VideoProcessor.',
           param: undefined,
-        },{
+        }, {
           name: 'processFrame is null',
           errorMsg: 'Received an invalid VideoProcessor.',
           param: { processFrame: null },
-        },{
+        }, {
           name: 'processFrame is undefined',
           errorMsg: 'Received an invalid VideoProcessor.',
           param: { processFrame: undefined },
-        },{
+        }, {
           name: 'processor is already set',
           errorMsg: 'A VideoProcessor has already been added.',
           param: { processFrame: sinon.spy() },
-          setup: () => videoTrack.processor = { processFrame: sinon.spy() }
-        },{
+          setup: () => { videoTrack.processor = { processFrame: sinon.spy() }; }
+        }, {
           name: 'dummyEl is not set',
           errorMsg: 'VideoTrack has not been initialized.',
           param: { processFrame: sinon.spy() },
-          setup: () => videoTrack._dummyEl = null
-        }].forEach(({name, errorMsg, param, setup}) => {
+          setup: () => { videoTrack._dummyEl = null; }
+        }].forEach(({ name, errorMsg, param, setup }) => {
           it(`when ${name}`, () => {
             if (setup) {
               setup();
             }
             const regex = new RegExp(errorMsg);
-            assert.throws(() => {videoTrack.addProcessor(param)}, regex);
+            assert.throws(() => { videoTrack.addProcessor(param); }, regex);
           });
         });
       });
@@ -179,10 +179,10 @@ describe('VideoTrack', () => {
       videoTrack._attachments.add('foo');
       videoTrack.processor = { processFrame };
 
-      videoTrack._dummyEl.play = () => ({ then: (cb) => {
+      videoTrack._dummyEl.play = () => ({ then: cb => {
         cb();
         return { catch: sinon.stub() };
-      }});
+      } });
 
       videoTrack._inputFrame = new OffscreenCanvas(mediaStreamTrackSettings.width, mediaStreamTrackSettings.height);
       videoTrack._outputFrame = new OffscreenCanvas(mediaStreamTrackSettings.width, mediaStreamTrackSettings.height);
@@ -199,25 +199,25 @@ describe('VideoTrack', () => {
         name: 'should draw the processed frame to the outputFrame if the return value is valid and not a promise',
         getReturnValue: () => 'myframe',
         expectedDrawing: { image: 'myframe', x: 0, y: 0, width: 1280, height: 720 }
-      },{
+      }, {
         name: 'should draw the processed frame to the outputFrame if the return value is valid in a promise',
         getReturnValue: () =>  Promise.resolve('myframe'),
         expectedDrawing: { image: 'myframe', x: 0, y: 0, width: 1280, height: 720 }
-      },{
+      }, {
         name: 'should drop the frame if processFrame throws an exception',
-        getReturnValue:  () => { throw new Error('foo'); },
+        getReturnValue: () => { throw new Error('foo'); },
         expectedDrawing: {}
-      },{
+      }, {
         name: 'should drop the frame if processFrame returns null',
-        getReturnValue:  () => null,
+        getReturnValue: () => null,
         expectedDrawing: {}
-      },{
+      }, {
         name: 'should drop the frame if processFrame returns a promise which resolves to null',
-        getReturnValue:  () => Promise.resolve(null),
+        getReturnValue: () => Promise.resolve(null),
         expectedDrawing: {}
-      }].forEach(({name, getReturnValue, expectedDrawing}) => {
+      }].forEach(({ name, getReturnValue, expectedDrawing }) => {
         it(name, async () => {
-          videoTrack.processor.processFrame = (inputFrame) => getReturnValue();
+          videoTrack.processor.processFrame = () => getReturnValue();
           videoTrack._captureFrames();
           clock.tick(timeoutMs);
           await internalPromise();
@@ -234,10 +234,10 @@ describe('VideoTrack', () => {
       });
 
       it('should use requestVideoFrameCallback when available', async () => {
-        videoTrack._dummyEl.requestVideoFrameCallback = (cb) => {
+        videoTrack._dummyEl.requestVideoFrameCallback = cb => {
           setTimeout(() => {
-            cb();
             onVideoFrame();
+            cb();
           }, timeoutMs);
         };
         videoTrack._captureFrames();
@@ -310,7 +310,7 @@ describe('VideoTrack', () => {
   });
 });
 
-function OffscreenCanvas(width, height){
+function OffscreenCanvas(width, height) {
   this.width = width;
   this.height = height;
   this.drawing = {};

--- a/tsdef/VideoProcessor.d.ts
+++ b/tsdef/VideoProcessor.d.ts
@@ -1,5 +1,5 @@
 export class VideoProcessor {
-  processFrame(inputFrame: HTMLCanvasElement | OffscreenCanvas)
-    : Promise<HTMLCanvasElement | OffscreenCanvas | null>
-    | HTMLCanvasElement | OffscreenCanvas | null;
+  processFrame(inputFrame: OffscreenCanvas)
+    : Promise<OffscreenCanvas | null>
+    | OffscreenCanvas | null;
 }

--- a/tsdef/VideoProcessor.d.ts
+++ b/tsdef/VideoProcessor.d.ts
@@ -1,0 +1,5 @@
+export class VideoProcessor {
+  processFrame(inputFrame: HTMLCanvasElement | OffscreenCanvas)
+    : Promise<HTMLCanvasElement | OffscreenCanvas | null>
+    | HTMLCanvasElement | OffscreenCanvas | null;
+}

--- a/tsdef/VideoTrack.d.ts
+++ b/tsdef/VideoTrack.d.ts
@@ -1,4 +1,5 @@
 import { Track } from './Track';
+import { VideoProcessor } from './VideoProcessor';
 
 export namespace VideoTrack {
   interface Dimensions {
@@ -14,6 +15,7 @@ export class VideoTrack extends Track {
   kind: 'video';
   mediaStreamTrack: MediaStreamTrack;
 
+  addProcessor(processor: VideoProcessor): this;
   attach(element?: HTMLMediaElement | string): HTMLVideoElement;
   detach(element?: HTMLMediaElement | string): HTMLVideoElement[];
 

--- a/tsdef/index.d.ts
+++ b/tsdef/index.d.ts
@@ -22,6 +22,7 @@ export { LocalTrackPublication } from './LocalTrackPublication';
 export { LocalVideoTrack } from './LocalVideoTrack';
 export { LocalVideoTrackPublication } from './LocalVideoTrackPublication';
 export { Log } from './loglevel';
+export { VideoProcessor } from './VideoProcessor';
 export { Participant } from './Participant';
 export { RemoteAudioTrack } from './RemoteAudioTrack';
 export { RemoteAudioTrackPublication } from './RemoteAudioTrackPublication';


### PR DESCRIPTION
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

This PR:
- Implements addProcessor API base on the following specifications:
  - IDL: https://code.hq.twilio.com/client/video-sdk-api/pull/77
  - FRD: https://code.hq.twilio.com/client/sdk-frd/pull/63

TODO (in this PR):
 - Unit tests

TODO (in the removeProcessor ticket):
- Implement removeProcessor
- Account for `track.restart` and `track.stop`