### PR TITLE
streamline MSP processing

### DIFF
--- a/lib/signaling/v2/msptransport.js
+++ b/lib/signaling/v2/msptransport.js
@@ -1,0 +1,75 @@
+/* eslint callback-return:0 */
+'use strict';
+
+const EventEmitter = require('events');
+
+let nInstances = 0;
+class MSPTransport extends EventEmitter {
+  /**
+   * Construct a {@link MSPTransport}.
+   * @param {Promise<DataTrackReceiver>} getReceive
+   */
+  constructor(getReceiver, options) {
+    super();
+    Object.defineProperties(this, {
+      _instanceId: {
+        value: nInstances++
+      },
+      _log: {
+        value: options.log.createLog('default', this)
+      },
+      _getReceiver: {
+        value: getReceiver
+      },
+      _receiverPromise: {
+        value: null,
+        writable: true,
+      },
+      mediaSignalingTransport: {
+        value: null,
+        writable: true
+      }
+    });
+  }
+
+  isSetup() {
+    return !!this._receiverPromise;
+  }
+
+  isReady() {
+    return !!this.mediaSignalingTransport;
+  }
+
+  toString() {
+    return `[MSPController #${this._instanceId}]`;
+  }
+
+  setup(id) {
+    this._teardown();
+    this._log.info('setting up for id:', id);
+    const receiverPromise = this._getReceiver(id).then(receiver => {
+      if (receiver.kind !== 'data') {
+        throw new Error('Expected a DataTrackReceiver');
+      } if (this._receiverPromise !== receiverPromise) {
+        return;
+      }
+
+      this.mediaSignalingTransport = receiver.toDataTransport();
+      this.emit('ready', this.mediaSignalingTransport);
+
+      receiver.once('close', () => this._teardown());
+    });
+    this._receiverPromise = receiverPromise;
+  }
+
+  _teardown() {
+    if (this.mediaSignalingTransport) {
+      this._log.info('Tearing down');
+      this.mediaSignalingTransport = null;
+      this._receiverPromise = null;
+      this.emit('teardown');
+    }
+  }
+}
+
+module.exports = MSPTransport;

--- a/lib/signaling/v2/renderhintscontroller.js
+++ b/lib/signaling/v2/renderhintscontroller.js
@@ -1,0 +1,117 @@
+/* eslint callback-return:0 */
+'use strict';
+
+let messageId = 1;
+let nInstances = 0;
+class RenderHintsController  {
+  /**
+   * Construct a {@link RenderHintsController}.
+   */
+  constructor(mspTransport, options) {
+    this._log.info('RenderHintsController constructor');
+    Object.defineProperties(this, {
+      _instanceId: {
+        value: nInstances++
+      },
+      _log: {
+        value: options.log.createLog('default', this)
+      },
+      _mspTransport: {
+        value: mspTransport
+      },
+      _trackHints: {
+        value: new Map() // map of trackSid => { renderHint }
+      },
+      _dirtyTracks: {
+        value: new Set() // set of track sids that we have not yet sent to server.
+      },
+      _updatePending: {
+        value: false,
+        writable: true,
+      },
+    });
+
+    // when transport goes ready (either 1st time, or due after VMS failover)
+    this._mspTransport.on('ready', mediaSignalingTransport => {
+      // start listening for messages
+      mediaSignalingTransport.on('message', message => {
+        // https://code.hq.twilio.com/client/room-signaling-protocol/blob/master/schema/media/render_hints/server.yaml
+        switch (message.type) {
+          case 'render_hints':
+            this._processHintResults((message && message.subscriber && message.subscriber.hints) || []);
+            break;
+          default:
+            this._log.warn('Unknown message type: ', message.type);
+            break;
+        }
+      });
+
+      // and send the current state of tracks initially.
+      this._sendHints(Array.from(this._trackHints.keys()));
+    });
+  }
+
+  toString() {
+    return `[RenderHintsController #${this._instanceId}]`;
+  }
+
+  _processHintResults(hintResults) {
+    hintResults.forEach(hintResult => {
+      if (hintResult.result !== 'OK') {
+        this._log.error('Server error processing hint: ', hintResult);
+      }
+    });
+    this._updatePending = false;
+    this._sendUpdates();
+  }
+
+  // sends given hints.
+  _sendHints(trackSidArray) {
+    const hints = [];
+    trackSidArray.forEach(trackSid => {
+      const hint = this._trackHints.get(trackSid);
+      hints.push({
+        'track_sid': trackSid,
+        'enabled': hint.enabled,
+        'render_dimension': {
+          height: hint.renderDimension.height,
+          width: hint.renderDimension.width,
+        }
+      });
+    });
+
+    // send the update. schema is described here.
+    // https://code.hq.twilio.com/client/room-signaling-protocol/blob/master/schema/media/render_hints/client.yaml
+    this._mspController.mediaSignalingTransport.publishMessage({ type: 'render_hints',
+      subscriber: {
+        id: messageId++,
+        hints
+      } });
+    this._updatePending = true;
+  }
+
+  _sendUpdates() {
+    if (this.isReady() && !this._updatePending) {
+      this._sendHints(Array.from(this._dirtyTracks));
+      this._dirtyTracks.clear();
+    }
+  }
+
+  /**
+   * @param {Track.SID} trackSid
+   */
+  sendTrackHint(trackSid, renderHint) {
+    // save updated track state.
+    this._trackHints.set(trackSid, renderHint);
+    this._dirtyTracks.add(trackSid);
+    this._sendUpdates();
+  }
+
+  // must be called when track is unsubscribed.
+  deleteTrackState(trackSid) {
+    this._trackHints.delete(trackSid);
+    this._dirtyTracks.delete(trackSid);
+  }
+}
+
+module.exports = RenderHintsController;

--- a/lib/signaling/v2/renderhintscontroller.js
+++ b/lib/signaling/v2/renderhintscontroller.js
@@ -8,13 +8,14 @@ class RenderHintsController  {
    * Construct a {@link RenderHintsController}.
    */
   constructor(mspTransport, options) {
-    this._log.info('RenderHintsController constructor');
+    const log = options.log.createLog('default', this);
+    log.info('RenderHintsController constructor');
     Object.defineProperties(this, {
       _instanceId: {
         value: nInstances++
       },
       _log: {
-        value: options.log.createLog('default', this)
+        value: log
       },
       _mspTransport: {
         value: mspTransport

--- a/lib/signaling/v2/renderhintscontroller.js
+++ b/lib/signaling/v2/renderhintscontroller.js
@@ -7,7 +7,7 @@ class RenderHintsController  {
   /**
    * Construct a {@link RenderHintsController}.
    */
-  constructor(mspTransport, options) {
+  constructor(options) {
     const log = options.log.createLog('default', this);
     log.info('RenderHintsController constructor');
     Object.defineProperties(this, {
@@ -18,38 +18,45 @@ class RenderHintsController  {
         value: log
       },
       _mspTransport: {
-        value: mspTransport
+        value: null,
+        writable: true,
       },
       _trackHints: {
         value: new Map() // map of trackSid => { renderHint }
       },
       _dirtyTracks: {
-        value: new Set() // set of track sids that we have not yet sent to server.
+        value: new Set() // set of track sids that are not yet sent to server.
       },
       _updatePending: {
         value: false,
         writable: true,
       },
-    });
-
-    // when transport goes ready (either 1st time, or due after VMS failover)
-    this._mspTransport.on('ready', mediaSignalingTransport => {
-      // start listening for messages
-      mediaSignalingTransport.on('message', message => {
+      _messageCallback: {
+        value: message => {
         // https://code.hq.twilio.com/client/room-signaling-protocol/blob/master/schema/media/render_hints/server.yaml
-        switch (message.type) {
-          case 'render_hints':
-            this._processHintResults((message && message.subscriber && message.subscriber.hints) || []);
-            break;
-          default:
-            this._log.warn('Unknown message type: ', message.type);
-            break;
+          switch (message.type) {
+            case 'render_hints':
+              this._processHintResults((message && message.subscriber && message.subscriber.hints) || []);
+              break;
+            default:
+              this._log.warn('Unknown message type: ', message.type);
+              break;
+          }
         }
-      });
-
-      // and send the current state of tracks initially.
-      this._sendHints(Array.from(this._trackHints.keys()));
+      }
     });
+  }
+
+  setTransport(mspTransport) {
+    if (this._mspTransport) {
+      this._mspTransport.removeListener('message', this._messageCallback);
+    }
+
+    this._mspTransport = mspTransport;
+    if (this._mspTransport) {
+      mspTransport.addListener('message',  this._messageCallback);
+      this._sendHints(Array.from(this._trackHints.keys()));
+    }
   }
 
   toString() {
@@ -79,27 +86,34 @@ class RenderHintsController  {
           width: hint.renderDimension.width,
         }
       });
+      this._dirtyTracks.delete(trackSid);
     });
 
-    // send the update. schema is described here.
-    // https://code.hq.twilio.com/client/room-signaling-protocol/blob/master/schema/media/render_hints/client.yaml
-    this._mspController.mediaSignalingTransport.publishMessage({ type: 'render_hints',
-      subscriber: {
-        id: messageId++,
-        hints
-      } });
-    this._updatePending = true;
+    if (hints.length > 0) {
+      // send the update. schema is described here.
+      // https://code.hq.twilio.com/client/room-signaling-protocol/blob/master/schema/media/render_hints/client.yaml
+      this._mspTransport.publish({ type: 'render_hints',
+        subscriber: {
+          id: messageId++,
+          hints
+        } });
+      this._updatePending = true;
+    }
   }
 
+  /**
+   * @private
+   * sends out any dirtyTracks
+   */
   _sendUpdates() {
-    if (this.isReady() && !this._updatePending) {
+    if (this._mspTransport && !this._updatePending) {
       this._sendHints(Array.from(this._dirtyTracks));
-      this._dirtyTracks.clear();
     }
   }
 
   /**
    * @param {Track.SID} trackSid
+   * @param {RenderHint} renderHint
    */
   sendTrackHint(trackSid, renderHint) {
     // save updated track state.
@@ -108,7 +122,10 @@ class RenderHintsController  {
     this._sendUpdates();
   }
 
-  // must be called when track is unsubscribed.
+  /**
+   * must be called when track is unsubscribed.
+   * @param {Track.SID} trackSid
+   */
   deleteTrackState(trackSid) {
     this._trackHints.delete(trackSid);
     this._dirtyTracks.delete(trackSid);

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -9,6 +9,8 @@ const RemoteParticipantV2 = require('./remoteparticipant');
 const StatsReport = require('../../stats/statsreport');
 const TrackPrioritySignaling = require('./trackprioritysignaling');
 const TrackSwitchOffSignaling = require('./trackswitchoffsignaling');
+const MSPTransport = require('./msptransport');
+const RenderHintsController = require('./renderhintscontroller');
 
 const {
   constants: { DEFAULT_SESSION_TIMEOUT_SEC },
@@ -50,17 +52,12 @@ class RoomV2 extends RoomSignaling {
 
     super(localParticipant, initialState.sid, initialState.name, options);
 
+    const getTrackReceiver = id => this._getTrackReceiver(id);
+    const log = this._log;
+
     Object.defineProperties(this, {
-      _dominantSpeakerSignaling: {
-        value: null,
-        writable: true
-      },
       _DominantSpeakerSignaling: {
         value: options.DominantSpeakerSignaling
-      },
-      _dominantSpeakerSignalingPromise: {
-        value: null,
-        writable: true
       },
       _disconnectedParticipantRevisions: {
         value: new Map()
@@ -76,10 +73,6 @@ class RoomV2 extends RoomSignaling {
         writable: true
       },
       _networkQualityMonitor: {
-        value: null,
-        writable: true
-      },
-      _networkQualityMonitorPromise: {
         value: null,
         writable: true
       },
@@ -109,19 +102,26 @@ class RoomV2 extends RoomSignaling {
       _subscriptionFailures: {
         value: new Map()
       },
-      _trackPriorityPromise: {
+      _renderHintsMSP: {
+        value: new MSPTransport(getTrackReceiver, { log })
+      },
+      _renderHintsController: {
         value: null,
-        writable: true
+        writable: true,
+      },
+      _trackPriorityMSP: {
+        value: new MSPTransport(getTrackReceiver, { log })
+      },
+      _trackSwitchOffMSP: {
+        value: new MSPTransport(getTrackReceiver, { log })
+      },
+      _dominantSpeakerMSP: {
+        value: new MSPTransport(getTrackReceiver, { log })
+      },
+      _networkQualityMSP: {
+        value: new MSPTransport(getTrackReceiver, { log })
       },
       _trackPrioritySignaling: {
-        value: null,
-        writable: true
-      },
-      _trackSwitchOffPromise: {
-        value: null,
-        writable: true
-      },
-      _trackSwitchOffSignaling: {
         value: null,
         writable: true
       },
@@ -145,6 +145,12 @@ class RoomV2 extends RoomSignaling {
         value: initialState.options.media_region || null
       }
     });
+
+    this._initTrackPrioritySignaling();
+    this._initTrackSwitchOffSignaling();
+    this._initDominantSpeakerSignaling();
+    this._initNetworkQualityMonitorSignaling();
+    this._initRenderHints();
 
     handleLocalParticipantEvents(this, localParticipant);
     handlePeerConnectionEvents(this, peerConnectionManager);
@@ -226,7 +232,6 @@ class RoomV2 extends RoomSignaling {
   _disconnect(error) {
     const didDisconnect = super._disconnect.call(this, error);
     if (didDisconnect) {
-      this._teardownDominantSpeakerSignaling();
       this._teardownNetworkQualityMonitor();
       this._transport.disconnect();
       this._peerConnectionManager.close();
@@ -420,226 +425,120 @@ class RoomV2 extends RoomSignaling {
         roomState.participant.identity);
     }
 
-    if (!this._dominantSpeakerSignalingPromise
-      && roomState.media_signaling
-      && roomState.media_signaling.active_speaker
-      && roomState.media_signaling.active_speaker.transport
-      && roomState.media_signaling.active_speaker.transport.type === 'data-channel') {
-      this._setupDataTransportBackedDominantSpeakerSignaling(roomState.media_signaling.active_speaker.transport.label);
-    }
-
-    if (!this._networkQualityMonitorPromise
-      && roomState.media_signaling
-      && roomState.media_signaling.network_quality
-      && roomState.media_signaling.network_quality.transport
-      && roomState.media_signaling.network_quality.transport.type === 'data-channel') {
-      this._setupDataTransportBackedNetworkQualityMonitor(roomState.media_signaling.network_quality.transport.label);
-    }
-
-    if (!this._trackPriorityPromise
-      && roomState.media_signaling
-      && roomState.media_signaling.track_priority
-      && roomState.media_signaling.track_priority.transport
-      && roomState.media_signaling.track_priority.transport.type === 'data-channel') {
-      this._setupTrackPrioritySignaling(roomState.media_signaling.track_priority.transport.label);
-    }
-
-    if (!this._trackSwitchOffPromise
-      && roomState.media_signaling
-      && roomState.media_signaling.track_switch_off
-      && roomState.media_signaling.track_switch_off.transport
-      && roomState.media_signaling.track_switch_off.transport.type === 'data-channel') {
-      this._setupTrackSwitchOffMonitor(roomState.media_signaling.track_switch_off.transport.label);
-    }
+    // setup msp transports
+    [
+      { channel: 'active_speaker', mspObject: this._dominantSpeakerMSP },
+      { channel: 'network_quality', mspObject: this._networkQualityMSP },
+      { channel: 'track_priority', mspObject: this._trackPriorityMSP },
+      { channel: 'track_switch_off', mspObject: this._trackSwitchOffMSP },
+      { channel: 'render_hints', mspObject: this._renderHintsMSP }
+    ].forEach(({ channel, mspObject }) => {
+      if (!mspObject.isSetup()
+        && roomState.media_signaling
+        && roomState.media_signaling[channel]
+        && roomState.media_signaling[channel].transport
+        && roomState.media_signaling[channel].transport.type === 'data-channel') {
+        mspObject.setup(roomState.media_signaling[channel].transport.label);
+      }
+    });
 
     return this;
   }
 
   // track priority signaling MSP is now used only for subscribe side priority changes.
   // publisher side priority changes and notifications are handled by RSP.
-  _setupTrackPrioritySignaling(id) {
-    this._teardownTrackPrioritySignaling();
-    const trackPriorityPromise = this._getTrackReceiver(id).then(receiver => {
-      if (receiver.kind !== 'data') {
-        throw new Error('Expected a DataTrackReceiver');
-      } if (this._trackPriorityPromise !== trackPriorityPromise) {
-        return;
-      }
-
-      // NOTE(mmalavalli): The underlying RTCDataChannel is closed whenever
-      // the VMS instance fails over, and a new RTCDataChannel is created in order
-      // to resume sending Track Priority updates.
-      receiver.once('close', () => this._teardownTrackPrioritySignaling());
-
-      this._trackPrioritySignaling = new this._TrackPrioritySignaling(receiver.toDataTransport());
+  _initTrackPrioritySignaling() {
+    this._trackPriorityMSP.on('ready', mediaSignalingTransport => {
+      this._trackPrioritySignaling = new this._TrackPrioritySignaling(mediaSignalingTransport);
       [...this.participants.values()].forEach(participant => {
         participant.setTrackPrioritySignaling(this._trackPrioritySignaling);
       });
     });
-    this._trackPriorityPromise = trackPriorityPromise;
-  }
 
-  _setupTrackSwitchOff(trackSwitchOffSignaling) {
-    this._trackSwitchOffSignaling = trackSwitchOffSignaling;
-    trackSwitchOffSignaling.on('updated', (tracksOff, tracksOn) => {
-      try {
-        this._log.warn('trackSwitchOff: On: ', tracksOn, ' Off: ', tracksOff);
-        const trackUpdates = new Map();
-        tracksOn.forEach(trackSid => trackUpdates.set(trackSid, true));
-        tracksOff.forEach(trackSid => {
-          if (trackUpdates.get(trackSid)) {
-            // NOTE(mpatwardhan): This means that VIDEO-3762 has been reproduced.
-            this._log.warn(`${trackSid} is DUPLICATED in both tracksOff and tracksOn list`);
-          }
-          trackUpdates.set(trackSid, false);
-        });
-        this.participants.forEach(participant => {
-          participant.tracks.forEach(track => {
-            const isOn = trackUpdates.get(track.sid);
-            if (typeof isOn !== 'undefined') {
-              track.setSwitchedOff(!isOn);
-              trackUpdates.delete(track.sid);
-            }
-          });
-        });
-
-        // NOTE(mpatwardhan): Cache any notification about the tracks that we do not yet know about.
-        trackUpdates.forEach((isOn, trackSid) => this._pendingSwitchOffStates.set(trackSid, !isOn));
-      } catch (ex) {
-        this._log.error('error processing track switch off:', ex);
-      }
-    });
-  }
-
-  _setupTrackSwitchOffMonitor(id) {
-    this._teardownTrackSwitchOff();
-    const trackSwitchOffPromise = this._getTrackReceiver(id).then(receiver => {
-      if (receiver.kind !== 'data') {
-        throw new Error('Expected a DataTrackReceiver');
-      } if (this._trackSwitchOffPromise !== trackSwitchOffPromise) {
-        return;
-      }
-
-      // NOTE(mpatwardhan): The underlying RTCDataChannel is closed whenever
-      // the VMS instance fails over, and a new RTCDataChannel is created in order
-      // to resume sending Dominant Speaker updates.
-      receiver.once('close', () => this._teardownTrackSwitchOff());
-
-      const trackSwitchOffSignaling = new this._TrackSwitchOffSignaling(receiver.toDataTransport());
-      this._setupTrackSwitchOff(trackSwitchOffSignaling);
-    });
-    this._trackSwitchOffPromise = trackSwitchOffPromise;
-  }
-
-  /**
-   * Create a {@link DataTransport}-backed {@link DominantSpeakerSignaling}.
-   * @private
-   * @param {ID} id - ID of the {@link DataTrackReceiver} that will ultimately
-   *   be converted into a {@link DataTrackTransport} for use with
-   *   {@link DominantSpeakerSignaling}
-   * @returns {Promise<void>}
-   */
-  _setupDataTransportBackedDominantSpeakerSignaling(id) {
-    this._teardownDominantSpeakerSignaling();
-    const dominantSpeakerSignalingPromise = this._getTrackReceiver(id).then(receiver => {
-      if (receiver.kind !== 'data') {
-        throw new Error('Expected a DataTrackReceiver');
-      } if (this._dominantSpeakerSignalingPromise !== dominantSpeakerSignalingPromise) {
-        // NOTE(mroberts): _teardownDominantSpeakerSignaling was called.
-        return;
-      }
-
-      // NOTE(mpatwardhan): The underlying RTCDataChannel is closed whenever
-      // the VMS instance fails over, and a new RTCDataChannel is created in order
-      // to resume sending Dominant Speaker updates.
-      receiver.once('close', () => this._teardownDominantSpeakerSignaling());
-
-      const dominantSpeakerSignaling = new this._DominantSpeakerSignaling(receiver.toDataTransport());
-      this._setDominantSpeakerSignaling(dominantSpeakerSignaling);
-    });
-    this._dominantSpeakerSignalingPromise = dominantSpeakerSignalingPromise;
-  }
-  /**
-   * Create a {@link DataTransport}-backed {@link NetworkQualityMonitor}.
-   * @private
-   * @param {ID} id - ID of the {@link DataTrackReceiver} that will ultimately
-   *   be converted into a {@link DataTrackTransport} for use with
-   *   {@link NetworkQualitySignaling}
-   * @returns {Promise<void>}
-   */
-  _setupDataTransportBackedNetworkQualityMonitor(id) {
-    var self = this;
-    this._teardownNetworkQualityMonitor();
-    const networkQualityMonitorPromise = this._getTrackReceiver(id).then(receiver => {
-      if (receiver.kind !== 'data') {
-        throw new Error('Expected a DataTrackReceiver');
-      } if (this._networkQualityMonitorPromise !== networkQualityMonitorPromise) {
-        // NOTE(mroberts): _teardownNetworkQualityMonitor was called.
-        return;
-      }
-
-      // NOTE(mpatwardhan): The underlying RTCDataChannel is closed whenever
-      // the VMS instance fails over, and new a RTCDataChannel is created in order
-      // to resume exchanging Network Quality messages.
-      receiver.once('close', () => this. _teardownNetworkQualityMonitor());
-
-      const networkQualitySignaling = new this._NetworkQualitySignaling(
-        receiver.toDataTransport(), self._networkQualityConfiguration);
-      const networkQualityMonitor = new this._NetworkQualityMonitor(this._peerConnectionManager, networkQualitySignaling);
-      this._setNetworkQualityMonitor(networkQualityMonitor);
-    });
-    this._networkQualityMonitorPromise = networkQualityMonitorPromise;
-  }
-
-  _setDominantSpeakerSignaling(dominantSpeakerSignaling) {
-    this._dominantSpeakerSignaling = dominantSpeakerSignaling;
-    dominantSpeakerSignaling.on('updated', () => this.setDominantSpeaker(dominantSpeakerSignaling.loudestParticipantSid));
-  }
-
-  _setNetworkQualityMonitor(networkQualityMonitor) {
-    this._networkQualityMonitor = networkQualityMonitor;
-    networkQualityMonitor.on('updated', () => {
-      if (this.iceConnectionState === 'failed') {
-        return;
-      }
-      this.localParticipant.setNetworkQualityLevel(
-        networkQualityMonitor.level,
-        networkQualityMonitor.levels);
+    this._trackPriorityMSP.on('teardown', () => {
+      this._trackPrioritySignaling = null;
+      this.localParticipant.setTrackPrioritySignaling(null);
       this.participants.forEach(participant => {
-        const levels = networkQualityMonitor.remoteLevels.get(participant.sid);
-        if (levels) {
-          participant.setNetworkQualityLevel(levels.level, levels);
+        participant.setTrackPrioritySignaling(null);
+      });
+    });
+  }
+
+  _initTrackSwitchOffSignaling() {
+    this._trackSwitchOffMSP.on('ready', mediaSignalingTransport => {
+      const trackSwitchOffSignaling = new this._TrackSwitchOffSignaling(mediaSignalingTransport);
+      trackSwitchOffSignaling.on('updated', (tracksOff, tracksOn) => {
+        try {
+          this._log.warn('trackSwitchOff: On: ', tracksOn, ' Off: ', tracksOff);
+          const trackUpdates = new Map();
+          tracksOn.forEach(trackSid => trackUpdates.set(trackSid, true));
+          tracksOff.forEach(trackSid => {
+            if (trackUpdates.get(trackSid)) {
+              // NOTE(mpatwardhan): This means that VIDEO-3762 has been reproduced.
+              this._log.warn(`${trackSid} is DUPLICATED in both tracksOff and tracksOn list`);
+            }
+            trackUpdates.set(trackSid, false);
+          });
+          this.participants.forEach(participant => {
+            participant.tracks.forEach(track => {
+              const isOn = trackUpdates.get(track.sid);
+              if (typeof isOn !== 'undefined') {
+                track.setSwitchedOff(!isOn);
+                trackUpdates.delete(track.sid);
+              }
+            });
+          });
+          // NOTE(mpatwardhan): Cache any notification about the tracks that we do not yet know about.
+          trackUpdates.forEach((isOn, trackSid) => this._pendingSwitchOffStates.set(trackSid, !isOn));
+        } catch (ex) {
+          this._log.error('error processing track switch off:', ex);
         }
       });
     });
-    networkQualityMonitor.start();
   }
 
-  _teardownDominantSpeakerSignaling() {
-    this._dominantSpeakerSignalingPromise = null;
-    this._dominantSpeakerSignaling = null;
+  _initDominantSpeakerSignaling() {
+    this._dominantSpeakerMSP.on('ready', mediaSignalingTransport => {
+      const dominantSpeakerSignaling = new this._DominantSpeakerSignaling(mediaSignalingTransport);
+      dominantSpeakerSignaling.on('updated', () => this.setDominantSpeaker(dominantSpeakerSignaling.loudestParticipantSid));
+    });
+  }
+
+  _initRenderHints() {
+    this._renderHintsController = new RenderHintsController(this._renderHintsMSP, { log: this._log });
+  }
+
+  _initNetworkQualityMonitorSignaling() {
+    this._networkQualityMSP.on('ready', mediaSignalingTransport => {
+      const networkQualitySignaling = new this._NetworkQualitySignaling(
+        mediaSignalingTransport, this._networkQualityConfiguration);
+      const networkQualityMonitor = new this._NetworkQualityMonitor(this._peerConnectionManager, networkQualitySignaling);
+      this._networkQualityMonitor = networkQualityMonitor;
+      networkQualityMonitor.on('updated', () => {
+        if (this.iceConnectionState === 'failed') {
+          return;
+        }
+        this.localParticipant.setNetworkQualityLevel(
+          networkQualityMonitor.level,
+          networkQualityMonitor.levels);
+        this.participants.forEach(participant => {
+          const levels = networkQualityMonitor.remoteLevels.get(participant.sid);
+          if (levels) {
+            participant.setNetworkQualityLevel(levels.level, levels);
+          }
+        });
+      });
+      networkQualityMonitor.start();
+    });
+
+    this._networkQualityMSP.on('teardown', () => this._teardownNetworkQualityMonitor());
   }
 
   _teardownNetworkQualityMonitor() {
-    this._networkQualityMonitorPromise = null;
     if (this._networkQualityMonitor) {
       this._networkQualityMonitor.stop();
       this._networkQualityMonitor = null;
     }
-  }
-
-  _teardownTrackPrioritySignaling() {
-    this._trackPrioritySignaling = null;
-    this._trackPriorityPromise = null;
-    this.localParticipant.setTrackPrioritySignaling(null);
-    this.participants.forEach(participant => {
-      participant.setTrackPrioritySignaling(null);
-    });
-  }
-
-  _teardownTrackSwitchOff() {
-    this._trackSwitchOffSignaling = null;
-    this._trackSwitchOffPromise = null;
   }
 
   /**

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -106,8 +106,7 @@ class RoomV2 extends RoomSignaling {
         value: new MSPTransport(getTrackReceiver, { log })
       },
       _renderHintsController: {
-        value: null,
-        writable: true,
+        value: new RenderHintsController({ log }),
       },
       _trackPriorityMSP: {
         value: new MSPTransport(getTrackReceiver, { log })
@@ -505,7 +504,13 @@ class RoomV2 extends RoomSignaling {
   }
 
   _initRenderHints() {
-    this._renderHintsController = new RenderHintsController(this._renderHintsMSP, { log: this._log });
+    this._renderHintsMSP.on('ready', mediaSignalingTransport => {
+      this._renderHintsController.setTransport(mediaSignalingTransport);
+    });
+
+    this._renderHintsMSP.on('teardown', () => {
+      this._renderHintsController.setTransport(null);
+    });
   }
 
   _initNetworkQualityMonitorSignaling() {

--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -97,6 +97,7 @@ class TwilioConnectionTransport extends StateMachine {
       sdpFormat: getSdpFormat(options.sdpSemantics),
       trackPriority: true,
       trackSwitchOff: true,
+      renderHints: true,
       userAgent: getUserAgent()
     }, options);
     super('connecting', states);
@@ -119,6 +120,9 @@ class TwilioConnectionTransport extends StateMachine {
       },
       _dominantSpeaker: {
         value: options.dominantSpeaker
+      },
+      _renderHints: {
+        value: options.renderHints
       },
       _eventPublisher: {
         value: new EventPublisher(
@@ -248,7 +252,8 @@ class TwilioConnectionTransport extends StateMachine {
         this._dominantSpeaker,
         this._networkQuality,
         this._trackPriority,
-        this._trackSwitchOff);
+        this._trackSwitchOff,
+        this._renderHints);
 
       message.subscribe = createSubscribePayload(
         this._automaticSubscription);

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -661,9 +661,12 @@ function createBandwidthProfileVideoPayload(bandwidthProfileVideo) {
  *   protocol or not
  * @param {boolean} trackSwitchOff - whether to enable the Track Switch-Off
  *   protocol or not.
+ * renderHints
+ * @param {boolean} renderHints - whether to enable the renderHints
+ *   protocol or not.
  * @returns {object}
  */
-function createMediaSignalingPayload(dominantSpeaker, networkQuality, trackPriority, trackSwitchOff) {
+function createMediaSignalingPayload(dominantSpeaker, networkQuality, trackPriority, trackSwitchOff, renderHints) {
   const transports = { transports: [{ type: 'data-channel' }] };
   return Object.assign(
     dominantSpeaker
@@ -681,7 +684,11 @@ function createMediaSignalingPayload(dominantSpeaker, networkQuality, trackPrior
     trackSwitchOff
       // eslint-disable-next-line
       ? { track_switch_off: transports }
-      : {}
+      : {},
+    renderHints
+      // eslint-disable-next-line
+      ? { render_hints: transports }
+      : {},
   );
 }
 

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -39,6 +39,7 @@ require('./spec/signaling/participant');
 require('./spec/signaling/room');
 
 require('./spec/signaling/v2');
+require('./spec/signaling/v2/renderhintscontroller');
 require('./spec/signaling/v2/dominantspeakersignaling');
 require('./spec/signaling/v2/cancelableroomsignalingpromise');
 require('./spec/signaling/v2/icebox');

--- a/test/unit/spec/signaling/v2/renderhintscontroller.js
+++ b/test/unit/spec/signaling/v2/renderhintscontroller.js
@@ -1,0 +1,175 @@
+'use strict';
+
+const assert = require('assert');
+const sinon = require('sinon');
+
+const MediaSignalingTransport = require('../../../../../lib/data/transport');
+const RenderHintsController = require('../../../../../lib/signaling/v2/renderhintscontroller.js');
+const fakeLog = require('../../../../lib/fakelog');
+
+describe('RenderHintsController', () => {
+  describe('constructor', () => {
+    it('sets ._mspTransport to null', () => {
+      const subject = makeTest();
+      assert.strictEqual(subject._mspTransport, null);
+    });
+  });
+
+  describe('sendTrackHint', () => {
+    it('updates track state', () => {
+      let subject = makeTest();
+      subject.sendTrackHint('foo', { enabled: true, renderDimension: { width: 100, height: 100 } });
+      assert(subject._trackHints.has('foo'));
+      assert(subject._dirtyTracks.has('foo'));
+    });
+
+    it('if transport is set sends out the updated track state', () => {
+      let subject = makeTest();
+      let mspTransport = sinon.createStubInstance(MediaSignalingTransport);
+      subject.setTransport(mspTransport);
+      subject.sendTrackHint('foo', { enabled: true, renderDimension: { width: 100, height: 100 } });
+
+      sinon.assert.calledWith(mspTransport.publish, {
+        type: 'render_hints',
+        subscriber: {
+          id: sinon.match.number,
+          hints: [{
+            'track_sid': 'foo',
+            'enabled': true,
+            'render_dimension': { height: 100, width: 100 },
+          }]
+        }
+      });
+
+      assert(subject._trackHints.has('foo'));
+      assert(!subject._dirtyTracks.has('foo'));
+    });
+  });
+
+  describe('deleteTrackState', () => {
+    it('deletes stored track state.', () => {
+      let subject = makeTest();
+      subject.sendTrackHint('foo', { enabled: true, renderDimension: { width: 100, height: 100 } });
+      assert(subject._trackHints.has('foo'));
+      assert(subject._dirtyTracks.has('foo'));
+
+      subject.deleteTrackState('foo');
+      assert(!subject._trackHints.has('foo'));
+      assert(!subject._dirtyTracks.has('foo'));
+    });
+  });
+
+  describe('setTransport', () => {
+    let mspTransport = sinon.createStubInstance(MediaSignalingTransport);
+    let subject = makeTest();
+    let messageCallback = null;
+
+    it('hooks up for message callback', () => {
+      subject.setTransport(mspTransport);
+      assert(mspTransport.addListener.callCount === 1);
+      sinon.assert.calledWith(mspTransport.addListener, 'message');
+      subject.setTransport(null);
+      mspTransport.addListener.resetHistory();
+    });
+
+    it('sends latest state of the tracks', () => {
+      // queue some hints.
+      subject.sendTrackHint('foo', { enabled: true, renderDimension: { width: 100, height: 100 } });
+      subject.sendTrackHint('bar', { enabled: true, renderDimension: { width: 200, height: 200 } });
+      subject.sendTrackHint('baz', { enabled: false, renderDimension: { width: 0, height: 0 } });
+
+      mspTransport.addListener.callsFake((event, callback) => { messageCallback = callback; });
+
+      // and then set transport.
+      subject.setTransport(mspTransport);
+      sinon.assert.callCount(mspTransport.addListener, 1);
+      sinon.assert.calledWith(mspTransport.addListener, 'message');
+
+      sinon.assert.callCount(mspTransport.publish, 1);
+      sinon.assert.calledWith(mspTransport.publish, {
+        type: 'render_hints',
+        subscriber: {
+          id: sinon.match.number,
+          hints: [{
+            'track_sid': 'foo',
+            'enabled': true,
+            'render_dimension': { height: 100, width: 100 },
+          }, {
+            'track_sid': 'bar',
+            'enabled': true,
+            'render_dimension': { height: 200, width: 200 },
+          }, {
+            'track_sid': 'baz',
+            'enabled': false,
+            'render_dimension': { height: 0, width: 0 },
+          }],
+        }
+      });
+    });
+
+    it('waits for answer from server and then sends next update', () => {
+      // update some tracks
+      subject.sendTrackHint('baz', { enabled: true, renderDimension: { width: 20, height: 20 } });
+      subject.sendTrackHint('foo', { enabled: false, renderDimension: { width: 0, height: 0 } });
+
+      // this wont be sent yet, since last message is outstanding.
+      sinon.assert.callCount(mspTransport.publish, 1);
+
+      mspTransport.publish.resetHistory();
+      sinon.assert.callCount(mspTransport.publish, 0);
+
+      messageCallback({ type: 'render_hints', foo: 1 });
+
+      sinon.assert.callCount(mspTransport.publish, 1);
+      sinon.assert.calledWith(mspTransport.publish, {
+        type: 'render_hints',
+        subscriber: {
+          id: sinon.match.number,
+          hints: [{
+            'track_sid': 'baz',
+            'enabled': true,
+            'render_dimension': { height: 20, width: 20 },
+          }, {
+            'track_sid': 'foo',
+            'enabled': false,
+            'render_dimension': { height: 0, width: 0 },
+          }]
+        }
+      });
+    });
+
+    it('sends complete state when transport is set again', () => {
+      subject.setTransport(null);
+      mspTransport.publish.resetHistory();
+
+      subject.setTransport(mspTransport);
+      sinon.assert.callCount(mspTransport.publish, 1);
+      sinon.assert.calledWith(mspTransport.publish, {
+        type: 'render_hints',
+        subscriber: {
+          id: sinon.match.number,
+          hints: [{
+            'track_sid': 'foo',
+            'enabled': false,
+            'render_dimension': { height: 0, width: 0 },
+          }, {
+            'track_sid': 'bar',
+            'enabled': true,
+            'render_dimension': { height: 200, width: 200 },
+          }, {
+            'track_sid': 'baz',
+            'enabled': true,
+            'render_dimension': { height: 20, width: 20 },
+          }]
+        }
+      });
+    });
+  });
+});
+
+function makeTest(log) {
+  // mspTransport = mspTransport || sinon.createStubInstance(MediaSignalingTransport);
+  //
+  log = log || fakeLog;
+  return new RenderHintsController({ log });
+}


### PR DESCRIPTION
This change refactors MSP channel handling and manages to remove lots of boilerplate code. This is in preparation for implementing RenderHints Controller ( https://issues.corp.twilio.com/browse/VIDEO-3743 and https://issues.corp.twilio.com/browse/VIDEO-3744 )

TODO:
- [x] add unit tests. [renderhintscontroller](https://37667-46595751-gh.circle-artifacts.com/0/coverage/lcov-report/lib/signaling/v2/renderhintscontroller.js.html) + [msptransport.js](https://37667-46595751-gh.circle-artifacts.com/0/coverage/lcov-report/lib/signaling/v2/msptransport.js.html) 


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
