### PR TITLE
remove /r/n/t from the slack message text

### DIFF
--- a/.circleci/images/build_docker_image.sh
+++ b/.circleci/images/build_docker_image.sh
@@ -36,7 +36,8 @@ if [ "${NEW_VERSION}" == "${OLD_VERSION}" ]; then
     echo "========================================================="
     echo notpushed > ./logs/notpushed.txt
     SLACK_MESSAGE_TEXT="${BROWSER}-${BVER} is ${NEW_VERSION}"
-    curl -X POST -H 'Content-type: application/json' --data '{"text": '\""$SLACK_MESSAGE_TEXT"\"'}' $SLACK_WEBHOOK
+    CLEANEDUP_SLACK_MESSAGE_TEXT=$(echo $SLACK_MESSAGE_TEXT|tr -d '\n\r\t')
+    curl -X POST -H 'Content-type: application/json' --data '{"text": '\""$CLEANEDUP_SLACK_MESSAGE_TEXT"\"'}' $SLACK_WEBHOOK
     exit 0
 fi
 
@@ -50,7 +51,8 @@ echo "Pushing browserContainer image for ${BROWSER}-${BVER}"
 docker push twilio/twilio-video-browsers:${BROWSER}-${BVER}
 echo pushed > ./logs/pushed.txt
 SLACK_MESSAGE_TEXT="Updated: ${BROWSER}-${BVER} => ${NEW_VERSION}"
-curl -X POST -H 'Content-type: application/json' --data '{"text": '\""$SLACK_MESSAGE_TEXT"\"'}' $SLACK_WEBHOOK
+CLEANEDUP_SLACK_MESSAGE_TEXT=$(echo $SLACK_MESSAGE_TEXT|tr -d '\n\r\t')
+curl -X POST -H 'Content-type: application/json' --data '{"text": '\""$CLEANEDUP_SLACK_MESSAGE_TEXT"\"'}' $SLACK_WEBHOOK
 
 echo "========================================================="
 echo "Done Pushing browserContainer image for ${BROWSER}-${BVER}"


### PR DESCRIPTION
our docker image build job is [failing to send](https://app.circleci.com/pipelines/github/twilio/twilio-video.js/4156/workflows/a7a904c9-9bdf-4aa2-bd0a-5a2544cfa1f3/jobs/45230?invite=true#step-102-184) results on slack message, because of `\r` characters in the text. This fixes it. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
