### PR TITLE
send idleTrackSwitchOff and renderDimenstions=auto to insights

### DIFF
--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -617,17 +617,15 @@ function createRoomConnectEventPayload(connectOptions) {
   if (connectOptions.bandwidthProfile && connectOptions.bandwidthProfile.video) {
     const videoBPOptions = connectOptions.bandwidthProfile.video || {};
     payload.bandwidthProfileOptions = {};
-    ['mode', 'maxTracks', 'trackSwitchOffMode', 'dominantSpeakerPriority', 'maxSubscriptionBitrate'].forEach(prop => {
+    ['mode', 'maxTracks', 'trackSwitchOffMode', 'dominantSpeakerPriority', 'maxSubscriptionBitrate', 'renderDimensions', 'idleTrackSwitchOff'].forEach(prop => {
       if (typeof videoBPOptions[prop] === 'number' || typeof videoBPOptions[prop] === 'string') {
-        if (prop in videoBPOptions) {
-          payload.bandwidthProfileOptions[prop] = videoBPOptions[prop];
-        }
+        payload.bandwidthProfileOptions[prop] = videoBPOptions[prop];
+      } else if (typeof videoBPOptions[prop] === 'boolean') {
+        payload.bandwidthProfileOptions[prop] = boolToString(videoBPOptions[prop]);
+      } else if (typeof videoBPOptions[prop] === 'object') {
+        payload.bandwidthProfileOptions[prop] = JSON.stringify(videoBPOptions[prop]);
       }
     });
-
-    if ('renderDimensions' in videoBPOptions) {
-      payload.bandwidthProfileOptions.renderDimensions = JSON.stringify(videoBPOptions.renderDimensions);
-    }
   }
 
   return {


### PR DESCRIPTION
include new field in insights report. does not require change in insights spec because 
- a) bandwidthProfile [allows new fields](https://code.hq.twilio.com/client/rtc-insights-spec/blob/master/schema/video/event/room/connect.json#L60) already
- b) renderDimenstions was already a string property.

Example Kibana Query: https://kibana.us1.eak.twilio.com/video/goto/d24229d03db03d16c2fa823d45bedb84

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
