### PR TITLE
VIDEO-4718 Adding A/V sync metrics, elapsed time and level to "stats-report" insights message.

### DIFF
--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -15,11 +15,13 @@ const {
   constants: { DEFAULT_SESSION_TIMEOUT_SEC },
   createBandwidthProfilePayload,
   defer,
+  difference,
   filterObject,
   flatMap,
   oncePerTick
 } = require('../../util');
 
+const MovingAverageDelta = require('../../util/movingaveragedelta');
 const { createTwilioError } = require('../../util/twilio-video-errors');
 
 const STATS_PUBLISH_INTERVAL_MS = 10000;
@@ -655,6 +657,7 @@ function handleTransportEvents(roomV2, transport) {
  * @param {Number} intervalMs
  */
 function periodicallyPublishStats(roomV2, transport, intervalMs) {
+  const movingAverageDeltas = new Map();
   let oddPublishCount = false;
   const interval = setInterval(() => {
     roomV2.getStats().then(stats => {
@@ -665,22 +668,35 @@ function periodicallyPublishStats(roomV2, transport, intervalMs) {
         // StatsReport will add zeros to properties that do not exist.
         const report = new StatsReport(id, response, true /* prepareForInsights */);
 
+        // NOTE(mmalavalli): Since A/V sync metrics are not part of the StatsReport class,
+        // we add them to the insights payload here.
         transport.eventObserver.emit('event', {
           group: 'quality',
           level: 'info',
           name: 'stats-report',
           payload: {
             audioTrackStats: report.remoteAudioTrackStats.map((trackStat, i) =>
-              addAVSyncMetricsToRemoteTrackStats(trackStat, response.remoteAudioTrackStats[i])),
+              addAVSyncMetricsToRemoteTrackStats(trackStat, response.remoteAudioTrackStats[i], movingAverageDeltas)),
             localAudioTrackStats: report.localAudioTrackStats.map((trackStat, i) =>
-              addAVSyncMetricsToLocalTrackStats(trackStat, response.localAudioTrackStats[i])),
+              addAVSyncMetricsToLocalTrackStats(trackStat, response.localAudioTrackStats[i], movingAverageDeltas)),
             localVideoTrackStats: report.localVideoTrackStats.map((trackStat, i) =>
-              addAVSyncMetricsToLocalTrackStats(trackStat, response.localVideoTrackStats[i])),
+              addAVSyncMetricsToLocalTrackStats(trackStat, response.localVideoTrackStats[i], movingAverageDeltas)),
             peerConnectionId: report.peerConnectionId,
             videoTrackStats: report.remoteVideoTrackStats.map((trackStat, i) =>
-              addAVSyncMetricsToRemoteTrackStats(trackStat, response.remoteVideoTrackStats[i])),
+              addAVSyncMetricsToRemoteTrackStats(trackStat, response.remoteVideoTrackStats[i], movingAverageDeltas)),
           }
         });
+
+        // NOTE(mmalavalli): Clean up entries for Tracks that are no longer published or subscribed to.
+        const movingAverageDeltaTrackSids = Array.from(movingAverageDeltas.keys());
+        const trackSids = flatMap([
+          'localAudioTrackStats',
+          'localVideoTrackStats',
+          'remoteAudioTrackStats',
+          'remoteVideoTrackStats'
+        ], prop => report[prop].map(({ trackSid }) => trackSid));
+        const movingAverageDeltaTrackSidsToBeRemoved = difference(movingAverageDeltaTrackSids, trackSids);
+        movingAverageDeltaTrackSidsToBeRemoved.forEach(trackSid => movingAverageDeltas.delete(trackSid));
 
         if (oddPublishCount) {
           // NOTE(mmalavalli): null properties of the "active-ice-candidate-pair"
@@ -733,7 +749,12 @@ function handleSubscriptions(room) {
   });
 }
 
-function addAVSyncMetricsToLocalTrackStats(trackStats, trackResponse) {
+/**
+ * NOTE(mmalavalli): Since A/V sync metrics are not part of the public StatsReport class, we add them
+ * only for reporting purposes.
+ * @private
+ */
+function addAVSyncMetricsToLocalTrackStats(trackStats, trackResponse, movingAverageDeltas) {
   const {
     framesEncoded,
     packetsSent,
@@ -741,23 +762,32 @@ function addAVSyncMetricsToLocalTrackStats(trackStats, trackResponse) {
     totalPacketSendDelay
   } = trackResponse;
   const augmentedTrackStats = Object.assign({}, trackStats);
+  const trackMovingAverageDeltas = movingAverageDeltas.get(trackStats.trackSid) || new Map();
 
   if (typeof totalEncodeTime === 'number' && typeof framesEncoded === 'number') {
-    const totalEncodeTimeMs = totalEncodeTime * 1000;
-    augmentedTrackStats.avgEncodeDelay = Math.round(framesEncoded <= 0
-      ? totalEncodeTimeMs
-      : totalEncodeTimeMs / framesEncoded);
+    const trackAvgEncodeDelayMovingAverageDelta = trackMovingAverageDeltas.get('avgEncodeDelay')
+      || new MovingAverageDelta(3);
+    trackAvgEncodeDelayMovingAverageDelta.putSample(totalEncodeTime * 1000, framesEncoded);
+    augmentedTrackStats.avgEncodeDelay = trackAvgEncodeDelayMovingAverageDelta.get();
+    trackMovingAverageDeltas.set('avgEncodeDelay', trackAvgEncodeDelayMovingAverageDelta);
   }
   if (typeof totalPacketSendDelay === 'number' && typeof packetsSent === 'number') {
-    const totalPacketSendDelayMs = totalPacketSendDelay * 1000;
-    augmentedTrackStats.avgPacketSendDelay = Math.round(packetsSent <= 0
-      ? totalPacketSendDelayMs
-      : totalPacketSendDelayMs / packetsSent);
+    const trackAvgPacketSendDelayMovingAverageDelta = trackMovingAverageDeltas.get('avgPacketSendDelay')
+      || new MovingAverageDelta(3);
+    trackAvgPacketSendDelayMovingAverageDelta.putSample(totalPacketSendDelay * 1000, packetsSent);
+    augmentedTrackStats.avgPacketSendDelay = trackAvgPacketSendDelayMovingAverageDelta.get();
+    trackMovingAverageDeltas.set('avgPacketSendDelay', trackAvgPacketSendDelayMovingAverageDelta);
   }
+  movingAverageDeltas.set(trackStats.trackSid, trackMovingAverageDeltas);
   return augmentedTrackStats;
 }
 
-function addAVSyncMetricsToRemoteTrackStats(trackStats, trackResponse) {
+/**
+ * NOTE(mmalavalli): Since A/V sync metrics are not part of the public StatsReport class, we add them
+ * only for reporting purposes.
+ * @private
+ */
+function addAVSyncMetricsToRemoteTrackStats(trackStats, trackResponse, movingAverageDeltas) {
   const {
     estimatedPlayoutTimestamp,
     framesDecoded,
@@ -766,22 +796,26 @@ function addAVSyncMetricsToRemoteTrackStats(trackStats, trackResponse) {
     totalDecodeTime
   } = trackResponse;
   const augmentedTrackStats = Object.assign({}, trackStats);
+  const trackMovingAverageDeltas = movingAverageDeltas.get(trackStats.trackSid) || new Map();
 
   if (typeof estimatedPlayoutTimestamp === 'number') {
     augmentedTrackStats.estimatedPlayoutTimestamp = estimatedPlayoutTimestamp;
   }
   if (typeof framesDecoded === 'number' && typeof totalDecodeTime === 'number') {
-    const totalDecodeTimeMs = totalDecodeTime * 1000;
-    augmentedTrackStats.avgDecodeDelay = Math.round(framesDecoded <= 0
-      ? totalDecodeTimeMs
-      : totalDecodeTimeMs / framesDecoded);
+    const trackAvgDecodeDelayMovingAverageDelta = trackMovingAverageDeltas.get('avgDecodeDelay')
+      || new MovingAverageDelta(3);
+    trackAvgDecodeDelayMovingAverageDelta.putSample(totalDecodeTime * 1000, framesDecoded);
+    augmentedTrackStats.avgDecodeDelay = trackAvgDecodeDelayMovingAverageDelta.get();
+    trackMovingAverageDeltas.set('avgDecodeDelay', trackAvgDecodeDelayMovingAverageDelta);
   }
   if (typeof jitterBufferDelay === 'number' && typeof jitterBufferEmittedCount === 'number') {
-    const jitterBufferDelayMs = jitterBufferDelay * 1000;
-    augmentedTrackStats.avgJitterBufferDelay = Math.round(jitterBufferEmittedCount <= 0
-      ? jitterBufferDelayMs
-      : jitterBufferDelayMs / jitterBufferEmittedCount);
+    const trackAvgJitterBufferDelayMovingAverageDelta = trackMovingAverageDeltas.get('avgJitterBufferDelay')
+      || new MovingAverageDelta(3);
+    trackAvgJitterBufferDelayMovingAverageDelta.putSample(jitterBufferDelay * 1000, jitterBufferEmittedCount);
+    augmentedTrackStats.avgJitterBufferDelay = trackAvgJitterBufferDelayMovingAverageDelta.get();
+    trackMovingAverageDeltas.set('avgJitterBufferDelay', trackAvgJitterBufferDelayMovingAverageDelta);
   }
+  movingAverageDeltas.set(trackStats.trackSid, trackMovingAverageDeltas);
   return augmentedTrackStats;
 }
 

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -683,15 +683,14 @@ function periodicallyPublishStats(roomV2, transport, intervalMs) {
         });
 
         // NOTE(mmalavalli): Clean up entries for Tracks that are no longer published or subscribed to.
-        const movingAverageDeltaTrackSids = Array.from(movingAverageDeltas.keys());
-        const trackSids = flatMap([
+        const keys = flatMap([
           'localAudioTrackStats',
           'localVideoTrackStats',
           'remoteAudioTrackStats',
           'remoteVideoTrackStats'
-        ], prop => report[prop].map(({ trackSid }) => trackSid));
-        const movingAverageDeltaTrackSidsToBeRemoved = difference(movingAverageDeltaTrackSids, trackSids);
-        movingAverageDeltaTrackSidsToBeRemoved.forEach(trackSid => movingAverageDeltas.delete(trackSid));
+        ], prop => report[prop].map(({ ssrc, trackSid }) => `${trackSid}+${ssrc}`));
+        const movingAverageDeltaKeysToBeRemoved = difference(Array.from(movingAverageDeltas.keys()), keys);
+        movingAverageDeltaKeysToBeRemoved.forEach(key => movingAverageDeltas.delete(key));
 
         if (oddPublishCount) {
           // NOTE(mmalavalli): null properties of the "active-ice-candidate-pair"

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -670,21 +670,16 @@ function periodicallyPublishStats(roomV2, transport, intervalMs) {
 
         // NOTE(mmalavalli): Since A/V sync metrics are not part of the StatsReport class,
         // we add them to the insights payload here.
-        transport.eventObserver.emit('event', {
-          group: 'quality',
-          level: 'info',
-          name: 'stats-report',
-          payload: {
-            audioTrackStats: report.remoteAudioTrackStats.map((trackStat, i) =>
-              addAVSyncMetricsToRemoteTrackStats(trackStat, response.remoteAudioTrackStats[i], movingAverageDeltas)),
-            localAudioTrackStats: report.localAudioTrackStats.map((trackStat, i) =>
-              addAVSyncMetricsToLocalTrackStats(trackStat, response.localAudioTrackStats[i], movingAverageDeltas)),
-            localVideoTrackStats: report.localVideoTrackStats.map((trackStat, i) =>
-              addAVSyncMetricsToLocalTrackStats(trackStat, response.localVideoTrackStats[i], movingAverageDeltas)),
-            peerConnectionId: report.peerConnectionId,
-            videoTrackStats: report.remoteVideoTrackStats.map((trackStat, i) =>
-              addAVSyncMetricsToRemoteTrackStats(trackStat, response.remoteVideoTrackStats[i], movingAverageDeltas)),
-          }
+        transport.publishEvent('quality', 'stats-report', 'info', {
+          audioTrackStats: report.remoteAudioTrackStats.map((trackStat, i) =>
+            addAVSyncMetricsToRemoteTrackStats(trackStat, response.remoteAudioTrackStats[i], movingAverageDeltas)),
+          localAudioTrackStats: report.localAudioTrackStats.map((trackStat, i) =>
+            addAVSyncMetricsToLocalTrackStats(trackStat, response.localAudioTrackStats[i], movingAverageDeltas)),
+          localVideoTrackStats: report.localVideoTrackStats.map((trackStat, i) =>
+            addAVSyncMetricsToLocalTrackStats(trackStat, response.localVideoTrackStats[i], movingAverageDeltas)),
+          peerConnectionId: report.peerConnectionId,
+          videoTrackStats: report.remoteVideoTrackStats.map((trackStat, i) =>
+            addAVSyncMetricsToRemoteTrackStats(trackStat, response.remoteVideoTrackStats[i], movingAverageDeltas)),
         });
 
         // NOTE(mmalavalli): Clean up entries for Tracks that are no longer published or subscribed to.
@@ -706,12 +701,11 @@ function periodicallyPublishStats(roomV2, transport, intervalMs) {
             response.activeIceCandidatePair,
             report.peerConnectionId);
 
-          transport.eventObserver.emit('event', {
-            group: 'quality',
-            level: 'info',
-            name: 'active-ice-candidate-pair',
-            payload: activeIceCandidatePair
-          });
+          transport.publishEvent(
+            'quality',
+            'active-ice-candidate-pair',
+            'info',
+            activeIceCandidatePair);
         }
       });
     }, () => {
@@ -762,23 +756,24 @@ function addAVSyncMetricsToLocalTrackStats(trackStats, trackResponse, movingAver
     totalPacketSendDelay
   } = trackResponse;
   const augmentedTrackStats = Object.assign({}, trackStats);
-  const trackMovingAverageDeltas = movingAverageDeltas.get(trackStats.trackSid) || new Map();
+  const key = `${trackStats.trackSid}+${trackStats.ssrc}`;
+  const trackMovingAverageDeltas = movingAverageDeltas.get(key) || new Map();
 
   if (typeof totalEncodeTime === 'number' && typeof framesEncoded === 'number') {
     const trackAvgEncodeDelayMovingAverageDelta = trackMovingAverageDeltas.get('avgEncodeDelay')
-      || new MovingAverageDelta(3);
+      || new MovingAverageDelta();
     trackAvgEncodeDelayMovingAverageDelta.putSample(totalEncodeTime * 1000, framesEncoded);
     augmentedTrackStats.avgEncodeDelay = trackAvgEncodeDelayMovingAverageDelta.get();
     trackMovingAverageDeltas.set('avgEncodeDelay', trackAvgEncodeDelayMovingAverageDelta);
   }
   if (typeof totalPacketSendDelay === 'number' && typeof packetsSent === 'number') {
     const trackAvgPacketSendDelayMovingAverageDelta = trackMovingAverageDeltas.get('avgPacketSendDelay')
-      || new MovingAverageDelta(3);
+      || new MovingAverageDelta();
     trackAvgPacketSendDelayMovingAverageDelta.putSample(totalPacketSendDelay * 1000, packetsSent);
     augmentedTrackStats.avgPacketSendDelay = trackAvgPacketSendDelayMovingAverageDelta.get();
     trackMovingAverageDeltas.set('avgPacketSendDelay', trackAvgPacketSendDelayMovingAverageDelta);
   }
-  movingAverageDeltas.set(trackStats.trackSid, trackMovingAverageDeltas);
+  movingAverageDeltas.set(key, trackMovingAverageDeltas);
   return augmentedTrackStats;
 }
 
@@ -796,26 +791,27 @@ function addAVSyncMetricsToRemoteTrackStats(trackStats, trackResponse, movingAve
     totalDecodeTime
   } = trackResponse;
   const augmentedTrackStats = Object.assign({}, trackStats);
-  const trackMovingAverageDeltas = movingAverageDeltas.get(trackStats.trackSid) || new Map();
+  const key = `${trackStats.trackSid}+${trackStats.ssrc}`;
+  const trackMovingAverageDeltas = movingAverageDeltas.get(key) || new Map();
 
   if (typeof estimatedPlayoutTimestamp === 'number') {
     augmentedTrackStats.estimatedPlayoutTimestamp = estimatedPlayoutTimestamp;
   }
   if (typeof framesDecoded === 'number' && typeof totalDecodeTime === 'number') {
     const trackAvgDecodeDelayMovingAverageDelta = trackMovingAverageDeltas.get('avgDecodeDelay')
-      || new MovingAverageDelta(3);
+      || new MovingAverageDelta();
     trackAvgDecodeDelayMovingAverageDelta.putSample(totalDecodeTime * 1000, framesDecoded);
     augmentedTrackStats.avgDecodeDelay = trackAvgDecodeDelayMovingAverageDelta.get();
     trackMovingAverageDeltas.set('avgDecodeDelay', trackAvgDecodeDelayMovingAverageDelta);
   }
   if (typeof jitterBufferDelay === 'number' && typeof jitterBufferEmittedCount === 'number') {
     const trackAvgJitterBufferDelayMovingAverageDelta = trackMovingAverageDeltas.get('avgJitterBufferDelay')
-      || new MovingAverageDelta(3);
+      || new MovingAverageDelta();
     trackAvgJitterBufferDelayMovingAverageDelta.putSample(jitterBufferDelay * 1000, jitterBufferEmittedCount);
     augmentedTrackStats.avgJitterBufferDelay = trackAvgJitterBufferDelayMovingAverageDelta.get();
     trackMovingAverageDeltas.set('avgJitterBufferDelay', trackAvgJitterBufferDelayMovingAverageDelta);
   }
-  movingAverageDeltas.set(trackStats.trackSid, trackMovingAverageDeltas);
+  movingAverageDeltas.set(key, trackMovingAverageDeltas);
   return augmentedTrackStats;
 }
 

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -665,12 +665,21 @@ function periodicallyPublishStats(roomV2, transport, intervalMs) {
         // StatsReport will add zeros to properties that do not exist.
         const report = new StatsReport(id, response, true /* prepareForInsights */);
 
-        transport.publishEvent('quality', 'stats-report', {
-          audioTrackStats: report.remoteAudioTrackStats,
-          localAudioTrackStats: report.localAudioTrackStats,
-          localVideoTrackStats: report.localVideoTrackStats,
-          peerConnectionId: report.peerConnectionId,
-          videoTrackStats: report.remoteVideoTrackStats
+        transport.eventObserver.emit('event', {
+          group: 'quality',
+          level: 'info',
+          name: 'stats-report',
+          payload: {
+            audioTrackStats: report.remoteAudioTrackStats.map((trackStat, i) =>
+              addAVSyncMetricsToRemoteTrackStats(trackStat, response.remoteAudioTrackStats[i])),
+            localAudioTrackStats: report.localAudioTrackStats.map((trackStat, i) =>
+              addAVSyncMetricsToLocalTrackStats(trackStat, response.localAudioTrackStats[i])),
+            localVideoTrackStats: report.localVideoTrackStats.map((trackStat, i) =>
+              addAVSyncMetricsToLocalTrackStats(trackStat, response.localVideoTrackStats[i])),
+            peerConnectionId: report.peerConnectionId,
+            videoTrackStats: report.remoteVideoTrackStats.map((trackStat, i) =>
+              addAVSyncMetricsToRemoteTrackStats(trackStat, response.remoteVideoTrackStats[i])),
+          }
         });
 
         if (oddPublishCount) {
@@ -681,7 +690,12 @@ function periodicallyPublishStats(roomV2, transport, intervalMs) {
             response.activeIceCandidatePair,
             report.peerConnectionId);
 
-          transport.publishEvent('quality', 'active-ice-candidate-pair', activeIceCandidatePair);
+          transport.eventObserver.emit('event', {
+            group: 'quality',
+            level: 'info',
+            name: 'active-ice-candidate-pair',
+            payload: activeIceCandidatePair
+          });
         }
       });
     }, () => {
@@ -717,6 +731,58 @@ function handleSubscriptions(room) {
       room._getTrackReceiver(trackId).then(trackReceiver => trackSignaling.setTrackTransceiver(trackReceiver));
     }
   });
+}
+
+function addAVSyncMetricsToLocalTrackStats(trackStats, trackResponse) {
+  const {
+    framesEncoded,
+    packetsSent,
+    totalEncodeTime,
+    totalPacketSendDelay
+  } = trackResponse;
+  const augmentedTrackStats = Object.assign({}, trackStats);
+
+  if (typeof totalEncodeTime === 'number' && typeof framesEncoded === 'number') {
+    const totalEncodeTimeMs = totalEncodeTime * 1000;
+    augmentedTrackStats.avgEncodeDelay = Math.round(framesEncoded <= 0
+      ? totalEncodeTimeMs
+      : totalEncodeTimeMs / framesEncoded);
+  }
+  if (typeof totalPacketSendDelay === 'number' && typeof packetsSent === 'number') {
+    const totalPacketSendDelayMs = totalPacketSendDelay * 1000;
+    augmentedTrackStats.avgPacketSendDelay = Math.round(packetsSent <= 0
+      ? totalPacketSendDelayMs
+      : totalPacketSendDelayMs / packetsSent);
+  }
+  return augmentedTrackStats;
+}
+
+function addAVSyncMetricsToRemoteTrackStats(trackStats, trackResponse) {
+  const {
+    estimatedPlayoutTimestamp,
+    framesDecoded,
+    jitterBufferDelay,
+    jitterBufferEmittedCount,
+    totalDecodeTime
+  } = trackResponse;
+  const augmentedTrackStats = Object.assign({}, trackStats);
+
+  if (typeof estimatedPlayoutTimestamp === 'number') {
+    augmentedTrackStats.estimatedPlayoutTimestamp = estimatedPlayoutTimestamp;
+  }
+  if (typeof framesDecoded === 'number' && typeof totalDecodeTime === 'number') {
+    const totalDecodeTimeMs = totalDecodeTime * 1000;
+    augmentedTrackStats.avgDecodeDelay = Math.round(framesDecoded <= 0
+      ? totalDecodeTimeMs
+      : totalDecodeTimeMs / framesDecoded);
+  }
+  if (typeof jitterBufferDelay === 'number' && typeof jitterBufferEmittedCount === 'number') {
+    const jitterBufferDelayMs = jitterBufferDelay * 1000;
+    augmentedTrackStats.avgJitterBufferDelay = Math.round(jitterBufferEmittedCount <= 0
+      ? jitterBufferDelayMs
+      : jitterBufferDelayMs / jitterBufferEmittedCount);
+  }
+  return augmentedTrackStats;
 }
 
 function replaceNullsWithDefaults(activeIceCandidatePair, peerConnectionId) {

--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -108,6 +108,14 @@ class TwilioConnectionTransport extends StateMachine {
     }
 
     const EventPublisher = options.insights ? options.InsightsPublisher : options.NullInsightsPublisher;
+    const eventPublisher = new EventPublisher(
+      accessToken,
+      SDK_NAME,
+      SDK_VERSION,
+      options.environment,
+      options.realm,
+      eventPublisherOptions);
+
     Object.defineProperties(this, {
       _accessToken: {
         value: accessToken
@@ -118,20 +126,18 @@ class TwilioConnectionTransport extends StateMachine {
       _bandwidthProfile: {
         value: options.bandwidthProfile
       },
+      _disconnectEventPublisher: {
+        value: () => eventPublisher.disconnect()
+      },
       _dominantSpeaker: {
         value: options.dominantSpeaker
       },
+      _eventObserver: {
+        value: options.eventObserver,
+        writable: false
+      },
       _renderHints: {
         value: options.renderHints
-      },
-      _eventPublisher: {
-        value: new EventPublisher(
-          accessToken,
-          SDK_NAME,
-          SDK_VERSION,
-          options.environment,
-          options.realm,
-          eventPublisherOptions)
       },
       _iceServersStatus: {
         value: Array.isArray(options.iceServers)
@@ -189,18 +195,14 @@ class TwilioConnectionTransport extends StateMachine {
       },
       _wsServer: {
         value: wsServer
-      },
-      eventObserver: {
-        value: options.eventObserver,
-        writable: false
       }
     });
 
-    this.eventObserver.setPublisher(this._eventPublisher);
+    this._eventObserver.setPublisher(eventPublisher);
     setupTransport(this);
 
     this.once('connected', ({ sid, participant }) => {
-      this._eventPublisher.connect(sid, participant.sid);
+      eventPublisher.connect(sid, participant.sid);
     });
   }
 
@@ -309,7 +311,7 @@ class TwilioConnectionTransport extends StateMachine {
       this.preempt('disconnected', null, [error]);
       this._sendConnectOrSyncOrDisconnectMessage();
       this._twilioConnection.close();
-      this._eventPublisher.disconnect();
+      this._disconnectEventPublisher();
       return true;
     }
     return false;
@@ -342,13 +344,14 @@ class TwilioConnectionTransport extends StateMachine {
 
   /**
    * Publish (or queue) an event to the Insights gateway.
-   * @param {string} groupName - Event group name
-   * @param {string} eventName - Event name
+   * @param {string} group - Event group name
+   * @param {string} name - Event name
+   * @param {string} level - Event level
    * @param {object} payload - Event payload
-   * @returns {boolean} true if queued or published, false if disconnected from the Insights gateway
+   * @returns {void}
    */
-  publishEvent(groupName, eventName, payload) {
-    return this._eventPublisher.publish(groupName, eventName, payload);
+  publishEvent(group, name, level, payload) {
+    this._eventObserver.emit('event', { group, name, level, payload });
   }
 
   /**

--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -189,13 +189,14 @@ class TwilioConnectionTransport extends StateMachine {
       },
       _wsServer: {
         value: wsServer
+      },
+      eventObserver: {
+        value: options.eventObserver,
+        writable: false
       }
     });
 
-    if (options.eventObserver) {
-      options.eventObserver.setPublisher(this._eventPublisher);
-    }
-
+    this.eventObserver.setPublisher(this._eventPublisher);
     setupTransport(this);
 
     this.once('connected', ({ sid, participant }) => {

--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -198,7 +198,10 @@ class TwilioConnectionTransport extends StateMachine {
       }
     });
 
+    // TODO(mmalavalli): Create and set EventPublisher outside this class, so
+    // that the EventPublisher constructor is no longer a dependency.
     this._eventObserver.setPublisher(eventPublisher);
+
     setupTransport(this);
 
     this.once('connected', ({ sid, participant }) => {

--- a/lib/util/eventobserver.js
+++ b/lib/util/eventobserver.js
@@ -27,8 +27,8 @@ class EventObserver extends EventEmitter {
   /**
    * Constructor.
    * @param {number} connectTimestamp
-   * @param {log} Log
-   * @param {EventListener} eventListener
+   * @param {Log} log
+   * @param {EventListener} [eventListener]
    */
   constructor(connectTimestamp, log, eventListener = null) {
     super();

--- a/lib/util/eventobserver.js
+++ b/lib/util/eventobserver.js
@@ -6,7 +6,8 @@ const { EventEmitter } = require('events');
 const VALID_GROUPS = [
   'signaling',
   'room',
-  'media'
+  'media',
+  'quality'
 ];
 
 const VALID_LEVELS = [
@@ -56,16 +57,16 @@ class EventObserver extends EventEmitter {
       const elapsedTime = timestamp - connectTimestamp;
 
       if (this._publisher) {
-        const publisherPayload = Object.assign(payload ? payload : {}, { elapsedTime, level });
+        const publisherPayload = Object.assign({ elapsedTime, level }, payload ? payload : {});
         this._publisher.publish(group, name, publisherPayload);
       }
-      const event = Object.assign(payload ? { payload } : {}, {
+      const event = Object.assign({
         elapsedTime,
         group,
         level,
         name,
         timestamp
-      });
+      }, payload ? { payload } : {});
 
       const logLevel = {
         debug: 'debug',
@@ -76,13 +77,6 @@ class EventObserver extends EventEmitter {
       log[logLevel]('event', event);
 
       if (eventListener && group === 'signaling') {
-        const event = Object.assign(payload ? { payload } : {}, {
-          elapsedTime,
-          group,
-          level,
-          name,
-          timestamp
-        });
         eventListener.emit('event', event);
       }
     });

--- a/lib/util/movingaveragedelta.js
+++ b/lib/util/movingaveragedelta.js
@@ -1,24 +1,23 @@
 'use strict';
 
 /**
- * Calculates the moving average delta for the given samples. A sample (S) consists of
- * a numerator (Sn) and a denominator (Sd). Given the sample size n, the moving average
- * delta is calculated as follows:
+ * Calculates the moving average delta for the given pair ofsamples. A sample (S)
+ * consists of a numerator (Sn) and a denominator (Sd).The moving average delta is
+ * calculated as follows:
  *
- * AvgDelta = Sum((Sn[i] - Sn[i-1]) / (Sd[i] - Sd[i-1])) for all i in [1, n - 1]
+ * MovingAvgDelta = (Sn[1] - Sn[0]) / (Sd[1] - Sd[0])
  */
 class MovingAverageDelta {
   /**
    * Constructor.
-   * @param size
    */
-  constructor(size) {
+  constructor() {
     Object.defineProperties(this, {
       _samples: {
-        value: [],
-      },
-      _size: {
-        value: size
+        value: [
+          { denominator: 0, numerator: 0 },
+          { denominator: 0, numerator: 0 }
+        ],
       }
     });
   }
@@ -29,37 +28,19 @@ class MovingAverageDelta {
    */
   get() {
     const { _samples: samples } = this;
-    if (samples.length <= 0) {
-      return 0;
-    }
-    if (samples.length === 1) {
-      return Math.round(samples[0].numerator / samples[0].denominator);
-    }
-    const sampleDifferencesRight = samples.slice(0, samples.length - 1);
-    const sampleDifferencesLeft = samples.slice(1);
-
-    const sampleSumDifferences = sampleDifferencesLeft.reduce((sum, sampleDifferenceLeft, i) => {
-      const { denominator: denominatorLeft, numerator: numeratorLeft } = sampleDifferenceLeft;
-      const { denominator: denominatorRight, numerator: numeratorRight } = sampleDifferencesRight[i];
-      const denominatorDifference = denominatorLeft - denominatorRight;
-      const numeratorDifference = numeratorLeft - numeratorRight;
-      const averageDelta = denominatorDifference > 0 ? (numeratorDifference / denominatorDifference) : 0;
-      return sum + averageDelta;
-    }, 0);
-
-    return Math.round(sampleSumDifferences / (samples.length - 1));
+    const denominatorDelta = (samples[1].denominator - samples[0].denominator) || 1;
+    const numeratorDelta = samples[1].numerator - samples[0].numerator;
+    return Math.round(numeratorDelta / denominatorDelta);
   }
 
   /**
-   * Put a sample and maybe get rid of the older samples to maintain sample size.
+   * Put a sample and get rid of the older sample to maintain sample size of 2.
    * @param numerator
    * @param denominator
    */
   putSample(numerator, denominator) {
-    const { _samples: samples, _size: size } = this;
-    if (samples.length >= size) {
-      samples.shift();
-    }
+    const { _samples: samples } = this;
+    samples.shift();
     samples.push({ denominator, numerator });
   }
 }

--- a/lib/util/movingaveragedelta.js
+++ b/lib/util/movingaveragedelta.js
@@ -1,0 +1,67 @@
+'use strict';
+
+/**
+ * Calculates the moving average delta for the given samples. A sample (S) consists of
+ * a numerator (Sn) and a denominator (Sd). Given the sample size n, the moving average
+ * delta is calculated as follows:
+ *
+ * AvgDelta = Sum((Sn[i] - Sn[i-1]) / (Sd[i] - Sd[i-1])) for all i in [1, n - 1]
+ */
+class MovingAverageDelta {
+  /**
+   * Constructor.
+   * @param size
+   */
+  constructor(size) {
+    Object.defineProperties(this, {
+      _samples: {
+        value: [],
+      },
+      _size: {
+        value: size
+      }
+    });
+  }
+
+  /**
+   * Get the moving average delta.
+   * @returns {number}
+   */
+  get() {
+    const { _samples: samples } = this;
+    if (samples.length <= 0) {
+      return 0;
+    }
+    if (samples.length === 1) {
+      return Math.round(samples[0].numerator / samples[0].denominator);
+    }
+    const sampleDifferencesRight = samples.slice(0, samples.length - 1);
+    const sampleDifferencesLeft = samples.slice(1);
+
+    const sampleSumDifferences = sampleDifferencesLeft.reduce((sum, sampleDifferenceLeft, i) => {
+      const { denominator: denominatorLeft, numerator: numeratorLeft } = sampleDifferenceLeft;
+      const { denominator: denominatorRight, numerator: numeratorRight } = sampleDifferencesRight[i];
+      const denominatorDifference = denominatorLeft - denominatorRight;
+      const numeratorDifference = numeratorLeft - numeratorRight;
+      const averageDelta = denominatorDifference > 0 ? (numeratorDifference / denominatorDifference) : 0;
+      return sum + averageDelta;
+    }, 0);
+
+    return Math.round(sampleSumDifferences / (samples.length - 1));
+  }
+
+  /**
+   * Put a sample and maybe get rid of the older samples to maintain sample size.
+   * @param numerator
+   * @param denominator
+   */
+  putSample(numerator, denominator) {
+    const { _samples: samples, _size: size } = this;
+    if (samples.length >= size) {
+      samples.shift();
+    }
+    samples.push({ denominator, numerator });
+  }
+}
+
+module.exports = MovingAverageDelta;

--- a/lib/util/movingaveragedelta.js
+++ b/lib/util/movingaveragedelta.js
@@ -28,7 +28,7 @@ class MovingAverageDelta {
    */
   get() {
     const { _samples: samples } = this;
-    const denominatorDelta = (samples[1].denominator - samples[0].denominator) || 1;
+    const denominatorDelta = (samples[1].denominator - samples[0].denominator) || Infinity;
     const numeratorDelta = samples[1].numerator - samples[0].numerator;
     return Math.round(numeratorDelta / denominatorDelta);
   }

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- ./test/unit/index.js"
   },
   "dependencies": {
-    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#VIDEO-4718/av-sync-metrics",
+    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#dea68ee99426959cdc7d08c5d48e02abe2890650",
     "backoff": "^2.5.0",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- ./test/unit/index.js"
   },
   "dependencies": {
-    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#4.3.3-rc1",
+    "@twilio/webrtc": "github:twilio/twilio-webrtc.js#VIDEO-4718/av-sync-metrics",
     "backoff": "^2.5.0",
     "ws": "^3.3.1",
     "xmlhttprequest": "^1.8.0"

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -67,13 +67,14 @@ require('./spec/util/eventobserver');
 require('./spec/util/documentvisibilitymonitor');
 require('./spec/util/insightspublisher');
 require('./spec/util/log');
+require('./spec/util/movingaveragedelta');
+require('./spec/util/networkmonitor');
 require('./spec/util/sdp');
 require('./spec/util/sdp/issue8329');
 require('./spec/util/support');
 require('./spec/util/trackmatcher/mid');
 require('./spec/util/trackmatcher/ordered');
 require('./spec/util/twilioerror');
-require('./spec/util/networkmonitor');
 
 require('./spec/webaudio/audiocontext');
 

--- a/test/unit/spec/signaling/v2/room.js
+++ b/test/unit/spec/signaling/v2/room.js
@@ -226,7 +226,7 @@ describe('RoomV2', () => {
         ]
       ];
       await wait(225);
-      test.transport.publishEvent.args.slice(0, expectedArgs.length).forEach(([, name, payload], i) => {
+      test.transport.publishEvent.args.slice(0, expectedArgs.length).forEach(([/* group */, name, /* level */, payload], i) => {
         if (name === 'stats-report') {
           assert.deepEqual(payload, expectedArgs[i][2]);
           return;

--- a/test/unit/spec/util/movingaveragedelta.js
+++ b/test/unit/spec/util/movingaveragedelta.js
@@ -1,0 +1,42 @@
+const assert = require('assert');
+const MovingAverageDelta = require('../../../../lib/util/movingaveragedelta');
+
+describe('MovingAverageDelta', () => {
+  describe('#get', () => {
+    let movingAverageDelta;
+
+    before(() => {
+      movingAverageDelta = new MovingAverageDelta();
+    });
+
+    context('when the first sample is put', () => {
+      before(() => {
+        movingAverageDelta.putSample(1000, 40);
+      });
+
+      it('should return the result of Math.round(numerator0 / denominator0)', () => {
+        assert.equal(movingAverageDelta.get(), Math.round(1000 / 40));
+      });
+    });
+
+    context('when the second sample is put, that has the same denominator as the previous sample', () => {
+      before(() => {
+        movingAverageDelta.putSample(2000, 40);
+      });
+
+      it('should return the result of (numerator1 - numerator0)', () => {
+        assert.equal(movingAverageDelta.get(), 1000);
+      });
+    });
+
+    context('when the third sample is put', () => {
+      before(() => {
+        movingAverageDelta.putSample(3000, 80);
+      });
+
+      it('should return the result of Math.round((numerator2 - numerator1) / (denominator2 - denominator1))', () => {
+        assert.equal(movingAverageDelta.get(), Math.round(1000 / 40));
+      });
+    });
+  });
+});

--- a/test/unit/spec/util/movingaveragedelta.js
+++ b/test/unit/spec/util/movingaveragedelta.js
@@ -24,8 +24,8 @@ describe('MovingAverageDelta', () => {
         movingAverageDelta.putSample(2000, 40);
       });
 
-      it('should return the result of (numerator1 - numerator0)', () => {
-        assert.equal(movingAverageDelta.get(), 1000);
+      it('should return 0', () => {
+        assert.equal(movingAverageDelta.get(), 0);
       });
     });
 


### PR DESCRIPTION
@makarandp0 @PikaJoyce 

Adds A/V sync metrics ([example](https://kibana.us1.eak.twilio.com/video/goto/269fed43d045922091455a100a0a7d0a)) to insights, as defined [here](https://issues.corp.twilio.com/browse/VIDEO-4718).

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
