### PR TITLE
Video-4657 auto dimensions not sent when idleTrackSwitch of is disabled.

### DIFF
--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -109,7 +109,13 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
 
   attach(el) {
     const result = super.attach(el);
-    this._invisibleElements.add(result);
+
+    if (this._idleTrackSwitchOff) {
+      // start off the element as invisible. will mark it
+      // visible once intersection observer calls back.
+      this._invisibleElements.add(result);
+    }
+
     this._intersectionObserver.observe(result);
     this._resizeObserver.observe(result);
 

--- a/test/integration/spec/bandwidthprofile.js
+++ b/test/integration/spec/bandwidthprofile.js
@@ -406,24 +406,24 @@ describe('BandwidthProfileOptions', function() {
     [
       {
         dimA: { width: 1024, height: 720 },
-        dimB: { width: 320, height: 240 },
+        dimB: { width: 50, height: 40 },
         idleTrackSwitchOff: true,
         expectBandwidthUsageIncrease: false
       },
       {
         dimA: { width: 1024, height: 720 },
-        dimB: { width: 320, height: 240 },
+        dimB: { width: 50, height: 40 },
         idleTrackSwitchOff: false,
         expectBandwidthUsageIncrease: false
       },
       {
-        dimA: { width: 320, height: 240 },
+        dimA: { width: 50, height: 40 },
         dimB: { width: 1024, height: 720 },
         idleTrackSwitchOff: true,
         expectBandwidthUsageIncrease: true
       },
       {
-        dimA: { width: 320, height: 240 },
+        dimA: { width: 50, height: 40 },
         dimB: { width: 1024, height: 720 },
         idleTrackSwitchOff: false,
         expectBandwidthUsageIncrease: true
@@ -462,7 +462,7 @@ describe('BandwidthProfileOptions', function() {
         // wait couple of seconds before running media flow test.
         await waitForSometime(2000);
 
-        const duration = 10000;
+        const duration = 15000;
         let { bytesReceivedBefore, bytesReceivedAfter, testTimeMS } = await validateMediaFlow(bobRoom, duration, ['remoteVideoTrackStats']);
         const bytesReceivedA = bytesReceivedAfter - bytesReceivedBefore;
         const kbps1 =  Math.round(((bytesReceivedA / testTimeMS) * 10) / 10);

--- a/test/integration/spec/bandwidthprofile.js
+++ b/test/integration/spec/bandwidthprofile.js
@@ -30,6 +30,7 @@ const {
 
 const { trackPriority: { PRIORITY_HIGH, PRIORITY_LOW, PRIORITY_STANDARD } } = require('../../../lib/util/constants');
 const { trackSwitchOffMode: { MODE_DISABLED, MODE_DETECTED, MODE_PREDICTED } } = require('../../../lib/util/constants');
+const { waitForSometime } = require('../../../lib/util');
 
 function monitorTrackSwitchOffs(remoteTrack, trackName) {
   console.log(`${trackName} [${remoteTrack.sid}] ${remoteTrack.isSwitchedOff ? 'OFF' : 'ON'}`);
@@ -458,6 +459,9 @@ describe('BandwidthProfileOptions', function() {
         videoElement.setAttribute('height', `${dimA.height}`);
         videoElement.setAttribute('width', `${dimA.width}`);
 
+        // wait couple of seconds before running media flow test.
+        await waitForSometime(2000);
+
         const duration = 10000;
         let { bytesReceivedBefore, bytesReceivedAfter, testTimeMS } = await validateMediaFlow(bobRoom, duration, ['remoteVideoTrackStats']);
         const bytesReceivedA = bytesReceivedAfter - bytesReceivedBefore;
@@ -466,6 +470,9 @@ describe('BandwidthProfileOptions', function() {
 
         videoElement.setAttribute('height', `${dimB.height}`);
         videoElement.setAttribute('width', `${dimB.width}`);
+
+        // wait couple of seconds before running media flow test.
+        await waitForSometime(2000);
 
         ({ bytesReceivedBefore, bytesReceivedAfter, testTimeMS } = await validateMediaFlow(bobRoom, duration, ['remoteVideoTrackStats']));
         const bytesReceivedB = bytesReceivedAfter - bytesReceivedBefore;

--- a/test/integration/spec/bandwidthprofile.js
+++ b/test/integration/spec/bandwidthprofile.js
@@ -24,6 +24,7 @@ const {
   waitFor,
   setupAliceAndBob,
   assertMediaFlow,
+  validateMediaFlow,
   waitForNot
 } = require('../../lib/util');
 
@@ -399,6 +400,89 @@ describe('BandwidthProfileOptions', function() {
       await waitFor(trackSwitchedOn(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch on: ${roomSid}`);
       assert.strictEqual(aliceRemoteTrack.isSwitchedOff, false, `Alice's Track.isSwitchedOff = ${aliceRemoteTrack.isSwitchedOff}`);
       await assertMediaFlow(bobRoom, true, `was expecting media flow: ${roomSid}`);
+    });
+
+    [
+      {
+        dimA: { width: 1024, height: 720 },
+        dimB: { width: 320, height: 240 },
+        idleTrackSwitchOff: true,
+        expectBandwidthUsageIncrease: false
+      },
+      {
+        dimA: { width: 1024, height: 720 },
+        dimB: { width: 320, height: 240 },
+        idleTrackSwitchOff: false,
+        expectBandwidthUsageIncrease: false
+      },
+      {
+        dimA: { width: 320, height: 240 },
+        dimB: { width: 1024, height: 720 },
+        idleTrackSwitchOff: true,
+        expectBandwidthUsageIncrease: true
+      },
+      {
+        dimA: { width: 320, height: 240 },
+        dimB: { width: 1024, height: 720 },
+        idleTrackSwitchOff: false,
+        expectBandwidthUsageIncrease: true
+      }
+    ].forEach(({ dimA, dimB, idleTrackSwitchOff, expectBandwidthUsageIncrease }) => {
+      it(`video dimension ${dimA.width}x${dimA.height} => ${dimB.width}x${dimB.height} ${expectBandwidthUsageIncrease ? 'increases' : 'decreases'} bandwidth usage, when idleTrackSwitchOff: ${idleTrackSwitchOff}`, async () => {
+        const aliceLocalVideo = await waitFor(createLocalVideoTrack(), 'alice local video track');
+        const aliceOptions = { tracks: [aliceLocalVideo] };
+        const bobOptions = {
+          tracks: [],
+          loggerName: 'BobLogger',
+          bandwidthProfile: {
+            video: {
+              idleTrackSwitchOff,
+              dominantSpeakerPriority: PRIORITY_STANDARD
+            }
+          },
+        };
+
+        const bobLogger = Logger.getLogger('BobLogger');
+        bobLogger.setLevel('info');
+
+        const { roomSid, aliceRoom, bobRoom, aliceRemote } = await setupAliceAndBob({ aliceOptions,  bobOptions });
+
+        await waitFor(tracksSubscribed(aliceRemote, 1), `Bob to subscribe to Alice's track: ${roomSid}`);
+        const aliceRemoteTrack = Array.from(aliceRemote.videoTracks.values())[0].track;
+
+        const videoElement = aliceRemoteTrack.attach();
+        document.body.appendChild(videoElement);
+
+        // track should switch on
+        await waitFor(trackSwitchedOn(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch on: ${roomSid}`);
+        videoElement.setAttribute('height', `${dimA.height}`);
+        videoElement.setAttribute('width', `${dimA.width}`);
+
+        const duration = 10000;
+        let { bytesReceivedBefore, bytesReceivedAfter, testTimeMS } = await validateMediaFlow(bobRoom, duration, ['remoteVideoTrackStats']);
+        const bytesReceivedA = bytesReceivedAfter - bytesReceivedBefore;
+        const kbps1 =  Math.round(((bytesReceivedA / testTimeMS) * 10) / 10);
+        console.log('KBPS 1: ', kbps1);
+
+        videoElement.setAttribute('height', `${dimB.height}`);
+        videoElement.setAttribute('width', `${dimB.width}`);
+
+        ({ bytesReceivedBefore, bytesReceivedAfter, testTimeMS } = await validateMediaFlow(bobRoom, duration, ['remoteVideoTrackStats']));
+        const bytesReceivedB = bytesReceivedAfter - bytesReceivedBefore;
+        const kbps2 =  Math.round(((bytesReceivedB / testTimeMS) * 10) / 10);
+        console.log('KBPS 2: ', kbps2);
+
+        aliceRemoteTrack.detach(videoElement);
+        videoElement.remove();
+
+        if (expectBandwidthUsageIncrease) {
+          assert(bytesReceivedB > bytesReceivedA, `was expecting bandwidth usage to increase: ${bytesReceivedA} => ${bytesReceivedB}`);
+        } else {
+          assert(bytesReceivedB < bytesReceivedA, `was expecting bandwidth usage to decrease: ${bytesReceivedA} => ${bytesReceivedB}`);
+        }
+
+        [aliceRoom, bobRoom].forEach(room => room.disconnect());
+      });
     });
   });
 });

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -713,7 +713,7 @@ function getTotalBytesReceived(statReports, trackTypes = ['remoteVideoTrackStats
  * validates that media was flowing in given rooms.
  * @param {Room} room
  * @param {number} testTimeMS
- * @returns {Promise<>}
+ * @returns {Promise<{bytesReceivedBefore, bytesReceivedAfter, testTimeMS}>}
  */
 async function validateMediaFlow(room, testTimeMS = 6000, trackTypes = ['remoteVideoTrackStats', 'remoteAudioTrackStats']) {
   // wait for some time.
@@ -734,6 +734,7 @@ async function validateMediaFlow(room, testTimeMS = 6000, trackTypes = ['remoteV
   if (bytesReceivedAfter <= bytesReceivedBefore) {
     throw new Error('no media flow detected');
   }
+  return { bytesReceivedBefore, bytesReceivedAfter, testTimeMS };
 }
 
 async function assertMediaFlow(room, mediaFlowExpected,  errorMessage) {


### PR DESCRIPTION
https://issues.corp.twilio.com/browse/VIDEO-4657
when connected with
```
const connectOptions = {
  "bandwidthProfile":{
    "video":{
      "idleTrackSwitchOff": false, 
      "renderDimensions": "auto"
    }
  }
}
```
RenderHints are not sent when element is resized. This happens because we mark video element as invisible initially when attached, and mark them as  visible only on IntersectionObserver callback - But when `idleTrackSwitchOff === false` the callback never comes.  This causes ResizeObserver callback to not send render hints  thinking the elements are invisible.

This change fixes the issue by marking elements invisible only when `idleTrackSwitchOff` is enabled. Because that the only time we care about their visibility.

This also adds integration tests which verify auto renderDimensions behavior. (VIDEO-4073)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
