### PR TITLE
video-4521: renderdimensions=auto

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -284,9 +284,9 @@ function connect(token, options) {
   }
 
   // Note(mpatwardhan): "idleTrackSwitchOff" is an Opt-out option if "bandwidthProfile" is enabled.
-  options.idleTrackSwitchOff =  false;
+  options.idleTrackSwitchOff = false;
   // Note(mpatwardhan): renderHints are enabled if "renderDimensions" is set to "auto" or is unspecified
-  options.renderHints =  false;
+  options.renderHints = false;
   if (options.bandwidthProfile) {
     options.idleTrackSwitchOff = true;
     options.renderHints = true;

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -283,10 +283,9 @@ function connect(token, options) {
     return CancelablePromise.reject(error);
   }
 
-
-  // Note(mpatwardhan): "idleTrackSwitchOff" and "renderHints" are to be Opt-out options
-  //  if "bandwidthProfile" is enabled
+  // Note(mpatwardhan): "idleTrackSwitchOff" is an Opt-out option if "bandwidthProfile" is enabled.
   options.idleTrackSwitchOff =  false;
+  // Note(mpatwardhan): renderHints are enabled if "renderDimensions" is set to "auto" or is unspecified
   options.renderHints =  false;
   if (options.bandwidthProfile) {
     options.idleTrackSwitchOff = true;
@@ -295,7 +294,7 @@ function connect(token, options) {
       if (options.bandwidthProfile.video.idleTrackSwitchOff === false) {
         options.idleTrackSwitchOff = false;
       }
-      if (options.bandwidthProfile.video.renderHints === false) {
+      if (options.bandwidthProfile.video.renderDimensions && options.bandwidthProfile.video.renderDimensions !== 'auto') {
         options.renderHints = false;
       }
     }
@@ -470,9 +469,6 @@ function connect(token, options) {
  *    {@link RemoteVideoTrack} when no video element is attached to the track, or when all attached video
  *    elements of the track are not visible, or when the Document is not visible. This is enabled by default
  *    if <code>bandwidthProfile</code> is specified in {@link ConnectOptions}.
-* @property {boolean} [renderHints] -  Optional parameter that when enabled regulates the bandwidth and
- *    quality of a {@link RemoteVideoTrack} based on the dimensions of the largest <video> element attached to it.
- *    This is enabled by default if <code>bandwidthProfile</code> is specified in {@link ConnectOptions}.
  * @property {number} [maxTracks] - Optional parameter to specify the maximum number of visible
  *   {@link RemoteVideoTrack}s, which will be selected based on {@link Track.Priority} and an N-Loudest
  *   policy. By default there are no limits on the number of visible {@link RemoteVideoTrack}s.
@@ -480,16 +476,18 @@ function connect(token, options) {
  * @property {BandwidthProfileMode} [mode="grid"] - Optional parameter to specify how the {@link RemoteVideoTrack}s'
  *   TrackPriority values are mapped to bandwidth allocation in Group Rooms. This defaults to "grid",
  *   which results in equal bandwidth share allocation to all {@link RemoteVideoTrack}s.
- * @property {VideoRenderDimensions} [renderDimensions] - Optional parameter to specify the desired
- *   render dimensions of {@link RemoteVideoTrack}s based on {@link Track.Priority} and the
- *   {@link RemoteVideoTrack}s of the Dominant Speaker.
+ * @property {"auto"|VideoRenderDimensions} [renderDimensions="auto"] - Optional parameter to specify the desired
+ *   render dimensions of {@link RemoteVideoTrack}s By default the SDK monitors and uses the dimensions
+ *   of video elements attached to the remote tracks to determine the track dimensions. Tracks rendered in
+ *   larger video elements will get higher resolution tracks compared to tracks rendered in smaller video elements.
+ *   You can override this parameter to specify the dimensions to use based on {@link Track.Priority}.
  * @property {TrackSwitchOffMode} [trackSwitchOffMode="predicted"] - Optional parameter to configure
  *   how {@link RemoteVideoTrack}s are switched off in response to bandwidth pressure. Defaults to "predicted".
  */
 
 /**
- * {@link VideoRenderDimensions} allows you to specify the desired render dimensions of {@link RemoteVideoTrack}s
- * based on {@link Track.Priority}. The bandwidth allocation algorithm will distribute the available downlink bandwidth
+ * {@link VideoRenderDimensions} allows you to specify the desired render dimensions of {@link RemoteVideoTrack}s.
+ * You can specify 'auto' for this field - which is also default value -  based on {@link Track.Priority}. The bandwidth allocation algorithm will distribute the available downlink bandwidth
  * proportional to the requested render dimensions. This is just an input for calculating the bandwidth to be allocated
  * and does not affect the actual resolution of the {@link RemoteVideoTrack}s.
  * @typedef {object} VideoRenderDimensions

--- a/lib/util/validate.js
+++ b/lib/util/validate.js
@@ -84,12 +84,15 @@ function validateObject(object, name, propChecks = []) {
 }
 
 /**
- * Validate the {@link VideoRenderDimensions} object.
- * @param {VideoRenderDimensions} renderDimensions
+ * Validates the renderDimensions field to be "auto" or {@link VideoRenderDimensions} object.
+ * @param {string|VideoRenderDimensions} renderDimensions
  * @returns {?Error} - null if valid, Error if not.
  */
 function validateRenderDimensions(renderDimensions) {
   const name = 'options.bandwidthProfile.video.renderDimensions';
+  if (renderDimensions === 'auto') {
+    return null;
+  }
   let error = validateObject(renderDimensions, name);
   return renderDimensions ? error || Object.values(trackPriority).reduce((error, prop) => {
     return error || validateObject(renderDimensions[prop], `${name}.${prop}`, [

--- a/tsdef/twilio-video-tests.ts
+++ b/tsdef/twilio-video-tests.ts
@@ -256,6 +256,16 @@ async function initRoom() {
     },
   });
 
+  // with renderDimension=auto
+  await Video.connect('$TOKEN', {
+    bandwidthProfile: {
+      video: {
+        idleTrackSwitchOff: true,
+        renderDimensions: 'auto'
+      }
+    },
+  });
+
   localVideoTrack = await Video.createLocalVideoTrack({ name: 'camera' });
   await localVideoTrack.restart({ facingMode: 'environment' });
   localAudioTrack = await Video.createLocalAudioTrack({ name: 'microphone' });

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -103,7 +103,7 @@ export interface VideoBandwidthProfileOptions {
   maxSubscriptionBitrate?: number;
   maxTracks?: number;
   mode?: BandwidthProfileMode;
-  renderDimensions?: VideoRenderDimensions;
+  renderDimensions?: 'auto'|VideoRenderDimensions;
   trackSwitchOffMode?: TrackSwitchOffMode;
 }
 


### PR DESCRIPTION
We decided to use `renderDimensions=auto` instead of `renderHints=true`. That way its clear that renderDimensions are mutually exclusive with renderHints. + added typescript definition for the new property.
corresponding idl PR: https://code.hq.twilio.com/client/video-sdk-api/pull/84 


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
