### PR TITLE
VIDEO-3695: early track swichoffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Bug Fixes
 ---------
 
 - Fixed a bug where calling `LocalMediaTrack.restart()` logged a warning about PeerConnection being closed in Peer to Peer Rooms. (JSDK-2912)
+- Fixed a race condition that sometimes caused `switchedOff` event for `RemoteVideoTrack` to not get emitted, which also resulted in wrong value for `RemoteVideoTrack.isSwitchedOff` property. (VIDEO-3695)
 
 2.11.0 (January 26, 2021)
 =========================

--- a/lib/media/track/remoteaudiotrack.js
+++ b/lib/media/track/remoteaudiotrack.js
@@ -25,12 +25,13 @@ class RemoteAudioTrack extends RemoteMediaAudioTrack {
    * @param {Track.SID} sid - The {@link RemoteAudioTrack}'s SID
    * @param {MediaTrackReceiver} mediaTrackReceiver - An audio MediaStreamTrack container
    * @param {boolean} isEnabled - Whether the {@link RemoteAudioTrack} is enabled
+   * @param {boolean} isSwitchedOff - Whether the {@link RemoteAudioTrack} is switched off
    * @param {function(?Track.Priority): void} setPriority - Set or clear the subscribe
    *  {@link Track.Priority} of the {@link RemoteAudioTrack}
    * @param {{log: Log}} options - The {@link RemoteTrack} options
    */
-  constructor(sid, mediaTrackReceiver, isEnabled, setPriority, options) {
-    super(sid, mediaTrackReceiver, isEnabled, setPriority, options);
+  constructor(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, setPriority, options) {
+    super(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, setPriority, options);
   }
 
   toString() {

--- a/lib/media/track/remotemediatrack.js
+++ b/lib/media/track/remotemediatrack.js
@@ -23,11 +23,12 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
      * @param {Track.SID} sid
      * @param {MediaTrackReceiver} mediaTrackReceiver
      * @param {boolean} isEnabled
+      @param {boolean} isSwitchedOff
      * @param {function(?Track.Priority): void} setPriority - Set or clear the subscribe
      *  {@link Track.Priority} of the {@link RemoteMediaTrack}
      * @param {{log: Log, name: ?string}} options
      */
-    constructor(sid, mediaTrackReceiver, isEnabled, setPriority, options) {
+    constructor(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, setPriority, options) {
       options = Object.assign({
         // NOTE(mpatwardhan): WebKit bug: 212780 sometimes causes the audio/video elements to stay paused when safari
         // regains foreground. To workaround it, when safari gains foreground - we will play any elements that were
@@ -46,7 +47,7 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
           writable: true
         },
         _isSwitchedOff: {
-          value: false,
+          value: isSwitchedOff,
           writable: true
         },
         _priority: {

--- a/lib/media/track/remotetrackpublication.js
+++ b/lib/media/track/remotetrackpublication.js
@@ -95,7 +95,7 @@ class RemoteTrackPublication extends TrackPublication {
         this.emit(signaling.isEnabled ? 'trackEnabled' : 'trackDisabled');
       }
       if (isSwitchedOff !== signaling.isSwitchedOff) {
-        this._log.warn(`${this.track ? this.track.sid : 'null'}: ${isSwitchedOff ? 'OFF' : 'ON'} => ${signaling.isSwitchedOff ? 'OFF' : 'ON'}`);
+        this._log.warn(`${this.trackSid}: ${isSwitchedOff ? 'OFF' : 'ON'} => ${signaling.isSwitchedOff ? 'OFF' : 'ON'}`);
         isSwitchedOff = signaling.isSwitchedOff;
         if (this.track) {
           this.track._setSwitchedOff(signaling.isSwitchedOff);
@@ -122,9 +122,6 @@ class RemoteTrackPublication extends TrackPublication {
   _subscribed(track) {
     if (!this._track && track) {
       this._track = track;
-      // if (this._signaling.isSwitchedOff !== this.track.isSwitchedOff) {
-      //   this._log.error(`BUGBUG [${track.sid}] ${this._signaling.isSwitchedOff} !== ${track.isSwitchedOff}`);
-      // }
       this.emit('subscribed', track);
     }
   }

--- a/lib/media/track/remotetrackpublication.js
+++ b/lib/media/track/remotetrackpublication.js
@@ -95,10 +95,13 @@ class RemoteTrackPublication extends TrackPublication {
         this.emit(signaling.isEnabled ? 'trackEnabled' : 'trackDisabled');
       }
       if (isSwitchedOff !== signaling.isSwitchedOff) {
+        this._log.warn(`${this.track ? this.track.sid : 'null'}: ${isSwitchedOff ? 'OFF' : 'ON'} => ${signaling.isSwitchedOff ? 'OFF' : 'ON'}`);
         isSwitchedOff = signaling.isSwitchedOff;
         if (this.track) {
           this.track._setSwitchedOff(signaling.isSwitchedOff);
-          this.emit(signaling.isSwitchedOff ? 'trackSwitchedOff' : 'trackSwitchedOn',  this.track);
+          this.emit(isSwitchedOff ? 'trackSwitchedOff' : 'trackSwitchedOn',  this.track);
+        } else if (isSwitchedOff) {
+          this._log.warn('Track was not subscribed when switched Off.');
         }
       }
       if (priority !== signaling.priority) {
@@ -119,6 +122,9 @@ class RemoteTrackPublication extends TrackPublication {
   _subscribed(track) {
     if (!this._track && track) {
       this._track = track;
+      // if (this._signaling.isSwitchedOff !== this.track.isSwitchedOff) {
+      //   this._log.error(`BUGBUG [${track.sid}] ${this._signaling.isSwitchedOff} !== ${track.isSwitchedOff}`);
+      // }
       this.emit('subscribed', track);
     }
   }

--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -26,12 +26,13 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
    * @param {Track.SID} sid - The {@link RemoteVideoTrack}'s SID
    * @param {MediaTrackReceiver} mediaTrackReceiver - A video MediaStreamTrack container
    * @param {boolean} isEnabled - whether the {@link RemoteVideoTrack} is enabled
+   * @param {boolean} isSwitchedOff - Whether the {@link RemoteVideoTrack} is switched off
    * @param {function(?Track.Priority): void} setPriority - Set or clear the subscribe
    *  {@link Track.Priority} of the {@link RemoteVideoTrack}
    * @param {{log: Log}} options - The {@link RemoteTrack} options
    */
-  constructor(sid, mediaTrackReceiver, isEnabled, setPriority, options) {
-    super(sid, mediaTrackReceiver, isEnabled, setPriority, options);
+  constructor(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, setPriority, options) {
+    super(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, setPriority, options);
   }
 
   toString() {

--- a/lib/media/track/trackpublication.js
+++ b/lib/media/track/trackpublication.js
@@ -35,7 +35,7 @@ class TrackPublication extends EventEmitter {
         value: nInstances++
       },
       _log: {
-        value: options.log || new Log('default', this, logLevels, options.loggerName)
+        value: options.log ? options.log.createLog('default', this) : new Log('default', this, logLevels, options.loggerName)
       },
       trackName: {
         enumerable: true,

--- a/lib/participant.js
+++ b/lib/participant.js
@@ -315,7 +315,7 @@ class Participant extends EventEmitter {
     }
 
     function trackSignalingSubscribed(signaling) {
-      const { isEnabled, name, kind, sid, trackTransceiver } = signaling;
+      const { isEnabled, name, kind, sid, trackTransceiver, isSwitchedOff } = signaling;
       const RemoteTrack = {
         audio: RemoteAudioTrack,
         video: RemoteVideoTrack,
@@ -335,7 +335,7 @@ class Participant extends EventEmitter {
       const setPriority = newPriority => participantSignaling.updateSubscriberTrackPriority(sid, newPriority);
       const track = kind === 'data'
         ? new RemoteTrack(sid, trackTransceiver, options)
-        : new RemoteTrack(sid, trackTransceiver, isEnabled, setPriority, options);
+        : new RemoteTrack(sid, trackTransceiver, isEnabled, isSwitchedOff, setPriority, options);
 
       self._addTrack(track, publication, trackTransceiver.id);
     }

--- a/lib/signaling/remotetrackpublication.js
+++ b/lib/signaling/remotetrackpublication.js
@@ -14,12 +14,13 @@ class RemoteTrackPublicationSignaling extends TrackSignaling {
    * @param {Track.Kind} kind
    * @param {boolean} isEnabled
    * @param {Track.Priority} priority
+   * @param {boolean} isSwitchedOff
    */
-  constructor(sid, name, kind, isEnabled, priority) {
+  constructor(sid, name, kind, isEnabled, priority, isSwitchedOff) {
     super(name, kind, isEnabled, priority);
     Object.defineProperties(this, {
       _isSwitchedOff: {
-        value: false,
+        value: isSwitchedOff,
         writable: true
       },
     });

--- a/lib/signaling/room.js
+++ b/lib/signaling/room.js
@@ -3,12 +3,17 @@
 const DefaultRecordingSignaling = require('./recording');
 const StateMachine = require('../statemachine');
 const DefaultTimeout = require('../util/timeout');
+const { buildLogLevels } = require('../util');
+const { DEFAULT_LOG_LEVEL } = require('../util/constants');
+const Log = require('../util/log');
 
 const {
   MediaConnectionError,
   MediaDTLSTransportFailedError,
   SignalingConnectionDisconnectedError
 } = require('../util/twilio-video-errors');
+
+let nInstances = 0;
 
 /*
 RoomSignaling States
@@ -70,9 +75,12 @@ class RoomSignaling extends StateMachine {
    */
   constructor(localParticipant, sid, name, options) {
     options = Object.assign({
+      logLevel: DEFAULT_LOG_LEVEL,
       RecordingSignaling: DefaultRecordingSignaling,
       Timeout: DefaultTimeout
     }, options);
+
+    const logLevels = buildLogLevels(options.logLevel);
 
     super('connected', states);
 
@@ -83,6 +91,12 @@ class RoomSignaling extends StateMachine {
     }, options.sessionTimeout, false);
 
     Object.defineProperties(this, {
+      _instanceId: {
+        value: nInstances++
+      },
+      _log: {
+        value: options.log ? options.log.createLog('default', this) : new Log('default', this, logLevels, options.loggerName)
+      },
       _mediaConnectionIsReconnecting: {
         writable: true,
         value: false
@@ -153,6 +167,10 @@ class RoomSignaling extends StateMachine {
       return true;
     }
     return false;
+  }
+
+  toString() {
+    return `[RoomSignaling #${this._instanceId}]`;
   }
 
   /**

--- a/lib/signaling/room.js
+++ b/lib/signaling/room.js
@@ -95,7 +95,9 @@ class RoomSignaling extends StateMachine {
         value: nInstances++
       },
       _log: {
-        value: options.log ? options.log.createLog('default', this) : new Log('default', this, logLevels, options.loggerName)
+        value: options.log
+          ? options.log.createLog('default', this)
+          : new Log('default', this, logLevels, options.loggerName)
       },
       _mediaConnectionIsReconnecting: {
         writable: true,

--- a/lib/signaling/v2/remoteparticipant.js
+++ b/lib/signaling/v2/remoteparticipant.js
@@ -12,9 +12,11 @@ class RemoteParticipantV2 extends RemoteParticipantSignaling {
    * Construct a {@link RemoteParticipantV2}.
    * @param {object} participantState
    * @param {function(string): Promise<DataTrackReceiver|MediaTrackReceiver>} getTrackReceiver
+   * @param {function(string): boolean} getInitialTrackSwitchOffState
+   *
    * @param {object} [options]
    */
-  constructor(participantState, getTrackReceiver, options) {
+  constructor(participantState, getTrackReceiver, getInitialTrackSwitchOffState, options) {
     super(participantState.sid, participantState.identity);
 
     options = Object.assign({
@@ -31,6 +33,9 @@ class RemoteParticipantV2 extends RemoteParticipantSignaling {
       },
       _getTrackReceiver: {
         value: getTrackReceiver
+      },
+      _getInitialTrackSwitchOffState: {
+        value: getInitialTrackSwitchOffState
       },
       revision: {
         enumerable: true,
@@ -50,7 +55,8 @@ class RemoteParticipantV2 extends RemoteParticipantSignaling {
     const RemoteTrackPublicationV2 = this._RemoteTrackPublicationV2;
     let track = this.tracks.get(trackState.sid);
     if (!track) {
-      track = new RemoteTrackPublicationV2(trackState);
+      const isSwitchedOff = this._getInitialTrackSwitchOffState(trackState.sid);
+      track = new RemoteTrackPublicationV2(trackState, isSwitchedOff);
       this.addTrack(track);
     }
     return track;

--- a/lib/signaling/v2/remotetrackpublication.js
+++ b/lib/signaling/v2/remotetrackpublication.js
@@ -9,9 +9,11 @@ class RemoteTrackPublicationV2 extends RemoteTrackPublicationSignaling {
   /**
    * Construct a {@link RemoteTrackPublicationV2}.
    * @param {RemoteTrackPublicationV2#Representation} track
+   * @param {boolean} isSwitchedOff
+   *
    */
-  constructor(track) {
-    super(track.sid, track.name, track.kind, track.enabled, track.priority);
+  constructor(track, isSwitchedOff) {
+    super(track.sid, track.name, track.kind, track.enabled, track.priority, isSwitchedOff);
   }
 
   /**

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -131,6 +131,9 @@ class RoomV2 extends RoomSignaling {
       _TrackSwitchOffSignaling: {
         value: options.TrackSwitchOffSignaling
       },
+      _pendingSwitchOffStates: {
+        value: new Map()
+      },
       _transport: {
         value: transport
       },
@@ -249,6 +252,19 @@ class RoomV2 extends RoomSignaling {
   /**
    * @private
    */
+  _getInitialTrackSwitchOffState(trackSid) {
+    const initiallySwitchedOff = this._pendingSwitchOffStates.get(trackSid) || false;
+    this._pendingSwitchOffStates.delete(trackSid);
+    if (initiallySwitchedOff) {
+      this._log.warn(`[${trackSid}] was initially switched off! `);
+    }
+    return initiallySwitchedOff;
+  }
+
+
+  /**
+   * @private
+   */
   _getTrackSidsToTrackSignalings() {
     const trackSidsToTrackSignalings = flatMap(this.participants, participant => Array.from(participant.tracks));
     return new Map(trackSidsToTrackSignalings);
@@ -262,7 +278,7 @@ class RoomV2 extends RoomSignaling {
     let participant = this.participants.get(participantState.sid);
     const self = this;
     if (!participant) {
-      participant = new RemoteParticipantV2(participantState, this._getTrackReceiver.bind(this));
+      participant = new RemoteParticipantV2(participantState, this._getTrackReceiver.bind(this), this._getInitialTrackSwitchOffState.bind(this));
       participant.on('stateChanged', function stateChanged(state) {
         if (state === 'disconnected') {
           participant.removeListener('stateChanged', stateChanged);
@@ -270,6 +286,7 @@ class RoomV2 extends RoomSignaling {
           self._disconnectedParticipantRevisions.set(participant.sid, participant.revision);
         }
       });
+
       this.connectParticipant(participant);
       participant.setTrackPrioritySignaling(this._trackPrioritySignaling);
     }
@@ -466,16 +483,33 @@ class RoomV2 extends RoomSignaling {
   _setupTrackSwitchOff(trackSwitchOffSignaling) {
     this._trackSwitchOffSignaling = trackSwitchOffSignaling;
     trackSwitchOffSignaling.on('updated', (tracksOff, tracksOn) => {
-      this.participants.forEach(participant => {
-        participant.tracks.forEach(track => {
-          if (tracksOff.includes(track.sid)) {
-            track.setSwitchedOff(true);
+      try {
+        this._log.warn('trackSwitchOff: On: ', tracksOn, ' Off: ', tracksOff);
+        const trackUpdates = new Map();
+        tracksOn.forEach(trackSid => trackUpdates.set(trackSid, true));
+        tracksOff.forEach(trackSid => {
+          if (trackUpdates.get(trackSid)) {
+            // https://issues.corp.twilio.com/browse/VIDEO-3762
+            this._log.warn(`${trackSid} is DUPLICATED in both tracksOff and tracksOn list`);
           }
-          if (tracksOn.includes(track.sid)) {
-            track.setSwitchedOff(false);
-          }
+          trackUpdates.set(trackSid, false);
         });
-      });
+        this.participants.forEach(participant => {
+          participant.tracks.forEach(track => {
+            const isOn = trackUpdates.get(track.sid);
+            if (typeof isOn !== 'undefined') {
+              // RemoteTrackPublicationSignaling.setSwitchedOff => emit(updated) => RemoteTrackPublication
+              track.setSwitchedOff(!isOn);
+              trackUpdates.delete(track.sid);
+            }
+          });
+        });
+
+        // cache any notification about the tracks that we do not yet know about.
+        trackUpdates.forEach((isOn, trackSid) => this._pendingSwitchOffStates.set(trackSid, !isOn));
+      } catch (ex) {
+        this._log.error('error processing track switch off:', ex);
+      }
     });
   }
 

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -286,7 +286,6 @@ class RoomV2 extends RoomSignaling {
           self._disconnectedParticipantRevisions.set(participant.sid, participant.revision);
         }
       });
-
       this.connectParticipant(participant);
       participant.setTrackPrioritySignaling(this._trackPrioritySignaling);
     }
@@ -489,7 +488,7 @@ class RoomV2 extends RoomSignaling {
         tracksOn.forEach(trackSid => trackUpdates.set(trackSid, true));
         tracksOff.forEach(trackSid => {
           if (trackUpdates.get(trackSid)) {
-            // https://issues.corp.twilio.com/browse/VIDEO-3762
+            // NOTE(mpatwardhan): This means that VIDEO-3762 has been reproduced.
             this._log.warn(`${trackSid} is DUPLICATED in both tracksOff and tracksOn list`);
           }
           trackUpdates.set(trackSid, false);
@@ -498,14 +497,13 @@ class RoomV2 extends RoomSignaling {
           participant.tracks.forEach(track => {
             const isOn = trackUpdates.get(track.sid);
             if (typeof isOn !== 'undefined') {
-              // RemoteTrackPublicationSignaling.setSwitchedOff => emit(updated) => RemoteTrackPublication
               track.setSwitchedOff(!isOn);
               trackUpdates.delete(track.sid);
             }
           });
         });
 
-        // cache any notification about the tracks that we do not yet know about.
+        // NOTE(mpatwardhan): Cache any notification about the tracks that we do not yet know about.
         trackUpdates.forEach((isOn, trackSid) => this._pendingSwitchOffStates.set(trackSid, !isOn));
       } catch (ex) {
         this._log.error('error processing track switch off:', ex);

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -509,7 +509,6 @@ describe('LocalTrackPublication', function() {
       });
     });
 
-
     [PRIORITY_LOW, PRIORITY_STANDARD, PRIORITY_HIGH].forEach(beforePriority => {
       [PRIORITY_LOW, PRIORITY_STANDARD, PRIORITY_HIGH].forEach(afterPriority => {
         const expectNotification = beforePriority !== afterPriority;
@@ -641,6 +640,7 @@ describe('LocalTrackPublication', function() {
       assert.equal(trackAPubLocal.priority, PRIORITY_STANDARD);
       assert.equal(trackBPubLocal.priority, PRIORITY_LOW);
 
+
       // wait for alice to subscribe two tracks
       await waitFor(tracksSubscribed(bobRemote, 2), `wait for alice to subscribe to Bobs tracks: ${roomSid}`);
 
@@ -649,10 +649,11 @@ describe('LocalTrackPublication', function() {
       const trackBPubRemote = bobRemote.videoTracks.get(trackBPubLocal.trackSid);
       assert(trackBPubRemote);
 
+
       await waitFor([
         trackSwitchedOn(trackAPubRemote.track),
         trackSwitchedOff(trackBPubRemote.track)
-      ], `Step 1] trackA=On, trackB=Off: ${roomSid}`);
+      ], `Step 1] trackA[${trackAPubRemote.track.sid}]=On, trackB[${trackBPubRemote.track.sid}]=Off: ${roomSid}`);
       assert.equal(trackAPubRemote.publishPriority, PRIORITY_STANDARD);
       assert.equal(trackBPubRemote.publishPriority, PRIORITY_LOW);
 
@@ -668,7 +669,7 @@ describe('LocalTrackPublication', function() {
       await waitFor([
         trackSwitchedOn(trackBPubRemote.track),
         trackSwitchedOff(trackAPubRemote.track)
-      ], `Step 2] trackA=Off, trackB=On: ${roomSid}`);
+      ], `Step 2] trackA[${trackAPubRemote.track.sid}]=Off, trackB[${trackBPubRemote.track.sid}]=On: ${roomSid}`);
 
       // wait for trackBPriorityChangedToHigh before checking publishPriority.
       await waitFor(trackBPriorityChangedToHigh, `trackB priority changed to High: ${roomSid}`);
@@ -687,7 +688,7 @@ describe('LocalTrackPublication', function() {
       await waitFor([
         trackSwitchedOn(trackAPubRemote.track),
         trackSwitchedOff(trackBPubRemote.track)
-      ], `Step 3] trackA=On, trackB=Off: ${roomSid}`);
+      ], `Step 3] trackA[${trackAPubRemote.track.sid}]=On, trackB[${trackBPubRemote.track.sid}]=Off: ${roomSid}`);
 
       // wait for trackBPriorityChangedToLow before checking publishPriority.
       await waitFor(trackBPriorityChangedToLow, `trackB priority changed to Low: ${roomSid}`);

--- a/test/unit/spec/media/track/remotemediatrack.js
+++ b/test/unit/spec/media/track/remotemediatrack.js
@@ -23,7 +23,7 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
 
           before(() => {
             try {
-              track = makeTrack('foo', 'bar', kind, true, getOptions(), RemoteTrack);
+              track = makeTrack({ id: 'foo', sid: 'bar', kind, isEnabled: true, isSwitchedOff: false, options: getOptions(), RemoteTrack });
             } catch (e) {
               error = e;
             }
@@ -68,7 +68,7 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
       let onPriorityChange;
       beforeEach(() => {
         onPriorityChange = sinon.spy();
-        track = makeTrack('foo', 'bar', kind, true, options, RemoteTrack, onPriorityChange);
+        track = makeTrack({ id: 'foo', sid: 'bar', kind, isEnabled: true, options, RemoteTrack, setPriority: onPriorityChange });
       });
 
       [null, ...Object.values(trackPriority)].forEach(priorityValue => {
@@ -111,7 +111,7 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
 
           before(() => {
             arg = null;
-            track = makeTrack('foo', 'bar', kind, isEnabled, null, RemoteTrack);
+            track = makeTrack({ id: 'foo', sid: 'bar', kind, isEnabled, options: null, RemoteTrack });
             track.once('disabled', _arg => {
               trackDisabled = true;
               arg = _arg;
@@ -164,10 +164,7 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
 
           before(() => {
             arg = null;
-            track = makeTrack('foo', 'bar', kind, true, null, RemoteTrack);
-            if (isSwitchedOff) {
-              track._setSwitchedOff(isSwitchedOff);
-            }
+            track = makeTrack({ id: 'foo', sid: 'bar', kind, isSwitchedOff, isEnabled: true, options: null, RemoteTrack });
             track.once('switchedOff', _arg => {
               trackSwitchedOff = true;
               arg = _arg;
@@ -209,7 +206,7 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
       let track;
 
       before(() => {
-        track = makeTrack('foo', 'MT1', kind, true, null, RemoteTrack);
+        track = makeTrack({ id: 'foo', sid: 'MT1', kind, isEnabled: true, options: null, RemoteTrack });
       });
 
       it('only returns public properties', () => {
@@ -242,7 +239,7 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
 
     describe('#attach', () => {
       it('enables the track if disabled', () => {
-        let track = makeTrack('foo', 'MT1', kind, true, null, RemoteTrack);
+        let track = makeTrack({ id: 'foo', sid: 'MT1', kind, isEnabled: true, options: null, RemoteTrack });
         track._createElement = sinon.spy(() => {
           // return a unique element.
           return {
@@ -262,7 +259,7 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
       let el2;
       let track;
       beforeEach(() => {
-        track = makeTrack('foo', 'MT1', kind, true, null, RemoteTrack);
+        track = makeTrack({ id: 'foo', sid: 'MT1', kind, isEnabled: true, options: null, RemoteTrack });
         track._createElement = sinon.spy(() => {
           // return a unique element.
           return {
@@ -302,7 +299,7 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
       let track;
 
       before(() => {
-        track = makeTrack('foo', 'MT1', kind, true, null, RemoteTrack);
+        track = makeTrack({ id: 'foo', sid: 'MT1', kind, isEnabled: true, options: null, RemoteTrack });
       });
 
       it('only returns public properties', () => {
@@ -335,10 +332,11 @@ const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
   });
 });
 
-function makeTrack(id, sid, kind, isEnabled, options, RemoteTrack, setPriority) {
+function makeTrack({ id, sid, kind, isEnabled, options, RemoteTrack, setPriority, isSwitchedOff }) {
   const emptyFn = () => undefined;
   setPriority = setPriority || emptyFn;
+  isSwitchedOff = !!isSwitchedOff;
   const mediaStreamTrack = new FakeMediaStreamTrack(kind);
   const mediaTrackReceiver = new MediaTrackReceiver(id, mediaStreamTrack);
-  return new RemoteTrack(sid, mediaTrackReceiver, isEnabled, setPriority, options);
+  return new RemoteTrack(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, setPriority, options);
 }

--- a/test/unit/spec/remoteparticipant.js
+++ b/test/unit/spec/remoteparticipant.js
@@ -1513,7 +1513,7 @@ function makeTest(options) {
   }
   options.trackSignalings = options.trackSignalings || [];
 
-  options.RemoteAudioTrack = sinon.spy(function RemoteAudioTrack(sid, mediaTrackReceiver, isEnabled, setPriorityCallback, opts) {
+  options.RemoteAudioTrack = sinon.spy(function RemoteAudioTrack(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, setPriorityCallback, opts) {
     EventEmitter.call(this);
     this.enabled = true;
     this.kind = mediaTrackReceiver.kind;
@@ -1522,11 +1522,12 @@ function makeTest(options) {
     this.sid = sid;
     this.setPriority = setPriorityCallback;
     this._setEnabled = enabled => { this.enabled = enabled; };
+    this._setSwitchedOff = switchedOff => { this.switchedOff = switchedOff; };
     options.tracks.push(this);
   });
   inherits(options.RemoteAudioTrack, EventEmitter);
 
-  options.RemoteVideoTrack = sinon.spy(function RemoteVideoTrack(sid, mediaTrackReceiver, isEnabled, setPriorityCallback, opts) {
+  options.RemoteVideoTrack = sinon.spy(function RemoteVideoTrack(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, setPriorityCallback, opts) {
     EventEmitter.call(this);
     this.enabled = true;
     this.kind = mediaTrackReceiver.kind;
@@ -1535,6 +1536,7 @@ function makeTest(options) {
     this.sid = sid;
     this.setPriority = setPriorityCallback;
     this._setEnabled = enabled => { this.enabled = enabled; };
+    this._setSwitchedOff = switchedOff => { this.switchedOff = switchedOff; };
     options.tracks.push(this);
   });
   inherits(options.RemoteVideoTrack, EventEmitter);
@@ -1548,6 +1550,7 @@ function makeTest(options) {
     this.name = opts && opts.name ? opts.name : dataTrackReceiver.id;
     this.sid = sid;
     this._setEnabled = enabled => { this.enabled = enabled; };
+    this._setSwitchedOff = switchedOff => { this.switchedOff = switchedOff; };
     options.tracks.push(this);
   });
   inherits(options.RemoteDataTrack, EventEmitter);
@@ -1620,6 +1623,8 @@ function makeTrackSignaling(options) {
   track.subscribeFailed = error => {
     track.error = error;
     track.emit('updated');
+  };
+  track._setSwitchedOff = () => {
   };
   track.trackTransceiver = null;
   if (!options.shouldSubscriptionFail && !options.testTrackSubscriptionRestApi) {

--- a/test/unit/spec/signaling/v2/remoteparticipant.js
+++ b/test/unit/spec/signaling/v2/remoteparticipant.js
@@ -902,6 +902,7 @@ function makeTest(options) {
     || sinon.spy(() => options.getTrackTransceiverDeferred.promise);
   options.RemoteTrackPublicationV2 = options.RemoteTrackPublicationV2 || makeRemoteTrackPublicationV2Constructor(options);
 
+  options.getInitialTrackSwitchOffState = options.getInitialTrackSwitchOffState || sinon.spy(() => { return false; });
   options.participant = options.participant || makeRemoteParticipantV2(options);
 
   options.state = revision => {
@@ -945,16 +946,17 @@ RemoteParticipantStateBuilder.prototype.setTracks = function setTracks(tracks) {
 };
 
 function makeRemoteParticipantV2(options) {
-  return new RemoteParticipantV2(options, options.getTrackTransceiver, options);
+  return new RemoteParticipantV2(options, options.getTrackTransceiver, options.getInitialTrackSwitchOffState, options);
 }
 
 function makeRemoteTrackPublicationV2Constructor(testOptions) {
   testOptions = testOptions || {};
   testOptions.remoteTrackPublicationV2s = testOptions.remoteTrackPublicationV2s || [];
-  return function RemoteTrackPublicationV2(trackState) {
+  return function RemoteTrackPublicationV2(trackState, isSwitchedOff) {
     this.sid = trackState.sid;
     this.setTrackTransceiver = sinon.spy(() => {});
     this.update = sinon.spy(() => this);
+    this.isSwitchedOff = isSwitchedOff;
     testOptions.remoteTrackPublicationV2s.push(this);
   };
 }

--- a/test/unit/spec/signaling/v2/remotetrackpublication.js
+++ b/test/unit/spec/signaling/v2/remotetrackpublication.js
@@ -16,7 +16,8 @@ describe('RemoteTrackPublicationV2', () => {
           priority: makeUUID(),
           sid: makeSid()
         };
-        assert.equal((new RemoteTrackPublicationV2(trackState))[prop], trackState[prop]);
+        const isSwitchedOff = makeSwitchedOff();
+        assert.equal((new RemoteTrackPublicationV2(trackState, isSwitchedOff))[prop], trackState[prop]);
       });
     });
 
@@ -30,6 +31,20 @@ describe('RemoteTrackPublicationV2', () => {
             priority: makeUUID(),
             sid: makeSid()
           })).isEnabled, enabled);
+        });
+      });
+    });
+
+    [true, false].forEach(isSwitchedOff => {
+      context(`when isSwitchedOff is ${isSwitchedOff}`, () => {
+        it(`sets .isSwitchedOff to ${isSwitchedOff}`, () => {
+          assert.equal((new RemoteTrackPublicationV2({
+            enabled: makeEnabled(),
+            kind: makeKind(),
+            name: makeUUID(),
+            priority: makeUUID(),
+            sid: makeSid()
+          }, isSwitchedOff)).isSwitchedOff, isSwitchedOff);
         });
       });
     });
@@ -648,6 +663,10 @@ describe('RemoteTrackPublicationV2', () => {
 });
 
 function makeEnabled() {
+  return (Math.random() < 0.5);
+}
+
+function makeSwitchedOff() {
   return (Math.random() < 0.5);
 }
 


### PR DESCRIPTION
client can receive track switch off notification before tracks are subscribed to (or even before client knew of it being published). client used to drop such notification. This change fixes it to remember the most recent switch off state and apply it when a track is subscribed.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
