### PR TITLE
VIDEO-3561 | removeProcessor API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,56 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 
 **Support for the 1.x version ended on December 4th, 2020**. Check [this guide](https://www.twilio.com/docs/video/migrating-1x-2x) to plan your migration to the latest 2.x version.
 
+2.13.0 (In Progress)
+=====================
+
+New Features
+------------
+
+**Video Processor API Pilot**
+- You can now register a `VideoProcessor` with a VideoTrack in order to process its video frames. In a LocalVideoTrack, video frames are processed before being sent to the encoder. In a RemoteVideoTrack, video frames are processed before being sent to the attached `<video>` element(s). The `VideoProcessor` should implement the following interface:
+
+  ```ts
+  abstract class VideoProcessor {
+    abstract processFrame(inputFrame: OffscreenCanvas)
+      : Promise<OffscreenCanvas | null>
+      | OffscreenCanvas | null;
+  }
+  ```
+
+  A VideoTrack provides new methods `addProcessor` and `removeProcessor` which can be used to add and remove a VideoProcessor. It also provides a new property `processor` which points to the current VideoProcessor being used by the VideoTrack. For example, you can toggle a blur filter on a LocalVideoTrack as shown below:
+
+  ```ts
+  import { createLocalVideoTrack } from 'twilio-video';
+
+  class BlurVideoProcessor {
+    private readonly _outputFrameCtx: CanvasRenderingContext2D;
+    private readonly _outputFrame: OffscreenCanvas;
+
+    constructor(width: number, height: number, blurRadius: number) {
+      this._outputFrame = new OffscreenCanvas(width, height);
+      this._outputFrameCtx = this._outputFrame.getContext('2d');
+      this._outputFrameCtx.filter = `blur(${blurRadius}px)`;
+    }
+
+    processFrame(inputFrame: OffscreenCanvas) {
+      this._outputFrameCtx.drawImage(inputFrame, 0, 0);
+      return this._outputFrame;
+    }
+  }
+
+  createLocalVideoTrack({
+    width: 1280,
+    height: 720
+  }).then(track => {
+    const processor = new BlurVideoProcessor(1280, 720, 5);
+    document.getElementById('preview').appendChild(track.attach());
+    document.getElementById('toggle-blur').onclick = () => track.processor
+      ? track.removeProcessor(processor)
+      : track.addProcessor(processor);
+  });
+  ```
+
 2.12.0 (Feb 10, 2020)
 =====================
 

--- a/lib/media/track/localvideotrack.js
+++ b/lib/media/track/localvideotrack.js
@@ -39,6 +39,9 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
     super(mediaStreamTrack, options);
 
     Object.defineProperties(this, {
+      _unprocessedTrack: {
+        value: mediaStreamTrack
+      },
       _workaroundSilentLocalVideo: {
         value: options.workaroundSilentLocalVideo
           ? workaroundSilentLocalVideo
@@ -67,6 +70,15 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
    */
   _end() {
     return super._end.apply(this, arguments);
+  }
+
+  /**
+   * @private
+   */
+  _setSenderMediaStreamTrack(mediaStreamTrack) {
+    return this._trackSender.setMediaStreamTrack(mediaStreamTrack).catch(error =>
+      this._log.warn('setMediaStreamTrack failed on LocalVideoTrack RTCRtpSender',
+        { error, mediaStreamTrack }));
   }
 
   /**
@@ -102,9 +114,44 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
     }
 
     this._log.debug('Updating LocalVideoTrack\'s MediaStreamTrack with the processed MediaStreamTrack', this.processedTrack);
-    this._trackSender.setMediaStreamTrack(this.processedTrack).catch(error =>
-      this._log.warn('setMediaStreamTrack failed after adding a VideoProcessor:',
-        { error, mediaStreamTrack: this.processedTrack }));
+    this._setSenderMediaStreamTrack(this.processedTrack);
+
+    return result;
+  }
+
+  /**
+   * Remove the previously added {@link VideoProcessor} using `addProcessor` API.
+   * @param {VideoProcessor} processor - The {@link VideoProcessor} to remove.
+   * @returns {this}
+   * @example
+   * class GrayScaleProcessor {
+   *   constructor() {
+   *     this.outputFrame = new OffscreenCanvas(0, 0);
+   *   }
+   *   processFrame(inputFrame) {
+   *     this.outputFrame.width = inputFrame.width;
+   *     this.outputFrame.height = inputFrame.height;
+   *
+   *     const context = this.outputFrame.getContext('2d');
+   *     context.filter = 'grayscale(100%)';
+   *     context.drawImage(inputFrame, 0, 0, inputFrame.width, inputFrame.height);
+   *     return this.outputFrame;
+   *   }
+   * }
+   *
+   * const localVideoTrack = Array.from(room.localParticipant.videoTracks.values())[0].track;
+   * const grayScaleProcessor = new GrayScaleProcessor();
+   * localVideoTrack.addProcessor(grayScaleProcessor);
+   *
+   * document.getElementById('remove-button').onclick = () => localVideoTrack.removeProcessor(grayScaleProcessor);
+   */
+  removeProcessor() {
+    this._log.debug('Removing VideoProcessor from the LocalVideoTrack');
+    const result = super.removeProcessor.apply(this, arguments);
+
+    this._log.debug('Updating LocalVideoTrack\'s MediaStreamTrack with the original MediaStreamTrack');
+    this._setSenderMediaStreamTrack(this._unprocessedTrack)
+      .then(() => this._updateElementsMediaStreamTrack());
 
     return result;
   }
@@ -129,17 +176,24 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
    * @fires VideoTrack#enabled
   *//**
    * Enable or disable the {@link LocalVideoTrack}. This is effectively "unpause"
-   * or "pause".
+   * or "pause". If a {@link VideoProcessor} is added,
+   * then `processedTrack` is enabled or disabled as well.
    * @param {boolean} [enabled] - Specify false to pause the
    *   {@link LocalVideoTrack}
    * @returns {this}
    * @fires VideoTrack#disabled
    * @fires VideoTrack#enabled
    */
-  enable() {
+  enable(enabled) {
     if (this.processedTrack) {
-      this.processedTrack.enabled = true;
-      this._captureFrames();
+      enabled = typeof enabled === 'boolean' ? enabled : true;
+      this.processedTrack.enabled = enabled;
+
+      if (enabled) {
+        this._captureFrames();
+        this._log.debug('Updating LocalVideoTrack\'s MediaStreamTrack with the processed MediaStreamTrack', this.processedTrack);
+        this._setSenderMediaStreamTrack(this.processedTrack);
+      }
     }
     return super.enable.apply(this, arguments);
   }
@@ -183,7 +237,16 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
       this._workaroundSilentLocalVideoCleanup();
       this._workaroundSilentLocalVideoCleanup = null;
     }
+
+    const processor = this.processor;
+    if (processor) {
+      this.removeProcessor(processor);
+    }
     const promise = super.restart.apply(this, arguments);
+
+    if (processor) {
+      promise.then(() => this.addProcessor(processor));
+    }
 
     if (this._workaroundSilentLocalVideo) {
       promise.finally(() => {

--- a/lib/media/track/localvideotrack.js
+++ b/lib/media/track/localvideotrack.js
@@ -39,9 +39,6 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
     super(mediaStreamTrack, options);
 
     Object.defineProperties(this, {
-      _unprocessedTrack: {
-        value: mediaStreamTrack
-      },
       _workaroundSilentLocalVideo: {
         value: options.workaroundSilentLocalVideo
           ? workaroundSilentLocalVideo
@@ -75,7 +72,10 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
   /**
    * @private
    */
-  _setSenderMediaStreamTrack(mediaStreamTrack) {
+  _setSenderMediaStreamTrack(useProcessed) {
+    const mediaStreamTrack = useProcessed ? this.processedTrack : this.mediaStreamTrack;
+    this._unprocessedTrack = useProcessed ? this.mediaStreamTrack : null;
+
     return this._trackSender.setMediaStreamTrack(mediaStreamTrack).catch(error =>
       this._log.warn('setMediaStreamTrack failed on LocalVideoTrack RTCRtpSender',
         { error, mediaStreamTrack }));
@@ -114,7 +114,7 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
     }
 
     this._log.debug('Updating LocalVideoTrack\'s MediaStreamTrack with the processed MediaStreamTrack', this.processedTrack);
-    this._setSenderMediaStreamTrack(this.processedTrack);
+    this._setSenderMediaStreamTrack(true);
 
     return result;
   }
@@ -150,7 +150,7 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
     const result = super.removeProcessor.apply(this, arguments);
 
     this._log.debug('Updating LocalVideoTrack\'s MediaStreamTrack with the original MediaStreamTrack');
-    this._setSenderMediaStreamTrack(this._unprocessedTrack)
+    this._setSenderMediaStreamTrack()
       .then(() => this._updateElementsMediaStreamTrack());
 
     return result;
@@ -163,10 +163,11 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
    * @fires VideoTrack#disabled
    */
   disable() {
+    const result = super.disable.apply(this, arguments);
     if (this.processedTrack) {
       this.processedTrack.enabled = false;
     }
-    return super.disable.apply(this, arguments);
+    return result;
   }
 
   /**
@@ -184,18 +185,18 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
    * @fires VideoTrack#disabled
    * @fires VideoTrack#enabled
    */
-  enable(enabled) {
+  enable(enabled = true) {
+    const result = super.enable.apply(this, arguments);
     if (this.processedTrack) {
-      enabled = typeof enabled === 'boolean' ? enabled : true;
       this.processedTrack.enabled = enabled;
 
       if (enabled) {
         this._captureFrames();
         this._log.debug('Updating LocalVideoTrack\'s MediaStreamTrack with the processed MediaStreamTrack', this.processedTrack);
-        this._setSenderMediaStreamTrack(this.processedTrack);
+        this._setSenderMediaStreamTrack(true);
       }
     }
-    return super.enable.apply(this, arguments);
+    return result;
   }
 
   /**
@@ -206,7 +207,9 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
    * the <code>mediaStreamTrack</code> property. If you want to listen to events on
    * the MediaStreamTrack directly, please do so in the "started" event handler. Also,
    * the {@link LocalVideoTrack}'s ID is no longer guaranteed to be the same as the
-   * underlying MediaStreamTrack's ID.
+   * underlying MediaStreamTrack's ID. Additionally, the {@link LocalVideoTrack}'s `processor`
+   * and `processedTrack` properties will be null while the restart is in progress and will
+   * become available again once restart is complete.
    * @param {MediaTrackConstraints} [constraints] - The optional <a href="https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints" target="_blank">MediaTrackConstraints</a>
    *   for restarting the {@link LocalVideoTrack}; If not specified, then the current MediaTrackConstraints
    *   will be used; If <code>{}</code> (empty object) is specified, then the default MediaTrackConstraints

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -72,6 +72,10 @@ class MediaTrack extends Track {
         value: options.workaroundWebKitBug212780
           || options.playPausedElementsIfNotBackgrounded
       },
+      _unprocessedTrack: {
+        value: null,
+        writable: true
+      },
       _MediaStream: {
         value: options.MediaStream
       },
@@ -84,7 +88,7 @@ class MediaTrack extends Track {
       mediaStreamTrack: {
         enumerable: true,
         get() {
-          return mediaTrackTransceiver.track;
+          return this._unprocessedTrack || mediaTrackTransceiver.track;
         }
       },
       processedTrack: {

--- a/lib/media/track/videotrack.js
+++ b/lib/media/track/videotrack.js
@@ -104,13 +104,19 @@ class VideoTrack extends MediaTrack {
     this._isCapturing = true;
     this._log.debug('Start capturing frames');
 
+    let startTime = Date.now();
+    let processFramePeriodMs;
     const { frameRate } = this.mediaStreamTrack.getSettings();
-    const capturePeriodMs = 1000 / frameRate;
+    const capturePeriodMs = Math.floor(1000 / frameRate);
 
     this._dummyEl.play().then(() => {
       const captureFrame = cb => {
         clearTimeout(this._captureTimeoutId);
-        this._captureTimeoutId = setTimeout(cb, capturePeriodMs);
+        let delay = capturePeriodMs - processFramePeriodMs;
+        if (delay < 0 || typeof processFramePeriodMs !== 'number') {
+          delay = 0;
+        }
+        this._captureTimeoutId = setTimeout(cb, delay);
       };
       const process = () => {
         if (!this._canCaptureFrames()) {
@@ -123,12 +129,14 @@ class VideoTrack extends MediaTrack {
 
         let result = null;
         try {
+          startTime = Date.now();
           result = this.processor.processFrame(this._inputFrame);
         } catch (ex) {
           this._log.debug('Exception detected after calling processFrame.', ex);
         }
         ((result instanceof Promise) ? result : Promise.resolve(result))
           .then(outputFrame => {
+            processFramePeriodMs = Date.now() - startTime;
             if (outputFrame) {
               this._outputFrame.getContext('2d')
                 .drawImage(outputFrame, 0, 0, this._outputFrame.width, this._outputFrame.height);

--- a/lib/media/track/videotrack.js
+++ b/lib/media/track/videotrack.js
@@ -32,6 +32,10 @@ class VideoTrack extends MediaTrack {
   constructor(mediaTrackTransceiver, options) {
     super(mediaTrackTransceiver, options);
     Object.defineProperties(this, {
+      _captureTimeoutId: {
+        value: null,
+        writable: true
+      },
       _isCapturing: {
         value: false,
         writable: true
@@ -64,17 +68,38 @@ class VideoTrack extends MediaTrack {
   /**
    * @private
    */
+  _canCaptureFrames() {
+    let canCaptureFrames = true;
+    const { enabled, readyState } = this.mediaStreamTrack;
+    if (!enabled) {
+      canCaptureFrames = false;
+      this._log.debug('MediaStreamTrack is disabled');
+    }
+    if (readyState === 'ended') {
+      canCaptureFrames = false;
+      this._log.debug('MediaStreamTrack is ended');
+    }
+    if (!this.processor) {
+      canCaptureFrames = false;
+      this._log.debug('VideoProcessor not detected.');
+    }
+    if (!this._attachments.size) {
+      canCaptureFrames = false;
+      this._log.debug('No attached video element.');
+    }
+    return canCaptureFrames;
+  }
+
+  /**
+   * @private
+   */
   _captureFrames() {
     if (this._isCapturing) {
       return this._log.debug('Ignoring captureFrames call. Capture is already in progress');
     }
-    if (!this.processor) {
+    if (!this._canCaptureFrames()) {
       this._isCapturing = false;
-      return this._log.info('VideoProcessor not detected. Stopping capturing frames.');
-    }
-    if (!this._attachments.size) {
-      this._isCapturing = false;
-      return this._log.info('No attached video element. Stopping capturing frames.');
+      return this._log.debug('Cannot capture frames. Ignoring captureFrames call.');
     }
     this._isCapturing = true;
     this._log.debug('Start capturing frames');
@@ -84,18 +109,15 @@ class VideoTrack extends MediaTrack {
 
     this._dummyEl.play().then(() => {
       const captureFrame = cb => {
-        const { enabled, muted, readyState } = this.mediaStreamTrack;
-        if (!enabled || muted || readyState === 'ended') {
-          return;
-        }
-        if (this._dummyEl.requestVideoFrameCallback) {
-          this._dummyEl.requestVideoFrameCallback(cb);
-        } else {
-          setTimeout(cb, capturePeriodMs);
-        }
+        clearTimeout(this._captureTimeoutId);
+        this._captureTimeoutId = setTimeout(cb, capturePeriodMs);
       };
-
       const process = () => {
+        if (!this._canCaptureFrames()) {
+          this._isCapturing = false;
+          return this._log.debug('Cannot capture frames. Stopping capturing frames.');
+        }
+
         this._inputFrame.getContext('2d')
           .drawImage(this._dummyEl, 0, 0, this._inputFrame.width, this._inputFrame.height);
 
@@ -184,7 +206,7 @@ class VideoTrack extends MediaTrack {
       return this._log.warn('Adding a VideoProcessor is not supported in this browser.');
     }
     if (!processor || typeof processor.processFrame !== 'function') {
-      throw new Error('Received an invalid VideoProcessor.');
+      throw new Error('Received an invalid VideoProcessor from addProcessor.');
     }
     if (this.processor) {
       throw new Error('A VideoProcessor has already been added.');
@@ -203,8 +225,6 @@ class VideoTrack extends MediaTrack {
     this.processedTrack = this._outputFrame.captureStream(frameRate).getTracks()[0];
     this.processedTrack.enabled = this.mediaStreamTrack.enabled;
     this.processor = processor;
-
-    this.mediaStreamTrack.addEventListener('unmute', () => this._captureFrames());
 
     this._updateElementsMediaStreamTrack();
     this._captureFrames();
@@ -306,6 +326,57 @@ class VideoTrack extends MediaTrack {
    */
   detach() {
     return super.detach.apply(this, arguments);
+  }
+
+  /**
+   * Remove the previously added {@link VideoProcessor} using `addProcessor` API.
+   * @param {VideoProcessor} processor - The {@link VideoProcessor} to remove.
+   * @returns {this}
+   * @example
+   * class GrayScaleProcessor {
+   *   constructor() {
+   *     this.outputFrame = new OffscreenCanvas(0, 0);
+   *   }
+   *   processFrame(inputFrame) {
+   *     this.outputFrame.width = inputFrame.width;
+   *     this.outputFrame.height = inputFrame.height;
+   *
+   *     const context = this.outputFrame.getContext('2d');
+   *     context.filter = 'grayscale(100%)';
+   *     context.drawImage(inputFrame, 0, 0, inputFrame.width, inputFrame.height);
+   *     return this.outputFrame;
+   *   }
+   * }
+   *
+   * Video.createLocalVideoTrack().then(function(videoTrack) {
+   *   const grayScaleProcessor = new GrayScaleProcessor();
+   *   videoTrack.addProcessor(grayScaleProcessor);
+   *   document.getElementById('remove-button').onclick = () => videoTrack.removeProcessor(grayScaleProcessor);
+   * });
+   */
+  removeProcessor(processor) {
+    if (!processor) {
+      throw new Error('Received an invalid VideoProcessor from removeProcessor.');
+    }
+    if (!this.processor) {
+      throw new Error('No existing VideoProcessor detected.');
+    }
+    if (processor !== this.processor) {
+      throw new Error('The provided VideoProcessor is different than the existing one.');
+    }
+    this._log.debug('Removing VideoProcessor from the VideoTrack', processor);
+    clearTimeout(this._captureTimeoutId);
+    this._isCapturing = false;
+
+    this.processor = null;
+    this.processedTrack = null;
+    this._inputFrame.getContext('2d').clearRect(0, 0, this._inputFrame.width, this._inputFrame.height);
+    this._outputFrame.getContext('2d').clearRect(0, 0, this._outputFrame.width, this._outputFrame.height);
+    this._inputFrame = null;
+    this._outputFrame = null;
+
+    this._updateElementsMediaStreamTrack();
+    return this;
   }
 }
 

--- a/test/unit/spec/media/track/localvideotrack.js
+++ b/test/unit/spec/media/track/localvideotrack.js
@@ -62,6 +62,7 @@ describe('LocalVideoTrack', () => {
       setMediaStreamTrack: sinon.stub().resolves({})
     };
     localVideoTrack._updateElementsMediaStreamTrack = sinon.stub();
+    localVideoTrack.mediaStreamTrack = mediaStreamTrack;
   });
 
   describe('#addProcessor', () => {

--- a/test/unit/spec/media/track/mediatrack.js
+++ b/test/unit/spec/media/track/mediatrack.js
@@ -29,12 +29,21 @@ describe('MediaTrack', () => {
   });
 
   describe('constructor', () => {
-    before(() => {
+    beforeEach(() => {
       track = createMediaTrack('1', 'audio');
     });
 
     it('should call ._initialize', () => {
       assert.equal(track._initialize.callCount, 1);
+    });
+
+    it('should return unprocessedTrack as the mediaStreamTrack if it exists', () => {
+      track._unprocessedTrack = 'foo';
+      assert.equal(track.mediaStreamTrack, 'foo');
+    });
+
+    it('should return the mediaTrackTransceiver.track as the mediaStreamTrack if unprocessedTrack does not exists', () => {
+      assert.equal(track.mediaStreamTrack, track.tranceiver.track);
     });
   });
 
@@ -586,7 +595,9 @@ describe('MediaTrack', () => {
 function createMediaTrack(id, kind, options) {
   const mediaStreamTrack = new MediaStreamTrack(id, kind);
   const mediaTrackTransceiver = new MediaTrackTransceiver(id, mediaStreamTrack);
-  return new MediaTrack(mediaTrackTransceiver, Object.assign({ log: log }, options));
+  const mediaTrack = new MediaTrack(mediaTrackTransceiver, Object.assign({ log: log }, options));
+  mediaTrack.tranceiver = mediaTrackTransceiver;
+  return mediaTrack;
 }
 
 function MediaStreamTrack(id, kind) {

--- a/test/unit/spec/media/track/videotrack.js
+++ b/test/unit/spec/media/track/videotrack.js
@@ -127,32 +127,24 @@ describe('VideoTrack', () => {
         it('should start capturing frames after setting the processor', () => {
           sinon.assert.calledOnce(videoTrack._captureFrames);
         });
-
-        it('should start capturing frames whenever mediaStreamTrack unmutes', () => {
-          sinon.assert.calledOnce(videoTrack._captureFrames);
-          mediaStreamTrack.emit('unmute');
-          sinon.assert.calledTwice(videoTrack._captureFrames);
-          mediaStreamTrack.emit('unmute');
-          sinon.assert.calledThrice(videoTrack._captureFrames);
-        });
       });
 
       context('raise an error', () => {
         [{
           name: 'processor is null',
-          errorMsg: 'Received an invalid VideoProcessor.',
+          errorMsg: 'Received an invalid VideoProcessor from addProcessor.',
           param: null,
         }, {
           name: 'processor is undefined',
-          errorMsg: 'Received an invalid VideoProcessor.',
+          errorMsg: 'Received an invalid VideoProcessor from addProcessor.',
           param: undefined,
         }, {
           name: 'processFrame is null',
-          errorMsg: 'Received an invalid VideoProcessor.',
+          errorMsg: 'Received an invalid VideoProcessor from addProcessor.',
           param: { processFrame: null },
         }, {
           name: 'processFrame is undefined',
-          errorMsg: 'Received an invalid VideoProcessor.',
+          errorMsg: 'Received an invalid VideoProcessor from addProcessor.',
           param: { processFrame: undefined },
         }, {
           name: 'processor is already set',
@@ -172,6 +164,109 @@ describe('VideoTrack', () => {
             const regex = new RegExp(errorMsg);
             assert.throws(() => { videoTrack.addProcessor(param); }, regex);
           });
+        });
+      });
+    });
+  });
+
+  describe('#removeProcessor', () => {
+    let processor;
+
+    beforeEach(() => {
+      processor = { foo: 'foo' };
+      videoTrack.processor = processor;
+      videoTrack.processedTrack = 'foo';
+      videoTrack._isCapturing = true;
+      videoTrack._inputFrame = new OffscreenCanvas(1, 2);
+      videoTrack._outputFrame = new OffscreenCanvas(3, 4);
+      videoTrack._updateElementsMediaStreamTrack = sinon.stub();
+    });
+
+    it('should clear existing timeout callback', () => {
+      let cb = sinon.stub();
+      videoTrack._captureTimeoutId = setTimeout(cb, 50);
+      clock.tick(50);
+      sinon.assert.calledOnce(cb);
+
+      cb = sinon.stub();
+      videoTrack._captureTimeoutId = setTimeout(cb, 50);
+      videoTrack.removeProcessor(processor);
+      clock.tick(50);
+      sinon.assert.notCalled(cb);
+    });
+
+    it('should update attached video elements mediaStreamTrack', () => {
+      videoTrack.removeProcessor(processor);
+      sinon.assert.calledOnce(videoTrack._updateElementsMediaStreamTrack);
+    });
+
+    it('should clear inputFrame canvas', () => {
+      const inputFrame = videoTrack._inputFrame;
+      assert(inputFrame.drawing);
+      videoTrack.removeProcessor(processor);
+      assert(!inputFrame.drawing);
+    });
+
+    it('should clear outputFrame canvas', () => {
+      const outputFrame = videoTrack._outputFrame;
+      assert(outputFrame.drawing);
+      videoTrack.removeProcessor(processor);
+      assert(!outputFrame.drawing);
+    });
+
+    describe('should reset field', () => {
+      beforeEach(() => {
+        videoTrack.removeProcessor(processor);
+      });
+
+      it('isCapturing flag', () => {
+        assert(!videoTrack._isCapturing);
+      });
+
+      it('existing VideoProcessor', () => {
+        assert(!videoTrack.processor);
+      });
+
+      it('processedTrack', () => {
+        assert(!videoTrack.processedTrack);
+      });
+
+      it('_inputFrame', () => {
+        assert(!videoTrack._inputFrame);
+      });
+
+      it('_outputFrame', () => {
+        assert(!videoTrack._outputFrame);
+      });
+    });
+
+    context('raise an error', () => {
+      [{
+        name: 'processor param is null',
+        errorMsg: 'Received an invalid VideoProcessor from removeProcessor.',
+        getParam: () => null
+      }, {
+        name: 'processor param is undefined',
+        errorMsg: 'Received an invalid VideoProcessor from removeProcessor.',
+        getParam: () => undefined
+      }, {
+        name: 'there is no existing processor',
+        errorMsg: 'No existing VideoProcessor detected.',
+        getParam: () => processor,
+        setup: () => {
+          videoTrack.processor = null;
+        }
+      }, {
+        name: 'processor param is not the same as the existing one',
+        errorMsg: 'The provided VideoProcessor is different than the existing one.',
+        getParam: () => ({ bar: 'bar' })
+      }].forEach(({ name, errorMsg, getParam, setup }) => {
+        it(`when ${name}`, () => {
+          if (setup) {
+            setup();
+          }
+          const regex = new RegExp(errorMsg);
+          assert.throws(() => { videoTrack.removeProcessor(getParam()); }, regex);
         });
       });
     });
@@ -236,78 +331,46 @@ describe('VideoTrack', () => {
       });
     });
 
-    describe('requestVideoFrameCallback', () => {
-      let onVideoFrame;
-
-      beforeEach(() => {
-        onVideoFrame = sinon.stub();
-      });
-
-      it('should use requestVideoFrameCallback when available', async () => {
-        videoTrack._dummyEl.requestVideoFrameCallback = cb => {
-          setTimeout(() => {
-            onVideoFrame();
-            cb();
-          }, timeoutMs);
-        };
+    describe('capture frame loop', () => {
+      it('should call processFrame with the correct frame rate', async () => {
         videoTrack._captureFrames();
 
         clock.tick(timeoutMs - 1);
         sinon.assert.notCalled(processFrame);
-        sinon.assert.notCalled(onVideoFrame);
         clock.tick(1);
         sinon.assert.calledOnce(processFrame);
-        sinon.assert.calledOnce(onVideoFrame);
 
         await internalPromise();
         clock.tick(timeoutMs);
         sinon.assert.calledTwice(processFrame);
-        sinon.assert.calledTwice(onVideoFrame);
 
         await internalPromise();
         clock.tick(timeoutMs);
         sinon.assert.calledThrice(processFrame);
-        sinon.assert.calledThrice(onVideoFrame);
-      });
-
-      it('should use setTimeout if requestVideoFrameCallback is not available', async () => {
-        videoTrack._captureFrames();
-
-        clock.tick(timeoutMs - 1);
-        sinon.assert.notCalled(processFrame);
-        sinon.assert.notCalled(onVideoFrame);
-        clock.tick(1);
-        sinon.assert.calledOnce(processFrame);
-        sinon.assert.notCalled(onVideoFrame);
-
-        await internalPromise();
-        clock.tick(timeoutMs);
-        sinon.assert.calledTwice(processFrame);
-        sinon.assert.notCalled(onVideoFrame);
-
-        await internalPromise();
-        clock.tick(timeoutMs);
-        sinon.assert.calledThrice(processFrame);
-        sinon.assert.notCalled(onVideoFrame);
       });
 
       [{
-        state: 'disabled',
+        state: 'mediaStreamTrack is disabled',
         setState: () => {
           mediaStreamTrack.enabled = false;
         }
       }, {
-        state: 'muted',
-        setState: () => {
-          mediaStreamTrack.muted = true;
-        }
-      }, {
-        state: 'ended',
+        state: 'mediaStreamTrack is ended',
         setState: () => {
           mediaStreamTrack.readyState = 'ended';
         }
+      }, {
+        state: 'there is no VideoProcessor added',
+        setState: () => {
+          videoTrack.processor = null;
+        }
+      }, {
+        state: 'there are no video elements attached',
+        setState: () => {
+          videoTrack._attachments.clear();
+        }
       }].forEach(({ state, setState }) => {
-        it(`should stop capturing frames if mediaStreamTrack is ${state}`, async () => {
+        it(`should stop capturing frames if ${state}`, async () => {
           videoTrack._captureFrames();
 
           clock.tick(timeoutMs);
@@ -319,7 +382,7 @@ describe('VideoTrack', () => {
           sinon.assert.calledOnce(processFrame);
         });
 
-        it(`should not start capturing frames if mediaStreamTrack is ${state}`, async () => {
+        it(`should not start capturing frames if ${state}`, async () => {
           setState();
           videoTrack._captureFrames();
           clock.tick(timeoutMs);
@@ -356,6 +419,18 @@ describe('VideoTrack', () => {
         videoTrack._captureFrames();
         sinon.assert.notCalled(videoTrack._dummyEl.play);
       });
+
+      it('when mediaStreamTrack is disabled', () => {
+        mediaStreamTrack.enabled = false;
+        videoTrack._captureFrames();
+        sinon.assert.notCalled(videoTrack._dummyEl.play);
+      });
+
+      it('when mediaStreamTrack is ended', () => {
+        mediaStreamTrack.readyState = 'ended';
+        videoTrack._captureFrames();
+        sinon.assert.notCalled(videoTrack._dummyEl.play);
+      });
     });
   });
 });
@@ -367,7 +442,8 @@ function OffscreenCanvas(width, height) {
   this.getContext = () => ({
     drawImage: (image, x, y, width, height) => {
       this.drawing = { image, x, y, width, height };
-    }
+    },
+    clearRect: () => { this.drawing = null; }
   });
 }
 

--- a/tsdef/VideoTrack.d.ts
+++ b/tsdef/VideoTrack.d.ts
@@ -16,6 +16,7 @@ export class VideoTrack extends Track {
   mediaStreamTrack: MediaStreamTrack;
 
   addProcessor(processor: VideoProcessor): this;
+  removeProcessor(processor: VideoProcessor): this;
   attach(element?: HTMLMediaElement | string): HTMLVideoElement;
   detach(element?: HTMLMediaElement | string): HTMLVideoElement[];
 


### PR DESCRIPTION
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

This PR:
- Implemented removeProcessor API
- Handle track.restart()
- Fixed an issue where processedTrack is not sent to RTCRtpSender after disable/enable
- Added checks before and during capture process whether capturing frames should proceed/stop or not. See `canCaptureFrames()` method
- Do not stop capturing frames on `mute`. This is because the track is automatically muted by the browser when not visible or looking at a different tab. In this case, we don't want to stop capturing frames.
- Stopped using `requestVideoFrameCallback` because this doesn't trigger when the page is not visible. For example, if the user is looking at a different tab. We don't want to stop capturing frames in this case. But we may want to figure out the correct timeout period, depending on the VideoProcessor performance.