### PR TITLE
Renderhints  updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,50 +8,71 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 New Features
 ------------
 
-**Idle Track Switch Off**
+**Subscribed Track Switch Off**
 
-- Idle Track Switch Off uses document visibility, track attachments, and the visibility of video elements to determine whether a RemoteVideoTrack should be switched off. A RemoteVideoTrack will be switched off when the document is no longer visible, no video elements are attached to the track, or when the video elements attached to the track are not visible.
+- This feature allows subscribers to control whether the media for a RemoteVideoTrack is received or not. Subscribed track switch off has two modes of operation:
+  - **auto** (default): The SDK determines whether tracks should be switched off based on document visibility, track attachments, and / or the visibility of video elements.
+  - **manual**: The application requests that individual tracks be switched off or on using the `RemoteVideoTrack.switchOff()` / `switchOn()` methods.
+- Note: If your application previously set the `maxTracks` property to limit the number of tracks visible, you should migrate to using `subscribedTrackSwitchOffMode` to take advantage of this feature.
 
-**Auto Render Dimensions**
+**Video Content Preferences**
 
-- The SDK now uses the dimensions of the video elements attached to a RemoteVideoTrack to determine the best video bitrate to receive. A RemoteVideoTrack attached to a video element with larger dimensions will get a higher quality video compared to a RemoteVideoTrack attached to a video renderer with smaller dimensions.
+- This feature allows subscribers to specify preferences about the media that they receive on a RemoteVideoTrack. Video content preferences has two modes of operation:
+  - **auto** (default): The SDK specifies content preferences based on video element size. A RemoteVideoTrack attached to a video element with larger dimensions will get a higher quality video compared to a RemoteVideoTrack attached to a video element with smaller dimensions.
+  - **manual**: The application specifies the content preferences for individual tracks using `RemoteVideoTrack.setContentPreferences()`.
+- Note: If your application previously set the `renderDimensions` property, you should migrate to using `contentPreferencesMode` to take advantage of this feature.
 
+Both of these features are available in Group Rooms and are enabled by default if your application specifies [Bandwidth Profile Options](https://media.twiliocdn.com/sdk/js/video/releases/2.12.0/docs/global.html#BandwidthProfileOptions__anchor) during connect. If your application previously set the `renderDimensions` property you should migrate it to `contentPreferencesMode` in order to take advantage of automatic behavior.
 
-Both these features are available in Group Rooms and are enabled by default if your application specifies [Bandwidth Profile options](https://media.twiliocdn.com/sdk/js/video/releases/2.12.0/docs/global.html#BandwidthProfileOptions__anchor) during connect. If your application previously set legacy `renderDimensions` you must change the value to `"auto"` in order to take advantage of automatic hinting.
-
-  ```js
-    const { connect } = require('twilio-video');
-
-    const room = await connect(token, {
-      name: 'my-new-room',
-      bandwidthProfile: {
-        video: {
-          idleTrackSwitchOff: true,
-          renderDimensions: 'auto',
-        }
+  ```ts
+  const { connect } = require('twilio-video');
+  const room = await connect(token, {
+    name: "my-new-room",
+    bandwidthProfile: {
+      video: {
+        # Use "auto" defaults for both features. Be sure to remove "renderDimensions" and "maxTracks".
       }
-    });
+    }
+  });
   ```
-
-Note: These features rely on applications using [attach](https://media.twiliocdn.com/sdk/js/video/releases/2.13.1/docs/RemoteVideoTrack.html#attach__anchor) and [detach](https://media.twiliocdn.com/sdk/js/video/releases/2.13.1/docs/RemoteVideoTrack.html#detach__anchor) methods of `RemoteVideoTrack`. If your application currently uses the underlying `MediaStreamTrack` to associate Tracks to video elements, you will need to update your application to use the attach/detach methods. `idleTrackSwitchOff` can be disabled by specifying `false` for the property in the VideoBandwidthProfileOptions dictionary. You can also specify explicit legacy `renderDimensions` if you want to allocate bandwidth based on Track priority instead of the dimensions of the attached video element(s).
-
-  ```js
-    const { connect } = require('twilio-video');
-
-    const room = await connect(token, {
-      name: 'my-new-room',
-      bandwidthProfile: {
-        video: {
-          idleTrackSwitchOff: false,
-          renderDimensions: {
-            low: { width: 320, height: 240 }
-            standard: { width: 640, height: 480 }
-            high: { width: 1080, height: 720 }
-          }
-        }
+**Migrating to Attach APIs**
+The automatic behaviors rely on applications using the [attach](https://media.twiliocdn.com/sdk/js/video/releases/2.12.0/docs/RemoteVideoTrack.html#attach__anchor) and [detach](https://media.twiliocdn.com/sdk/js/video/releases/2.12.0/docs/RemoteVideoTrack.html#detach__anchor) methods of `RemoteVideoTrack`. If your application currently uses the underlying `MediaStreamTrack` to associate Tracks to video elements, you will need to update your application to use the attach/detach methods or use the manual APIs.
+**Manual Controls**
+  ```ts
+  const room = await connect(token, {
+    bandwidthProfile: {
+      video: {
+        contentPreferencesMode: "manual",
+        subscribedTrackSwitchOffMode: "manual"
       }
-    });
+    }
+  });
   ```
+When manual controls are used you can operate directly on `RemoteVideoTrack` to specify preferences. For example, applications can:
+1. Force disabling a track.
+  ```ts
+  remoteTrack.switchOff();
+  ```
+2. Enable and request QVGA video.
+  ```ts
+  # Only needed if switchOff() was called first.
+  remoteTrack.switchOn();
+  remoteTrack.setContentPreferences({
+      renderDimensions: { width:  320, height: 240 }
+  });
+  ```
+3. Request HD (720p) video.
+
+  ```ts
+  remoteTrack.setContentPreferences({
+      renderDimensions: { width:  1280, height: 720 }
+  });
+  ```
+- `subscribedTrackSwitchOffMode` Optional property (defaults to "auto") that when set to "auto" switches off a `RemoteVideoTrack` when no video element is attached to the track, when all attached video elements of the track are not visible, or when the Document is not visible.
+- `contentPreferencesMode` Optional property (defaults to `"auto"`). When omitted or set to `"auto"` allows the SDK to select video bitrate based on dimension information of the video elements attached to each `RemoteVideoTrack`.
+- `renderDimensions` is deprecated and will raise a warning when set. Calling `switchOn()`, `switchOff()`, and `setContentPreferences()` on `RemoteVideoTrack` after setting `renderDimensions` is not allowed will raise an exception.
+- `maxTracks` is deprecated and will raise a warning when set. Setting both `maxTracks` and `subscribedTrackSwitchOffMode` is not allowed and will raise an exception.
+
 
 2.13.1 (March 17, 2021)
 =======================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,14 +30,18 @@ Both of these features are available in Group Rooms and are enabled by default i
     name: "my-new-room",
     bandwidthProfile: {
       video: {
-        # Use "auto" defaults for both features. Be sure to remove "renderDimensions" and "maxTracks".
+        /* Defaults to "auto" for both features. Be sure to remove "renderDimensions" and "maxTracks". */
       }
     }
   });
   ```
+
 **Migrating to Attach APIs**
+
 The automatic behaviors rely on applications using the [attach](https://media.twiliocdn.com/sdk/js/video/releases/2.12.0/docs/RemoteVideoTrack.html#attach__anchor) and [detach](https://media.twiliocdn.com/sdk/js/video/releases/2.12.0/docs/RemoteVideoTrack.html#detach__anchor) methods of `RemoteVideoTrack`. If your application currently uses the underlying `MediaStreamTrack` to associate Tracks to video elements, you will need to update your application to use the attach/detach methods or use the manual APIs.
+
 **Manual Controls**
+
   ```ts
   const room = await connect(token, {
     bandwidthProfile: {
@@ -48,12 +52,17 @@ The automatic behaviors rely on applications using the [attach](https://media.tw
     }
   });
   ```
+
 When manual controls are used you can operate directly on `RemoteVideoTrack` to specify preferences. For example, applications can:
+
 1. Force disabling a track.
+
   ```ts
   remoteTrack.switchOff();
   ```
+
 2. Enable and request QVGA video.
+
   ```ts
   # Only needed if switchOff() was called first.
   remoteTrack.switchOn();
@@ -61,6 +70,7 @@ When manual controls are used you can operate directly on `RemoteVideoTrack` to 
       renderDimensions: { width:  320, height: 240 }
   });
   ```
+
 3. Request HD (720p) video.
 
   ```ts
@@ -68,11 +78,14 @@ When manual controls are used you can operate directly on `RemoteVideoTrack` to 
       renderDimensions: { width:  1280, height: 720 }
   });
   ```
-- `subscribedTrackSwitchOffMode` Optional property (defaults to "auto") that when set to "auto" switches off a `RemoteVideoTrack` when no video element is attached to the track, when all attached video elements of the track are not visible, or when the Document is not visible.
-- `contentPreferencesMode` Optional property (defaults to `"auto"`). When omitted or set to `"auto"` allows the SDK to select video bitrate based on dimension information of the video elements attached to each `RemoteVideoTrack`.
-- `renderDimensions` is deprecated and will raise a warning when set. Calling `switchOn()`, `switchOff()`, and `setContentPreferences()` on `RemoteVideoTrack` after setting `renderDimensions` is not allowed will raise an exception.
-- `maxTracks` is deprecated and will raise a warning when set. Setting both `maxTracks` and `subscribedTrackSwitchOffMode` is not allowed and will raise an exception.
 
+- `subscribedTrackSwitchOffMode` Optional property (defaults to "auto") that when set to "auto" switches off a `RemoteVideoTrack` when no video element is attached to the track, when all attached video elements of the track are not visible, or when the Document is not visible.
+
+- `contentPreferencesMode` Optional property (defaults to `"auto"`). When omitted or set to `"auto"` allows the SDK to select video bitrate based on dimension information of the video elements attached to each `RemoteVideoTrack`.
+
+- `renderDimensions` is deprecated and will raise a warning when set. Calling `switchOn()`, `switchOff()`, and `setContentPreferences()` on `RemoteVideoTrack` after setting `renderDimensions` is not allowed will raise an exception.
+
+- `maxTracks` is deprecated and will raise a warning when set. Setting both `maxTracks` and `subscribedTrackSwitchOffMode` is not allowed and will raise an exception.
 
 2.13.1 (March 17, 2021)
 =======================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,11 +79,11 @@ When manual controls are used you can operate directly on `RemoteVideoTrack` to 
   });
   ```
 
-- `subscribedTrackSwitchOffMode` Optional property (defaults to "auto") that when set to "auto" switches off a `RemoteVideoTrack` when no video element is attached to the track, when all attached video elements of the track are not visible, or when the Document is not visible.
+- `subscribedTrackSwitchOffMode` Optional property (defaults to `"auto"`).  When omitted or set to "auto" switches off a `RemoteVideoTrack` when no video element is attached to the track, when all attached video elements of the track are not visible, or when the Document is not visible.
 
 - `contentPreferencesMode` Optional property (defaults to `"auto"`). When omitted or set to `"auto"` allows the SDK to select video bitrate based on dimension information of the video elements attached to each `RemoteVideoTrack`.
 
-- `renderDimensions` is deprecated and will raise a warning when set. Calling `switchOn()`, `switchOff()`, and `setContentPreferences()` on `RemoteVideoTrack` after setting `renderDimensions` is not allowed will raise an exception.
+- `renderDimensions` is deprecated and will raise a warning when set. Setting both `renderDimensions` and `contentPreferencesMode` is not allowed and will raise an exception.
 
 - `maxTracks` is deprecated and will raise a warning when set. Setting both `maxTracks` and `subscribedTrackSwitchOffMode` is not allowed and will raise an exception.
 

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -751,7 +751,7 @@ const SubscribedTrackSwitchOffMode = {
    * off automatically.
    */
   auto: 'auto',
-  
+
   /**
    * When set to manual, application can use {@link RemoteVideoTrack}s switchOff and switchOn apis to control turn the track on or off.
    */

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -53,6 +53,19 @@ if (safariVersion) {
   isSafariWithoutVP8Support = safariMajorVersion < 12 || (safariMajorVersion === 12 && safariMinorVersion < 1);
 }
 
+const deprecatedConnectOptionsProps = new Set([
+  { didWarn: false, shouldDelete: true, name: 'abortOnIceServersTimeout' },
+  { didWarn: false, shouldDelete: true, name: 'dscpTagging', newName: 'enableDscp' },
+  { didWarn: false, shouldDelete: true, name: 'iceServersTimeout' },
+  { didWarn: false, shouldDelete: false, name: 'eventListener', newName: 'Video.Logger' },
+  { didWarn: false, shouldDelete: false, name: 'logLevel', newName: 'Video.Logger' },
+]);
+
+const deprecatedBandwidthProfileOptions = new Set([
+  { didWarn: false, shouldDelete: false, name: 'maxTracks', newName: 'bandwidthProfile.video.subscribedTrackSwitchOffMode' },
+  { didWarn: false, shouldDelete: false, name: 'renderDimensions', newName: 'bandwidthProfile.video.contentPreferencesMode' },
+]);
+
 /**
  * Connect to a {@link Room}.
  *   <br><br>
@@ -202,7 +215,7 @@ function connect(token, options) {
   // NOTE(csantos): Log a warning for the deprecated ConnectOptions properties.
   // The warning is displayed only for the first call to connect() per browser session.
   // Additionally, the options that are no longer needed will be removed.
-  deprecateOptions(options, log);
+  deprecateOptions(options, log, deprecatedConnectOptionsProps);
 
   options = Object.assign({
     automaticSubscription: true,
@@ -283,19 +296,41 @@ function connect(token, options) {
     return CancelablePromise.reject(error);
   }
 
-  // Note(mpatwardhan): "idleTrackSwitchOff" is an Opt-out option if "bandwidthProfile" is enabled.
-  options.idleTrackSwitchOff = false;
-  // Note(mpatwardhan): renderHints are enabled if "renderDimensions" is set to "auto" or is unspecified
-  options.renderHints = false;
+  // Note(mpatwardhan): "subscribedTrackSwitchOffMode" allows tracks to be switched off
+  // and "contentPreferencesMode" allows track dimensions to be specified dynamically.
+  // The properties can have one of the three values internally:
+  // 1) "auto" = sdk will decide and send the hints.
+  // 2) "manual" - app can use api to send the hints.
+  // 3) "disabled" = do not enable this feature. (this is internal only value)
+  // 'disabled' is needed because subscribedTrackSwitchOffMode and contentPreferencesMode are incompatible with
+  // deprecated properties maxTracks and renderDimensions respectively. once we make @breaking_version_change
+  // we can remove 'disabled' state along with maxTracks and renderDimensions.
+  options.subscribedTrackSwitchOffMode = 'disabled'; // should sdk turn off idle tracks automatically?
+  options.contentPreferencesMode = 'disabled'; // should sdk  use video element dimensions for content hints?
   if (options.bandwidthProfile) {
-    options.idleTrackSwitchOff = true;
-    options.renderHints = true;
+    options.subscribedTrackSwitchOffMode = 'auto';
+    options.contentPreferencesMode = 'auto';
     if (options.bandwidthProfile.video) {
-      if (options.bandwidthProfile.video.idleTrackSwitchOff === false) {
-        options.idleTrackSwitchOff = false;
+
+      // log any warnings about deprecated bwp options
+      deprecateOptions(options.bandwidthProfile.video, log, deprecatedBandwidthProfileOptions);
+
+      if ('maxTracks' in options.bandwidthProfile.video) {
+        // when deprecated maxTracks is specified. disable subscribedTrackSwitchOffMode
+        options.subscribedTrackSwitchOffMode = 'disabled';
+      } else if (options.bandwidthProfile.video.subscribedTrackSwitchOffMode === 'manual') {
+        options.subscribedTrackSwitchOffMode = 'manual';
+      } else {
+        options.subscribedTrackSwitchOffMode = 'auto';
       }
-      if (options.bandwidthProfile.video.renderDimensions && options.bandwidthProfile.video.renderDimensions !== 'auto') {
-        options.renderHints = false;
+
+      if ('renderDimensions' in options.bandwidthProfile.video) {
+        // when deprecated renderDimensions is specified. disable contentPreferencesMode
+        options.contentPreferencesMode = 'disabled';
+      } else if (options.bandwidthProfile.video.contentPreferencesMode === 'manual') {
+        options.contentPreferencesMode = 'manual';
+      } else {
+        options.contentPreferencesMode = 'auto';
       }
     }
   }
@@ -465,27 +500,31 @@ function connect(token, options) {
  * @property {number} [maxSubscriptionBitrate] - Optional parameter to specify the maximum
  *   downlink video bandwidth in bits per second (bps). By default, there are no limits on
  *   the downlink video bandwidth.
- * @property {boolean} [idleTrackSwitchOff] - Optional parameter that when enabled switches off a
- *    {@link RemoteVideoTrack} when no video element is attached to the track, or when all attached video
- *    elements of the track are not visible, or when the Document is not visible. This is enabled by default
- *    if <code>bandwidthProfile</code> is specified in {@link ConnectOptions}.
- * @property {number} [maxTracks] - Optional parameter to specify the maximum number of visible
- *   {@link RemoteVideoTrack}s, which will be selected based on {@link Track.Priority} and an N-Loudest
- *   policy. By default there are no limits on the number of visible {@link RemoteVideoTrack}s.
+ * @property {SubscribedTrackSwitchOffMode} [subscribedTrackSwitchOffMode="auto"] - Optional parameter that determines
+ *    when to turn the {@link RemoteVideoTrack} on or off. when set to "auto" (default) SDK will use the visibility of the
+ *    attached elements to determine if track should be turned off or on. When attached video elements become invisible the Track will
+ *    be turned off, and when elements become visible they will be turned on. When set to "manual" you can turn the {@link RemoteVideoTrack}
+ *    on and off using the api {@link RemoteVideoTrack#switchOn} and {@link RemoteVideoTrack#switchOff} respectively.
+ * @property {VideoContentPreferencesMode} [contentPreferencesMode="auto"] - This Optional parameter configures
+ *    the mode for specifying content preferences for the {@link RemoteVideoTrack}. When set to "auto" (default) the
+ *    SDK determines the render dimensions by inspecting the video elements attached to the track. Video Tracks rendered in smaller video elements
+ *    will get lower resolution stream compared to the video rendered in larger video elements. When set to "manual" you can set
+ *    the dimensions programmatically by calling the api {@link RemoteVideoTrack#setContentPreferences}
+ * @property {number} [maxTracks] - <code>(deprecated: use "subscribedTrackSwitchOffMode" instead)</code>. Optional
+ *   parameter to specify the maximum number of visible {@link RemoteVideoTrack}s, which will be selected based on
+ *   {@link Track.Priority} and an N-Loudest policy. By default there are no limits on the number of visible {@link RemoteVideoTrack}s.
  *   0 or a negative value will remove any limit on the maximum number of visible {@link RemoteVideoTrack}s.
  * @property {BandwidthProfileMode} [mode="grid"] - Optional parameter to specify how the {@link RemoteVideoTrack}s'
  *   TrackPriority values are mapped to bandwidth allocation in Group Rooms. This defaults to "grid",
  *   which results in equal bandwidth share allocation to all {@link RemoteVideoTrack}s.
- * @property {"auto"|VideoRenderDimensions} [renderDimensions="auto"] - Optional parameter to specify the desired
- *   render dimensions of {@link RemoteVideoTrack}s. By default the SDK monitors and uses the dimensions
- *   of video elements attached to the remote tracks to determine the track dimensions. Tracks attached to
- *   larger video elements will get higher resolution compared to tracks rendered by smaller video elements.
- *   You can override this parameter to specify the dimensions to use based on {@link Track.Priority}.
+ * @property {VideoRenderDimensions} [renderDimensions] - <code>(deprecated: use "contentPreferencesMode" instead)</code>. Optional
+ * parameter to specify the desired render dimensions of {@link RemoteVideoTrack}s.
  * @property {TrackSwitchOffMode} [trackSwitchOffMode="predicted"] - Optional parameter to configure
  *   how {@link RemoteVideoTrack}s are switched off in response to bandwidth pressure. Defaults to "predicted".
  */
 
 /**
+ * @deprecated
  * {@link VideoRenderDimensions} allows you to specify the desired render dimensions of {@link RemoteVideoTrack}s.
  * You can specify 'auto' for this field - which is also default value -  based on {@link Track.Priority}. The bandwidth allocation algorithm will distribute the available downlink bandwidth
  * proportional to the requested render dimensions. This is just an input for calculating the bandwidth to be allocated
@@ -679,6 +718,45 @@ const BandwidthProfileMode = {
   presentation: 'presentation'
 };
 
+/**
+ * {@link VideoContentPreferencesMode} specifies how {@link RemoteVideoTrack}s' renderDimensions are
+ * decided by the SDK.
+ * @enum {string}
+ */
+// eslint-disable-next-line
+const VideoContentPreferencesMode = {
+  /**
+   * when set to auto, SDK uses the sizes of the video elements attached to the to the  {@link RemoteVideoTrack} dynamically to
+   * decide the render dimensions. Tracks rendered in smaller video elements will be given smaller bandwidth allocation
+   * compared to the tracks rendered in large video elements.
+   */
+  auto: 'auto',
+  /**
+   * When set to manual, application can use {@link RemoteVideoTrack}s setContentPreference api to set the
+   * desired renderDimensions for the {@link RemoteVideoTrack}
+   */
+  manual: 'manual'
+};
+
+
+/**
+ * {@link SubscribedTrackSwitchOffMode} specifies how {@link RemoteVideoTrack}s' turned on and off
+ * @enum {string}
+ */
+// eslint-disable-next-line
+const SubscribedTrackSwitchOffMode = {
+  /**
+   * when set to auto, SDK uses the visibility of the video elements attached to the to the  {@link RemoteVideoTrack} to decide.
+   * on turning tracks on or off. The track that are not attached to any video elements or not visible on the screen will be turned
+   * off automatically.
+   */
+  auto: 'auto',
+  /**
+   * When set to manual, application can use {@link RemoteVideoTrack}s switchOff and switchOn apis to control turn the track on or off.
+   */
+  manual: 'manual'
+};
+
 
 /**
  * Names of the supported levels for {@link EventListenerEvent}s.
@@ -797,16 +875,9 @@ const EventListenerGroup = {
  * @property {string} name='waiting'
  */
 
-const deprecatedConnectOptionsProps = new Set([
-  { didWarn: false, shouldDelete: true, name: 'abortOnIceServersTimeout' },
-  { didWarn: false, shouldDelete: true, name: 'dscpTagging', newName: 'enableDscp' },
-  { didWarn: false, shouldDelete: true, name: 'iceServersTimeout' },
-  { didWarn: false, shouldDelete: false, name: 'eventListener', newName: 'Video.Logger' },
-  { didWarn: false, shouldDelete: false, name: 'logLevel', newName: 'Video.Logger' },
-]);
 
-function deprecateOptions(options, log) {
-  deprecatedConnectOptionsProps.forEach(prop => {
+function deprecateOptions(options, log, deprecationTable) {
+  deprecationTable.forEach(prop => {
     const { didWarn, name, newName, shouldDelete } = prop;
     if (name in options && typeof options[name] !== 'undefined') {
       if (newName && shouldDelete) {

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -729,7 +729,6 @@ const VideoContentPreferencesMode = {
    * decide the render dimensions. {@link RemoteVideoTrack}s rendered in smaller video elements will be given smaller bandwidth allocation
    * compared to the tracks rendered in large video elements.
    */
-
   auto: 'auto',
   /**
    * When set to manual, application can use {@link RemoteVideoTrack#setContentPreference} to set the

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -325,7 +325,6 @@ function connect(token, options) {
       }
 
       if ('renderDimensions' in options.bandwidthProfile.video) {
-        // when deprecated renderDimensions is specified. disable contentPreferencesMode
         options.contentPreferencesMode = 'disabled';
       } else if (options.bandwidthProfile.video.contentPreferencesMode === 'manual') {
         options.contentPreferencesMode = 'manual';
@@ -501,15 +500,15 @@ function connect(token, options) {
  *   downlink video bandwidth in bits per second (bps). By default, there are no limits on
  *   the downlink video bandwidth.
  * @property {SubscribedTrackSwitchOffMode} [subscribedTrackSwitchOffMode="auto"] - Optional parameter that determines
- *    when to turn the {@link RemoteVideoTrack} on or off. when set to "auto" (default) SDK will use the visibility of the
- *    attached elements to determine if track should be turned off or on. When attached video elements become invisible the Track will
+ *    when to turn the {@link RemoteVideoTrack} on or off. When set to "auto", SDK will use the visibility of the
+ *    attached elements to determine if the {@link RemoteVideoTrack} should be turned off or on. When the attached video elements become invisible the {@link RemoteVideoTrack} will
  *    be turned off, and when elements become visible they will be turned on. When set to "manual" you can turn the {@link RemoteVideoTrack}
  *    on and off using the api {@link RemoteVideoTrack#switchOn} and {@link RemoteVideoTrack#switchOff} respectively.
  * @property {VideoContentPreferencesMode} [contentPreferencesMode="auto"] - This Optional parameter configures
- *    the mode for specifying content preferences for the {@link RemoteVideoTrack}. When set to "auto" (default) the
- *    SDK determines the render dimensions by inspecting the video elements attached to the track. Video Tracks rendered in smaller video elements
- *    will get lower resolution stream compared to the video rendered in larger video elements. When set to "manual" you can set
- *    the dimensions programmatically by calling the api {@link RemoteVideoTrack#setContentPreferences}
+ *    the mode for specifying content preferences for the {@link RemoteVideoTrack}. When set to "auto" the
+ *    SDK determines the render dimensions by inspecting the attached video elements. {@link RemoteVideoTrack}s rendered in smaller video elements
+ *    will receive a lower resolution stream compared to the video rendered in larger video elements. When set to "manual" you can set
+ *    the dimensions programmatically by calling {@link RemoteVideoTrack#setContentPreferences}.
  * @property {number} [maxTracks] - <code>(deprecated: use "subscribedTrackSwitchOffMode" instead)</code>. Optional
  *   parameter to specify the maximum number of visible {@link RemoteVideoTrack}s, which will be selected based on
  *   {@link Track.Priority} and an N-Loudest policy. By default there are no limits on the number of visible {@link RemoteVideoTrack}s.
@@ -719,7 +718,7 @@ const BandwidthProfileMode = {
 };
 
 /**
- * {@link VideoContentPreferencesMode} specifies how {@link RemoteVideoTrack}s' renderDimensions are
+ * {@link VideoContentPreferencesMode} specifies how {@link RemoteVideoTrack}s' render dimensions are
  * decided by the SDK.
  * @enum {string}
  */
@@ -727,13 +726,14 @@ const BandwidthProfileMode = {
 const VideoContentPreferencesMode = {
   /**
    * when set to auto, SDK uses the sizes of the video elements attached to the to the  {@link RemoteVideoTrack} dynamically to
-   * decide the render dimensions. Tracks rendered in smaller video elements will be given smaller bandwidth allocation
+   * decide the render dimensions. {@link RemoteVideoTrack}s rendered in smaller video elements will be given smaller bandwidth allocation
    * compared to the tracks rendered in large video elements.
    */
+
   auto: 'auto',
   /**
-   * When set to manual, application can use {@link RemoteVideoTrack}s setContentPreference api to set the
-   * desired renderDimensions for the {@link RemoteVideoTrack}
+   * When set to manual, application can use {@link RemoteVideoTrack#setContentPreference} to set the
+   * desired render dimensions for the {@link RemoteVideoTrack}.
    */
   manual: 'manual'
 };
@@ -751,6 +751,7 @@ const SubscribedTrackSwitchOffMode = {
    * off automatically.
    */
   auto: 'auto',
+  
   /**
    * When set to manual, application can use {@link RemoteVideoTrack}s switchOff and switchOn apis to control turn the track on or off.
    */

--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -143,7 +143,7 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
    */
   setContentPreferences(contentPreferences) {
     if (this._contentPreferencesMode !== 'manual') {
-      throw new Error('Invalid state. You can call switchOn only when connected with bandwidthProfile.video.renderDimensions set to "manual"');
+      throw new Error('Invalid state. You can call switchOn only when connected with bandwidthProfile.video.contentPreferencesMode set to "manual"');
     }
 
     if (contentPreferences.renderDimensions) {
@@ -159,15 +159,15 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
       // start off the element as invisible. will mark it
       // visible once intersection observer calls back.
       this._invisibleElements.add(result);
+
+      // NOTE(mpatwardhan): we do not call updateRenderHints here,
+      // because the dimensions are not known for freshly created
+      // elements. we will get non-zero dimensions in _intersectionObserver
+      // callback and then will call updateRenderHints.
     }
 
     this._intersectionObserver.observe(result);
     this._resizeObserver.observe(result);
-
-    // NOTE(mpatwardhan): we do not call updateRenderHints here,
-    // because the dimensions are not known for freshly created
-    // elements. we will get non-zero dimensions in _intersectionObserver
-    // callback and then will call updateRenderHints.
 
     if (this._enableDocumentVisibilityTurnOff) {
       this._documentVisibilityTurnOffCleanup = this._documentVisibilityTurnOffCleanup || setupDocumentVisibilityTurnOff(this);
@@ -304,7 +304,7 @@ function updateRenderHints(removeVideoTrack) {
   }
 
   let elements = removeVideoTrack._getAllAttachedElements();
-  let updatedRenderHint = { enabled: true };
+  let updatedRenderHint = { };
   if (removeVideoTrack._subscribedTrackSwitchOffMode === 'auto') {
     // consider only visible elements.
     elements = elements.filter(el => !removeVideoTrack._invisibleElements.has(el));

--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -39,6 +39,8 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
       idleTrackSwitchOff: true,
       renderHints: true,
       enableDocumentVisibilityTurnOff: true,
+      allowManualSwitchOff: true,
+      allowManualContentHints: true,
       IntersectionObserver: typeof IntersectionObserver === 'undefined' || options.idleTrackSwitchOff === false  ? NullObserver : IntersectionObserver,
       ResizeObserver: typeof ResizeObserver === 'undefined' || options.renderHints === false ?  NullObserver : ResizeObserver,
     }, options);
@@ -46,6 +48,12 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
     super(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, setPriority, setRenderHint, options);
 
     Object.defineProperties(this, {
+      _allowManualSwitchOff: {
+        value: options.allowManualSwitchOff !== false
+      },
+      _allowManualContentHints: {
+        value: options.allowManualContentHints !== false
+      },
       _enableDocumentVisibilityTurnOff: {
         value: options.enableDocumentVisibilityTurnOff === true && options.idleTrackSwitchOff === true,
       },
@@ -106,6 +114,52 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
     return result;
   }
 
+  /**
+   * Makes a Request to media server to turn on {@link RemoteVideoTrack}.
+   * Once track gets turned on {@link RemoteVideoTrack#switchedOn} event is emitted by the track
+   * This method is applicable only for the group rooms and only when connected with
+   * bandwidthProfile.video.subscribedTrackSwitchOff set to 'manual'
+   * @returns {this}
+   */
+  switchOn() {
+    if (!this._allowManualSwitchOff) {
+      throw new Error('Invalid state. You can call switchOn only when connected with bandwidthProfile.video.subscribedTrackSwitchOff set to "manual"');
+    }
+    this._setRenderHint({ enabled: true });
+    return this;
+  }
+
+  /**
+   * Turn off the track. Makes a Request to media server that the {@link RemoteVideoTrack} be turned off.
+   * Once track gets turned off {@link RemoteVideoTrack#switchedOff} event is emitted by the track
+   * This method is applicable only for the group rooms and only when connected with
+   * bandwidthProfile.video.subscribedTrackSwitchOff set to 'manual'
+   * @returns {this}
+   */
+  switchOff() {
+    if (!this._allowManualSwitchOff) {
+      throw new Error('Invalid state. You can call switchOff only when connected with bandwidthProfile.video.subscribedTrackSwitchOff set to "manual"');
+    }
+    this._setRenderHint({ enabled: false });
+    return this;
+  }
+
+  /**
+   * Requests the preferred content options. {@link TODO }.
+   * This method is applicable only for the group rooms and only when connected with
+   * bandwidthProfile.video.renderDimensions set to 'manual'
+   * @returns {this}
+   */
+  setContentPreferences(content) {
+    if (!this._allowManualContentHints) {
+      throw new Error('Invalid state. You can call switchOn only when connected with bandwidthProfile.video.renderDimensions set to "manual"');
+    }
+
+    if (content.renderDimensions) {
+      this._setRenderHint({ renderDimensions: content.renderDimensions });
+    }
+    return this;
+  }
 
   attach(el) {
     const result = super.attach(el);

--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -36,36 +36,31 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
    */
   constructor(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, setPriority, setRenderHint, options) {
     options = Object.assign({
-      idleTrackSwitchOff: true,
-      renderHints: true,
+      subscribedTrackSwitchOffMode: 'auto',
+      contentPreferencesMode: 'auto',
       enableDocumentVisibilityTurnOff: true,
-      allowManualSwitchOff: true,
-      allowManualContentHints: true,
-      IntersectionObserver: typeof IntersectionObserver === 'undefined' || options.idleTrackSwitchOff === false  ? NullObserver : IntersectionObserver,
-      ResizeObserver: typeof ResizeObserver === 'undefined' || options.renderHints === false ?  NullObserver : ResizeObserver,
+    }, options);
+
+    options = Object.assign({
+      IntersectionObserver: typeof IntersectionObserver === 'undefined' || options.subscribedTrackSwitchOffMode !== 'auto'  ? NullObserver : IntersectionObserver,
+      ResizeObserver: typeof ResizeObserver === 'undefined' || options.contentPreferencesMode !== 'auto' ?  NullObserver : ResizeObserver,
     }, options);
 
     super(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, setPriority, setRenderHint, options);
 
     Object.defineProperties(this, {
-      _allowManualSwitchOff: {
-        value: options.allowManualSwitchOff !== false
-      },
-      _allowManualContentHints: {
-        value: options.allowManualContentHints !== false
-      },
       _enableDocumentVisibilityTurnOff: {
-        value: options.enableDocumentVisibilityTurnOff === true && options.idleTrackSwitchOff === true,
+        value: options.enableDocumentVisibilityTurnOff === true && options.subscribedTrackSwitchOffMode === 'auto',
       },
       _documentVisibilityTurnOffCleanup: {
         value: null,
         writable: true
       },
-      _idleTrackSwitchOff: {
-        value: options.idleTrackSwitchOff !== false,
+      _subscribedTrackSwitchOffMode: {
+        value: options.subscribedTrackSwitchOffMode,
       },
-      _renderHints: {
-        value: options.renderHints !== false,
+      _contentPreferencesMode: {
+        value: options.contentPreferencesMode,
       },
       _invisibleElements: {
         value: new WeakSet(),
@@ -76,7 +71,7 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
           // to ensure that ResizeObserver does not end-up turning off a track when a fresh Video element is
           // attached and IntersectionObserver has not had its callback executed yet.
           const visibleElementResized = entries.find(entry => !this._invisibleElements.has(entry.target));
-          if (visibleElementResized && this._renderHints) {
+          if (visibleElementResized && this._contentPreferencesMode === 'auto') {
             updateRenderHints(this);
           }
         })
@@ -115,48 +110,44 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
   }
 
   /**
-   * Makes a Request to media server to turn on {@link RemoteVideoTrack}.
-   * Once track gets turned on {@link RemoteVideoTrack#switchedOn} event is emitted by the track
-   * This method is applicable only for the group rooms and only when connected with
-   * bandwidthProfile.video.subscribedTrackSwitchOff set to 'manual'
+   * Request to switch on a {@link RemoteVideoTrack}, This method is applicable only for the group rooms and only when connected with
+   * subscribedTrackSwitchOffMode in video bandwidth profile options set to 'manual'
    * @returns {this}
    */
   switchOn() {
-    if (!this._allowManualSwitchOff) {
-      throw new Error('Invalid state. You can call switchOn only when connected with bandwidthProfile.video.subscribedTrackSwitchOff set to "manual"');
+    if (this._subscribedTrackSwitchOffMode !== 'manual') {
+      throw new Error('Invalid state. You can call switchOn only when connected with bandwidthProfile.video.subscribedTrackSwitchOffMode set to "manual"');
     }
     this._setRenderHint({ enabled: true });
     return this;
   }
 
   /**
-   * Turn off the track. Makes a Request to media server that the {@link RemoteVideoTrack} be turned off.
-   * Once track gets turned off {@link RemoteVideoTrack#switchedOff} event is emitted by the track
-   * This method is applicable only for the group rooms and only when connected with
-   * bandwidthProfile.video.subscribedTrackSwitchOff set to 'manual'
+   * Request to switch off a {@link RemoteVideoTrack}, This method is applicable only for the group rooms and only when connected with
+   * subscribedTrackSwitchOffMode in video bandwidth profile options set to 'manual'
    * @returns {this}
    */
   switchOff() {
-    if (!this._allowManualSwitchOff) {
-      throw new Error('Invalid state. You can call switchOff only when connected with bandwidthProfile.video.subscribedTrackSwitchOff set to "manual"');
+    if (this._subscribedTrackSwitchOffMode !== 'manual') {
+      throw new Error('Invalid state. You can call switchOff only when connected with bandwidthProfile.video.subscribedTrackSwitchOffMode set to "manual"');
     }
     this._setRenderHint({ enabled: false });
     return this;
   }
 
   /**
-   * Requests the preferred content options. {@link TODO }.
-   * This method is applicable only for the group rooms and only when connected with
-   * bandwidthProfile.video.renderDimensions set to 'manual'
+   * Set the {@link RemoteVideoTrack}'s content preferences. This method is applicable only for the group rooms and only when connected with
+   * videoContentPreferencesMode in video bandwidth profile options set to 'manual'
+   * @param {VideoContentPreferences} contentPreferences - requested preferences.
    * @returns {this}
    */
-  setContentPreferences(content) {
-    if (!this._allowManualContentHints) {
+  setContentPreferences(contentPreferences) {
+    if (this._contentPreferencesMode !== 'manual') {
       throw new Error('Invalid state. You can call switchOn only when connected with bandwidthProfile.video.renderDimensions set to "manual"');
     }
 
-    if (content.renderDimensions) {
-      this._setRenderHint({ renderDimensions: content.renderDimensions });
+    if (contentPreferences.renderDimensions) {
+      this._setRenderHint({ renderDimensions: contentPreferences.renderDimensions });
     }
     return this;
   }
@@ -164,7 +155,7 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
   attach(el) {
     const result = super.attach(el);
 
-    if (this._idleTrackSwitchOff) {
+    if (this._subscribedTrackSwitchOffMode === 'auto') {
       // start off the element as invisible. will mark it
       // visible once intersection observer calls back.
       this._invisibleElements.add(result);
@@ -307,23 +298,20 @@ function setupDocumentVisibilityTurnOff(removeVideoTrack) {
   };
 }
 
-/**
- * updates render hints
- */
 function updateRenderHints(removeVideoTrack) {
-  if (!removeVideoTrack._idleTrackSwitchOff && !removeVideoTrack._renderHints) {
+  if (removeVideoTrack._subscribedTrackSwitchOffMode === 'disabled' && removeVideoTrack._contentPreferencesMode === 'disabled') {
     return;
   }
 
   let elements = removeVideoTrack._getAllAttachedElements();
   let updatedRenderHint = { enabled: true };
-  if (removeVideoTrack._idleTrackSwitchOff) {
+  if (removeVideoTrack._subscribedTrackSwitchOffMode === 'auto') {
     // consider only visible elements.
     elements = elements.filter(el => !removeVideoTrack._invisibleElements.has(el));
     updatedRenderHint.enabled = document.visibilityState === 'visible' && elements.length > 0;
   }
 
-  if (removeVideoTrack._renderHints && elements.length > 0) {
+  if (removeVideoTrack._contentPreferencesMode === 'auto' && elements.length > 0) {
     const [{ clientHeight, clientWidth }] = elements.sort((el1, el2) =>
       el2.clientHeight + el2.clientWidth - el1.clientHeight - el1.clientWidth - 1);
     updatedRenderHint.renderDimensions = { height: clientHeight, width: clientWidth };
@@ -332,6 +320,10 @@ function updateRenderHints(removeVideoTrack) {
   removeVideoTrack._log.debug('updating render hint:', updatedRenderHint);
   removeVideoTrack._setRenderHint(updatedRenderHint);
 }
+/**
+ * @typedef {object} VideoContentPreferences
+ * @property {VideoTrack.Dimensions} [renderDimensions] - Render Dimensions to request for the {@link RemoteVideoTrack}.
+ */
 
 /**
  * The {@link RemoteVideoTrack}'s dimensions changed.

--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -116,7 +116,7 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
    */
   switchOn() {
     if (this._subscribedTrackSwitchOffMode !== 'manual') {
-      throw new Error('Invalid state. You can call switchOn only when connected with bandwidthProfile.video.subscribedTrackSwitchOffMode set to "manual"');
+      throw new Error('Invalid state. You can call switchOn only when bandwidthProfile.video.subscribedTrackSwitchOffMode is set to "manual"');
     }
     this._setRenderHint({ enabled: true });
     return this;
@@ -129,7 +129,7 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
    */
   switchOff() {
     if (this._subscribedTrackSwitchOffMode !== 'manual') {
-      throw new Error('Invalid state. You can call switchOff only when connected with bandwidthProfile.video.subscribedTrackSwitchOffMode set to "manual"');
+      throw new Error('Invalid state. You can call switchOff only when bandwidthProfile.video.subscribedTrackSwitchOffMode is set to "manual"');
     }
     this._setRenderHint({ enabled: false });
     return this;
@@ -143,7 +143,7 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
    */
   setContentPreferences(contentPreferences) {
     if (this._contentPreferencesMode !== 'manual') {
-      throw new Error('Invalid state. You can call switchOn only when connected with bandwidthProfile.video.contentPreferencesMode set to "manual"');
+      throw new Error('Invalid state. You can call switchOn only when bandwidthProfile.video.contentPreferencesMode is set to "manual"');
     }
 
     if (contentPreferences.renderDimensions) {

--- a/lib/participant.js
+++ b/lib/participant.js
@@ -95,11 +95,11 @@ class Participant extends EventEmitter {
       _instanceId: {
         value: ++nInstances
       },
-      _idleTrackSwitchOff: {
-        value: options.idleTrackSwitchOff,
+      _subscribedTrackSwitchOffMode: {
+        value: options.subscribedTrackSwitchOffMode,
       },
-      _renderHints: {
-        value: options.renderHints,
+      _contentPreferencesMode: {
+        value: options.contentPreferencesMode,
       },
       _log: {
         value: log
@@ -262,7 +262,7 @@ class Participant extends EventEmitter {
    * @private
    */
   _handleTrackSignalingEvents() {
-    const { _log: log, _idleTrackSwitchOff: idleTrackSwitchOff, _renderHints: renderHints } = this;
+    const { _log: log, _subscribedTrackSwitchOffMode: subscribedTrackSwitchOffMode, _contentPreferencesMode: contentPreferencesMode } = this;
     const self = this;
 
     if (this.state === 'disconnected') {
@@ -337,7 +337,7 @@ class Participant extends EventEmitter {
         return;
       }
 
-      const options = { log, name, idleTrackSwitchOff, renderHints };
+      const options = { log, name, subscribedTrackSwitchOffMode, contentPreferencesMode };
       const setPriority = newPriority => participantSignaling.updateSubscriberTrackPriority(sid, newPriority);
       const setRenderHint = renderHint => {
         if (signaling.isSubscribed) {

--- a/lib/room.js
+++ b/lib/room.js
@@ -67,11 +67,11 @@ class Room extends EventEmitter {
       _log: {
         value: log
       },
-      _idleTrackSwitchOff: {
-        value: options.idleTrackSwitchOff === true
+      _subscribedTrackSwitchOffMode: {
+        value: options.subscribedTrackSwitchOffMode || 'disabled'
       },
-      _renderHints: {
-        value: options.renderHints === true
+      _contentPreferencesMode: {
+        value: options.contentPreferencesMode || 'disabled'
       },
       _instanceId: {
         value: ++nInstances
@@ -456,8 +456,8 @@ function rewriteLocalTrackIds(room, trackStats) {
  */
 
 function connectParticipant(room, participantSignaling) {
-  const { _log: log, _idleTrackSwitchOff: idleTrackSwitchOff, _renderHints: renderHints } = room;
-  const participant = new RemoteParticipant(participantSignaling, { log, idleTrackSwitchOff, renderHints });
+  const { _log: log, _subscribedTrackSwitchOffMode: subscribedTrackSwitchOffMode, _contentPreferencesMode: contentPreferencesMode } = room;
+  const participant = new RemoteParticipant(participantSignaling, { log, subscribedTrackSwitchOffMode, contentPreferencesMode });
 
   log.info('A new RemoteParticipant connected:', participant);
   room._participants.set(participant.sid, participant);

--- a/lib/signaling/v2/cancelableroomsignalingpromise.js
+++ b/lib/signaling/v2/cancelableroomsignalingpromise.js
@@ -79,7 +79,8 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
     // dominantSpeaker, networkQuality
     const trackPriority = !!bandwidthProfile;
     const trackSwitchOff = !!bandwidthProfile;
-    const renderHints = !!bandwidthProfile && (options.idleTrackSwitchOff || options.renderHints);
+    const renderHints = !!bandwidthProfile &&
+      (options.subscribedTrackSwitchOffMode !== 'disabled' || options.contentPreferencesMode !== 'disabled');
 
     const transportOptions = Object.assign({
       automaticSubscription,

--- a/lib/signaling/v2/renderhintssignaling.js
+++ b/lib/signaling/v2/renderhintssignaling.js
@@ -86,8 +86,11 @@ class RenderHintsSignaling extends MediaSignaling {
     // convert hint to msp format
     const mspHint = {
       'track': trackSid,
-      'enabled': !!renderHint.enabled,
     };
+
+    if ('enabled' in renderHint) {
+      mspHint.enabled = !!renderHint.enabled;
+    }
 
     if (renderHint.renderDimensions) {
       // eslint-disable-next-line camelcase

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -84,3 +84,13 @@ module.exports.trackPriority = {
   PRIORITY_LOW: 'low',
   PRIORITY_STANDARD: 'standard'
 };
+
+module.exports.subscribedTrackSwitchOffMode = {
+  MODE_AUTO: 'auto',
+  MODE_MANUAL: 'manual'
+};
+
+module.exports.videoContentPreferencesMode = {
+  MODE_AUTO: 'auto',
+  MODE_MANUAL: 'manual'
+};

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -617,7 +617,7 @@ function createRoomConnectEventPayload(connectOptions) {
   if (connectOptions.bandwidthProfile && connectOptions.bandwidthProfile.video) {
     const videoBPOptions = connectOptions.bandwidthProfile.video || {};
     payload.bandwidthProfileOptions = {};
-    ['mode', 'maxTracks', 'trackSwitchOffMode', 'dominantSpeakerPriority', 'maxSubscriptionBitrate', 'renderDimensions', 'idleTrackSwitchOff'].forEach(prop => {
+    ['mode', 'maxTracks', 'trackSwitchOffMode', 'dominantSpeakerPriority', 'maxSubscriptionBitrate', 'renderDimensions', 'contentPreferencesMode', 'subscribedTrackSwitchOffMode'].forEach(prop => {
       if (typeof videoBPOptions[prop] === 'number' || typeof videoBPOptions[prop] === 'string') {
         payload.bandwidthProfileOptions[prop] = videoBPOptions[prop];
       } else if (typeof videoBPOptions[prop] === 'boolean') {

--- a/lib/util/validate.js
+++ b/lib/util/validate.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { isNonArrayObject } = require('./');
-const { typeErrors: E, subscriptionMode, trackPriority, trackSwitchOffMode } = require('./constants');
+const { typeErrors: E, subscribedTrackSwitchOffMode, videoContentPreferencesMode, subscriptionMode, trackPriority, trackSwitchOffMode } = require('./constants');
 
 /**
  * Validate the {@link BandwidthProfileOptions} object.
@@ -14,16 +14,37 @@ function validateBandwidthProfile(bandwidthProfile) {
     return error;
   }
   error = validateObject(bandwidthProfile.video, 'options.bandwidthProfile.video', [
+    { prop: 'contentPreferencesMode', values: Object.values(videoContentPreferencesMode) },
     { prop: 'dominantSpeakerPriority', values: Object.values(trackPriority) },
-    { prop: 'idleTrackSwitchOff', type: 'boolean' },
     { prop: 'maxSubscriptionBitrate', type: 'number' },
     { prop: 'maxTracks', type: 'number' },
     { prop: 'mode', values: Object.values(subscriptionMode) },
+    { prop: 'subscribedTrackSwitchOffMode', values: Object.values(subscribedTrackSwitchOffMode) },
     { prop: 'trackSwitchOffMode', values: Object.values(trackSwitchOffMode) }
   ]);
-  return error || (bandwidthProfile.video
-    ? validateRenderDimensions(bandwidthProfile.video.renderDimensions)
-    : null);
+
+  if (error) {
+    return error;
+  }
+
+  if (bandwidthProfile.video) {
+
+    // maxTracks is replaced by subscribedTrackSwitchOffMode.
+    // throw an error if both are specified.
+    if ('maxTracks' in bandwidthProfile.video && 'subscribedTrackSwitchOffMode' in bandwidthProfile.video) {
+      return new TypeError('options.bandwidthProfile.video.maTracks is deprecated. Use options.bandwidthProfile.video.subscribedTrackSwitchOffMode instead');
+    }
+
+    // renderDimensions is replaced by contentPreferencesMode.
+    // throw an error if both are specified.
+    if ('renderDimensions' in bandwidthProfile.video && 'contentPreferencesMode' in bandwidthProfile.video) {
+      return new TypeError('options.bandwidthProfile.video.renderDimensions is deprecated. Use options.bandwidthProfile.video.contentPreferencesMode instead');
+    }
+
+    return validateRenderDimensions(bandwidthProfile.video.renderDimensions);
+  }
+
+  return null;
 }
 
 /**
@@ -90,9 +111,6 @@ function validateObject(object, name, propChecks = []) {
  */
 function validateRenderDimensions(renderDimensions) {
   const name = 'options.bandwidthProfile.video.renderDimensions';
-  if (renderDimensions === 'auto') {
-    return null;
-  }
   let error = validateObject(renderDimensions, name);
   return renderDimensions ? error || Object.values(trackPriority).reduce((error, prop) => {
     return error || validateObject(renderDimensions[prop], `${name}.${prop}`, [

--- a/test/integration/spec/bandwidthprofile.js
+++ b/test/integration/spec/bandwidthprofile.js
@@ -489,9 +489,9 @@ describe('BandwidthProfileOptions', function() {
 
     [
       {
-        dimA: { width: 1024, height: 720 },
-        dimB: { width: 50, height: 40 },
-        expectBandwidthUsageIncrease: false
+        dimA: { width: 50, height: 40 },
+        dimB: { width: 1024, height: 720 },
+        expectBandwidthUsageIncrease: true
       },
       {
         dimA: { width: 1024, height: 720 },
@@ -507,7 +507,7 @@ describe('BandwidthProfileOptions', function() {
           loggerName: 'BobLogger',
           bandwidthProfile: {
             video: {
-              contentPreferencesMode: 'manual',
+              contentPreferencesMode: 'auto',
               dominantSpeakerPriority: PRIORITY_STANDARD
             }
           },

--- a/test/integration/spec/bandwidthprofile.js
+++ b/test/integration/spec/bandwidthprofile.js
@@ -363,7 +363,7 @@ describe('BandwidthProfileOptions', function() {
   });
 
   describe('renderHints', () => {
-    it('with _setRenderHint Bob can turn On/Off Alice\'s track on demand', async () => {
+    it('with RemoteVideoTrack.switchOn/switchOff Bob can turn On/Off Alice\'s track on demand', async () => {
       const aliceLocalVideo = await waitFor(createLocalVideoTrack(), 'alice local video track');
       const aliceOptions = { tracks: [aliceLocalVideo] };
       const bobOptions = {
@@ -390,14 +390,12 @@ describe('BandwidthProfileOptions', function() {
       assert.strictEqual(aliceRemoteTrack.isSwitchedOff, false, `Alice's Track.isSwitchedOff = ${aliceRemoteTrack.isSwitchedOff}`);
       await assertMediaFlow(bobRoom, true, `was expecting media flow: ${roomSid}`);
 
-      // call _setRenderHint to force switch OFF the track.
-      aliceRemoteTrack._setRenderHint({ enabled: false });
+      aliceRemoteTrack.switchOff();
       await waitFor(trackSwitchedOff(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch off: ${roomSid}`);
       assert.strictEqual(aliceRemoteTrack.isSwitchedOff, true, `Alice's Track.isSwitchedOff = ${aliceRemoteTrack.isSwitchedOff}`);
       await assertMediaFlow(bobRoom, false, `was not expecting media flow: ${roomSid}`);
 
-      // call _setRenderHint to force switch ON the track.
-      aliceRemoteTrack._setRenderHint({ enabled: true });
+      aliceRemoteTrack.switchOn();
       await waitFor(trackSwitchedOn(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch on: ${roomSid}`);
       assert.strictEqual(aliceRemoteTrack.isSwitchedOff, false, `Alice's Track.isSwitchedOff = ${aliceRemoteTrack.isSwitchedOff}`);
       await assertMediaFlow(bobRoom, true, `was expecting media flow: ${roomSid}`);

--- a/test/integration/spec/bandwidthprofile.js
+++ b/test/integration/spec/bandwidthprofile.js
@@ -271,98 +271,10 @@ describe('BandwidthProfileOptions', function() {
     });
   });
 
-
-  ['auto', 'manual'].forEach(subscribedTrackSwitchOffMode => {
-    describe(`subscribedTrackSwitchOffMode (${subscribedTrackSwitchOffMode})`, () => {
-      let roomSid = null;
-      let bobRoom;
-      let aliceRemote;
-      let aliceRemoteTrack;
-      let videoElement1;
-      let videoElement2;
-      before(async () => {
-        const aliceLocalVideo = await waitFor(createLocalVideoTrack(), 'alice local video track');
-        const aliceOptions = { tracks: [aliceLocalVideo] };
-        const bobOptions = {
-          tracks: [],
-          loggerName: 'BobLogger',
-          bandwidthProfile: {
-            video: {
-              subscribedTrackSwitchOffMode,
-              dominantSpeakerPriority: PRIORITY_STANDARD
-            }
-          },
-        };
-
-        const bobLogger = Logger.getLogger('BobLogger');
-        bobLogger.setLevel('info');
-
-        ({ roomSid, bobRoom, aliceRemote } = await setupAliceAndBob({ aliceOptions,  bobOptions }));
-
-        await waitFor(tracksSubscribed(aliceRemote, 1), `Bob to subscribe to Alice's track: ${roomSid}`);
-        aliceRemoteTrack = Array.from(aliceRemote.videoTracks.values())[0].track;
-      });
-
-      after(() => {
-        if (bobRoom) {
-          completeRoom(bobRoom);
-        }
-      });
-
-      if (subscribedTrackSwitchOffMode === 'auto') {
-        it('Track turns off if video element is not attached initially', async () => {
-          // since no video elements are attached. Tracks should switch off initially
-          await waitFor(trackSwitchedOff(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch off: ${roomSid}`);
-          assert.strictEqual(aliceRemoteTrack.isSwitchedOff, true, `Alice's Track.isSwitchedOff = ${aliceRemoteTrack.isSwitchedOff}`);
-          await assertMediaFlow(bobRoom, false, `was not expecting media flow: ${roomSid}`);
-        });
-
-        it('Track turns on when a video element is attached', async () => {
-          videoElement1 = aliceRemoteTrack.attach();
-          document.body.appendChild(videoElement1);
-          await waitFor(trackSwitchedOn(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch on: ${roomSid}`);
-          assert.strictEqual(aliceRemoteTrack.isSwitchedOff, false, `Alice's Track.isSwitchedOff = ${aliceRemoteTrack.isSwitchedOff}`);
-          await assertMediaFlow(bobRoom, true, `was expecting media flow: ${roomSid}`);
-        });
-
-        it('Track stays on when another video element is attached', async () => {
-          videoElement2 = aliceRemoteTrack.attach();
-          document.body.appendChild(videoElement2);
-          await waitFor(trackSwitchedOn(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch on: ${roomSid}`);
-          assert.strictEqual(aliceRemoteTrack.isSwitchedOff, false, `Alice's Track.isSwitchedOff = ${aliceRemoteTrack.isSwitchedOff}`);
-          await assertMediaFlow(bobRoom, true, `was expecting media flow: ${roomSid}`);
-        });
-
-        it('tracks stays on when one of the video element is detached ', async () => {
-          aliceRemoteTrack.detach(videoElement2);
-          videoElement2.remove();
-          await waitFor(trackSwitchedOn(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch on: ${roomSid}`);
-          assert.strictEqual(aliceRemoteTrack.isSwitchedOff, false, `Alice's Track.isSwitchedOff = ${aliceRemoteTrack.isSwitchedOff}`);
-          await assertMediaFlow(bobRoom, true, `was expecting media flow: ${roomSid}`);
-        });
-
-        it('tracks turns off when all video elements are detached ', async () => {
-          const elements = aliceRemoteTrack.detach();
-          elements.forEach(el => el.remove());
-          await waitFor(trackSwitchedOff(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch off: ${roomSid}`);
-          assert.strictEqual(aliceRemoteTrack.isSwitchedOff, true, `Alice's Track.isSwitchedOff = ${aliceRemoteTrack.isSwitchedOff}`);
-          await assertMediaFlow(bobRoom, false, `was not expecting media flow: ${roomSid}`);
-        });
-      } else {
-        it('Track turns on even if video element is not attached initially', async () => {
-          // since no video elements are attached. Tracks should switch off initially
-          await waitForNot(trackSwitchedOff(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch off: ${roomSid}`);
-          assert.strictEqual(aliceRemoteTrack.isSwitchedOff, false, `Alice's Track.isSwitchedOff = ${aliceRemoteTrack.isSwitchedOff}`);
-          await assertMediaFlow(bobRoom, true, `was expecting media flow: ${roomSid}`);
-        });
-      }
-    });
-  });
-
   describe('renderHints', () => {
     [
       {
-        testCase: 'subscribedTrackSwitchOffMode=manual',
+        testCase: 'when subscribedTrackSwitchOffMode=manual',
         bandwidthProfile: {
           video: {
             subscribedTrackSwitchOffMode: 'manual'
@@ -372,7 +284,7 @@ describe('BandwidthProfileOptions', function() {
         effectiveContentPreferencesMode: 'auto',
       },
       {
-        testCase: 'subscribedTrackSwitchOffMode=auto',
+        testCase: 'when subscribedTrackSwitchOffMode=auto',
         bandwidthProfile: {
           video: {
             subscribedTrackSwitchOffMode: 'auto'
@@ -382,7 +294,7 @@ describe('BandwidthProfileOptions', function() {
         effectiveContentPreferencesMode: 'auto',
       },
       {
-        testCase: 'subscribedTrackSwitchOffMode=unspecified',
+        testCase: 'when subscribedTrackSwitchOffMode=unspecified',
         bandwidthProfile: {
           video: {
           }
@@ -391,7 +303,7 @@ describe('BandwidthProfileOptions', function() {
         effectiveContentPreferencesMode: 'auto',
       },
       {
-        testCase: 'subscribedTrackSwitchOffMode=unspecified, maxTracks=5',
+        testCase: 'when subscribedTrackSwitchOffMode=unspecified, maxTracks=5',
         bandwidthProfile: {
           video: {
             maxTracks: 5,
@@ -401,7 +313,7 @@ describe('BandwidthProfileOptions', function() {
         effectiveContentPreferencesMode: 'auto',
       },
       {
-        testCase: 'contentPreferencesMode=manual',
+        testCase: 'when contentPreferencesMode=manual',
         bandwidthProfile: {
           video: {
             contentPreferencesMode: 'manual'
@@ -411,7 +323,7 @@ describe('BandwidthProfileOptions', function() {
         effectiveContentPreferencesMode: 'manual',
       },
       {
-        testCase: 'contentPreferencesMode=unspecified',
+        testCase: 'when contentPreferencesMode=unspecified',
         bandwidthProfile: {
           video: {
           }
@@ -432,72 +344,147 @@ describe('BandwidthProfileOptions', function() {
         effectiveContentPreferencesMode: 'disabled',
       }
     ].forEach(({ testCase, bandwidthProfile, effectiveSubscribedTrackSwitchOffMode,  effectiveContentPreferencesMode }) => {
-      beforeEach(() => {
+      let aliceRoom;
+      let bobRoom;
+      let roomSid;
+      let aliceRemote;
+      let aliceRemoteTrack;
+      let videoElement1;
+      let videoElement2;
+      context(testCase, () => {
+        before(async () => {
+          const aliceLocalVideo = await waitFor(createLocalVideoTrack(), 'alice local video track');
+          const aliceOptions = { tracks: [aliceLocalVideo] };
+          const bobOptions = {
+            tracks: [],
+            loggerName: 'BobLogger',
+            bandwidthProfile
+          };
 
+          const bobLogger = Logger.getLogger('BobLogger');
+          bobLogger.setLevel('info');
+
+          ({ roomSid, aliceRemote, aliceRoom, bobRoom } = await setupAliceAndBob({ aliceOptions,  bobOptions }));
+
+          await waitFor(tracksSubscribed(aliceRemote, 1), `Bob to subscribe to Alice's track: ${roomSid}`);
+
+          aliceRemoteTrack = Array.from(aliceRemote.videoTracks.values())[0].track;
+        });
+
+        after(() => {
+          [aliceRoom, bobRoom].forEach(room => room.disconnect());
+        });
+
+        it('sets correct render hint options for RemoteVideoTracks', () => {
+          assert(aliceRemoteTrack._subscribedTrackSwitchOffMode === effectiveSubscribedTrackSwitchOffMode);
+          assert(aliceRemoteTrack._contentPreferencesMode === effectiveContentPreferencesMode);
+        });
+
+        if (effectiveSubscribedTrackSwitchOffMode === 'manual') {
+          it('switchOn/switchOff can be used to turn tracks on/off', async () => {
+            // initially track should be switched on
+            await waitFor(trackSwitchedOn(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch on: ${roomSid}`);
+            assert.strictEqual(aliceRemoteTrack.isSwitchedOff, false, `Alice's Track.isSwitchedOff = ${aliceRemoteTrack.isSwitchedOff}`);
+            await assertMediaFlow(bobRoom, true, `was expecting media flow: ${roomSid}`);
+
+            aliceRemoteTrack.switchOff();
+            await waitFor(trackSwitchedOff(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch off: ${roomSid}`);
+            assert.strictEqual(aliceRemoteTrack.isSwitchedOff, true, `Alice's Track.isSwitchedOff = ${aliceRemoteTrack.isSwitchedOff}`);
+            await assertMediaFlow(bobRoom, false, `was not expecting media flow: ${roomSid}`);
+
+            aliceRemoteTrack.switchOn();
+            await waitFor(trackSwitchedOn(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch on: ${roomSid}`);
+            assert.strictEqual(aliceRemoteTrack.isSwitchedOff, false, `Alice's Track.isSwitchedOff = ${aliceRemoteTrack.isSwitchedOff}`);
+            await assertMediaFlow(bobRoom, true, `was expecting media flow: ${roomSid}`);
+          });
+        } else {
+          it('switchOff/switchOn methods throw an error', () => {
+            let switchOffError = false;
+            let switchOnError = false;
+            try {
+              aliceRemoteTrack.switchOff();
+            } catch (_e) {
+              switchOffError = true;
+            }
+
+            try {
+              aliceRemoteTrack.switchOn();
+            } catch (_e) {
+              switchOnError = true;
+            }
+
+            assert(switchOnError && switchOffError);
+          });
+        }
+
+        if (effectiveSubscribedTrackSwitchOffMode === 'auto') {
+          it('Track turns off if video element is not attached initially', async () => {
+            // since no video elements are attached. Tracks should switch off initially
+            await waitFor(trackSwitchedOff(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch off: ${roomSid}`);
+            assert.strictEqual(aliceRemoteTrack.isSwitchedOff, true, `Alice's Track.isSwitchedOff = ${aliceRemoteTrack.isSwitchedOff}`);
+            await assertMediaFlow(bobRoom, false, `was not expecting media flow: ${roomSid}`);
+          });
+
+          it('Track turns on when a video element is attached', async () => {
+            videoElement1 = aliceRemoteTrack.attach();
+            document.body.appendChild(videoElement1);
+            await waitFor(trackSwitchedOn(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch on: ${roomSid}`);
+            assert.strictEqual(aliceRemoteTrack.isSwitchedOff, false, `Alice's Track.isSwitchedOff = ${aliceRemoteTrack.isSwitchedOff}`);
+            await assertMediaFlow(bobRoom, true, `was expecting media flow: ${roomSid}`);
+          });
+
+          it('Track stays on when another video element is attached', async () => {
+            videoElement2 = aliceRemoteTrack.attach();
+            document.body.appendChild(videoElement2);
+            await waitFor(trackSwitchedOn(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch on: ${roomSid}`);
+            assert.strictEqual(aliceRemoteTrack.isSwitchedOff, false, `Alice's Track.isSwitchedOff = ${aliceRemoteTrack.isSwitchedOff}`);
+            await assertMediaFlow(bobRoom, true, `was expecting media flow: ${roomSid}`);
+          });
+
+          it('tracks stays on when one of the video element is detached ', async () => {
+            aliceRemoteTrack.detach(videoElement2);
+            videoElement2.remove();
+            await waitFor(trackSwitchedOn(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch on: ${roomSid}`);
+            assert.strictEqual(aliceRemoteTrack.isSwitchedOff, false, `Alice's Track.isSwitchedOff = ${aliceRemoteTrack.isSwitchedOff}`);
+            await assertMediaFlow(bobRoom, true, `was expecting media flow: ${roomSid}`);
+          });
+
+          it('tracks turns off when all video elements are detached ', async () => {
+            const elements = aliceRemoteTrack.detach();
+            elements.forEach(el => el.remove());
+            await waitFor(trackSwitchedOff(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch off: ${roomSid}`);
+            assert.strictEqual(aliceRemoteTrack.isSwitchedOff, true, `Alice's Track.isSwitchedOff = ${aliceRemoteTrack.isSwitchedOff}`);
+            await assertMediaFlow(bobRoom, false, `was not expecting media flow: ${roomSid}`);
+          });
+        } else {
+          it('Track turns on even if video element is not attached initially', async () => {
+            // since no video elements are attached. Tracks should switch off initially
+            await waitForNot(trackSwitchedOff(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch off: ${roomSid}`);
+            assert.strictEqual(aliceRemoteTrack.isSwitchedOff, false, `Alice's Track.isSwitchedOff = ${aliceRemoteTrack.isSwitchedOff}`);
+            await assertMediaFlow(bobRoom, true, `was expecting media flow: ${roomSid}`);
+          });
+        }
+
+        if (effectiveContentPreferencesMode === 'manual') {
+          it('setContentPreference does not throw', () => {
+            try {
+              aliceRemoteTrack.setContentPreferences({ renderDimensions: { width: 100, height: 100 } });
+            } catch (e) {
+              assert(false, 'was not expecting setContentPreferences to throw: ' + e);
+            }
+          });
+        } else {
+          it('setContentPreference throws', () => {
+            let errorThrown = false;
+            try {
+              aliceRemoteTrack.setContentPreferences({ renderDimensions: { width: 100, height: 100 } });
+            } catch (_e) {
+              errorThrown = true;
+            }
+            assert(errorThrown);
+          });
+        }
       });
-      afterEach(() => {
-
-      });
-
-      it('sets correct render hint options for RemoteVideoTracks when: ' + testCase, async () => {
-        const aliceLocalVideo = await waitFor(createLocalVideoTrack(), 'alice local video track');
-        const aliceOptions = { tracks: [aliceLocalVideo] };
-        const bobOptions = {
-          tracks: [],
-          loggerName: 'BobLogger',
-          bandwidthProfile
-        };
-
-        const bobLogger = Logger.getLogger('BobLogger');
-        bobLogger.setLevel('info');
-
-        const { roomSid, aliceRemote, aliceRoom, bobRoom } = await setupAliceAndBob({ aliceOptions,  bobOptions });
-
-        await waitFor(tracksSubscribed(aliceRemote, 1), `Bob to subscribe to Alice's track: ${roomSid}`);
-        const aliceRemoteTrack = Array.from(aliceRemote.videoTracks.values())[0].track;
-        assert(aliceRemoteTrack._subscribedTrackSwitchOffMode === effectiveSubscribedTrackSwitchOffMode);
-        assert(aliceRemoteTrack._contentPreferencesMode === effectiveContentPreferencesMode);
-
-        [aliceRoom, bobRoom].forEach(room => room.disconnect());
-      });
-    });
-
-    it('with RemoteVideoTrack.switchOn/switchOff Bob can turn On/Off Alice\'s track on demand', async () => {
-      const aliceLocalVideo = await waitFor(createLocalVideoTrack(), 'alice local video track');
-      const aliceOptions = { tracks: [aliceLocalVideo] };
-      const bobOptions = {
-        tracks: [],
-        loggerName: 'BobLogger',
-        bandwidthProfile: {
-          video: {
-            subscribedTrackSwitchOffMode: 'manual',
-            dominantSpeakerPriority: PRIORITY_STANDARD
-          }
-        },
-      };
-
-      const bobLogger = Logger.getLogger('BobLogger');
-      bobLogger.setLevel('info');
-
-      const { roomSid, bobRoom, aliceRemote } = await setupAliceAndBob({ aliceOptions,  bobOptions });
-
-      await waitFor(tracksSubscribed(aliceRemote, 1), `Bob to subscribe to Alice's track: ${roomSid}`);
-      const aliceRemoteTrack = Array.from(aliceRemote.videoTracks.values())[0].track;
-
-      // initially track should be switched on
-      await waitFor(trackSwitchedOn(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch on: ${roomSid}`);
-      assert.strictEqual(aliceRemoteTrack.isSwitchedOff, false, `Alice's Track.isSwitchedOff = ${aliceRemoteTrack.isSwitchedOff}`);
-      await assertMediaFlow(bobRoom, true, `was expecting media flow: ${roomSid}`);
-
-      aliceRemoteTrack.switchOff();
-      await waitFor(trackSwitchedOff(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch off: ${roomSid}`);
-      assert.strictEqual(aliceRemoteTrack.isSwitchedOff, true, `Alice's Track.isSwitchedOff = ${aliceRemoteTrack.isSwitchedOff}`);
-      await assertMediaFlow(bobRoom, false, `was not expecting media flow: ${roomSid}`);
-
-      aliceRemoteTrack.switchOn();
-      await waitFor(trackSwitchedOn(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch on: ${roomSid}`);
-      assert.strictEqual(aliceRemoteTrack.isSwitchedOff, false, `Alice's Track.isSwitchedOff = ${aliceRemoteTrack.isSwitchedOff}`);
-      await assertMediaFlow(bobRoom, true, `was expecting media flow: ${roomSid}`);
     });
 
     [

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -125,6 +125,39 @@ describe('connect', function() {
     });
   });
 
+  describe('should return a CancelablePromise that rejects when called with invalid bandwidth Profile options: ', () => {
+    [
+      {
+        name: 'both maxTracks and subscriberTrackSwitchOffMode=auto specified',
+        bandwidthProfile: { video: { maxTracks: 5,  subscribedTrackSwitchOffMode: 'auto' } }
+      },
+      {
+        name: 'both maxTracks and subscriberTrackSwitchOffMode=manual specified',
+        bandwidthProfile: { video: { maxTracks: 5,  subscribedTrackSwitchOffMode: 'manual' } }
+      },
+      {
+        name: 'both renderDimensions and contentPreferencesMode=auto specified',
+        bandwidthProfile: { video: { renderDimensions: {},  contentPreferencesMode: 'auto' } }
+      },
+      {
+        name: 'both renderDimensions and contentPreferencesMode=manual specified',
+        bandwidthProfile: { video: { renderDimensions: {},  contentPreferencesMode: 'manual' } }
+      },
+    ].forEach(testCase => {
+      it(testCase.name, async () => {
+        try {
+          const identity = randomName();
+          const token = getToken(identity);
+          const room = await connect(token, Object.assign({}, defaults, { bandwidthProfile: testCase.bandwidthProfile }));
+          room.disconnect();
+          throw new Error(`Connected to ${room.sid} with an invalid bandwidthProfile`);
+        } catch (error) {
+          assert(error instanceof TypeError);
+        }
+      });
+    });
+  });
+
   describe(`automaticSubscription (${defaults.topology} topology)`, () => {
     [undefined, true, false].forEach(automaticSubscription => {
       const automaticSubscriptionOptions = typeof automaticSubscription === 'boolean'

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -375,7 +375,6 @@ describe('LocalTrackPublication', function() {
           testOptions: {
             bandwidthProfile: {
               video: {
-                idleTrackSwitchOff: false,
                 maxTracks: 1,
                 dominantSpeakerPriority: 'low'
               }
@@ -521,7 +520,6 @@ describe('LocalTrackPublication', function() {
             aliceOptions: {
               bandwidthProfile: {
                 video: {
-                  idleTrackSwitchOff: false,
                   maxTracks: 1,
                   dominantSpeakerPriority: 'low'
                 }
@@ -633,7 +631,6 @@ describe('LocalTrackPublication', function() {
         aliceOptions: {
           bandwidthProfile: {
             video: {
-              idleTrackSwitchOff: false,
               maxTracks: 1,
               dominantSpeakerPriority: 'low'
             }

--- a/test/integration/spec/remotetracks.js
+++ b/test/integration/spec/remotetracks.js
@@ -58,7 +58,6 @@ describe('RemoteVideoTrack', function() {
         testOptions: {
           bandwidthProfile: {
             video: {
-              idleTrackSwitchOff: false,
               maxTracks: 1,
               dominantSpeakerPriority: 'low'
             }
@@ -205,7 +204,6 @@ describe('RemoteVideoTrack', function() {
         logLevel: 'warn',
         bandwidthProfile: {
           video: {
-            idleTrackSwitchOff: false,
             maxTracks: 1,
             dominantSpeakerPriority: 'low'
           }

--- a/test/integration/spec/room.js
+++ b/test/integration/spec/room.js
@@ -603,7 +603,7 @@ describe('Room', function() {
     before(async () => {
       let thoseRooms;
       [, aliceRoom, thoseRooms] = await setup({
-        testOptions: { tracks: [], bandwidthProfile: { video: { maxTracks: 1, idleTrackSwitchOff: false } } },
+        testOptions: { tracks: [], bandwidthProfile: { video: { maxTracks: 1 } } },
         otherOptions: { tracks: [] },
         participantNames: ['Alice', 'Bob', 'Charlie'],
         nTracks: 0

--- a/test/unit/spec/connect.js
+++ b/test/unit/spec/connect.js
@@ -14,8 +14,10 @@ const {
   WS_SERVER,
   DEFAULT_REGION,
   subscriptionMode,
+  subscribedTrackSwitchOffMode,
   trackSwitchOffMode,
-  trackPriority
+  trackPriority,
+  videoContentPreferencesMode,
 } = require('../../../lib/util/constants');
 
 const Log = require('../../../lib/util/log');
@@ -165,6 +167,8 @@ describe('connect', () => {
     const subscriptionModes = Object.values(subscriptionMode);
     const trackPriorities = Object.values(trackPriority);
     const trackSwitchOffModes = Object.values(trackSwitchOffMode);
+    const subscribedTrackSwitchOffModes = Object.values(subscribedTrackSwitchOffMode);
+    const contentPreferencesModes = Object.values(videoContentPreferencesMode);
 
     let mockSignaling;
     let signaling;
@@ -208,6 +212,14 @@ describe('connect', () => {
       [{ video: { renderDimensions: { standard: { width: 'foo', height: 100 } } } }, 'whose .video.renderDimensions.standard.width is not a number', TypeError, 'number'],
       [{ video: { renderDimensions: { standard: { width: 200, height: false } } } }, 'whose .video.renderDimensions.standard.height is not a number', TypeError, 'number'],
       [{ video: { renderDimensions: { standard: { width: 200, height: false } } } }, 'whose .video.renderDimensions.standard.height is not a number', TypeError, 'number'],
+      [{ video: { subscribedTrackSwitchOffMode: 2 } }, `whose .video.subscribedTrackSwitchOffMode is not one of ${subscribedTrackSwitchOffModes.join(', ')}`, RangeError, subscribedTrackSwitchOffModes],
+      [{ video: { subscribedTrackSwitchOffMode: 'foo' } }, `whose .video.subscribedTrackSwitchOffMode is not one of ${subscribedTrackSwitchOffModes.join(', ')}`, RangeError, subscribedTrackSwitchOffModes],
+      [{ video: { subscribedTrackSwitchOffMode: 'auto', maxTracks: 5 } }, 'which specified both maxTracks and subscribedTrackSwitchOffMode', Error, 'options.bandwidthProfile.video.maTracks is deprecated. Use options.bandwidthProfile.video.subscribedTrackSwitchOffMode instead'],
+      [{ video: { subscribedTrackSwitchOffMode: 'manual', maxTracks: 5 } }, 'which specified both maxTracks and subscribedTrackSwitchOffMode', Error, 'options.bandwidthProfile.video.maTracks is deprecated. Use options.bandwidthProfile.video.subscribedTrackSwitchOffMode instead'],
+      [{ video: { contentPreferencesMode: 2 } }, `whose .video.videoContentPreferences is not one of ${contentPreferencesModes.join(', ')}`, RangeError, contentPreferencesModes],
+      [{ video: { contentPreferencesMode: 'foo' } }, `whose .video.videoContentPreferences is not one of ${contentPreferencesModes.join(', ')}`, RangeError, contentPreferencesModes],
+      [{ video: { contentPreferencesMode: 'auto', renderDimensions: {} } }, 'which specified both contentPreferences and renderDimensions', Error, 'options.bandwidthProfile.video.renderDimensions is deprecated. Use options.bandwidthProfile.video.contentPreferencesMode instead'],
+      [{ video: { contentPreferencesMode: 'manual', renderDimensions: {} } }, 'which specified both contentPreferences and renderDimensions', Error, 'options.bandwidthProfile.video.renderDimensions is deprecated. Use options.bandwidthProfile.video.contentPreferencesMode instead'],
     ].forEach(([bandwidthProfile, scenario, ExpectedError, expectedTypeOrValues]) => {
       context(scenario, () => {
         it(`should reject the CancelablePromise with a ${ExpectedError.name}`, async () => {
@@ -242,6 +254,8 @@ describe('connect', () => {
 
           if (ExpectedError === TypeError) {
             expectedErrorMessage += ` must be ${a(expectedTypeOrValues)} ${expectedTypeOrValues}`;
+          } else if (typeof expectedTypeOrValues === 'string') {
+            expectedErrorMessage = expectedTypeOrValues;
           } else {
             expectedErrorMessage += ` must be one of ${expectedTypeOrValues.join(', ')}`;
           }

--- a/test/unit/spec/media/track/remotevideotrack.js
+++ b/test/unit/spec/media/track/remotevideotrack.js
@@ -13,18 +13,18 @@ const { NullIntersectionObserver: IntersectionObserver, NullResizeObserver: Resi
 describe('RemoteVideoTrack', () => {
   combinationContext([
     [
-      [true, false, undefined],
-      x => `when idleTrackSwitchOff is ${typeof x === 'boolean' ? `set to ${x}` : 'not set'}`
+      ['auto', 'manual', 'disabled', undefined],
+      x => `when subscribedTrackSwitchOffMode is ${typeof x === 'string' ? `set to ${x}` : 'not set'}`
     ],
     [
-      [true, false, undefined],
-      x => `when renderHints is ${typeof x === 'boolean' ? `set to ${x}` : 'not set'}`
+      ['auto', 'manual', 'disabled', undefined],
+      x => `when contentPreferencesMode is ${typeof x === 'boolean' ? `set to ${x}` : 'not set'}`
     ],
     [
       [true, false, undefined],
       x => `when enableDocumentVisibilityTurnOff is ${typeof x === 'boolean' ? `set to ${x}` : 'not set'}`
     ],
-  ], ([idleTrackSwitchOff, renderHints, enableDocumentVisibilityTurnOff]) => {
+  ], ([subscribedTrackSwitchOffMode, contentPreferencesMode, enableDocumentVisibilityTurnOff]) => {
     let track;
     let el;
     let IntersectionObserverSpy;
@@ -33,7 +33,7 @@ describe('RemoteVideoTrack', () => {
     let intersectionUnobserveSpy;
     let resizeObserveSpy;
     let resizeUnobserveSpy;
-    let setRenderHintSpy;
+    let setRenderHintsSpy;
     let addEventListenerStub;
     let removeEventListenerStub;
     before(() => {
@@ -43,11 +43,11 @@ describe('RemoteVideoTrack', () => {
       if (typeof enableDocumentVisibilityTurnOff === 'boolean') {
         options.enableDocumentVisibilityTurnOff = enableDocumentVisibilityTurnOff;
       }
-      if (typeof idleTrackSwitchOff === 'boolean') {
-        options.idleTrackSwitchOff = idleTrackSwitchOff;
+      if (typeof subscribedTrackSwitchOffMode === 'string') {
+        options.subscribedTrackSwitchOffMode = subscribedTrackSwitchOffMode;
       }
-      if (typeof renderHints === 'boolean') {
-        options.renderHints = renderHints;
+      if (typeof contentPreferencesMode === 'string') {
+        options.contentPreferencesMode = contentPreferencesMode;
       }
 
       global.document = global.document || new Document();
@@ -58,9 +58,9 @@ describe('RemoteVideoTrack', () => {
       removeEventListenerStub = sinon.spy(document, 'removeEventListener');
 
       el = document.createElement('video');
-      setRenderHintSpy = sinon.spy();
+      setRenderHintsSpy = sinon.spy();
 
-      track = makeTrack({ id: 'foo', sid: 'bar', setRenderHint: setRenderHintSpy, options });
+      track = makeTrack({ id: 'foo', sid: 'bar', setRenderHint: setRenderHintsSpy, options });
       intersectionObserveSpy = sinon.spy(track._intersectionObserver, 'observe');
       intersectionUnobserveSpy = sinon.spy(track._intersectionObserver, 'unobserve');
       resizeObserveSpy = sinon.spy(track._resizeObserver, 'observe');
@@ -75,24 +75,26 @@ describe('RemoteVideoTrack', () => {
       }
     });
 
-    const effectiveIdleTrackSwitchOff = idleTrackSwitchOff !== false;
-    const effectiveRenderHints = renderHints !== false;
-    const effectiveDocVisibility = effectiveIdleTrackSwitchOff && enableDocumentVisibilityTurnOff !== false;
+    const effectiveSubscribedTrackSwitchOffMode = subscribedTrackSwitchOffMode || 'auto';
+    const effectiveContentPreferencesMode = contentPreferencesMode || 'auto';
+    const effectiveDocVisibility = effectiveSubscribedTrackSwitchOffMode === 'auto' && enableDocumentVisibilityTurnOff !== false;
+    const autoTrackSwitchOff = effectiveSubscribedTrackSwitchOffMode === 'auto';
+    const autoContentPreferencesMode = effectiveContentPreferencesMode === 'auto';
 
     describe('constructor', () => {
-      it('sets correct default for _idleTrackSwitchOff', () => {
-        assert(track._idleTrackSwitchOff === effectiveIdleTrackSwitchOff);
+      it('sets correct default for _subscribedTrackSwitchOffMode', () => {
+        assert(track._subscribedTrackSwitchOffMode === effectiveSubscribedTrackSwitchOffMode);
       });
 
-      it('sets correct default for _renderHints', () => {
-        assert(track._renderHints === effectiveRenderHints);
+      it('sets correct default for _contentPreferencesMode', () => {
+        assert(track._contentPreferencesMode === effectiveContentPreferencesMode);
       });
 
       it('sets correct default for _enableDocumentVisibilityTurnOff', () => {
         assert(track._enableDocumentVisibilityTurnOff === effectiveDocVisibility);
       });
 
-      if (effectiveIdleTrackSwitchOff) {
+      if (autoTrackSwitchOff) {
         it('constructs IntersectionObserver', () => {
           sinon.assert.callCount(IntersectionObserverSpy, 1);
         });
@@ -102,7 +104,7 @@ describe('RemoteVideoTrack', () => {
         });
       }
 
-      if (effectiveRenderHints) {
+      if (autoContentPreferencesMode) {
         it('constructs ResizeObserver', () => {
           sinon.assert.callCount(ResizeObserverSpy, 1);
         });
@@ -142,7 +144,7 @@ describe('RemoteVideoTrack', () => {
       }
     });
 
-    context('when an element is detached', () => {
+    describe('when an element is detached', () => {
       before(() => {
         track.detach(el);
       });
@@ -152,10 +154,9 @@ describe('RemoteVideoTrack', () => {
         sinon.assert.calledWith(intersectionUnobserveSpy, el);
       });
 
-      if (effectiveIdleTrackSwitchOff || effectiveRenderHints) {
+      if (autoTrackSwitchOff) {
         it(' _setRenderHint gets called with { enable: false }', () => {
-          const enabled = effectiveIdleTrackSwitchOff === false;
-          sinon.assert.calledWith(setRenderHintSpy, { enabled });
+          sinon.assert.calledWith(setRenderHintsSpy, { enabled: false });
         });
       }
 
@@ -179,79 +180,66 @@ describe('RemoteVideoTrack', () => {
       }
     });
 
-  });
-
-  describe('#switchOn', () => {
-    [true, false, undefined].forEach(allowManualSwitchOff => {
-      let setRenderHintSpy;
-      let track;
+    describe('#switchOn', () => {
       beforeEach(() => {
-        setRenderHintSpy = sinon.spy();
-        track = makeTrack({ id: 'foo', sid: 'bar', setRenderHint: setRenderHintSpy, options: { allowManualSwitchOff } });
+        setRenderHintsSpy.resetHistory();
       });
-      if (allowManualSwitchOff !== false) {
-        it('calls _setRenderHint with enable = true when allowManualSwitchOff = ' + allowManualSwitchOff, () => {
+      const allowManualSwitchOff = effectiveSubscribedTrackSwitchOffMode === 'manual';
+      if (allowManualSwitchOff) {
+        it('calls _setRenderHint with enable = true', () => {
           track.switchOn();
-          sinon.assert.calledWith(setRenderHintSpy, sinon.match.has('enabled', true));
+          sinon.assert.calledWith(setRenderHintsSpy, sinon.match.has('enabled', true));
         });
       } else {
-        it('throws an error when allowManualSwitchOff = ' + allowManualSwitchOff, () => {
+        it('throws an error', () => {
           let errorThrown = null;
           try {
             track.switchOn();
           } catch (error) {
             errorThrown = error;
           }
-          assert.strictEqual(errorThrown.message, 'Invalid state. You can call switchOn only when connected with bandwidthProfile.video.subscribedTrackSwitchOff set to "manual"');
-          sinon.assert.notCalled(setRenderHintSpy);
+          assert.strictEqual(errorThrown.message, 'Invalid state. You can call switchOn only when connected with bandwidthProfile.video.subscribedTrackSwitchOffMode set to "manual"');
+          sinon.assert.notCalled(setRenderHintsSpy);
         });
       }
     });
-  });
 
-  describe('#switchOff', () => {
-    [true, false, undefined].forEach(allowManualSwitchOff => {
-      let setRenderHintSpy;
-      let track;
+    describe('#switchOff', () => {
       beforeEach(() => {
-        setRenderHintSpy = sinon.spy();
-        track = makeTrack({ id: 'foo', sid: 'bar', setRenderHint: setRenderHintSpy, options: { allowManualSwitchOff } });
+        setRenderHintsSpy.resetHistory();
       });
-      if (allowManualSwitchOff !== false) {
-        it('calls _setRenderHint with enable = true when allowManualSwitchOff = ' + allowManualSwitchOff, () => {
+      const allowManualSwitchOff = effectiveSubscribedTrackSwitchOffMode === 'manual';
+      if (allowManualSwitchOff) {
+        it('calls _setRenderHint with enable = false', () => {
           track.switchOff();
-          sinon.assert.calledWith(setRenderHintSpy, sinon.match.has('enabled', false));
+          sinon.assert.calledWith(setRenderHintsSpy, sinon.match.has('enabled', false));
         });
       } else {
-        it('throws an error when allowManualSwitchOff = ' + allowManualSwitchOff, () => {
+        it('throws an error', () => {
           let errorThrown = null;
           try {
             track.switchOff();
           } catch (error) {
             errorThrown = error;
           }
-          assert.strictEqual(errorThrown.message, 'Invalid state. You can call switchOff only when connected with bandwidthProfile.video.subscribedTrackSwitchOff set to "manual"');
-          sinon.assert.notCalled(setRenderHintSpy);
+          assert.strictEqual(errorThrown.message, 'Invalid state. You can call switchOff only when connected with bandwidthProfile.video.subscribedTrackSwitchOffMode set to "manual"');
+          sinon.assert.notCalled(setRenderHintsSpy);
         });
       }
     });
-  });
 
-  describe('#setContentPreferences', () => {
-    [true, false, undefined].forEach(allowManualContentHints => {
-      let setRenderHintSpy;
-      let track;
+    describe('#setContentPreferences', () => {
       beforeEach(() => {
-        setRenderHintSpy = sinon.spy();
-        track = makeTrack({ id: 'foo', sid: 'bar', setRenderHint: setRenderHintSpy, options: { allowManualContentHints } });
+        setRenderHintsSpy.resetHistory();
       });
+      const allowManualContentHints = effectiveContentPreferencesMode === 'manual';
       if (allowManualContentHints !== false) {
-        it('calls _setRenderHint with enable = true when allowManualContentHints = ' + allowManualContentHints, () => {
+        it('calls _setRenderHint with given dimensions', () => {
           track.setContentPreferences({ renderDimensions: { width: 100, height: 101 } });
-          sinon.assert.calledWith(setRenderHintSpy, sinon.match.has('renderDimensions', { width: 100, height: 101 }));
+          sinon.assert.calledWith(setRenderHintsSpy, sinon.match.has('renderDimensions', { width: 100, height: 101 }));
         });
       } else {
-        it('throws an error when allowManualContentHints = ' + allowManualContentHints, () => {
+        it('throws an error', () => {
           let errorThrown = null;
           try {
             track.setContentPreferences({ renderDimensions: { width: 100, height: 101 } });
@@ -259,7 +247,7 @@ describe('RemoteVideoTrack', () => {
             errorThrown = error;
           }
           assert.strictEqual(errorThrown.message, 'Invalid state. You can call switchOn only when connected with bandwidthProfile.video.renderDimensions set to "manual"');
-          sinon.assert.notCalled(setRenderHintSpy);
+          sinon.assert.notCalled(setRenderHintsSpy);
         });
       }
     });
@@ -271,13 +259,13 @@ describe('IntersectionObserver', () => {
   let el;
   let observeSpy;
   let unobserveSpy;
-  let setRenderHintSpy;
+  let setRenderHintsSpy;
 
   before(() => {
     global.document = global.document || new Document();
     el = document.createElement('video');
-    setRenderHintSpy = sinon.spy();
-    track = makeTrack({ id: 'foo', sid: 'bar', setRenderHint: setRenderHintSpy, options: { IntersectionObserver } });
+    setRenderHintsSpy = sinon.spy();
+    track = makeTrack({ id: 'foo', sid: 'bar', setRenderHint: setRenderHintsSpy, options: { IntersectionObserver } });
     observeSpy = sinon.spy(IntersectionObserver.prototype, 'observe');
     unobserveSpy = sinon.spy(IntersectionObserver.prototype, 'unobserve');
   });
@@ -293,18 +281,18 @@ describe('IntersectionObserver', () => {
   context('when an element is', () => {
     before(() => {
       track.attach(el);
-      setRenderHintSpy.reset();
+      setRenderHintsSpy.reset();
     });
 
     it('visible, _setRenderHint gets called with { enable: true }', () => {
       track._intersectionObserver.makeVisible(el);
-      sinon.assert.calledWith(setRenderHintSpy, sinon.match.has('enabled', true));
-      sinon.assert.calledWith(setRenderHintSpy, sinon.match.has('renderDimensions', { height: sinon.match.any, width: sinon.match.any }));
+      sinon.assert.calledWith(setRenderHintsSpy, sinon.match.has('enabled', true));
+      sinon.assert.calledWith(setRenderHintsSpy, sinon.match.has('renderDimensions', { height: sinon.match.any, width: sinon.match.any }));
     });
 
     it('invisible, _setRenderHint gets called with { enable: false }', () => {
       track._intersectionObserver.makeInvisible(el);
-      sinon.assert.calledWith(setRenderHintSpy, { enabled: false });
+      sinon.assert.calledWith(setRenderHintsSpy, { enabled: false });
     });
 
   });
@@ -315,13 +303,13 @@ describe('ResizeObserver', () => {
   let el;
   let observeSpy;
   let unobserveSpy;
-  let setRenderHintSpy;
+  let setRenderHintsSpy;
 
   before(() => {
     global.document = global.document || new Document();
     el = document.createElement('video');
-    setRenderHintSpy = sinon.spy();
-    track = makeTrack({ id: 'foo', sid: 'bar', setRenderHint: setRenderHintSpy, options: { ResizeObserver } });
+    setRenderHintsSpy = sinon.spy();
+    track = makeTrack({ id: 'foo', sid: 'bar', setRenderHint: setRenderHintsSpy, options: { ResizeObserver } });
     observeSpy = sinon.spy(track._resizeObserver, 'observe');
     unobserveSpy = sinon.spy(track._resizeObserver, 'unobserve');
   });
@@ -340,12 +328,12 @@ describe('ResizeObserver', () => {
       track._intersectionObserver.makeVisible(el);
       el.clientWidth = 100;
       el.clientHeight = 100;
-      setRenderHintSpy.reset();
+      setRenderHintsSpy.reset();
     });
 
     it('_setRenderHint gets called with { enable: true }', () => {
       track._resizeObserver.resize(el);
-      sinon.assert.calledWith(setRenderHintSpy, { enabled: true, renderDimensions: { height: 100, width: 100 } });
+      sinon.assert.calledWith(setRenderHintsSpy, { enabled: true, renderDimensions: { height: 100, width: 100 } });
     });
   });
 
@@ -355,12 +343,12 @@ describe('ResizeObserver', () => {
       track._intersectionObserver.makeInvisible(el);
       el.clientWidth = 100;
       el.clientHeight = 100;
-      setRenderHintSpy.reset();
+      setRenderHintsSpy.reset();
     });
 
     it('_setRenderHint does not get called', () => {
       track._resizeObserver.resize(el);
-      sinon.assert.notCalled(setRenderHintSpy);
+      sinon.assert.notCalled(setRenderHintsSpy);
     });
   });
 
@@ -376,7 +364,7 @@ describe('ResizeObserver', () => {
       track._intersectionObserver.makeVisible(el2);
       el2.clientWidth = 200;
       el2.clientHeight = 200;
-      setRenderHintSpy.reset();
+      setRenderHintsSpy.reset();
     });
 
     it('_setRenderHint does not get called', () => {
@@ -384,7 +372,7 @@ describe('ResizeObserver', () => {
       track._resizeObserver.resize(el);
 
       // expect reported size to be 200x200
-      sinon.assert.calledWith(setRenderHintSpy, { enabled: true, renderDimensions: { height: 200, width: 200 } });
+      sinon.assert.calledWith(setRenderHintsSpy, { enabled: true, renderDimensions: { height: 200, width: 200 } });
     });
   });
 

--- a/test/unit/spec/media/track/remotevideotrack.js
+++ b/test/unit/spec/media/track/remotevideotrack.js
@@ -246,7 +246,7 @@ describe('RemoteVideoTrack', () => {
           } catch (error) {
             errorThrown = error;
           }
-          assert.strictEqual(errorThrown.message, 'Invalid state. You can call switchOn only when connected with bandwidthProfile.video.renderDimensions set to "manual"');
+          assert.strictEqual(errorThrown.message, 'Invalid state. You can call switchOn only when connected with bandwidthProfile.video.contentPreferencesMode set to "manual"');
           sinon.assert.notCalled(setRenderHintsSpy);
         });
       }

--- a/test/unit/spec/media/track/remotevideotrack.js
+++ b/test/unit/spec/media/track/remotevideotrack.js
@@ -198,7 +198,7 @@ describe('RemoteVideoTrack', () => {
           } catch (error) {
             errorThrown = error;
           }
-          assert.strictEqual(errorThrown.message, 'Invalid state. You can call switchOn only when connected with bandwidthProfile.video.subscribedTrackSwitchOffMode set to "manual"');
+          assert.strictEqual(errorThrown.message, 'Invalid state. You can call switchOn only when bandwidthProfile.video.subscribedTrackSwitchOffMode is set to "manual"');
           sinon.assert.notCalled(setRenderHintsSpy);
         });
       }
@@ -222,7 +222,7 @@ describe('RemoteVideoTrack', () => {
           } catch (error) {
             errorThrown = error;
           }
-          assert.strictEqual(errorThrown.message, 'Invalid state. You can call switchOff only when connected with bandwidthProfile.video.subscribedTrackSwitchOffMode set to "manual"');
+          assert.strictEqual(errorThrown.message, 'Invalid state. You can call switchOff only when bandwidthProfile.video.subscribedTrackSwitchOffMode is set to "manual"');
           sinon.assert.notCalled(setRenderHintsSpy);
         });
       }
@@ -246,7 +246,7 @@ describe('RemoteVideoTrack', () => {
           } catch (error) {
             errorThrown = error;
           }
-          assert.strictEqual(errorThrown.message, 'Invalid state. You can call switchOn only when connected with bandwidthProfile.video.contentPreferencesMode set to "manual"');
+          assert.strictEqual(errorThrown.message, 'Invalid state. You can call switchOn only when bandwidthProfile.video.contentPreferencesMode is set to "manual"');
           sinon.assert.notCalled(setRenderHintsSpy);
         });
       }

--- a/test/unit/spec/media/track/remotevideotrack.js
+++ b/test/unit/spec/media/track/remotevideotrack.js
@@ -180,6 +180,90 @@ describe('RemoteVideoTrack', () => {
     });
 
   });
+
+  describe('#switchOn', () => {
+    [true, false, undefined].forEach(allowManualSwitchOff => {
+      let setRenderHintSpy;
+      let track;
+      beforeEach(() => {
+        setRenderHintSpy = sinon.spy();
+        track = makeTrack({ id: 'foo', sid: 'bar', setRenderHint: setRenderHintSpy, options: { allowManualSwitchOff } });
+      });
+      if (allowManualSwitchOff !== false) {
+        it('calls _setRenderHint with enable = true when allowManualSwitchOff = ' + allowManualSwitchOff, () => {
+          track.switchOn();
+          sinon.assert.calledWith(setRenderHintSpy, sinon.match.has('enabled', true));
+        });
+      } else {
+        it('throws an error when allowManualSwitchOff = ' + allowManualSwitchOff, () => {
+          let errorThrown = null;
+          try {
+            track.switchOn();
+          } catch (error) {
+            errorThrown = error;
+          }
+          assert.strictEqual(errorThrown.message, 'Invalid state. You can call switchOn only when connected with bandwidthProfile.video.subscribedTrackSwitchOff set to "manual"');
+          sinon.assert.notCalled(setRenderHintSpy);
+        });
+      }
+    });
+  });
+
+  describe('#switchOff', () => {
+    [true, false, undefined].forEach(allowManualSwitchOff => {
+      let setRenderHintSpy;
+      let track;
+      beforeEach(() => {
+        setRenderHintSpy = sinon.spy();
+        track = makeTrack({ id: 'foo', sid: 'bar', setRenderHint: setRenderHintSpy, options: { allowManualSwitchOff } });
+      });
+      if (allowManualSwitchOff !== false) {
+        it('calls _setRenderHint with enable = true when allowManualSwitchOff = ' + allowManualSwitchOff, () => {
+          track.switchOff();
+          sinon.assert.calledWith(setRenderHintSpy, sinon.match.has('enabled', false));
+        });
+      } else {
+        it('throws an error when allowManualSwitchOff = ' + allowManualSwitchOff, () => {
+          let errorThrown = null;
+          try {
+            track.switchOff();
+          } catch (error) {
+            errorThrown = error;
+          }
+          assert.strictEqual(errorThrown.message, 'Invalid state. You can call switchOff only when connected with bandwidthProfile.video.subscribedTrackSwitchOff set to "manual"');
+          sinon.assert.notCalled(setRenderHintSpy);
+        });
+      }
+    });
+  });
+
+  describe('#setContentPreferences', () => {
+    [true, false, undefined].forEach(allowManualContentHints => {
+      let setRenderHintSpy;
+      let track;
+      beforeEach(() => {
+        setRenderHintSpy = sinon.spy();
+        track = makeTrack({ id: 'foo', sid: 'bar', setRenderHint: setRenderHintSpy, options: { allowManualContentHints } });
+      });
+      if (allowManualContentHints !== false) {
+        it('calls _setRenderHint with enable = true when allowManualContentHints = ' + allowManualContentHints, () => {
+          track.setContentPreferences({ renderDimensions: { width: 100, height: 101 } });
+          sinon.assert.calledWith(setRenderHintSpy, sinon.match.has('renderDimensions', { width: 100, height: 101 }));
+        });
+      } else {
+        it('throws an error when allowManualContentHints = ' + allowManualContentHints, () => {
+          let errorThrown = null;
+          try {
+            track.setContentPreferences({ renderDimensions: { width: 100, height: 101 } });
+          } catch (error) {
+            errorThrown = error;
+          }
+          assert.strictEqual(errorThrown.message, 'Invalid state. You can call switchOn only when connected with bandwidthProfile.video.renderDimensions set to "manual"');
+          sinon.assert.notCalled(setRenderHintSpy);
+        });
+      }
+    });
+  });
 });
 
 describe('IntersectionObserver', () => {

--- a/test/unit/spec/signaling/v2/cancelableroomsignalingpromise.js
+++ b/test/unit/spec/signaling/v2/cancelableroomsignalingpromise.js
@@ -117,8 +117,8 @@ describe('createCancelableRoomSignalingPromise', () => {
       name: 'case 1: no bandwidth profile specified',
       options: {
         bandwidthProfile: undefined,
-        idleTrackSwitchOff: true,
-        renderHints: true,
+        subscribedTrackSwitchOffMode: 'auto',
+        contentPreferencesMode: 'auto',
       },
       expected: {
         trackPriority: false,
@@ -127,11 +127,11 @@ describe('createCancelableRoomSignalingPromise', () => {
       }
     },
     {
-      name: 'case 2: idleTrackSwitchOff enabled',
+      name: 'case 2: subscribedTrackSwitchOffMode(manual) contentPreferencesMode(auto)',
       options: {
         bandwidthProfile: {},
-        idleTrackSwitchOff: true,
-        renderHints: false,
+        subscribedTrackSwitchOffMode: 'manual',
+        contentPreferencesMode: 'auto',
       },
       expected: {
         trackPriority: true,
@@ -140,11 +140,11 @@ describe('createCancelableRoomSignalingPromise', () => {
       }
     },
     {
-      name: 'case 3: renderHints enabled',
+      name: 'case 2: subscribedTrackSwitchOffMode(manual) contentPreferencesMode(disabled)',
       options: {
         bandwidthProfile: {},
-        idleTrackSwitchOff: false,
-        renderHints: true,
+        subscribedTrackSwitchOffMode: 'manual',
+        contentPreferencesMode: 'disabled',
       },
       expected: {
         trackPriority: true,
@@ -153,11 +153,11 @@ describe('createCancelableRoomSignalingPromise', () => {
       }
     },
     {
-      name: 'case 3: no render_hints channel needed',
+      name: 'case 3: subscribedTrackSwitchOffMode(disabled) contentPreferencesMode(disabled)',
       options: {
         bandwidthProfile: {},
-        idleTrackSwitchOff: false,
-        renderHints: false,
+        subscribedTrackSwitchOffMode: 'disabled',
+        contentPreferencesMode: 'disabled',
       },
       expected: {
         trackPriority: true,

--- a/tsdef/RemoteVideoTrack.d.ts
+++ b/tsdef/RemoteVideoTrack.d.ts
@@ -1,6 +1,10 @@
 import { Track } from './Track';
 import { VideoTrack } from './VideoTrack';
 
+export interface ContentPreferences {
+  renderDimensions?: VideoTrack.Dimensions;
+}
+
 export class RemoteVideoTrack extends VideoTrack {
   sid: Track.SID;
   priority: Track.Priority | null;
@@ -8,6 +12,9 @@ export class RemoteVideoTrack extends VideoTrack {
   isEnabled: boolean;
 
   setPriority(priority: Track.Priority | null): this;
+  switchOn(): this;
+  switchOff(): this;
+  setContentPreferences(content: ContentPreferences): this;
 
   on(event: 'dimensionsChanged', listener: (track: this) => void): this;
   on(event: 'disabled', listener: (track: this) => void): this;

--- a/tsdef/RemoteVideoTrack.d.ts
+++ b/tsdef/RemoteVideoTrack.d.ts
@@ -1,7 +1,7 @@
 import { Track } from './Track';
 import { VideoTrack } from './VideoTrack';
 
-export interface ContentPreferences {
+export interface VideoContentPreferences {
   renderDimensions?: VideoTrack.Dimensions;
 }
 
@@ -14,7 +14,7 @@ export class RemoteVideoTrack extends VideoTrack {
   setPriority(priority: Track.Priority | null): this;
   switchOn(): this;
   switchOff(): this;
-  setContentPreferences(content: ContentPreferences): this;
+  setContentPreferences(content: VideoContentPreferences): this;
 
   on(event: 'dimensionsChanged', listener: (track: this) => void): this;
   on(event: 'disabled', listener: (track: this) => void): this;

--- a/tsdef/twilio-video-tests.ts
+++ b/tsdef/twilio-video-tests.ts
@@ -236,7 +236,8 @@ async function initRoom() {
     maxVideoBitrate: 200,
     bandwidthProfile: {
       video: {
-        idleTrackSwitchOff: false,
+        subscribedTrackSwitchOffMode: 'auto',
+        contentPreferencesMode: 'auto',
         dominantSpeakerPriority: 'high',
         renderDimensions: {
           low: {
@@ -256,12 +257,12 @@ async function initRoom() {
     },
   });
 
-  // with renderDimensions=auto
+  // with manual contentPreferencesMode mode.
   await Video.connect('$TOKEN', {
     bandwidthProfile: {
       video: {
-        idleTrackSwitchOff: true,
-        renderDimensions: 'auto'
+        contentPreferencesMode: 'manual',
+        subscribedTrackSwitchOffMode: 'manual',
       }
     },
   });

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -91,6 +91,12 @@ export interface LogLevels {
 export type TrackSwitchOffMode = 'detected' | 'predicted' | 'disabled';
 export type BandwidthProfileMode = 'grid' | 'collaboration' | 'presentation';
 
+export type VideoContentPreferencesMode = 'auto' | 'manual';
+export type SubscribedTrackSwitchOffMode = 'auto' | 'manual';
+
+/**
+* @deprecated
+*/
 export interface VideoRenderDimensions {
   high?: VideoTrack.Dimensions;
   low?: VideoTrack.Dimensions;
@@ -98,12 +104,19 @@ export interface VideoRenderDimensions {
 }
 
 export interface VideoBandwidthProfileOptions {
-  idleTrackSwitchOff?: boolean;
+  contentPreferencesMode?: VideoContentPreferencesMode;
   dominantSpeakerPriority?: Track.Priority;
   maxSubscriptionBitrate?: number;
+  /**
+  * @deprecated use subscribedTrackSwitchOffMode instead
+  */
   maxTracks?: number;
   mode?: BandwidthProfileMode;
-  renderDimensions?: 'auto'|VideoRenderDimensions;
+  /**
+  * @deprecated use contentPreferences instead
+  */
+  renderDimensions?: VideoRenderDimensions;
+  subscribedTrackSwitchOffMode?: SubscribedTrackSwitchOffMode;
   trackSwitchOffMode?: TrackSwitchOffMode;
 }
 


### PR DESCRIPTION
This change follows the blueprint to iterate on the api and options.
- rename connectOptions property: `idleTrackSwitchOff: boolean` => `subscribedTrackSwitchOffMode: enum("auto", "manual")`. This option deprecated `maxTracks`  property
- add a new property `contentPreferencesMode: enum("auto", "manual")`.  This option deprecates `renderDimensions` property.   
- added [switchOn](https://42412-46595751-gh.circle-artifacts.com/0/dist/docs/RemoteVideoTrack.html#switchOn), [switchOff](https://42412-46595751-gh.circle-artifacts.com/0/dist/docs/RemoteVideoTrack.html#switchOff), and [setContentPreferences](https://42412-46595751-gh.circle-artifacts.com/0/dist/docs/RemoteVideoTrack.html#setContentPreferences) api to RemoteVideoTrack
- updated changelog

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
