### PR TITLE
Fix: Promise.all cannot iterate empty map (_replaceTrackPromises)

### DIFF
--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -930,7 +930,7 @@ class PeerConnectionV2 extends StateMachine {
       offerOptions.iceRestart = true;
     }
 
-    return Promise.all(this._replaceTrackPromises.values()).then(() => {
+    return Promise.all(Array.from(this._replaceTrackPromises.values())).then(() => {
       return this._peerConnection.createOffer(offerOptions);
     }).catch(error => {
       const errorToThrow = new MediaClientLocalDescFailedError();


### PR DESCRIPTION
This PR fixes an issue that `Promise.all` cannot iterate empty map (`_replaceTrackPromises`). `this._replaceTrackPromises.values()` was an empty MapIterator which `Promise.all` couldn't iterate.

This fixes https://github.com/twilio/twilio-video.js/issues/963.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

[X] I acknowledge that all my contributions will be made under the project's license.
