### PR TITLE
remove workaround introduced for video_4191

### DIFF
--- a/test/integration/spec/room.js
+++ b/test/integration/spec/room.js
@@ -6,6 +6,7 @@ const assert = require('assert');
 const {
   connect,
   createLocalTracks,
+  Logger,
   LocalDataTrack
 } = require('../../../lib');
 
@@ -603,11 +604,14 @@ describe('Room', function() {
     before(async () => {
       let thoseRooms;
       [, aliceRoom, thoseRooms] = await setup({
-        testOptions: { tracks: [], bandwidthProfile: { video: { maxTracks: 1 } } },
+        testOptions: { loggerName: 'Alice', tracks: [], bandwidthProfile: { video: { maxTracks: 1, idleTrackSwitchOff: false } } },
         otherOptions: { tracks: [] },
         participantNames: ['Alice', 'Bob', 'Charlie'],
         nTracks: 0
       });
+
+      const aliceLogger = Logger.getLogger('Charlie');
+      aliceLogger.setLevel('debug');
 
       [bobRoom, charlieRoom] = thoseRooms;
       alice = aliceRoom.localParticipant;
@@ -623,8 +627,7 @@ describe('Room', function() {
 
       // Let bob publish a LocalTrack with low priority.
       loPriTrack = await createLocalVideoTrack(smallVideoConstraints);
-      const bobTrackPub = bob.publishTrack(loPriTrack, { priority: PRIORITY_LOW });
-      await waitFor(bob.publishTrack(loPriTrack, { priority: PRIORITY_LOW }), `${bob.sid} to publish LocalTrack: ${aliceRoom.sid}`);
+      const bobTrackPub = await waitFor(bob.publishTrack(loPriTrack, { priority: PRIORITY_LOW }), `${bob.sid} to publish LocalTrack: ${aliceRoom.sid}`);
       console.log('Bob\'s track:', bobTrackPub.trackSid);
 
       remoteBob = aliceRoom.participants.get(bob.sid);
@@ -665,8 +668,7 @@ describe('Room', function() {
       }));
 
       // Induce a track switch off by having charlie publish a track with high priority.
-      const charlieTrackPub = charlie.publishTrack(hiPriTrack, { priority: PRIORITY_HIGH });
-      await waitFor(charlieTrackPub, `${charlie.sid} to publish a high priority LocalTrack: ${aliceRoom.sid}`);
+      const charlieTrackPub = await waitFor(charlie.publishTrack(hiPriTrack, { priority: PRIORITY_HIGH }), `${charlie.sid} to publish a high priority LocalTrack: ${aliceRoom.sid}`);
       console.log('Charlie\'s Track:', charlieTrackPub.trackSid);
       await waitFor(tracksSubscribed(remoteCharlie, 1), `${alice.sid} to subscribe to charlie's RemoteTrack ${hiPriTrack.sid}: ${aliceRoom.sid}`);
 
@@ -702,8 +704,6 @@ describe('Room', function() {
       // Let Charlie unpublish the high priority LocalTrack.
       // NOTE(mmalavalli): This test fails if charlie disconnects from the Room, which might
       // be a potential bug.
-      // NOTE(mpatwardhan): Test  also fails if charlie unpublish track immediately (VIDEO-4191),
-      await waitForSometime(4000);
       charlie.unpublishTrack(hiPriTrack);
 
       // Alice should see track switch on event on all 4 objects.

--- a/test/integration/spec/room.js
+++ b/test/integration/spec/room.js
@@ -6,7 +6,6 @@ const assert = require('assert');
 const {
   connect,
   createLocalTracks,
-  Logger,
   LocalDataTrack
 } = require('../../../lib');
 
@@ -604,14 +603,11 @@ describe('Room', function() {
     before(async () => {
       let thoseRooms;
       [, aliceRoom, thoseRooms] = await setup({
-        testOptions: { loggerName: 'Alice', tracks: [], bandwidthProfile: { video: { maxTracks: 1, idleTrackSwitchOff: false } } },
+        testOptions: { tracks: [], bandwidthProfile: { video: { maxTracks: 1 } } },
         otherOptions: { tracks: [] },
         participantNames: ['Alice', 'Bob', 'Charlie'],
         nTracks: 0
       });
-
-      const aliceLogger = Logger.getLogger('Charlie');
-      aliceLogger.setLevel('debug');
 
       [bobRoom, charlieRoom] = thoseRooms;
       alice = aliceRoom.localParticipant;


### PR DESCRIPTION
We [introduced a workaround](https://github.com/twilio/twilio-video.js/pull/1397) - by adding a delay - as one of the bandwidth profile test was failing because of some race condition on SFU side.  This change removes the workaround as root cause is now fixed on SFU side.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
