### PR TITLE
video-4493: clear render hints when track unpublished

### DIFF
--- a/lib/participant.js
+++ b/lib/participant.js
@@ -339,7 +339,11 @@ class Participant extends EventEmitter {
 
       const options = { log, name, idleTrackSwitchOff, renderHints };
       const setPriority = newPriority => participantSignaling.updateSubscriberTrackPriority(sid, newPriority);
-      const setRenderHint = renderHint => participantSignaling.updateTrackRenderHint(sid, renderHint);
+      const setRenderHint = renderHint => {
+        if (signaling.isSubscribed) {
+          participantSignaling.updateTrackRenderHint(sid, renderHint);
+        }
+      };
       const track = kind === 'data'
         ? new RemoteTrack(sid, trackTransceiver, options)
         : new RemoteTrack(sid, trackTransceiver, isEnabled, isSwitchedOff, setPriority, setRenderHint, options);

--- a/lib/remoteparticipant.js
+++ b/lib/remoteparticipant.js
@@ -128,6 +128,7 @@ class RemoteParticipant extends Participant {
    * @returns {?RemoteTrackPublication}
    */
   _removeTrackPublication(publication) {
+    this._signaling.clearTrackHint(publication.trackSid);
     const removedPublication = super._removeTrackPublication(publication);
     if (!removedPublication) {
       return null;

--- a/lib/signaling/v2/remoteparticipant.js
+++ b/lib/signaling/v2/remoteparticipant.js
@@ -14,9 +14,10 @@ class RemoteParticipantV2 extends RemoteParticipantSignaling {
    * @param {function(Track.SID): boolean} getInitialTrackSwitchOffState
    * @param {function(Track.SID, Track.Priority): boolean} setPriority
    * @param {function(Track.SID, ClientRenderHint): Promise<void>} setRenderHint
+   * @param {function(Track.SID): void} clearTrackHint
    * @param {object} [options]
    */
-  constructor(participantState, getInitialTrackSwitchOffState, setPriority, setRenderHint, options) {
+  constructor(participantState, getInitialTrackSwitchOffState, setPriority, setRenderHint, clearTrackHint, options) {
     super(participantState.sid, participantState.identity);
 
     options = Object.assign({
@@ -39,6 +40,9 @@ class RemoteParticipantV2 extends RemoteParticipantSignaling {
       },
       updateTrackRenderHint: {
         value: (trackSid, renderHint) => setRenderHint(trackSid, renderHint)
+      },
+      clearTrackHint: {
+        value: trackSid => clearTrackHint(trackSid)
       },
       revision: {
         enumerable: true,

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -268,7 +268,8 @@ class RoomV2 extends RoomSignaling {
         participantState,
         trackSid => this._getInitialTrackSwitchOffState(trackSid),
         (trackSid, priority) => this._trackPrioritySignaling.sendTrackPriorityUpdate(trackSid, 'subscribe', priority),
-        (trackSid, hint) => this._renderHintsSignaling.setTrackHint(trackSid, hint)
+        (trackSid, hint) => this._renderHintsSignaling.setTrackHint(trackSid, hint),
+        trackSid => this._renderHintsSignaling.clearTrackHint(trackSid)
       );
       participant.on('stateChanged', function stateChanged(state) {
         if (state === 'disconnected') {

--- a/test/unit/spec/remoteparticipant.js
+++ b/test/unit/spec/remoteparticipant.js
@@ -1571,6 +1571,7 @@ function makeSignaling(options) {
   signaling.identity = options.identity;
   signaling.state = options.state;
   signaling.tracks = options.trackSignalings || [];
+  signaling.clearTrackHint =  sinon.spy();
   return signaling;
 }
 

--- a/test/unit/spec/signaling/v2/remoteparticipant.js
+++ b/test/unit/spec/signaling/v2/remoteparticipant.js
@@ -905,6 +905,7 @@ function makeTest(options) {
   options.getInitialTrackSwitchOffState = options.getInitialTrackSwitchOffState || sinon.spy(() => { return false; });
   options.setRenderHints = options.setRenderHints || sinon.spy(() => { return false; });
   options.setPriority = options.setPriority || sinon.spy(() => { return false; });
+  options.clearRenderHint = options.clearRenderHint || sinon.spy(() => { return false; });
   options.participant = options.participant || makeRemoteParticipantV2(options);
 
   options.state = revision => {
@@ -948,7 +949,7 @@ RemoteParticipantStateBuilder.prototype.setTracks = function setTracks(tracks) {
 };
 
 function makeRemoteParticipantV2(options) {
-  return new RemoteParticipantV2(options, options.getInitialTrackSwitchOffState, options.setPriority, options.setRenderHints, options);
+  return new RemoteParticipantV2(options, options.getInitialTrackSwitchOffState, options.setPriority, options.setRenderHints, options.clearRenderHint, options);
 }
 
 function makeRemoteTrackPublicationV2Constructor(testOptions) {


### PR DESCRIPTION
we must not send hints about tracks that are no more valid - This change ensure that 1) we do not send renderhints for the tracks we are not subscribed to 2) clear any cached hints when track is removed.
  
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
