### PR TITLE
video-4524 msp field rename

### DIFF
--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -266,7 +266,7 @@ function updateRenderHints(removeVideoTrack) {
   if (removeVideoTrack._renderHints && elements.length > 0) {
     const [{ clientHeight, clientWidth }] = elements.sort((el1, el2) =>
       el2.clientHeight + el2.clientWidth - el1.clientHeight - el1.clientWidth - 1);
-    updatedRenderHint.renderDimension = { height: clientHeight, width: clientWidth };
+    updatedRenderHint.renderDimensions = { height: clientHeight, width: clientWidth };
   }
 
   removeVideoTrack._log.debug('updating render hint:', updatedRenderHint);

--- a/lib/signaling/v2/renderhintssignaling.js
+++ b/lib/signaling/v2/renderhintssignaling.js
@@ -85,13 +85,13 @@ class RenderHintsSignaling extends MediaSignaling {
   setTrackHint(trackSid, renderHint) {
     // convert hint to msp format
     const mspHint = {
-      'track_sid': trackSid,
+      'track': trackSid,
       'enabled': !!renderHint.enabled,
     };
 
-    if (renderHint.renderDimension) {
+    if (renderHint.renderDimensions) {
       // eslint-disable-next-line camelcase
-      mspHint.render_dimension = renderHint.renderDimension;
+      mspHint.render_dimensions = renderHint.renderDimensions;
     }
 
     const oldHint = this._trackSidsToRenderHints.get(trackSid);

--- a/test/unit/spec/media/track/remotevideotrack.js
+++ b/test/unit/spec/media/track/remotevideotrack.js
@@ -215,7 +215,7 @@ describe('IntersectionObserver', () => {
     it('visible, _setRenderHint gets called with { enable: true }', () => {
       track._intersectionObserver.makeVisible(el);
       sinon.assert.calledWith(setRenderHintSpy, sinon.match.has('enabled', true));
-      sinon.assert.calledWith(setRenderHintSpy, sinon.match.has('renderDimension', { height: sinon.match.any, width: sinon.match.any }));
+      sinon.assert.calledWith(setRenderHintSpy, sinon.match.has('renderDimensions', { height: sinon.match.any, width: sinon.match.any }));
     });
 
     it('invisible, _setRenderHint gets called with { enable: false }', () => {
@@ -261,7 +261,7 @@ describe('ResizeObserver', () => {
 
     it('_setRenderHint gets called with { enable: true }', () => {
       track._resizeObserver.resize(el);
-      sinon.assert.calledWith(setRenderHintSpy, { enabled: true, renderDimension: { height: 100, width: 100 } });
+      sinon.assert.calledWith(setRenderHintSpy, { enabled: true, renderDimensions: { height: 100, width: 100 } });
     });
   });
 
@@ -300,7 +300,7 @@ describe('ResizeObserver', () => {
       track._resizeObserver.resize(el);
 
       // expect reported size to be 200x200
-      sinon.assert.calledWith(setRenderHintSpy, { enabled: true, renderDimension: { height: 200, width: 200 } });
+      sinon.assert.calledWith(setRenderHintSpy, { enabled: true, renderDimensions: { height: 200, width: 200 } });
     });
   });
 

--- a/test/unit/spec/signaling/v2/renderhintssignaling.js
+++ b/test/unit/spec/signaling/v2/renderhintssignaling.js
@@ -31,7 +31,7 @@ describe('RenderHintsSignaling', () => {
   describe('setTrackHint', () => {
     it('updates track state', () => {
       const subject = makeTest(makeTransport());
-      subject.setTrackHint('foo', { enabled: true, renderDimension: { width: 100, height: 100 } });
+      subject.setTrackHint('foo', { enabled: true, renderDimensions: { width: 100, height: 100 } });
       assert(subject._trackSidsToRenderHints.has('foo'));
       assert(subject._dirtyTrackSids.has('foo'));
     });
@@ -39,9 +39,9 @@ describe('RenderHintsSignaling', () => {
     it('flattens and sends updated track states ', () => {
       const mst = makeTransport();
       const subject = makeTest(mst);
-      subject.setTrackHint('foo', { enabled: true, renderDimension: { width: 100, height: 100 } });
-      subject.setTrackHint('bar', { enabled: false, renderDimension: { width: 100, height: 100 } });
-      subject.setTrackHint('foo', { enabled: true, renderDimension: { width: 101, height: 101 } });
+      subject.setTrackHint('foo', { enabled: true, renderDimensions: { width: 100, height: 100 } });
+      subject.setTrackHint('bar', { enabled: false, renderDimensions: { width: 100, height: 100 } });
+      subject.setTrackHint('foo', { enabled: true, renderDimensions: { width: 101, height: 101 } });
 
       assert(subject._trackSidsToRenderHints.has('foo'));
       assert(subject._trackSidsToRenderHints.has('bar'));
@@ -59,13 +59,13 @@ describe('RenderHintsSignaling', () => {
           subscriber: {
             id: sinon.match.number,
             hints: [{
-              'track_sid': 'foo',
+              'track': 'foo',
               'enabled': true,
-              'render_dimension': { height: 101, width: 101 },
+              'render_dimensions': { height: 101, width: 101 },
             }, {
-              'track_sid': 'bar',
+              'track': 'bar',
               'enabled': false,
-              'render_dimension': { height: 100, width: 100 },
+              'render_dimensions': { height: 100, width: 100 },
             }]
           }
         });
@@ -82,7 +82,7 @@ describe('RenderHintsSignaling', () => {
     it('does nothing if track state did not change', async () => {
       const mst = makeTransport();
       const subject = makeTest(mst);
-      subject.setTrackHint('foo', { enabled: true, renderDimension: { width: 100, height: 100 } });
+      subject.setTrackHint('foo', { enabled: true, renderDimensions: { width: 100, height: 100 } });
       assert(subject._trackSidsToRenderHints.has('foo'));
       assert(subject._dirtyTrackSids.has('foo'));
 
@@ -99,11 +99,11 @@ describe('RenderHintsSignaling', () => {
       assert(!subject._dirtyTrackSids.has('foo'));
 
       // subsequent setTrackHint with same values does not mark track as dirty
-      subject.setTrackHint('foo', { enabled: true, renderDimension: { width: 100, height: 100 } });
+      subject.setTrackHint('foo', { enabled: true, renderDimensions: { width: 100, height: 100 } });
       assert(!subject._dirtyTrackSids.has('foo'));
 
       // but any changes causes it be marked dirty
-      subject.setTrackHint('foo', { enabled: true, renderDimension: { width: 101, height: 100 } });
+      subject.setTrackHint('foo', { enabled: true, renderDimensions: { width: 101, height: 100 } });
       assert(subject._dirtyTrackSids.has('foo'));
     });
 
@@ -128,17 +128,17 @@ describe('RenderHintsSignaling', () => {
         subscriber: {
           id: sinon.match.number,
           hints: [{
-            'track_sid': 'foo',
+            'track': 'foo',
             'enabled': true,
           }, {
-            'track_sid': 'boo',
+            'track': 'boo',
             'enabled': false,
           }]
         }
       });
 
       // send another hint
-      subject.setTrackHint('bar', { enabled: true, renderDimension: { width: 200, height: 200 } });
+      subject.setTrackHint('bar', { enabled: true, renderDimensions: { width: 200, height: 200 } });
       await waitForSometime(10);
       assert(publishCalls, 1);
 
@@ -148,11 +148,11 @@ describe('RenderHintsSignaling', () => {
           'id': 42,
           'hints': [
             {
-              'track_sid': 'foo',
+              'track': 'foo',
               'result': 'OK'
             },
             {
-              'track_sid': 'boo',
+              'track': 'boo',
               'result': 'INVALID_RENDER_HINT'
             }
           ]
@@ -168,9 +168,9 @@ describe('RenderHintsSignaling', () => {
         subscriber: {
           id: sinon.match.number,
           hints: [{
-            'track_sid': 'bar',
+            'track': 'bar',
             'enabled': true,
-            'render_dimension': { height: 200, width: 200 },
+            'render_dimensions': { height: 200, width: 200 },
           }]
         }
       });
@@ -180,7 +180,7 @@ describe('RenderHintsSignaling', () => {
   describe('clearTrackHint', () => {
     it('deletes stored track state.', () => {
       let subject = makeTest(makeTransport());
-      subject.setTrackHint('foo', { enabled: true, renderDimension: { width: 100, height: 100 } });
+      subject.setTrackHint('foo', { enabled: true, renderDimensions: { width: 100, height: 100 } });
       assert(subject._trackSidsToRenderHints.has('foo'));
       assert(subject._dirtyTrackSids.has('foo'));
 

--- a/tsdef/twilio-video-tests.ts
+++ b/tsdef/twilio-video-tests.ts
@@ -256,7 +256,7 @@ async function initRoom() {
     },
   });
 
-  // with renderDimension=auto
+  // with renderDimensions=auto
   await Video.connect('$TOKEN', {
     bandwidthProfile: {
       video: {


### PR DESCRIPTION
we decided to rename two msp fields in render_hints protocol - the msp protocol change is described here: https://code.hq.twilio.com/client/room-signaling-protocol/pull/70

for render_hint protocol:
`render_dimension` => `render_dimensions`
`track_sid` => `track`

This PR updates sdk to accommodate it.  I have verified the client against dev environment. We will merge this change only after related VMS changes are in stage. (Note: circleCi job against this PR is expected fail till then) 

Along with protocol change, this also changes an internal structure from `renderDimension` => `renderDimensions`

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
