### PR TITLE
Adding MediaStreamTrackOptions to the LocalParticipant publishTrack m…

### DIFF
--- a/tsdef/LocalParticipant.d.ts
+++ b/tsdef/LocalParticipant.d.ts
@@ -1,4 +1,4 @@
-import { EncodingParameters, LocalTrack, LocalTrackPublishOptions, NetworkQualityConfiguration } from './types';
+import { EncodingParameters, LocalTrack, LocalTrackPublishOptions, MediaStreamTrackPublishOptions, NetworkQualityConfiguration } from './types';
 import { LocalAudioTrackPublication } from './LocalAudioTrackPublication';
 import { LocalDataTrackPublication } from './LocalDataTrackPublication';
 import { LocalTrackPublication } from './LocalTrackPublication';
@@ -15,7 +15,7 @@ export class LocalParticipant extends Participant {
   videoTracks: Map<Track.SID, LocalVideoTrackPublication>;
   signalingRegion: string;
 
-  publishTrack(track: LocalTrack | MediaStreamTrack, options?: LocalTrackPublishOptions): Promise<LocalTrackPublication>;
+  publishTrack(track: LocalTrack | MediaStreamTrack, options?: LocalTrackPublishOptions | MediaStreamTrackPublishOptions): Promise<LocalTrackPublication>;
   publishTracks(tracks: Array<LocalTrack | MediaStreamTrack>): Promise<LocalTrackPublication[]>;
   setNetworkQualityConfiguration(networkQualityConfiguration: NetworkQualityConfiguration): this;
   setParameters(encodingParameters?: EncodingParameters | null): this;

--- a/tsdef/LocalParticipant.d.ts
+++ b/tsdef/LocalParticipant.d.ts
@@ -15,7 +15,8 @@ export class LocalParticipant extends Participant {
   videoTracks: Map<Track.SID, LocalVideoTrackPublication>;
   signalingRegion: string;
 
-  publishTrack(track: LocalTrack | MediaStreamTrack, options?: LocalTrackPublishOptions | MediaStreamTrackPublishOptions): Promise<LocalTrackPublication>;
+  publishTrack(track: LocalTrack, options?: LocalTrackPublishOptions): Promise<LocalTrackPublication>;
+  publishTrack(track: MediaStreamTrack, options?: MediaStreamTrackPublishOptions): Promise<LocalTrackPublication>;
   publishTracks(tracks: Array<LocalTrack | MediaStreamTrack>): Promise<LocalTrackPublication[]>;
   setNetworkQualityConfiguration(networkQualityConfiguration: NetworkQualityConfiguration): this;
   setParameters(encodingParameters?: EncodingParameters | null): this;

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -148,6 +148,7 @@ export interface LocalTrackPublishOptions {
 }
 
 export interface MediaStreamTrackPublishOptions {
+  name?: string;
   priority?: Track.Priority;
 }
 

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -148,7 +148,6 @@ export interface LocalTrackPublishOptions {
 }
 
 export interface MediaStreamTrackPublishOptions {
-  name?: string;
   priority?: Track.Priority;
 }
 

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -147,8 +147,7 @@ export interface LocalTrackPublishOptions {
   priority?: Track.Priority;
 }
 
-export interface MediaStreamTrackPublishOptions {
-  name?: string;
+export interface MediaStreamTrackPublishOptions extends LocalTrackOptions{
   priority?: Track.Priority;
 }
 


### PR DESCRIPTION
JIRA Ticket: [VIDEO-4460](https://issues.corp.twilio.com/browse/VIDEO-4460)

This is a PR which addresses an [issue](https://github.com/twilio/twilio-video.js/pull/1410) with our Type definitions. I have since added `MediaStreamTrackOptions` to the `publishTrack` method on the `LocalParticipant`. I have also double checked that the shape of `MediaStreamTrackOptions` should match the shape of `LocalTrackPublishOptions` so there is a fix for that as well.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
