### PR TITLE
VIDEO-5116-LocalDataTrackOptions Type Definitions Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Bug Fixes
 ---------
 
 - Fixed a bug where loading `twilio-video.js` resulted in page errors on Firefox Galaxy S9 simulation mode. (VIDEO-4654)
+- Fixed LocalDataTrackOptions TypeScript Definition to match documentation and extend properties from LocalTrackOptions. (VIDEO-5116)
 
 
 2.13.1 (March 17, 2021)

--- a/tsdef/LocalDataTrackOptions.d.ts
+++ b/tsdef/LocalDataTrackOptions.d.ts
@@ -1,4 +1,6 @@
-export interface LocalDataTrackOptions {
+import { LocalTrackOptions } from './types';
+
+export interface LocalDataTrackOptions extends LocalTrackOptions {
   maxPacketLifeTime?: number | null;
   maxRetransmits?: number | null;
   ordered?: boolean;


### PR DESCRIPTION
JIRA Ticket : [VIDEO-5116](https://issues.corp.twilio.com/browse/VIDEO-5116)
Fix from [this PR](https://github.com/twilio/twilio-video.js/pull/1459)

Reported from @xdumaine, 
"Fixes the type to match documentation, and allowing providing a name in options of LocalDataTrack constructor."

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
