### PR TITLE
fix (#1458) LocalDataTrackOptions should extend LocalTrackOptions to enable providing a name

### DIFF
--- a/tsdef/LocalDataTrackOptions.d.ts
+++ b/tsdef/LocalDataTrackOptions.d.ts
@@ -1,4 +1,6 @@
-export interface LocalDataTrackOptions {
+import { LocalTrackOptions } from "./types";
+
+export interface LocalDataTrackOptions extends LocalTrackOptions {
   maxPacketLifeTime?: number | null;
   maxRetransmits?: number | null;
   ordered?: boolean;


### PR DESCRIPTION
Fixes the type to match documentation, and allowing providing a name in options of LocalDataTrack constructor. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
