### PR TITLE
VIDEO-4472: request bwp msp channels as needed

### DIFF
--- a/lib/signaling/v2/cancelableroomsignalingpromise.js
+++ b/lib/signaling/v2/cancelableroomsignalingpromise.js
@@ -75,6 +75,12 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
       wsServerInsights
     } = options;
 
+    // decide which msp channels to request
+    // dominantSpeaker, networkQuality
+    const trackPriority = !!bandwidthProfile;
+    const trackSwitchOff = !!bandwidthProfile;
+    const renderHints = bandwidthProfile && (options.idleTrackSwitchOff || options.renderHints);
+
     const transportOptions = Object.assign({
       automaticSubscription,
       dominantSpeaker,
@@ -88,7 +94,10 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
       insights,
       onIced,
       realm,
-      sdpSemantics
+      renderHints,
+      sdpSemantics,
+      trackPriority,
+      trackSwitchOff
     }, typeof wsServerInsights === 'string' ? {
       wsServerInsights
     } : {}, InsightsPublisher ? {

--- a/lib/signaling/v2/cancelableroomsignalingpromise.js
+++ b/lib/signaling/v2/cancelableroomsignalingpromise.js
@@ -79,7 +79,7 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
     // dominantSpeaker, networkQuality
     const trackPriority = !!bandwidthProfile;
     const trackSwitchOff = !!bandwidthProfile;
-    const renderHints = bandwidthProfile && (options.idleTrackSwitchOff || options.renderHints);
+    const renderHints = !!bandwidthProfile && (options.idleTrackSwitchOff || options.renderHints);
 
     const transportOptions = Object.assign({
       automaticSubscription,


### PR DESCRIPTION
SDK was requesting MSP channels even when Bandwidth Profile was not specified. now requests `render_hints`, `track_priority` and `track_switch_off` only as needed.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
