### PR TITLE
VIDEO-4419 | Update isSupported to match browser matrix support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 
 **Version 1.x will End of Life on September 8th, 2021.** Check [this guide](https://www.twilio.com/docs/video/migrating-1x-2x) to plan your migration to the latest 2.x version. Support for the 1.x version ended on December 4th, 2020.
 
+2.14.1 (In Progress)
+=====================
+
+Bug Fixes
+---------
+
+- Fixed a bug where `isSupported` is returning `true` on certain unsupported mobile browsers. With this release, `isSupported` should now match our list of [supported browsers](https://www.twilio.com/docs/video/javascript#supported-browsers).
+
 2.14.0 (May 11, 2021)
 =====================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 Bug Fixes
 ---------
 
-- Fixed a bug where `isSupported` is returning `true` on certain unsupported mobile browsers. With this release, `isSupported` should now match our list of [supported browsers](https://www.twilio.com/docs/video/javascript#supported-browsers).
+- Fixed a bug where `isSupported` was returning `true` on certain unsupported mobile browsers. With this release, `isSupported` should now return true only for the [browsers supported by twilio-video.js](https://www.twilio.com/docs/video/javascript#supported-browsers).
 
 2.14.0 (May 11, 2021)
 =====================

--- a/lib/util/support.js
+++ b/lib/util/support.js
@@ -7,8 +7,17 @@ const SUPPORTED_CHROME_BASED_BROWSERS = [
   'edg',
   'edge',
   'electron',
-  'headlesschrome'
+  'headlesschrome',
 ];
+const SUPPORTED_ANDROID_BROWSERS = [
+  'chrome',
+  'firefox',
+];
+const SUPPORTED_IOS_BROWSERS = [
+  'safari',
+];
+// Currently none. Add 'brave', 'edg', and 'edge' here once we start supporting them
+const SUPPORTED_MOBILE_WEBKIT_BASED_BROWSERS = [];
 
 /**
  * Get the top level parenthesized substrings within a given string. Unmatched
@@ -31,6 +40,16 @@ function getParenthesizedSubstrings(string) {
     }
   }
   return substrings;
+}
+
+/**
+ * Check whether the current browser is a mobile browser
+ * @param {string} userAgent
+ * @returns {boolean}
+ */
+function isMobile(userAgent) {
+  userAgent = userAgent || navigator.userAgent;
+  return /Mobi/.test(userAgent);
 }
 
 /**
@@ -87,16 +106,41 @@ function rebrandedChromeBrowser(browser) {
 }
 
 /**
+ * Get the name of the mobile webkit based browser, if any.
+ * @param browser
+ * @returns {?string} Name of the mobile webkit based browser, or null if the browser
+ *   is either not webkit based or mobile safari.
+ */
+function mobileWebKitBrowser(browser) {
+  if (browser !== 'safari') {
+    return null;
+  }
+  if ('brave' in navigator) {
+    return 'brave';
+  }
+
+  return ['edge', 'edg'].find(name => {
+    return navigator.userAgent.toLowerCase().includes(name);
+  }) || null;
+}
+
+/**
  * Check if the current browser is officially supported by twilio-video.js.
  * @returns {boolean}
  */
 function isSupported() {
   const browser = guessBrowser();
   const rebrandedChrome = rebrandedChromeBrowser(browser);
+  const mobileWebKit = mobileWebKitBrowser(browser);
+  const supportedMobileBrowsers = /android/.test(navigator.userAgent) ?
+    SUPPORTED_ANDROID_BROWSERS : SUPPORTED_IOS_BROWSERS;
+
   return !!browser
-    && isWebRTCSupported()
-    && (!rebrandedChrome || SUPPORTED_CHROME_BASED_BROWSERS.includes(rebrandedChrome))
-    && !isNonChromiumEdge(browser);
+  && isWebRTCSupported()
+  && (!rebrandedChrome || SUPPORTED_CHROME_BASED_BROWSERS.includes(rebrandedChrome))
+  && !isNonChromiumEdge(browser)
+  && (!mobileWebKit || SUPPORTED_MOBILE_WEBKIT_BASED_BROWSERS.includes(mobileWebKit))
+  && (!isMobile() || supportedMobileBrowsers.includes(browser));
 }
 
 module.exports = isSupported;

--- a/lib/util/support.js
+++ b/lib/util/support.js
@@ -132,7 +132,7 @@ function isSupported() {
   const browser = guessBrowser();
   const rebrandedChrome = rebrandedChromeBrowser(browser);
   const mobileWebKit = mobileWebKitBrowser(browser);
-  const supportedMobileBrowsers = /android/.test(navigator.userAgent) ?
+  const supportedMobileBrowsers = /android/.test(navigator.userAgent.toLowerCase()) ?
     SUPPORTED_ANDROID_BROWSERS : SUPPORTED_IOS_BROWSERS;
 
   return !!browser

--- a/lib/util/support.js
+++ b/lib/util/support.js
@@ -7,14 +7,14 @@ const SUPPORTED_CHROME_BASED_BROWSERS = [
   'edg',
   'edge',
   'electron',
-  'headlesschrome',
+  'headlesschrome'
 ];
 const SUPPORTED_ANDROID_BROWSERS = [
   'chrome',
-  'firefox',
+  'firefox'
 ];
 const SUPPORTED_IOS_BROWSERS = [
-  'safari',
+  'safari'
 ];
 // Currently none. Add 'brave', 'edg', and 'edge' here once we start supporting them
 const SUPPORTED_MOBILE_WEBKIT_BASED_BROWSERS = [];

--- a/lib/util/support.js
+++ b/lib/util/support.js
@@ -136,11 +136,11 @@ function isSupported() {
     SUPPORTED_ANDROID_BROWSERS : SUPPORTED_IOS_BROWSERS;
 
   return !!browser
-  && isWebRTCSupported()
-  && (!rebrandedChrome || SUPPORTED_CHROME_BASED_BROWSERS.includes(rebrandedChrome))
-  && !isNonChromiumEdge(browser)
-  && (!mobileWebKit || SUPPORTED_MOBILE_WEBKIT_BASED_BROWSERS.includes(mobileWebKit))
-  && (!isMobile() || supportedMobileBrowsers.includes(browser));
+    && isWebRTCSupported()
+    && (!rebrandedChrome || SUPPORTED_CHROME_BASED_BROWSERS.includes(rebrandedChrome))
+    && !isNonChromiumEdge(browser)
+    && (!mobileWebKit || SUPPORTED_MOBILE_WEBKIT_BASED_BROWSERS.includes(mobileWebKit))
+    && (!isMobile() || supportedMobileBrowsers.includes(browser));
 }
 
 module.exports = isSupported;

--- a/test/framework/webdriver.js
+++ b/test/framework/webdriver.js
@@ -13,6 +13,9 @@ const webdriver = require('selenium-webdriver');
  */
 function buildWebDriverForChrome() {
   const chromeOptions = new chrome.Options()
+    .addArguments('headless')
+    .addArguments('no-sandbox')
+    .addArguments('disable-dev-shm-usage')
     .addArguments('allow-file-access-from-files')
     .addArguments('use-fake-device-for-media-stream')
     .addArguments('use-fake-ui-for-media-stream');

--- a/test/unit/spec/util/support.js
+++ b/test/unit/spec/util/support.js
@@ -15,13 +15,17 @@ describe('isSupported', () => {
 
   [
     [
-      'Chrome on Windows',
-      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36',
-      { runtime: {} }
+      'Moto G7 Android Chrome',
+      'Mozilla/5.0 (Linux; Android 9; moto g(7) power) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.96 Mobile Safari/537.36'
     ],
     [
       'Chrome on Mac',
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36',
+      { runtime: {} }
+    ],
+    [
+      'Chrome on Windows',
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36',
       { runtime: {} }
     ],
     [
@@ -30,8 +34,24 @@ describe('isSupported', () => {
       { runtime: {} }
     ],
     [
-      'Safari on Mac',
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13 Safari/605.1.15'
+      'Electron',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Electron/3.1.12 Safari/537.36'
+    ],
+    [
+      'Firefox on Android',
+      'Mozilla/5.0 (Android 7.0; Mobile; rv:54.0) Gecko/54.0 Firefox/54.0'
+    ],
+    [
+      'Firefox on Linux',
+      'Mozilla/5.0 (X11; Linux i586; rv:31.0) Gecko/20100101 Firefox/69.0'
+    ],
+    [
+      'Firefox on Mac',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:61.0) Gecko/20100101 Firefox/69.0'
+    ],
+    [
+      'Firefox on Windows',
+      'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:54.0) Gecko/20100101 Firefox/69.0'
     ],
     [
       'Safari on iPad',
@@ -42,33 +62,18 @@ describe('isSupported', () => {
       'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13 Mobile/15E148 Safari/604.1'
     ],
     [
-      'Firefox on Windows',
-      'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:54.0) Gecko/20100101 Firefox/69.0'
+      'Safari on Mac',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13 Safari/605.1.15'
     ],
     [
-      'Firefox on Mac',
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:61.0) Gecko/20100101 Firefox/69.0'
-    ],
-    [
-      'Firefox on Linux',
-      'Mozilla/5.0 (X11; Linux i586; rv:31.0) Gecko/20100101 Firefox/69.0'
-    ],
-    [
-      'Edge (Chromium)',
-      'Mozilla/5.0 (Windows NT 10.0; Win64; x64; Xbox; Xbox One) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edg/15.15063',
+      'Edge (Chromium) on Mac',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36 Edg/90.0.818.66',
       { runtime: {} }
     ],
     [
-      'Electron',
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Electron/3.1.12 Safari/537.36'
-    ],
-    [
-      'Moto G4 Android Chrome',
-      'Mozilla/5.0 (Linux; Android 6.0.1; Moto G (4)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Mobile Safari/537.36'
-    ],
-    [
-      'Moto G7 Android Chrome',
-      'Mozilla/5.0 (Linux; Android 9; moto g(7) power) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.96 Mobile Safari/537.36'
+      'Edge (Chromium) on Windows',
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64; Xbox; Xbox One) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edg/15.15063',
+      { runtime: {} }
     ]
   ].forEach(([browser, useragent, chrome]) => {
     it('returns true for supported browser: ' + browser, () => {
@@ -81,6 +86,23 @@ describe('isSupported', () => {
   });
 
   [
+    [
+      'Chrome on iPhone',
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/90.0.4430.216 Mobile/15E148 Safari/604.1',
+      {}
+    ],
+    [
+      'Firefox on iPhone',
+      'Mozilla/5.0 (iPhone; CPU OS 14_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/33.1 Mobile/15E148 Safari/605.1.15'
+    ],
+    [
+      'Edge on Android',
+      'Mozilla/5.0 (Linux; Android 10; HD1913) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Mobile Safari/537.36 EdgA/46.3.4.5155'
+    ],
+    [
+      'Edge on iPhone',
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 14_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 EdgiOS/46.3.13 Mobile/15E148 Safari/605.1.15'
+    ],
     [
       'Edge 42',
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64; Xbox; Xbox One) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.15063',
@@ -103,6 +125,18 @@ describe('isSupported', () => {
     [
       'Another Brave',
       'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Brave Chrome/78.0.3904.108 Safari/537.36'
+    ],
+    [
+      'Another Brave on Mac',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36',
+      null,
+      {}
+    ],
+    [
+      'Brave on iPhone',
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 14_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.2 Mobile/15E148 Safari/604.1',
+      null,
+      {}
     ],
     [
       'Latest Desktop Brave',


### PR DESCRIPTION
Previously, we don't check for mobile browser specifically, we only test for WebRTC support. Now that mobile browsers are starting to support WebRTC, isSupported is returning true for these browsers. We want to still return false for these until QE officially support them.