### PR TITLE
VIDEO-4205 | Mark bitrate test unstable

### DIFF
--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -805,7 +805,7 @@ describe('connect', function() {
         // TODO: Remove firefox check once this firefox bug is fixed
         // https://bugzilla.mozilla.org/show_bug.cgi?id=1688342
         if (!isFirefox) {
-          it(`should ${maxBitrates[kind] ? '' : 'not '}limit the ${kind} bitrate`, () => {
+          it(`should ${maxBitrates[kind] ? '' : 'not '}limit the ${kind} bitrate (@unstable: JSDK-2512)`, () => {
             const averageBitrate = kind === 'audio' ? averageAudioBitrate : averageVideoBitrate;
             const minBitrate = kind === 'audio' ? minAudioBitrate : minVideoBitrate;
             if (maxBitrates[kind]) {

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -805,7 +805,7 @@ describe('connect', function() {
         // TODO: Remove firefox check once this firefox bug is fixed
         // https://bugzilla.mozilla.org/show_bug.cgi?id=1688342
         if (!isFirefox) {
-          it(`should ${maxBitrates[kind] ? '' : 'not '}limit the ${kind} bitrate (@unstable: JSDK-2512)`, () => {
+          it(`should ${maxBitrates[kind] ? '' : 'not '}limit the ${kind} bitrate (@unstable: VIDEO-4205)`, () => {
             const averageBitrate = kind === 'audio' ? averageAudioBitrate : averageVideoBitrate;
             const minBitrate = kind === 'audio' ? minAudioBitrate : minVideoBitrate;
             if (maxBitrates[kind]) {


### PR DESCRIPTION
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
