### PR TITLE
renderhints after trackstarted (VIDEO-4275, VIDEO-3742)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,7 +311,28 @@ workflows:
               browser: ["chrome", "firefox"]
               bver: ["stable", "unstable", "beta"]
   Custom_Workflow:
-    when: << pipeline.parameters.custom_workflow >>
+    when:
+      and:
+        - << pipeline.parameters.custom_workflow >>
+        - equal: [ auto, << pipeline.parameters.test_files >> ]
+    jobs:
+      - run-integration-tests:
+          name: Integration(<< pipeline.parameters.test_stability >>) << pipeline.parameters.environment >> << pipeline.parameters.browser >>(<< pipeline.parameters.bver >>) << pipeline.parameters.topology >>
+          browser: << pipeline.parameters.browser >>
+          bver: << pipeline.parameters.bver >>
+          topology: << pipeline.parameters.topology >>
+          test_stability: << pipeline.parameters.test_stability >>
+      - run-network-tests:
+          name: Network(<< pipeline.parameters.test_stability >>) << pipeline.parameters.environment >> << pipeline.parameters.browser >> << pipeline.parameters.topology >>
+          browser: << pipeline.parameters.browser >>
+          topology: << pipeline.parameters.topology >>
+          test_stability: << pipeline.parameters.test_stability >>
+  Custom_Workflow_with_specific_test_file:
+    when:
+      and:
+        - << pipeline.parameters.custom_workflow >>
+        - not:
+            equal: [ auto, << pipeline.parameters.test_files >> ]
     jobs:
       - run-integration-tests:
           name: Integration(<< pipeline.parameters.test_stability >>) << pipeline.parameters.environment >> << pipeline.parameters.browser >>(<< pipeline.parameters.bver >>) << pipeline.parameters.topology >>
@@ -320,12 +341,6 @@ workflows:
           topology: << pipeline.parameters.topology >>
           test_stability: << pipeline.parameters.test_stability >>
           parallelism: 1
-      - run-network-tests:
-          name: Network(<< pipeline.parameters.test_stability >>) << pipeline.parameters.environment >> << pipeline.parameters.browser >> << pipeline.parameters.topology >>
-          browser: << pipeline.parameters.browser >>
-          topology: << pipeline.parameters.topology >>
-          test_stability: << pipeline.parameters.test_stability >>
-
   Backend_Workflow:
     when: << pipeline.parameters.backend_workflow >>
     jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 
 **Support for the 1.x version ended on December 4th, 2020**. Check [this guide](https://www.twilio.com/docs/video/migrating-1x-2x) to plan your migration to the latest 2.x version.
 
+2.14.0 (In Progress)
+====================
+New Features
+------------
+
+**Idle Track Switch Off**
+
+- Idle Track Switch Off uses document visibility, track attachments, and the visibility of video elements to determine whether a RemoteVideoTrack should be switched off. A RemoteVideoTrack will be switched off when the document is no longer visible, no video elements are attached to the track, or when the video elements attached to the track are not visible.
+
+This feature is available in Group Rooms and is enabled by default if your application specifies any Bandwidth Profile options during connect.
+
+```js
+  const { connect } = require('twilio-video');
+
+  const room = await connect(token, {
+    name: "my-new-room",
+    bandwidthProfile: {
+      video: {
+        idleTrackSwitchOff: true,
+        // Other Bandwidth Profile options...
+      }
+    }
+  });
+```
+
+Note: This feature rely on applications using `attach` and `detach` methods of `RemoteVideoTrack`. If your application currently uses the underlying MediaStreamTrack to associate Tracks to video elements, you will need to update your application to use the attach/detach methods. This feature can be disabled by setting `idleTrackSwitchOff` property to false in the BandwidthProfileOptions dictionary.
+
+```js
+  const { connect } = require('twilio-video');
+
+  const room = await connect(token, {
+    name: "my-new-room",
+    bandwidthProfile: {
+      video: {
+        idleTrackSwitchOff: false,
+        // Other Bandwidth Profile options
+      }
+    }
+  });
+```
+
+
 2.13.0 (March 3, 2021)
 ======================
 
@@ -53,10 +95,10 @@ New Features
   });
 
   ```
-  
+
   You can also toggle a blur filter on a RemoteVideoTrack as shown below.
-  
-  ```js
+
+  ```ts
   room.on('trackSubscribed', track => {
     if (track.kind === 'video') {
       const { width, height } = track.dimensions;

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -459,6 +459,9 @@ function connect(token, options) {
  * @property {number} [maxSubscriptionBitrate] - Optional parameter to specify the maximum
  *   downlink video bandwidth in bits per second (bps). By default, there are no limits on
  *   the downlink video bandwidth.
+ * @property {boolean} [idleTrackSwitchOff] - Optional parameter that when enabled switches off a
+ *    RemoteVideoTrack when no video element is attached to the track, or when all attached video
+ *    elements of the track are not visible, or when the Document is not visible. This is enabled by default
  * @property {number} [maxTracks] - Optional parameter to specify the maximum number of visible
  *   {@link RemoteVideoTrack}s, which will be selected based on {@link Track.Priority} and an N-Loudest
  *   policy. By default there are no limits on the number of visible {@link RemoteVideoTrack}s.

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -283,6 +283,18 @@ function connect(token, options) {
     return CancelablePromise.reject(error);
   }
 
+
+  options.idleTrackSwitchOff =  false;
+  if (options.bandwidthProfile) {
+    options.idleTrackSwitchOff = true;
+    if (options.bandwidthProfile.video) {
+      if (options.bandwidthProfile.video.idleTrackSwitchOff === false) {
+        options.idleTrackSwitchOff = false;
+      }
+      delete options.bandwidthProfile.video.idleTrackSwitchOff;
+    }
+  }
+
   const Signaling = options.signaling;
   const signaling = new Signaling(options.wsServer, options);
 

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -291,7 +291,6 @@ function connect(token, options) {
       if (options.bandwidthProfile.video.idleTrackSwitchOff === false) {
         options.idleTrackSwitchOff = false;
       }
-      delete options.bandwidthProfile.video.idleTrackSwitchOff;
     }
   }
 

--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -93,7 +93,7 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
 
   attach(el) {
     const result = super.attach(el);
-    if (this._intersectionObserver !== null) {
+    if (this._intersectionObserver) {
       this._invisibleElements.add(result);
       this._intersectionObserver.observe(result);
       // NOTE(mpatwardhan): we do not call updateRenderHints here,
@@ -113,7 +113,7 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
     const result = super.detach(el);
     const elements = Array.isArray(result) ? result : [result];
     elements.forEach(element => {
-      if (this._intersectionObserver !== null) {
+      if (this._intersectionObserver) {
         this._intersectionObserver.unobserve(element);
       }
       this._invisibleElements.delete(element);

--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -64,8 +64,10 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
             const wasVisible = !this._invisibleElements.has(entry.target);
             if (wasVisible !== entry.isIntersecting) {
               if (entry.isIntersecting) {
+                this._log.debug('intersectionObserver detected: Off => On');
                 this._invisibleElements.delete(entry.target);
               } else {
+                this._log.debug('intersectionObserver detected: On => Off');
                 this._invisibleElements.add(entry.target);
               }
               shouldSetRenderHint = true;
@@ -93,12 +95,16 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
     const result = super.attach(el);
     if (this._intersectionObserver !== null) {
       this._intersectionObserver.observe(result);
+      // NOTE(mpatwardhan): we do not call updateRenderHints here,
+      // because the dimensions are not known for freshly created
+      // elements. we will get non-zero dimensions in _intersectionObserver
+      // callback and then will call updateRenderHints.
     }
+
     if (this._enableDocumentVisibilityTurnOff) {
       this._documentVisibilityTurnOffCleanup = this._documentVisibilityTurnOffCleanup || setupDocumentVisibilityTurnOff(this);
     }
 
-    updateRenderHints(this);
     return result;
   }
 
@@ -106,10 +112,10 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
     const result = super.detach(el);
     const elements = Array.isArray(result) ? result : [result];
     elements.forEach(element => {
-      this._invisibleElements.delete(element);
       if (this._intersectionObserver !== null) {
         this._intersectionObserver.unobserve(element);
       }
+      this._invisibleElements.delete(element);
     });
 
     if (this._attachments.size === 0) {
@@ -240,9 +246,9 @@ function updateRenderHints(removeVideoTrack) {
   } else {
     const [{ clientHeight, clientWidth }] = visibleEls.sort((el1, el2) =>
       el2.clientHeight + el2.clientWidth - el1.clientHeight - el1.clientWidth - 1);
-    updatedRenderHint = { enabled: true, height: clientHeight, width: clientWidth };
+    updatedRenderHint = { enabled: true, renderDimensions: { height: clientHeight, width: clientWidth } };
   }
-  removeVideoTrack._log.info('updating render hint:', updatedRenderHint);
+  removeVideoTrack._log.debug('updating render hint:', updatedRenderHint);
   removeVideoTrack._setRenderHint(updatedRenderHint);
 }
 

--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -36,6 +36,7 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
   constructor(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, setPriority, setRenderHint, options) {
     const RealIntersectionObserver =  typeof IntersectionObserver !== 'undefined' ? IntersectionObserver : null;
     options = Object.assign({
+      idleTrackSwitchOff: true,
       enableDocumentVisibilityTurnOff: true,
       IntersectionObserver: RealIntersectionObserver,
     }, options);
@@ -49,6 +50,9 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
       _documentVisibilityTurnOffCleanup: {
         value: null,
         writable: true
+      },
+      _idleTrackSwitchOff: {
+        value: options.idleTrackSwitchOff,
       },
       _invisibleElements: {
         value: new WeakSet(),
@@ -225,6 +229,10 @@ function setupDocumentVisibilityTurnOff(removeVideoTrack) {
  * updates render hints
  */
 function updateRenderHints(removeVideoTrack) {
+  if (!removeVideoTrack._idleTrackSwitchOff) {
+    return;
+  }
+
   const visibleEls = removeVideoTrack._getAllAttachedElements().filter(el => !removeVideoTrack._invisibleElements.has(el));
   let updatedRenderHint;
   if (document.visibilityState !== 'visible' || visibleEls.length === 0) {

--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -94,6 +94,7 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
   attach(el) {
     const result = super.attach(el);
     if (this._intersectionObserver !== null) {
+      this._invisibleElements.add(result);
       this._intersectionObserver.observe(result);
       // NOTE(mpatwardhan): we do not call updateRenderHints here,
       // because the dimensions are not known for freshly created

--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -50,12 +50,20 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
         value: null,
         writable: true
       },
+      _invisibleElements: {
+        value: new WeakSet(),
+      },
       _intersectionObserver: {
         value: options.IntersectionObserver ? new options.IntersectionObserver(entries => {
           let shouldSetRenderHint = false;
           entries.forEach(entry => {
-            if (entry.target.isIntersecting !== entry.isIntersecting) {
-              entry.target.isIntersecting = entry.isIntersecting;
+            const wasVisible = !this._invisibleElements.has(entry.target);
+            if (wasVisible !== entry.isIntersecting) {
+              if (entry.isIntersecting) {
+                this._invisibleElements.delete(entry.target);
+              } else {
+                this._invisibleElements.add(entry.target);
+              }
               shouldSetRenderHint = true;
             }
           });
@@ -67,33 +75,47 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
     });
   }
 
+  /**
+   * @private
+   */
+  _start(dummyEl) {
+    const result = super._start.call(this, dummyEl);
+    updateRenderHints(this);
+    return result;
+  }
+
+
   attach(el) {
     const result = super.attach(el);
     if (this._intersectionObserver !== null) {
       this._intersectionObserver.observe(result);
     }
     if (this._enableDocumentVisibilityTurnOff) {
-      this._documentVisibilityTurnOffCleanup = this._documentVisibilityTurnOffCleanup
-        || setupDocumentVisibilityTurnOff(this);
+      this._documentVisibilityTurnOffCleanup = this._documentVisibilityTurnOffCleanup || setupDocumentVisibilityTurnOff(this);
     }
+
+    updateRenderHints(this);
     return result;
   }
 
   detach(el) {
     const result = super.detach(el);
-    if (this._intersectionObserver !== null) {
-      if (Array.isArray(result)) {
-        result.forEach(element => this._intersectionObserver.unobserve(element));
-      } else {
-        this._intersectionObserver.unobserve(result);
+    const elements = Array.isArray(result) ? result : [result];
+    elements.forEach(element => {
+      this._invisibleElements.delete(element);
+      if (this._intersectionObserver !== null) {
+        this._intersectionObserver.unobserve(element);
       }
-    }
+    });
+
     if (this._attachments.size === 0) {
-      if (this._enableDocumentVisibilityTurnOff) {
+      if (this._documentVisibilityTurnOffCleanup) {
         this._documentVisibilityTurnOffCleanup();
         this._documentVisibilityTurnOffCleanup = null;
       }
     }
+
+    updateRenderHints(this);
     return result;
   }
 
@@ -203,7 +225,7 @@ function setupDocumentVisibilityTurnOff(removeVideoTrack) {
  * updates render hints
  */
 function updateRenderHints(removeVideoTrack) {
-  const visibleEls = removeVideoTrack._getAllAttachedElements().filter(el => el.isIntersecting !== false);
+  const visibleEls = removeVideoTrack._getAllAttachedElements().filter(el => !removeVideoTrack._invisibleElements.has(el));
   let updatedRenderHint;
   if (document.visibilityState !== 'visible' || visibleEls.length === 0) {
     updatedRenderHint = { enabled: false };

--- a/lib/participant.js
+++ b/lib/participant.js
@@ -95,6 +95,9 @@ class Participant extends EventEmitter {
       _instanceId: {
         value: ++nInstances
       },
+      _idleTrackSwitchOff: {
+        value: options.idleTrackSwitchOff,
+      },
       _log: {
         value: log
       },
@@ -256,7 +259,7 @@ class Participant extends EventEmitter {
    * @private
    */
   _handleTrackSignalingEvents() {
-    const log = this._log;
+    const { _log: log, _idleTrackSwitchOff: idleTrackSwitchOff } = this;
     const self = this;
 
     if (this.state === 'disconnected') {
@@ -331,7 +334,7 @@ class Participant extends EventEmitter {
         return;
       }
 
-      const options = { log, name };
+      const options = { log, name, idleTrackSwitchOff };
       const setPriority = newPriority => participantSignaling.updateSubscriberTrackPriority(sid, newPriority);
       const setRenderHint = renderHint => participantSignaling.updateTrackRenderHint(sid, renderHint);
       const track = kind === 'data'

--- a/lib/room.js
+++ b/lib/room.js
@@ -67,6 +67,9 @@ class Room extends EventEmitter {
       _log: {
         value: log
       },
+      _idleTrackSwitchOff: {
+        value: options.idleTrackSwitchOff === true,
+      },
       _instanceId: {
         value: ++nInstances
       },
@@ -450,8 +453,8 @@ function rewriteLocalTrackIds(room, trackStats) {
  */
 
 function connectParticipant(room, participantSignaling) {
-  const log = room._log;
-  const participant = new RemoteParticipant(participantSignaling, { log });
+  const { _log: log, _idleTrackSwitchOff: idleTrackSwitchOff } = room;
+  const participant = new RemoteParticipant(participantSignaling, { log, idleTrackSwitchOff });
 
   log.info('A new RemoteParticipant connected:', participant);
   room._participants.set(participant.sid, participant);

--- a/lib/signaling/v2/renderhintssignaling.js
+++ b/lib/signaling/v2/renderhintssignaling.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const MediaSignaling = require('./mediasignaling');
+const { isDeepEqual } = require('../../util');
 
 let messageId = 1;
 class RenderHintsSignaling extends MediaSignaling {
@@ -93,9 +94,12 @@ class RenderHintsSignaling extends MediaSignaling {
       mspHint.render_dimension = renderHint.renderDimension;
     }
 
-    this._trackSidsToRenderHints.set(trackSid, mspHint);
-    this._dirtyTrackSids.add(trackSid);
-    this._sendHints();
+    const oldHint = this._trackSidsToRenderHints.get(trackSid);
+    if (!isDeepEqual(oldHint, mspHint)) {
+      this._trackSidsToRenderHints.set(trackSid, mspHint);
+      this._dirtyTrackSids.add(trackSid);
+      this._sendHints();
+    }
   }
 
   /**

--- a/lib/signaling/v2/renderhintssignaling.js
+++ b/lib/signaling/v2/renderhintssignaling.js
@@ -2,7 +2,6 @@
 'use strict';
 
 const MediaSignaling = require('./mediasignaling');
-const { SDMAX_FLATTEN_DELAY } = require('../../util/constants.js');
 
 let messageId = 1;
 class RenderHintsSignaling extends MediaSignaling {
@@ -95,12 +94,8 @@ class RenderHintsSignaling extends MediaSignaling {
     }
 
     this._trackSidsToRenderHints.set(trackSid, mspHint);
-    const needToQueueUpdate = this._dirtyTrackSids.size === 0;
     this._dirtyTrackSids.add(trackSid);
-
-    if (needToQueueUpdate) {
-      setTimeout(() => this._sendHints(), SDMAX_FLATTEN_DELAY);
-    }
+    this._sendHints();
   }
 
   /**

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -14,7 +14,6 @@ module.exports.WS_SERVER = (environment, region) => {
 module.exports.PUBLISH_MAX_ATTEMPTS = 5;
 module.exports.PUBLISH_BACKOFF_JITTER = 10;
 module.exports.PUBLISH_BACKOFF_MS = 20;
-module.exports.SDMAX_FLATTEN_DELAY = 100;
 
 /**
  * Returns the appropriate indefinite article ("a" | "an").

--- a/lib/util/validate.js
+++ b/lib/util/validate.js
@@ -15,6 +15,7 @@ function validateBandwidthProfile(bandwidthProfile) {
   }
   error = validateObject(bandwidthProfile.video, 'options.bandwidthProfile.video', [
     { prop: 'dominantSpeakerPriority', values: Object.values(trackPriority) },
+    { prop: 'idleTrackSwitchOff', type: 'boolean' },
     { prop: 'maxSubscriptionBitrate', type: 'number' },
     { prop: 'maxTracks', type: 'number' },
     { prop: 'mode', values: Object.values(subscriptionMode) },

--- a/test/integration/spec/bandwidthprofile.js
+++ b/test/integration/spec/bandwidthprofile.js
@@ -60,6 +60,7 @@ describe('BandwidthProfileOptions', function() {
           loggerName: 'Charlie',
           bandwidthProfile: {
             video: {
+              idleTrackSwitchOff: false,
               dominantSpeakerPriority: PRIORITY_STANDARD,
               maxTracks: 1
             }
@@ -169,6 +170,7 @@ describe('BandwidthProfileOptions', function() {
           testOptions: {
             bandwidthProfile: {
               video: {
+                idleTrackSwitchOff: false,
                 dominantSpeakerPriority,
                 ...trackLimitOptions
               }
@@ -282,7 +284,10 @@ describe('BandwidthProfileOptions', function() {
         tracks: [],
         loggerName: 'BobLogger',
         bandwidthProfile: {
-          video: { dominantSpeakerPriority: PRIORITY_STANDARD }
+          video: {
+            idleTrackSwitchOff: true,
+            dominantSpeakerPriority: PRIORITY_STANDARD
+          }
         },
       };
 
@@ -349,7 +354,10 @@ describe('BandwidthProfileOptions', function() {
         tracks: [],
         loggerName: 'BobLogger',
         bandwidthProfile: {
-          video: { dominantSpeakerPriority: PRIORITY_STANDARD }
+          video: {
+            idleTrackSwitchOff: false,
+            dominantSpeakerPriority: PRIORITY_STANDARD
+          }
         },
       };
 

--- a/test/integration/spec/bandwidthprofile.js
+++ b/test/integration/spec/bandwidthprofile.js
@@ -321,7 +321,7 @@ describe('BandwidthProfileOptions', function() {
       await assertMediaFlow(bobRoom, true, `was expecting media flow: ${roomSid}`);
     });
 
-    it('Track turns off  when another video element is attached', async () => {
+    it('Track stays on when another video element is attached', async () => {
       videoElement2 = aliceRemoteTrack.attach();
       document.body.appendChild(videoElement2);
       await waitFor(trackSwitchedOn(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch on: ${roomSid}`);

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -374,7 +374,11 @@ describe('LocalTrackPublication', function() {
         [, thisRoom, thoseRooms] = await setup({
           testOptions: {
             bandwidthProfile: {
-              video: { maxTracks: 1, dominantSpeakerPriority: 'low' }
+              video: {
+                idleTrackSwitchOff: false,
+                maxTracks: 1,
+                dominantSpeakerPriority: 'low'
+              }
             },
             tracks: [dataTrack]
           },
@@ -516,7 +520,11 @@ describe('LocalTrackPublication', function() {
           const { roomSid, aliceRoom, bobRoom, bobLocal, bobRemote } = await setupAliceAndBob({
             aliceOptions: {
               bandwidthProfile: {
-                video: { maxTracks: 1, dominantSpeakerPriority: 'low' }
+                video: {
+                  idleTrackSwitchOff: false,
+                  maxTracks: 1,
+                  dominantSpeakerPriority: 'low'
+                }
               },
               tracks: []
             },
@@ -624,7 +632,11 @@ describe('LocalTrackPublication', function() {
       const { roomSid, aliceRoom, bobRoom, bobLocal, bobRemote } = await setupAliceAndBob({
         aliceOptions: {
           bandwidthProfile: {
-            video: { maxTracks: 1, dominantSpeakerPriority: 'low' }
+            video: {
+              idleTrackSwitchOff: false,
+              maxTracks: 1,
+              dominantSpeakerPriority: 'low'
+            }
           },
           tracks: []
         },

--- a/test/integration/spec/remotetracks.js
+++ b/test/integration/spec/remotetracks.js
@@ -57,7 +57,11 @@ describe('RemoteVideoTrack', function() {
       [, thisRoom, thoseRooms] = await waitFor(setup({
         testOptions: {
           bandwidthProfile: {
-            video: { maxTracks: 1,  dominantSpeakerPriority: 'low' }
+            video: {
+              idleTrackSwitchOff: false,
+              maxTracks: 1,
+              dominantSpeakerPriority: 'low'
+            }
           },
           tracks: [dataTrack]
         },
@@ -200,7 +204,11 @@ describe('RemoteVideoTrack', function() {
         tracks: [],
         logLevel: 'warn',
         bandwidthProfile: {
-          video: { maxTracks: 1,  dominantSpeakerPriority: 'low' }
+          video: {
+            idleTrackSwitchOff: false,
+            maxTracks: 1,
+            dominantSpeakerPriority: 'low'
+          }
         },
       }, defaults);
 

--- a/test/integration/spec/room.js
+++ b/test/integration/spec/room.js
@@ -603,7 +603,7 @@ describe('Room', function() {
     before(async () => {
       let thoseRooms;
       [, aliceRoom, thoseRooms] = await setup({
-        testOptions: { tracks: [], bandwidthProfile: { video: { maxTracks: 1 } } },
+        testOptions: { tracks: [], bandwidthProfile: { video: { maxTracks: 1, idleTrackSwitchOff: false } } },
         otherOptions: { tracks: [] },
         participantNames: ['Alice', 'Bob', 'Charlie'],
         nTracks: 0

--- a/tsdef/twilio-video-tests.ts
+++ b/tsdef/twilio-video-tests.ts
@@ -236,6 +236,7 @@ async function initRoom() {
     maxVideoBitrate: 200,
     bandwidthProfile: {
       video: {
+        idleTrackSwitchOff: false,
         dominantSpeakerPriority: 'high',
         renderDimensions: {
           low: {

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -98,6 +98,7 @@ export interface VideoRenderDimensions {
 }
 
 export interface VideoBandwidthProfileOptions {
+  idleTrackSwitchOff?: boolean;
   dominantSpeakerPriority?: Track.Priority;
   maxSubscriptionBitrate?: number;
   maxTracks?: number;


### PR DESCRIPTION
Changes in this PR:

- updated the way render hints are sent to VMS - no more waiting for 100ms. as agreed [here](https://docs.google.com/document/d/11zgCOIYux9vwlNdzd-smrGgnLQf3x0863N-WQ7zzSq8/edit#heading=h.erhtiue0ftnq) to send update immediately if no update is in flight already.  https://github.com/twilio/twilio-video.js/pull/1408/commits/8d8aa1bdb557c331159aa5a76e74bace77784696
- VIDEO-3742: added a property `idleTrackSwitchOff` to bandwidthProfile.video object. (in the same commit as above https://github.com/twilio/twilio-video.js/pull/1408/commits/8d8aa1bdb557c331159aa5a76e74bace77784696 )
- typescript definitions and documentation for the new property: https://github.com/twilio/twilio-video.js/pull/1408/commits/7c21df010caeb830e2b45240d2e8e10da558ce2c

- VIDEO-4275: send initial update after track is started - this ensures that if no video elements were attached after track `started` was fired, we will request track switch off.  https://github.com/twilio/twilio-video.js/pull/1408/commits/2c3bc79bd912b44afc47f5b2bf8521dec82a8ee9

- Fixed a bug  where detach did not cause track switch off (now we send updates on `detach`).
- Also added code to no-op the updates if hint  state did not change. https://github.com/twilio/twilio-video.js/pull/1408/commits/afc015a15062aa7485ff71beb88b748fa17289df
- A small circleci workflow change to allow for parallelism in custom workflows. 
https://github.com/twilio/twilio-video.js/pull/1408/commits/857e26becefdfff27829730c3628bbdd283979db
- maintain a WeakSet of invisible elements instead of adding `isIntersecting` property into video elements.
- added bunch of integration tests to verify track attach/detach behavior.


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
