### PR TITLE
VIDEO-3843: update text for ParticipantMaxTracksExceededError 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,16 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 New Features
 ------------
 
-- You can now connect to a Group Room with Maximum Participants between 50 and 100 (Large Group Rooms).
-  Large Group Rooms are different from the other types of Rooms in the following ways:
+**100 Participant Rooms Pilot**
+- In this pilot program developers can connect to a Group Room with Maximum Participants set between 50 and 100.
+  A Room created with Max Participants greater than 50 is structured to support a small number of presenters and a large number of viewers. It has the following behavioral differences compared to regular Group Rooms:
   - "participantConnected" event is raised on the Room when a RemoteParticipant
     publishes the first LocalTrack.
   - "participantDisconnected" event is raised on the Room when a RemoteParticipant
     stops publishing all of its LocalTracks.
-  - The total number of published Tracks in the Room cannot exceed 16. Any attempt
+  - The total number of published Tracks in the Room cannot exceed 16 at any one time. Any attempt
     to publish more Tracks will be rejected with a `ParticipantMaxTracksExceededError`. (JSDK-3021)
 
-  NOTE: Large Group Rooms is currently in **beta**.
 
 Bug Fixes
 ---------

--- a/lib/util/twilio-video-errors.js
+++ b/lib/util/twilio-video-errors.js
@@ -580,14 +580,14 @@ Object.defineProperty(TwilioErrorByCode, 53202, { value: ParticipantIdentityChar
 
 /**
  * @class ParticipantMaxTracksExceededError
- * @classdesc Raised whenever a Participant has too many Tracks.
+ * @classdesc Raised whenever maximum number of published tracks allowed in the Room at the same time are reached.
  * @extends TwilioError
  * @property {number} code - 53203
- * @property {string} message - 'Participant has too many Tracks'
+ * @property {string} message - 'The maximum number of published tracks allowed in the Room at the same time has been reached'
  */
 class ParticipantMaxTracksExceededError extends TwilioError {
   constructor() {
-    super(53203, 'Published Tracks at maximum capacity');
+    super(53203, 'The maximum number of published tracks allowed in the Room at the same time has been reached');
   }
 }
 

--- a/lib/util/twilio-video-errors.js
+++ b/lib/util/twilio-video-errors.js
@@ -580,7 +580,7 @@ Object.defineProperty(TwilioErrorByCode, 53202, { value: ParticipantIdentityChar
 
 /**
  * @class ParticipantMaxTracksExceededError
- * @classdesc Raised whenever maximum number of published tracks allowed in the Room at the same time are reached.
+ * @classdesc Raised when the Room limit for published tracks has been reached and a Participant tries to publish a track to the Room.
  * @extends TwilioError
  * @property {number} code - 53203
  * @property {string} message - 'The maximum number of published tracks allowed in the Room at the same time has been reached'


### PR DESCRIPTION
minor change updates description for ParticipantMaxTracksExceededError.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
