### PR TITLE
Fix unresolved Promise getting track publication

### DIFF
--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -294,6 +294,7 @@ class LocalParticipant extends Participant {
 
         const sid = trackSignaling.sid;
         if (!sid) {
+          reject(new Error(`No SID for track publication for ${localTrack}`));
           return;
         }
 


### PR DESCRIPTION
This small fix addresses a theoretical scenario where the Promise returned from `_getOrCreateLocalTrackPublication` might never be resolved or rejected.

I'm not sure of the relevance of the scenario where `trackSignaling.sid` would be falsy, so I just provided a generic error message. A maintainer may want to provide a more helpful contextual error here.

Rejecting the Promise before calling `return;` is vital for all codepaths in a Promise constructor, or else any code awaiting the Promise will never resume.

Although this fix may possibly address #963, it's hard to say for certain without some sort of isolated reproduction, which has been hard to do as it seems to crop up mostly in response to changes in device power state for me. #963 still might not be fixed by this change if it turns out that the `'updated'` event is simply never fired from `trackSignaling` (which would also cause this Promise to never resolve, as all resolution paths are tied to that event).

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
