### PR TITLE
video_3739: use ResizeObserver to report video element sizes.

### DIFF
--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -3,7 +3,7 @@
 const mixinRemoteMediaTrack = require('./remotemediatrack');
 const VideoTrack = require('./videotrack');
 const documentVisibilityMonitor = require('../../util/documentvisibilitymonitor.js');
-const NullIntersectionObserver = require('../../util/nullintersectionobserver.js');
+const { NullIntersectionObserver, NullResizeObserver } = require('../../util/nullobserver.js');
 
 const RemoteMediaVideoTrack = mixinRemoteMediaTrack(VideoTrack);
 
@@ -39,6 +39,7 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
       idleTrackSwitchOff: true,
       enableDocumentVisibilityTurnOff: true,
       IntersectionObserver: typeof IntersectionObserver !== 'undefined' ? IntersectionObserver : NullIntersectionObserver,
+      ResizeObserver: typeof ResizeObserver !== 'undefined' ? ResizeObserver : NullResizeObserver,
     }, options);
 
     super(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, setPriority, setRenderHint, options);
@@ -56,6 +57,17 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
       },
       _invisibleElements: {
         value: new WeakSet(),
+      },
+      _resizeObserver: {
+        value: new options.ResizeObserver(entries => {
+          // NOTE(mpatwardhan): we ignore elements in _invisibleElements
+          // to ensure that ResizeObserver does not end-up turning off a track when a fresh Video element is
+          // attached and IntersectionObserver has not had its callback executed yet.
+          const visibleElementResized = entries.find(entry => !this._invisibleElements.has(entry.target));
+          if (visibleElementResized) {
+            updateRenderHints(this);
+          }
+        })
       },
       _intersectionObserver: {
         value: new options.IntersectionObserver(entries => {
@@ -95,6 +107,8 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
     const result = super.attach(el);
     this._invisibleElements.add(result);
     this._intersectionObserver.observe(result);
+    this._resizeObserver.observe(result);
+
     // NOTE(mpatwardhan): we do not call updateRenderHints here,
     // because the dimensions are not known for freshly created
     // elements. we will get non-zero dimensions in _intersectionObserver
@@ -112,6 +126,7 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
     const elements = Array.isArray(result) ? result : [result];
     elements.forEach(element => {
       this._intersectionObserver.unobserve(element);
+      this._resizeObserver.unobserve(element);
       this._invisibleElements.delete(element);
     });
 
@@ -243,7 +258,7 @@ function updateRenderHints(removeVideoTrack) {
   } else {
     const [{ clientHeight, clientWidth }] = visibleEls.sort((el1, el2) =>
       el2.clientHeight + el2.clientWidth - el1.clientHeight - el1.clientWidth - 1);
-    updatedRenderHint = { enabled: true, renderDimensions: { height: clientHeight, width: clientWidth } };
+    updatedRenderHint = { enabled: true, renderDimension: { height: clientHeight, width: clientWidth } };
   }
   removeVideoTrack._log.debug('updating render hint:', updatedRenderHint);
   removeVideoTrack._setRenderHint(updatedRenderHint);

--- a/lib/util/nullobserver.js
+++ b/lib/util/nullobserver.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 'use strict';
 
-class NullIntersectionObserver {
+class NullObserver {
   constructor(callback) {
     Object.defineProperties(this, {
       _callback: {
@@ -35,4 +35,8 @@ class NullIntersectionObserver {
   }
 }
 
-module.exports = NullIntersectionObserver;
+class NullIntersectionObserver extends NullObserver { }
+
+class NullResizeObserver extends NullObserver { }
+
+module.exports = { NullIntersectionObserver, NullResizeObserver };

--- a/lib/util/nullobserver.js
+++ b/lib/util/nullobserver.js
@@ -10,14 +10,10 @@ class NullObserver {
     });
   }
 
-  observe(videoEl) {
-    const visibleEntry = this._makeFakeEntry(videoEl, true);
-    this._callback([visibleEntry]);
+  observe() {
   }
 
-  unobserve(videoEl) {
-    const invisibleEntry = this._makeFakeEntry(videoEl, false);
-    this._callback([invisibleEntry]);
+  unobserve() {
   }
 
   makeVisible(videoEl) {
@@ -37,6 +33,12 @@ class NullObserver {
 
 class NullIntersectionObserver extends NullObserver { }
 
-class NullResizeObserver extends NullObserver { }
+class NullResizeObserver extends NullObserver {
+  resize(videoEl) {
+    const entry = this._makeFakeEntry(videoEl, true);
+    this._callback([entry]);
+  }
+}
+
 
 module.exports = { NullIntersectionObserver, NullResizeObserver };

--- a/test/unit/spec/media/track/remotemediatrack.js
+++ b/test/unit/spec/media/track/remotemediatrack.js
@@ -10,7 +10,7 @@ const RemoteAudioTrack = require('../../../../../lib/media/track/remoteaudiotrac
 const RemoteVideoTrack = require('../../../../../lib/media/track/remotevideotrack');
 const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
 const documentVisibilityMonitor = require('../../../../../lib/util/documentvisibilitymonitor');
-const NullIntersectionObserver = require('../../../../../lib/util/nullintersectionobserver');
+const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserver');
 
 [
   ['audio', RemoteAudioTrack],

--- a/test/unit/spec/media/track/remotevideotrack.js
+++ b/test/unit/spec/media/track/remotevideotrack.js
@@ -8,7 +8,7 @@ const MediaTrackReceiver = require('../../../../../lib/media/track/receiver');
 const RemoteVideoTrack = require('../../../../../lib/media/track/remotevideotrack');
 const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
 const documentVisibilityMonitor = require('../../../../../lib/util/documentvisibilitymonitor');
-const NullIntersectionObserver = require('../../../../../lib/util/nullintersectionobserver');
+const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserver');
 
 const kind = 'video';
 const RemoteTrack = RemoteVideoTrack;
@@ -116,7 +116,7 @@ describe('RemoteVideoTrack', () => {
 
       it('_setRenderHint gets called with { enable: true }', () => {
         sinon.assert.calledWith(setRenderHintSpy, sinon.match.has('enabled', true));
-        sinon.assert.calledWith(setRenderHintSpy, sinon.match.has('renderDimensions', { height: sinon.match.any, width: sinon.match.any }));
+        sinon.assert.calledWith(setRenderHintSpy, sinon.match.has('renderDimension', { height: sinon.match.any, width: sinon.match.any }));
       });
     });
 
@@ -148,7 +148,7 @@ describe('RemoteVideoTrack', () => {
       it('visible, _setRenderHint gets called with { enable: true }', () => {
         track._intersectionObserver.makeVisible(el);
         sinon.assert.calledWith(setRenderHintSpy, sinon.match.has('enabled', true));
-        sinon.assert.calledWith(setRenderHintSpy, sinon.match.has('renderDimensions', { height: sinon.match.any, width: sinon.match.any }));
+        sinon.assert.calledWith(setRenderHintSpy, sinon.match.has('renderDimension', { height: sinon.match.any, width: sinon.match.any }));
       });
     });
   });

--- a/test/unit/spec/media/track/remotevideotrack.js
+++ b/test/unit/spec/media/track/remotevideotrack.js
@@ -8,10 +8,9 @@ const MediaTrackReceiver = require('../../../../../lib/media/track/receiver');
 const RemoteVideoTrack = require('../../../../../lib/media/track/remotevideotrack');
 const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
 const documentVisibilityMonitor = require('../../../../../lib/util/documentvisibilitymonitor');
-const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserver');
+const { NullIntersectionObserver: IntersectionObserver, NullResizeObserver: ResizeObserver } = require('../../../../../lib/util/nullobserver');
 
 const kind = 'video';
-const RemoteTrack = RemoteVideoTrack;
 describe('RemoteVideoTrack', () => {
   describe('enableDocumentVisibilityTurnOff', () => {
     let addEventListenerStub;
@@ -37,7 +36,7 @@ describe('RemoteVideoTrack', () => {
         let track;
         before(() => {
           document.visibilityState = 'visible';
-          track = makeTrack({ id: 'foo', sid: 'bar', kind, isSwitchedOff: false, isEnabled: true, options: { enableDocumentVisibilityTurnOff: false }, RemoteTrack });
+          track = makeTrack({ id: 'foo', sid: 'bar', kind, isSwitchedOff: false, isEnabled: true, options: { enableDocumentVisibilityTurnOff: false } });
         });
 
         it('does not register for document visibility change', () => {
@@ -50,7 +49,7 @@ describe('RemoteVideoTrack', () => {
         let track;
         before(() => {
           document.visibilityState = 'visible';
-          track = makeTrack({ id: 'foo', sid: 'bar', kind, isSwitchedOff: false, isEnabled: true, options: { enableDocumentVisibilityTurnOff: true }, RemoteTrack });
+          track = makeTrack({ id: 'foo', sid: 'bar', kind, isSwitchedOff: false, isEnabled: true, options: { enableDocumentVisibilityTurnOff: true } });
         });
 
         it('sets enableDocumentVisibilityTurnOff to true', () => {
@@ -92,9 +91,9 @@ describe('RemoteVideoTrack', () => {
       global.document = global.document || new Document();
       el = document.createElement('video');
       setRenderHintSpy = sinon.spy();
-      track = makeTrack({ id: 'foo', sid: 'bar', kind, isSwitchedOff: false, setRenderHint: setRenderHintSpy, isEnabled: true, options: { IntersectionObserver: NullIntersectionObserver }, RemoteTrack });
-      observeSpy = sinon.spy(NullIntersectionObserver.prototype, 'observe');
-      unobserveSpy = sinon.spy(NullIntersectionObserver.prototype, 'unobserve');
+      track = makeTrack({ id: 'foo', sid: 'bar', kind, isSwitchedOff: false, setRenderHint: setRenderHintSpy, isEnabled: true, options: { IntersectionObserver } });
+      observeSpy = sinon.spy(IntersectionObserver.prototype, 'observe');
+      unobserveSpy = sinon.spy(IntersectionObserver.prototype, 'unobserve');
     });
 
     after(() => {
@@ -112,12 +111,13 @@ describe('RemoteVideoTrack', () => {
 
       it('IntersectionObserver observe is called', () => {
         sinon.assert.callCount(observeSpy, 1);
+        sinon.assert.calledWith(observeSpy, el);
       });
 
-      it('_setRenderHint gets called with { enable: true }', () => {
-        sinon.assert.calledWith(setRenderHintSpy, sinon.match.has('enabled', true));
-        sinon.assert.calledWith(setRenderHintSpy, sinon.match.has('renderDimension', { height: sinon.match.any, width: sinon.match.any }));
-      });
+      // it('_setRenderHint gets called with { enable: true } when observe call', () => {
+      //   sinon.assert.calledWith(setRenderHintSpy, sinon.match.has('enabled', true));
+      //   sinon.assert.calledWith(setRenderHintSpy, sinon.match.has('renderDimension', { height: sinon.match.any, width: sinon.match.any }));
+      // });
     });
 
     context('when an element is detached', () => {
@@ -127,6 +127,7 @@ describe('RemoteVideoTrack', () => {
 
       it('IntersectionObserver unobserve is called', () => {
         sinon.assert.callCount(unobserveSpy, 1);
+        sinon.assert.calledWith(unobserveSpy, el);
       });
 
       it(' _setRenderHint gets called with { enable: false }', () => {
@@ -140,27 +141,104 @@ describe('RemoteVideoTrack', () => {
         setRenderHintSpy.reset();
       });
 
-      it('invisible, _setRenderHint gets called with { enable: false }', () => {
-        track._intersectionObserver.makeInvisible(el);
-        sinon.assert.calledWith(setRenderHintSpy, { enabled: false });
-      });
-
       it('visible, _setRenderHint gets called with { enable: true }', () => {
         track._intersectionObserver.makeVisible(el);
         sinon.assert.calledWith(setRenderHintSpy, sinon.match.has('enabled', true));
         sinon.assert.calledWith(setRenderHintSpy, sinon.match.has('renderDimension', { height: sinon.match.any, width: sinon.match.any }));
       });
+
+      it('invisible, _setRenderHint gets called with { enable: false }', () => {
+        track._intersectionObserver.makeInvisible(el);
+        sinon.assert.calledWith(setRenderHintSpy, { enabled: false });
+      });
+
+    });
+  });
+
+  describe('ResizeObserver', () => {
+    let track;
+    let el;
+    let observeSpy;
+    let unobserveSpy;
+    let setRenderHintSpy;
+
+    before(() => {
+      global.document = global.document || new Document();
+      el = document.createElement('video');
+      setRenderHintSpy = sinon.spy();
+      track = makeTrack({ id: 'foo', sid: 'bar', kind, isSwitchedOff: false, setRenderHint: setRenderHintSpy, isEnabled: true, options: { ResizeObserver } });
+      observeSpy = sinon.spy(ResizeObserver.prototype, 'observe');
+      unobserveSpy = sinon.spy(ResizeObserver.prototype, 'unobserve');
+    });
+
+    after(() => {
+      observeSpy.restore();
+      unobserveSpy.restore();
+      if (global.document instanceof Document && kind === 'video') {
+        delete global.document;
+      }
+    });
+
+    context('when an element is attached', () => {
+      beforeEach(() => {
+        track.attach(el);
+      });
+
+      it('ResizeObserver.observe is called', () => {
+        sinon.assert.callCount(observeSpy, 1);
+        sinon.assert.calledWith(observeSpy, el);
+      });
+    });
+
+    context('when an element is detached', () => {
+      beforeEach(() => {
+        track.detach(el);
+      });
+
+      it('ResizeObserver.unobserve is called', () => {
+        sinon.assert.callCount(unobserveSpy, 1);
+        sinon.assert.calledWith(unobserveSpy, el);
+      });
+    });
+
+    context('detects size change of visible element', () => {
+      before(() => {
+        track.attach(el);
+        track._intersectionObserver.makeVisible(el);
+        el.clientWidth = 100;
+        el.clientHeight = 100;
+        setRenderHintSpy.reset();
+      });
+
+      it('_setRenderHint gets called with { enable: true }', () => {
+        track._resizeObserver.resize(el);
+        sinon.assert.calledWith(setRenderHintSpy, { enabled: true, renderDimension: { height: 100, width: 100 } });
+      });
+    });
+
+    context('detects size change of invisible element', () => {
+      before(() => {
+        track.attach(el);
+        track._intersectionObserver.makeInvisible(el);
+        el.clientWidth = 100;
+        el.clientHeight = 100;
+        setRenderHintSpy.reset();
+      });
+
+      it('_setRenderHint does not get called', () => {
+        track._resizeObserver.resize(el);
+        sinon.assert.notCalled(setRenderHintSpy);
+      });
     });
   });
 });
 
-function makeTrack({ id, sid, kind, isEnabled, options, RemoteTrack, setPriority, setRenderHint, isSwitchedOff }) {
+function makeTrack({ id, sid, kind, isEnabled, options, setPriority, setRenderHint, isSwitchedOff }) {
   const emptyFn = () => undefined;
   setPriority = setPriority || emptyFn;
   setRenderHint = setRenderHint || emptyFn;
   isSwitchedOff = !!isSwitchedOff;
   const mediaStreamTrack = new FakeMediaStreamTrack(kind);
   const mediaTrackReceiver = new MediaTrackReceiver(id, mediaStreamTrack);
-  options.IntersectionObserver = NullIntersectionObserver;
-  return new RemoteTrack(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, setPriority, setRenderHint, options);
+  return new RemoteVideoTrack(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, setPriority, setRenderHint, options);
 }


### PR DESCRIPTION
This change adds ResizeObserver - RemoteVideoTrack now watches the video element as they resize and report the size to VMS.

- [x] implementation
- [x] unit tests
- [ ] integration tests

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x]  I acknowledge that all my contributions will be made under the project's license.
