### PR TITLE
VIDEO-4191 test fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,32 +190,12 @@ jobs:
     steps:
       - echo-command:
           to: "Build Passed!"
-  run-integration-tests-custom:
-    parallelism: 1
-    parameters:
-      browser:
-        type: string
-      bver:
-        type: string
-      topology:
-        type: enum
-        enum: ["group", "peer-to-peer"]
-        default: "group"
-      test_stability:
-        type: string
-    environment:
-      TEST_TYPE: "integration"
-      TOPOLOGY: << parameters.topology >>
-      TEST_STABILITY: << parameters.test_stability >>
-      TEST_FILES: << pipeline.parameters.test_files >>
-    executor:
-      name: docker-with-browser
-      browser: << parameters.browser >>
-      bver: << parameters.bver >>
-    steps: [integration-tests]
   run-integration-tests:
-    parallelism: 6
+    parallelism: << parameters.parallelism >>
     parameters:
+      parallelism:
+        type: integer
+        default: 6
       browser:
         type: string
       bver:
@@ -339,6 +319,7 @@ workflows:
           bver: << pipeline.parameters.bver >>
           topology: << pipeline.parameters.topology >>
           test_stability: << pipeline.parameters.test_stability >>
+          parallelism: 1
       - run-network-tests:
           name: Network(<< pipeline.parameters.test_stability >>) << pipeline.parameters.environment >> << pipeline.parameters.browser >> << pipeline.parameters.topology >>
           browser: << pipeline.parameters.browser >>
@@ -348,7 +329,7 @@ workflows:
   Backend_Workflow:
     when: << pipeline.parameters.backend_workflow >>
     jobs:
-      - run-integration-tests-custom:
+      - run-integration-tests:
           name: << matrix.test_stability >> integration << matrix.topology >> tests << matrix.browser >>(<< matrix.bver >>)
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,9 @@ parameters:
   release_command:
     type: string
     default: "echo no release command was specified" # release-tool specifies the real command.
+  test_files: # specifies test files to execute.
+    type: string
+    default: "auto"
 
 defaultEnv: &defaultEnv
   ENVIRONMENT: << pipeline.parameters.environment >>
@@ -187,6 +190,29 @@ jobs:
     steps:
       - echo-command:
           to: "Build Passed!"
+  run-integration-tests-custom:
+    parallelism: 1
+    parameters:
+      browser:
+        type: string
+      bver:
+        type: string
+      topology:
+        type: enum
+        enum: ["group", "peer-to-peer"]
+        default: "group"
+      test_stability:
+        type: string
+    environment:
+      TEST_TYPE: "integration"
+      TOPOLOGY: << parameters.topology >>
+      TEST_STABILITY: << parameters.test_stability >>
+      TEST_FILES: << pipeline.parameters.test_files >>
+    executor:
+      name: docker-with-browser
+      browser: << parameters.browser >>
+      bver: << parameters.bver >>
+    steps: [integration-tests]
   run-integration-tests:
     parallelism: 6
     parameters:
@@ -204,6 +230,7 @@ jobs:
       TEST_TYPE: "integration"
       TOPOLOGY: << parameters.topology >>
       TEST_STABILITY: << parameters.test_stability >>
+      TEST_FILES: << pipeline.parameters.test_files >>
     executor:
       name: docker-with-browser
       browser: << parameters.browser >>
@@ -321,7 +348,7 @@ workflows:
   Backend_Workflow:
     when: << pipeline.parameters.backend_workflow >>
     jobs:
-      - run-integration-tests:
+      - run-integration-tests-custom:
           name: << matrix.test_stability >> integration << matrix.topology >> tests << matrix.browser >>(<< matrix.bver >>)
           matrix:
             parameters:

--- a/.circleci/runbuild.js
+++ b/.circleci/runbuild.js
@@ -67,7 +67,8 @@ function generateBuildRequest(program) {
       custom_workflow: program.workflow === 'custom',
       backend_workflow: program.workflow === 'backend',
       environment: program.environment,
-      test_stability: program.test_stability
+      test_stability: program.test_stability,
+      test_files: program.test_files
     }
   };
 
@@ -186,8 +187,17 @@ const topologyPrompt = {
   choices: ['group', 'peer-to-peer'],
   validate: answer => answer.length > 0,
   default: 'group',
-
 };
+
+const testFilesPrompt = {
+  when: (answers) => answers.workflow === 'custom',
+  type: 'input',
+  name: 'test_files',
+  message: 'Files to test against:',
+  default: 'auto',
+  validate: (val) => { return typeof val === 'string' && val.length > 3; }
+};
+
 
 // tag can be chosen only for backend workflow
 const tagPrompt = {
@@ -198,6 +208,7 @@ const tagPrompt = {
   default: '2.0.0-beta15',
   validate: (val) => { return typeof val === 'string' && val.length > 5; }
 };
+
 
 const confirmPrompt = {
   type: 'confirm',
@@ -221,11 +232,12 @@ inquirer.prompt([
   bverPrompt,
   topologyPrompt,
   stableTestsPrompt,
+  testFilesPrompt
 ]).then(answers => {
   console.log('Will make a CI request with:', answers);
 
   // get basic values from answers.
-  const { branch, token, workflow, tag } = answers;
+  const { branch, token, workflow, tag, test_files } = answers;
 
   // make combo of possible multi-select (checkbox) values.
   var combo = ['browser', 'bver', 'environment', 'topology', 'test_stability'].reduce( (acc, dim) => {
@@ -233,7 +245,7 @@ inquirer.prompt([
     const result = [];
     acc.forEach(accElement => dimValues.forEach(dimValue => result.push({ ...accElement, [dim]: dimValue})));
     return result;
-  }, [{ branch, token, workflow, tag }]);
+  }, [{ branch, token, workflow, tag, test_files }]);
 
   inquirer.prompt([confirmPrompt]).then(({ confirm }) => {
     if (confirm) {

--- a/.circleci/runbuild.js
+++ b/.circleci/runbuild.js
@@ -89,6 +89,7 @@ function generateBuildRequest(program) {
 
 // sends a request using given options/body
 function triggerBuild({options, body}) {
+  console.log('Triggering:', options, body);
   return new Promise((resolve, reject) => {
     const request = http.request(options, function(res) {
       const chunks = [];

--- a/scripts/circleci-run-tests.sh
+++ b/scripts/circleci-run-tests.sh
@@ -27,6 +27,7 @@ dev)
   export API_KEY_SECRET=${API_KEY_SECRET_DEV}
   export API_KEY_SID=${API_KEY_SID_DEV}
   export REGIONS='us1'
+  export WS_SERVER=wss://us2.vss.dev.twilio.com/signaling
   ;;
 stage)
   echo "Testing against stage"
@@ -57,8 +58,10 @@ network)
 integration)
   echo "Testing integration tests"
   # ask circleci to split tests by timing.
-  echo "Asking circleci to pick tests based on timings..."
-  export TEST_FILES=$(circleci tests glob "$PWD/test/integration/spec/**/*.js" | circleci tests split --split-by=timings)
+  if [ "${TEST_FILES}" == "auto" ]; then
+    echo "Asking circleci to pick tests based on timings..."
+    export TEST_FILES=$(circleci tests glob "$PWD/test/integration/spec/**/*.js" | circleci tests split --split-by=timings)
+  fi
   echo $TEST_FILES
   npm run test:integration
   ;;


### PR DESCRIPTION
This test has been failing because browser does not send  remb packets when bob unpublished tracks too soon. This adds a workaround (delay of 4 seconds) to make the test green.

It also adds some tooling to be able to run test against a specific file. You can now use `.circleci/runbuild.js` to queue a build with a specific integration test file. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
