### PR TITLE
Fix publishTrack types

### DIFF
--- a/tsdef/LocalParticipant.d.ts
+++ b/tsdef/LocalParticipant.d.ts
@@ -1,4 +1,4 @@
-import { EncodingParameters, LocalTrack, LocalTrackPublishOptions, NetworkQualityConfiguration } from './types';
+import { EncodingParameters, LocalTrack, LocalTrackPublishOptions, MediaStreamTrackPublishOptions, NetworkQualityConfiguration } from './types';
 import { LocalAudioTrackPublication } from './LocalAudioTrackPublication';
 import { LocalDataTrackPublication } from './LocalDataTrackPublication';
 import { LocalTrackPublication } from './LocalTrackPublication';
@@ -15,7 +15,8 @@ export class LocalParticipant extends Participant {
   videoTracks: Map<Track.SID, LocalVideoTrackPublication>;
   signalingRegion: string;
 
-  publishTrack(track: LocalTrack | MediaStreamTrack, options?: LocalTrackPublishOptions): Promise<LocalTrackPublication>;
+  publishTrack(track: LocalTrack, options?: LocalTrackPublishOptions): Promise<LocalTrackPublication>;
+  publishTrack(track: MediaStreamTrack, options?: MediaStreamTrackPublishOptions): Promise<LocalTrackPublication>;
   publishTracks(tracks: Array<LocalTrack | MediaStreamTrack>): Promise<LocalTrackPublication[]>;
   setNetworkQualityConfiguration(networkQualityConfiguration: NetworkQualityConfiguration): this;
   setParameters(encodingParameters?: EncodingParameters | null): this;


### PR DESCRIPTION
According to the [docs](https://media.twiliocdn.com/sdk/js/video/releases/2.13.0/docs/LocalParticipant.html), `publishTrack` method should accept different options depending on the first argument's type.

Currently, it does only accept `LocalTrackPublishOptions` and not `MediaStreamTrackPublishOptions` if mediaTrack was passed. This PR fixes the issue.


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
