### PR TITLE
VIDEO-5226: send auto track switch off hints bit delayed. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 
 **Version 1.x will End of Life on September 8th, 2021.** Check [this guide](https://www.twilio.com/docs/video/migrating-1x-2x) to plan your migration to the latest 2.x version. Support for the 1.x version ended on December 4th, 2020.
 
+2.15.2 (In Progress)
+====================
+
+Bug Fixes
+---------
+Fixed a bug where setting clientTrackSwitchOffControl to auto caused the tracks to get switched off aggressively, which resulted in momentary black track during app layout changes (JSDK-5226).
+
 2.15.1 (June 21, 2021)
 =====================
 

--- a/lib/media/track/remotemediatrack.js
+++ b/lib/media/track/remotemediatrack.js
@@ -59,7 +59,10 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
           value: setPriority
         },
         _setRenderHint: {
-          value: setRenderHint
+          value: renderHint => {
+            this._log.debug('updating render hint:', renderHint);
+            setRenderHint(renderHint);
+          }
         },
         isEnabled: {
           enumerable: true,

--- a/lib/media/track/remotetrackpublication.js
+++ b/lib/media/track/remotetrackpublication.js
@@ -95,7 +95,7 @@ class RemoteTrackPublication extends TrackPublication {
         this.emit(signaling.isEnabled ? 'trackEnabled' : 'trackDisabled');
       }
       if (isSwitchedOff !== signaling.isSwitchedOff) {
-        this._log.warn(`${this.trackSid}: ${isSwitchedOff ? 'OFF' : 'ON'} => ${signaling.isSwitchedOff ? 'OFF' : 'ON'}`);
+        this._log.debug(`${this.trackSid}: ${isSwitchedOff ? 'OFF' : 'ON'} => ${signaling.isSwitchedOff ? 'OFF' : 'ON'}`);
         isSwitchedOff = signaling.isSwitchedOff;
         if (this.track) {
           this.track._setSwitchedOff(signaling.isSwitchedOff);

--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -4,8 +4,10 @@ const mixinRemoteMediaTrack = require('./remotemediatrack');
 const VideoTrack = require('./videotrack');
 const documentVisibilityMonitor = require('../../util/documentvisibilitymonitor.js');
 const { NullObserver } = require('../../util/nullobserver.js');
+const Timeout = require('../../util/timeout');
 
 const RemoteMediaVideoTrack = mixinRemoteMediaTrack(VideoTrack);
+const TRACK_TURN_OF_DELAY_MS = 50;
 
 /**
  * A {@link RemoteVideoTrack} represents a {@link VideoTrack} published to a
@@ -64,6 +66,11 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
       },
       _invisibleElements: {
         value: new WeakSet(),
+      },
+      _turnOffTimer: {
+        value: new Timeout(() => {
+          this._setRenderHint({ enabled: false });
+        }, TRACK_TURN_OF_DELAY_MS, false),
       },
       _resizeObserver: {
         value: new options.ResizeObserver(entries => {
@@ -292,7 +299,14 @@ function maybeUpdateEnabledHint(removeVideoTrack) {
 
   const visibleElements = removeVideoTrack._getAllAttachedElements().filter(el => !removeVideoTrack._invisibleElements.has(el));
   const enabled = document.visibilityState === 'visible' && visibleElements.length > 0;
-  removeVideoTrack._setRenderHint({ enabled });
+
+  if (enabled === true) {
+    removeVideoTrack._turnOffTimer.clear();
+    removeVideoTrack._setRenderHint({ enabled: true });
+  } else if (!removeVideoTrack._turnOffTimer.isSet) {
+    // set the track to be turned off after some delay.
+    removeVideoTrack._turnOffTimer.start();
+  }
 }
 
 function maybeUpdateDimensionHint(removeVideoTrack) {

--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -72,7 +72,7 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
           // attached and IntersectionObserver has not had its callback executed yet.
           const visibleElementResized = entries.find(entry => !this._invisibleElements.has(entry.target));
           if (visibleElementResized) {
-            maybeUpdateRenderHints(this);
+            maybeUpdateDimensionHint(this);
           }
         })
       },
@@ -93,7 +93,7 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
             }
           });
           if (shouldSetRenderHint) {
-            maybeUpdateRenderHints(this);
+            maybeUpdateEnabledHint(this);
           }
         }, { threshold: 0.25 })
       },
@@ -105,10 +105,8 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
    */
   _start(dummyEl) {
     const result = super._start.call(this, dummyEl);
-    // NOTE(mpatwardhan): after emitting started, update render hints only if clientTrackSwitchOffControl is 'auto'.
-    if (this._clientTrackSwitchOffControl === 'auto') {
-      maybeUpdateRenderHints(this);
-    }
+    // NOTE(mpatwardhan): after emitting started, update turn off track if not visible.
+    maybeUpdateEnabledHint(this);
     return result;
   }
 
@@ -160,13 +158,8 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
 
     if (this._clientTrackSwitchOffControl === 'auto') {
       // start off the element as invisible. will mark it
-      // visible once intersection observer calls back.
+      // visible (and update render hints) once intersection observer calls back.
       this._invisibleElements.add(result);
-
-      // NOTE(mpatwardhan): we do not call maybeUpdateRenderHints here,
-      // because the dimensions are not known for freshly created
-      // elements. we will get non-zero dimensions in _intersectionObserver
-      // callback and then will call maybeUpdateRenderHints.
     }
 
     this._intersectionObserver.observe(result);
@@ -195,7 +188,8 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
       }
     }
 
-    maybeUpdateRenderHints(this);
+    maybeUpdateEnabledHint(this);
+    maybeUpdateDimensionHint(this);
     return result;
   }
 
@@ -282,7 +276,7 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
 
 function setupDocumentVisibilityTurnOff(removeVideoTrack) {
   function onVisibilityChanged() {
-    maybeUpdateRenderHints(removeVideoTrack);
+    maybeUpdateEnabledHint(removeVideoTrack);
   }
 
   documentVisibilityMonitor.onVisibilityChange(1, onVisibilityChanged);
@@ -291,29 +285,30 @@ function setupDocumentVisibilityTurnOff(removeVideoTrack) {
   };
 }
 
-function maybeUpdateRenderHints(removeVideoTrack) {
-  // maybeUpdateRenderHints is applicable only for "auto" modes.
-  if (removeVideoTrack._clientTrackSwitchOffControl !== 'auto' && removeVideoTrack._contentPreferencesMode !== 'auto') {
+function maybeUpdateEnabledHint(removeVideoTrack) {
+  if (removeVideoTrack._clientTrackSwitchOffControl !== 'auto') {
     return;
   }
 
-  let elements = removeVideoTrack._getAllAttachedElements();
-  let updatedRenderHint = { };
-  if (removeVideoTrack._clientTrackSwitchOffControl === 'auto') {
-    // consider only visible elements.
-    elements = elements.filter(el => !removeVideoTrack._invisibleElements.has(el));
-    updatedRenderHint.enabled = document.visibilityState === 'visible' && elements.length > 0;
-  }
-
-  if (removeVideoTrack._contentPreferencesMode === 'auto' && elements.length > 0) {
-    const [{ clientHeight, clientWidth }] = elements.sort((el1, el2) =>
-      el2.clientHeight + el2.clientWidth - el1.clientHeight - el1.clientWidth - 1);
-    updatedRenderHint.renderDimensions = { height: clientHeight, width: clientWidth };
-  }
-
-  removeVideoTrack._log.debug('updating render hint:', updatedRenderHint);
-  removeVideoTrack._setRenderHint(updatedRenderHint);
+  const visibleElements = removeVideoTrack._getAllAttachedElements().filter(el => !removeVideoTrack._invisibleElements.has(el));
+  const enabled = document.visibilityState === 'visible' && visibleElements.length > 0;
+  removeVideoTrack._setRenderHint({ enabled });
 }
+
+function maybeUpdateDimensionHint(removeVideoTrack) {
+  if (removeVideoTrack._contentPreferencesMode !== 'auto') {
+    return;
+  }
+
+  const visibleElements = removeVideoTrack._getAllAttachedElements().filter(el => !removeVideoTrack._invisibleElements.has(el));
+  if (visibleElements.length > 0) {
+    const [{ clientHeight, clientWidth }] = visibleElements.sort((el1, el2) =>
+      el2.clientHeight + el2.clientWidth - el1.clientHeight - el1.clientWidth - 1);
+    const renderDimensions = { height: clientHeight, width: clientWidth };
+    removeVideoTrack._setRenderHint({ renderDimensions });
+  }
+}
+
 /**
  * @typedef {object} VideoContentPreferences
  * @property {VideoTrack.Dimensions} [renderDimensions] - Render Dimensions to request for the {@link RemoteVideoTrack}.

--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -101,6 +101,10 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
           });
           if (shouldSetRenderHint) {
             maybeUpdateEnabledHint(this);
+
+            // when visibility of an element changes that may cause the "biggest" element to change,
+            // update dimensions as well. since dimensions are cached at signaling layer.
+            maybeUpdateDimensionHint(this);
           }
         }, { threshold: 0.25 })
       },

--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -103,7 +103,8 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
             maybeUpdateEnabledHint(this);
 
             // when visibility of an element changes that may cause the "biggest" element to change,
-            // update dimensions as well. since dimensions are cached at signaling layer.
+            // update dimensions as well. since dimensions are cached and de-duped at signaling layer,
+            // its okay if they got  resent.
             maybeUpdateDimensionHint(this);
           }
         }, { threshold: 0.25 })

--- a/lib/signaling/v2/renderhintssignaling.js
+++ b/lib/signaling/v2/renderhintssignaling.js
@@ -15,9 +15,6 @@ class RenderHintsSignaling extends MediaSignaling {
       _trackSidsToRenderHints: {
         value: new Map()
       },
-      _dirtyTrackSids: {
-        value: new Set()
-      },
       _isResponsePending: {
         value: false,
         writable: true,
@@ -39,7 +36,16 @@ class RenderHintsSignaling extends MediaSignaling {
 
       // NOTE(mpatwardhan): When transport is set (either 1st time of after vms failover)
       // resend all track states. For this simply mark all tracks as dirty.
-      Array.from(this._trackSidsToRenderHints.keys()).forEach(trackSid => this._dirtyTrackSids.add(trackSid));
+      Array.from(this._trackSidsToRenderHints.keys()).forEach(trackSid => {
+        const trackState = this._trackSidsToRenderHints.get(trackSid);
+        if (trackState.renderDimensions) {
+          trackState.isDimensionDirty = true;
+        }
+
+        if ('enabled' in trackState) {
+          trackState.isEnabledDirty = true;
+        }
+      });
       this._sendHints();
     });
   }
@@ -55,27 +61,42 @@ class RenderHintsSignaling extends MediaSignaling {
   }
 
   _sendHints() {
-    if (!this._transport || this._isResponsePending || this._dirtyTrackSids.size === 0) {
+    if (!this._transport || this._isResponsePending) {
       return;
     }
 
     const hints = [];
-    Array.from(this._dirtyTrackSids).forEach(trackSid => {
-      const mspHint = this._trackSidsToRenderHints.get(trackSid);
-      hints.push(mspHint);
-      this._dirtyTrackSids.delete(trackSid);
+    Array.from(this._trackSidsToRenderHints.keys()).forEach(trackSid => {
+      const trackState = this._trackSidsToRenderHints.get(trackSid);
+      if (trackState.isEnabledDirty || trackState.isDimensionDirty) {
+        const mspHint = {
+          'track': trackSid,
+        };
+        if (trackState.isEnabledDirty) {
+          mspHint.enabled = trackState.enabled;
+          trackState.isEnabledDirty = false;
+        }
+        if (trackState.isDimensionDirty) {
+          // eslint-disable-next-line camelcase
+          mspHint.render_dimensions = trackState.renderDimensions;
+          trackState.isDimensionDirty = false;
+        }
+        hints.push(mspHint);
+      }
     });
 
-    const payLoad = {
-      type: 'render_hints',
-      subscriber: {
-        id: messageId++,
-        hints
-      }
-    };
-    this._log.debug('Outgoing: ', payLoad);
-    this._transport.publish(payLoad);
-    this._isResponsePending = true;
+    if (hints.length > 0) {
+      const payLoad = {
+        type: 'render_hints',
+        subscriber: {
+          id: messageId++,
+          hints
+        }
+      };
+      this._log.debug('Outgoing: ', payLoad);
+      this._transport.publish(payLoad);
+      this._isResponsePending = true;
+    }
   }
 
   /**
@@ -83,26 +104,19 @@ class RenderHintsSignaling extends MediaSignaling {
    * @param {ClientRenderHint} renderHint
    */
   setTrackHint(trackSid, renderHint) {
-    // convert hint to msp format
-    const mspHint = {
-      'track': trackSid,
-    };
-
-    if ('enabled' in renderHint) {
-      mspHint.enabled = !!renderHint.enabled;
+    const trackState = this._trackSidsToRenderHints.get(trackSid) || { isEnabledDirty: false, isDimensionDirty: false };
+    if ('enabled' in renderHint && trackState.enabled !== renderHint.enabled) {
+      trackState.enabled = !!renderHint.enabled;
+      trackState.isEnabledDirty = true;
     }
 
-    if (renderHint.renderDimensions) {
+    if (renderHint.renderDimensions && !isDeepEqual(renderHint.renderDimensions, trackState.renderDimensions)) {
       // eslint-disable-next-line camelcase
-      mspHint.render_dimensions = renderHint.renderDimensions;
+      trackState.renderDimensions = renderHint.renderDimensions;
+      trackState.isDimensionDirty = true;
     }
-
-    const oldHint = this._trackSidsToRenderHints.get(trackSid);
-    if (!isDeepEqual(oldHint, mspHint)) {
-      this._trackSidsToRenderHints.set(trackSid, mspHint);
-      this._dirtyTrackSids.add(trackSid);
-      this._sendHints();
-    }
+    this._trackSidsToRenderHints.set(trackSid, trackState);
+    this._sendHints();
   }
 
   /**
@@ -111,7 +125,6 @@ class RenderHintsSignaling extends MediaSignaling {
    */
   clearTrackHint(trackSid) {
     this._trackSidsToRenderHints.delete(trackSid);
-    this._dirtyTrackSids.delete(trackSid);
   }
 }
 

--- a/test/integration/spec/bandwidthprofile.js
+++ b/test/integration/spec/bandwidthprofile.js
@@ -280,7 +280,7 @@ describe('BandwidthProfileOptions', function() {
             clientTrackSwitchOffControl: 'manual'
           }
         },
-        effectiveclientTrackSwitchOffControl: 'manual',
+        effectiveClientTrackSwitchOffControl: 'manual',
         effectiveContentPreferencesMode: 'auto',
       },
       {
@@ -290,7 +290,7 @@ describe('BandwidthProfileOptions', function() {
             clientTrackSwitchOffControl: 'auto'
           }
         },
-        effectiveclientTrackSwitchOffControl: 'auto',
+        effectiveClientTrackSwitchOffControl: 'auto',
         effectiveContentPreferencesMode: 'auto',
       },
       {
@@ -299,7 +299,7 @@ describe('BandwidthProfileOptions', function() {
           video: {
           }
         },
-        effectiveclientTrackSwitchOffControl: 'auto',
+        effectiveClientTrackSwitchOffControl: 'auto',
         effectiveContentPreferencesMode: 'auto',
       },
       {
@@ -309,7 +309,7 @@ describe('BandwidthProfileOptions', function() {
             maxTracks: 5,
           }
         },
-        effectiveclientTrackSwitchOffControl: 'disabled', // when maxTracks is specified, effectiveclientTrackSwitchOffControl should be disabled.
+        effectiveClientTrackSwitchOffControl: 'disabled', // when maxTracks is specified, effectiveClientTrackSwitchOffControl should be disabled.
         effectiveContentPreferencesMode: 'auto',
       },
       {
@@ -319,7 +319,7 @@ describe('BandwidthProfileOptions', function() {
             contentPreferencesMode: 'manual'
           }
         },
-        effectiveclientTrackSwitchOffControl: 'auto',
+        effectiveClientTrackSwitchOffControl: 'auto',
         effectiveContentPreferencesMode: 'manual',
       },
       {
@@ -328,7 +328,7 @@ describe('BandwidthProfileOptions', function() {
           video: {
           }
         },
-        effectiveclientTrackSwitchOffControl: 'auto',
+        effectiveClientTrackSwitchOffControl: 'auto',
         effectiveContentPreferencesMode: 'auto',
       },
       {
@@ -340,10 +340,10 @@ describe('BandwidthProfileOptions', function() {
             }
           }
         },
-        effectiveclientTrackSwitchOffControl: 'auto',
+        effectiveClientTrackSwitchOffControl: 'auto',
         effectiveContentPreferencesMode: 'disabled',
       }
-    ].forEach(({ testCase, bandwidthProfile, effectiveclientTrackSwitchOffControl,  effectiveContentPreferencesMode }) => {
+    ].forEach(({ testCase, bandwidthProfile, effectiveClientTrackSwitchOffControl,  effectiveContentPreferencesMode }) => {
       let aliceRoom;
       let bobRoom;
       let roomSid;
@@ -376,11 +376,11 @@ describe('BandwidthProfileOptions', function() {
         });
 
         it('sets correct render hint options for RemoteVideoTracks', () => {
-          assert(aliceRemoteTrack._clientTrackSwitchOffControl === effectiveclientTrackSwitchOffControl);
+          assert(aliceRemoteTrack._clientTrackSwitchOffControl === effectiveClientTrackSwitchOffControl);
           assert(aliceRemoteTrack._contentPreferencesMode === effectiveContentPreferencesMode);
         });
 
-        if (effectiveclientTrackSwitchOffControl === 'manual') {
+        if (effectiveClientTrackSwitchOffControl === 'manual') {
           it('switchOn/switchOff can be used to turn tracks on/off', async () => {
             // initially track should be switched on
             await waitFor(trackSwitchedOn(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch on: ${roomSid}`);
@@ -417,7 +417,7 @@ describe('BandwidthProfileOptions', function() {
           });
         }
 
-        if (effectiveclientTrackSwitchOffControl === 'auto') {
+        if (effectiveClientTrackSwitchOffControl === 'auto') {
           it('Track turns off if video element is not attached initially', async () => {
             // since no video elements are attached. Tracks should switch off initially
             await waitFor(trackSwitchedOff(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch off: ${roomSid}`);

--- a/test/integration/spec/bandwidthprofile.js
+++ b/test/integration/spec/bandwidthprofile.js
@@ -449,6 +449,14 @@ describe('BandwidthProfileOptions', function() {
             await assertMediaFlow(bobRoom, true, `was expecting media flow: ${roomSid}`);
           });
 
+          it('tracks does not turns off if video element is detached and attached quickly ', async () => {
+            const aliceTrackSwitchOffPromise = trackSwitchedOff(aliceRemoteTrack);
+            aliceRemoteTrack.detach(videoElement2);
+            await waitForSometime(10);
+            aliceRemoteTrack.attach(videoElement2);
+            await waitForNot(aliceTrackSwitchOffPromise, `Alice's Track [${aliceRemoteTrack.sid}] to not switch off: ${roomSid}`);
+          });
+
           it('tracks turns off when all video elements are detached ', async () => {
             const elements = aliceRemoteTrack.detach();
             elements.forEach(el => el.remove());
@@ -459,7 +467,7 @@ describe('BandwidthProfileOptions', function() {
         } else {
           it('Track turns on even if video element is not attached initially', async () => {
             // since no video elements are attached. Tracks should switch off initially
-            await waitForNot(trackSwitchedOff(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to switch off: ${roomSid}`);
+            await waitForNot(trackSwitchedOff(aliceRemoteTrack), `Alice's Track [${aliceRemoteTrack.sid}] to not switch off: ${roomSid}`);
             assert.strictEqual(aliceRemoteTrack.isSwitchedOff, false, `Alice's Track.isSwitchedOff = ${aliceRemoteTrack.isSwitchedOff}`);
             await assertMediaFlow(bobRoom, true, `was expecting media flow: ${roomSid}`);
           });

--- a/test/unit/spec/media/track/remotevideotrack.js
+++ b/test/unit/spec/media/track/remotevideotrack.js
@@ -309,8 +309,13 @@ describe('RemoteVideoTrack', () => {
       });
 
       it('visible, _setRenderHint gets called with { enable: true }', () => {
+        el.clientWidth = 103;
+        el.clientHeight = 104;
         track._intersectionObserver.makeVisible(el);
         sinon.assert.calledWith(setRenderHintsSpy, sinon.match.has('enabled', true));
+
+        // also dimensions get updated.
+        sinon.assert.calledWith(setRenderHintsSpy, { renderDimensions: { width: 103, height: 104 } });
       });
 
       it('invisible, _setRenderHint gets called with { enable: false } after some delay', async () => {

--- a/test/unit/spec/media/track/remotevideotrack.js
+++ b/test/unit/spec/media/track/remotevideotrack.js
@@ -274,131 +274,131 @@ describe('RemoteVideoTrack', () => {
       }
     });
   });
+
+  describe('IntersectionObserver', () => {
+    let track;
+    let el;
+    let observeSpy;
+    let unobserveSpy;
+    let setRenderHintsSpy;
+
+    before(() => {
+      global.document = global.document || new Document();
+      el = document.createElement('video');
+      setRenderHintsSpy = sinon.spy();
+      track = makeTrack({ id: 'foo', sid: 'bar', setRenderHint: setRenderHintsSpy, options: { IntersectionObserver } });
+      observeSpy = sinon.spy(IntersectionObserver.prototype, 'observe');
+      unobserveSpy = sinon.spy(IntersectionObserver.prototype, 'unobserve');
+    });
+
+    after(() => {
+      observeSpy.restore();
+      unobserveSpy.restore();
+      if (global.document instanceof Document) {
+        delete global.document;
+      }
+    });
+
+    context('when an element is', () => {
+      before(() => {
+        track.attach(el);
+        setRenderHintsSpy.resetHistory();
+      });
+
+      it('visible, _setRenderHint gets called with { enable: true }', () => {
+        track._intersectionObserver.makeVisible(el);
+        sinon.assert.calledWith(setRenderHintsSpy, sinon.match.has('enabled', true));
+        // sinon.assert.calledWith(setRenderHintsSpy, sinon.match.has('renderDimensions', { height: sinon.match.any, width: sinon.match.any }));
+      });
+
+      it('invisible, _setRenderHint gets called with { enable: false }', () => {
+        track._intersectionObserver.makeInvisible(el);
+        sinon.assert.calledWith(setRenderHintsSpy, { enabled: false });
+      });
+
+    });
+  });
+
+  describe('ResizeObserver', () => {
+    let track;
+    let el;
+    let observeSpy;
+    let unobserveSpy;
+    let setRenderHintsSpy;
+
+    before(() => {
+      global.document = global.document || new Document();
+      el = document.createElement('video');
+      setRenderHintsSpy = sinon.spy();
+      track = makeTrack({ id: 'foo', sid: 'bar', setRenderHint: setRenderHintsSpy, options: { ResizeObserver } });
+      observeSpy = sinon.spy(track._resizeObserver, 'observe');
+      unobserveSpy = sinon.spy(track._resizeObserver, 'unobserve');
+    });
+
+    after(() => {
+      observeSpy.restore();
+      unobserveSpy.restore();
+      if (global.document instanceof Document) {
+        delete global.document;
+      }
+    });
+
+    context('detects size change of visible element', () => {
+      before(() => {
+        track.attach(el);
+        track._intersectionObserver.makeVisible(el);
+        el.clientWidth = 100;
+        el.clientHeight = 100;
+        setRenderHintsSpy.resetHistory();
+      });
+
+      it('_setRenderHint gets called with { enable: true }', () => {
+        track._resizeObserver.resize(el);
+        sinon.assert.calledWith(setRenderHintsSpy, { renderDimensions: { height: 100, width: 100 } });
+      });
+    });
+
+    context('ignores size change of invisible element', () => {
+      before(() => {
+        track.attach(el);
+        track._intersectionObserver.makeInvisible(el);
+        el.clientWidth = 100;
+        el.clientHeight = 100;
+        setRenderHintsSpy.resetHistory();
+      });
+
+      it('_setRenderHint does not get called', () => {
+        track._resizeObserver.resize(el);
+        sinon.assert.notCalled(setRenderHintsSpy);
+      });
+    });
+
+    context('reports SDmax size among attached visible elements', () => {
+      before(() => {
+        track.attach(el);
+        track._intersectionObserver.makeVisible(el);
+        el.clientWidth = 100;
+        el.clientHeight = 100;
+
+        const el2 = document.createElement('video');
+        track.attach(el2);
+        track._intersectionObserver.makeVisible(el2);
+        el2.clientWidth = 200;
+        el2.clientHeight = 200;
+        setRenderHintsSpy.resetHistory();
+      });
+
+      it('_setRenderHint does not get called', () => {
+        // even though 100x100 element was resized.
+        track._resizeObserver.resize(el);
+
+        // expect reported size to be 200x200
+        sinon.assert.calledWith(setRenderHintsSpy, { renderDimensions: { height: 200, width: 200 } });
+      });
+    });
+  });
 });
 
-describe('IntersectionObserver', () => {
-  let track;
-  let el;
-  let observeSpy;
-  let unobserveSpy;
-  let setRenderHintsSpy;
-
-  before(() => {
-    global.document = global.document || new Document();
-    el = document.createElement('video');
-    setRenderHintsSpy = sinon.spy();
-    track = makeTrack({ id: 'foo', sid: 'bar', setRenderHint: setRenderHintsSpy, options: { IntersectionObserver } });
-    observeSpy = sinon.spy(IntersectionObserver.prototype, 'observe');
-    unobserveSpy = sinon.spy(IntersectionObserver.prototype, 'unobserve');
-  });
-
-  after(() => {
-    observeSpy.restore();
-    unobserveSpy.restore();
-    if (global.document instanceof Document) {
-      delete global.document;
-    }
-  });
-
-  context('when an element is', () => {
-    before(() => {
-      track.attach(el);
-      setRenderHintsSpy.reset();
-    });
-
-    it('visible, _setRenderHint gets called with { enable: true }', () => {
-      track._intersectionObserver.makeVisible(el);
-      sinon.assert.calledWith(setRenderHintsSpy, sinon.match.has('enabled', true));
-      sinon.assert.calledWith(setRenderHintsSpy, sinon.match.has('renderDimensions', { height: sinon.match.any, width: sinon.match.any }));
-    });
-
-    it('invisible, _setRenderHint gets called with { enable: false }', () => {
-      track._intersectionObserver.makeInvisible(el);
-      sinon.assert.calledWith(setRenderHintsSpy, { enabled: false });
-    });
-
-  });
-});
-
-describe('ResizeObserver', () => {
-  let track;
-  let el;
-  let observeSpy;
-  let unobserveSpy;
-  let setRenderHintsSpy;
-
-  before(() => {
-    global.document = global.document || new Document();
-    el = document.createElement('video');
-    setRenderHintsSpy = sinon.spy();
-    track = makeTrack({ id: 'foo', sid: 'bar', setRenderHint: setRenderHintsSpy, options: { ResizeObserver } });
-    observeSpy = sinon.spy(track._resizeObserver, 'observe');
-    unobserveSpy = sinon.spy(track._resizeObserver, 'unobserve');
-  });
-
-  after(() => {
-    observeSpy.restore();
-    unobserveSpy.restore();
-    if (global.document instanceof Document) {
-      delete global.document;
-    }
-  });
-
-  context('detects size change of visible element', () => {
-    before(() => {
-      track.attach(el);
-      track._intersectionObserver.makeVisible(el);
-      el.clientWidth = 100;
-      el.clientHeight = 100;
-      setRenderHintsSpy.reset();
-    });
-
-    it('_setRenderHint gets called with { enable: true }', () => {
-      track._resizeObserver.resize(el);
-      sinon.assert.calledWith(setRenderHintsSpy, { enabled: true, renderDimensions: { height: 100, width: 100 } });
-    });
-  });
-
-  context('ignores size change of invisible element', () => {
-    before(() => {
-      track.attach(el);
-      track._intersectionObserver.makeInvisible(el);
-      el.clientWidth = 100;
-      el.clientHeight = 100;
-      setRenderHintsSpy.reset();
-    });
-
-    it('_setRenderHint does not get called', () => {
-      track._resizeObserver.resize(el);
-      sinon.assert.notCalled(setRenderHintsSpy);
-    });
-  });
-
-  context('reports SDmax size among attached visible elements', () => {
-    before(() => {
-      track.attach(el);
-      track._intersectionObserver.makeVisible(el);
-      el.clientWidth = 100;
-      el.clientHeight = 100;
-
-      const el2 = document.createElement('video');
-      track.attach(el2);
-      track._intersectionObserver.makeVisible(el2);
-      el2.clientWidth = 200;
-      el2.clientHeight = 200;
-      setRenderHintsSpy.reset();
-    });
-
-    it('_setRenderHint does not get called', () => {
-      // even though 100x100 element was resized.
-      track._resizeObserver.resize(el);
-
-      // expect reported size to be 200x200
-      sinon.assert.calledWith(setRenderHintsSpy, { enabled: true, renderDimensions: { height: 200, width: 200 } });
-    });
-  });
-
-});
 
 function makeTrack({ id, sid, isEnabled, options, setPriority, setRenderHint, isSwitchedOff }) {
   const emptyFn = () => undefined;

--- a/test/unit/spec/media/track/remotevideotrack.js
+++ b/test/unit/spec/media/track/remotevideotrack.js
@@ -9,6 +9,7 @@ const RemoteVideoTrack = require('../../../../../lib/media/track/remotevideotrac
 const { FakeMediaStreamTrack } = require('../../../../lib/fakemediastream');
 const documentVisibilityMonitor = require('../../../../../lib/util/documentvisibilitymonitor');
 const { NullIntersectionObserver: IntersectionObserver, NullResizeObserver: ResizeObserver } = require('../../../../../lib/util/nullobserver');
+const { waitForSometime } = require('../../../../../lib/util');
 
 describe('RemoteVideoTrack', () => {
   combinationContext([
@@ -80,15 +81,15 @@ describe('RemoteVideoTrack', () => {
       }
     });
 
-    const effectiveclientTrackSwitchOffControl = clientTrackSwitchOffControl || 'auto';
+    const effectiveClientTrackSwitchOffControl = clientTrackSwitchOffControl || 'auto';
     const effectiveContentPreferencesMode = contentPreferencesMode || 'auto';
-    const effectiveDocVisibility = effectiveclientTrackSwitchOffControl === 'auto' && enableDocumentVisibilityTurnOff !== false;
-    const autoTrackSwitchOff = effectiveclientTrackSwitchOffControl === 'auto';
+    const effectiveDocVisibility = effectiveClientTrackSwitchOffControl === 'auto' && enableDocumentVisibilityTurnOff !== false;
+    const autoTrackSwitchOff = effectiveClientTrackSwitchOffControl === 'auto';
     const autoContentPreferencesMode = effectiveContentPreferencesMode === 'auto';
 
     describe('constructor', () => {
       it('sets correct default for _clientTrackSwitchOffControl', () => {
-        assert(track._clientTrackSwitchOffControl === effectiveclientTrackSwitchOffControl);
+        assert(track._clientTrackSwitchOffControl === effectiveClientTrackSwitchOffControl);
       });
 
       it('sets correct default for _contentPreferencesMode', () => {
@@ -155,8 +156,9 @@ describe('RemoteVideoTrack', () => {
         el.oncanplay(); // simulate started event.
       });
 
-      if (effectiveclientTrackSwitchOffControl === 'auto') {
-        it('_setRenderHint gets called', () => {
+      if (effectiveClientTrackSwitchOffControl === 'auto') {
+        it('_setRenderHint gets called with a delay', async () => {
+          await waitForSometime(1000);
           sinon.assert.callCount(setRenderHintsSpy, 1);
         });
       } else {
@@ -177,7 +179,8 @@ describe('RemoteVideoTrack', () => {
       });
 
       if (autoTrackSwitchOff) {
-        it(' _setRenderHint gets called with { enable: false }', () => {
+        it(' _setRenderHint gets called with { enable: false } after a delay', async () => {
+          await waitForSometime(200);
           sinon.assert.calledWith(setRenderHintsSpy, { enabled: false });
         });
       }
@@ -206,7 +209,7 @@ describe('RemoteVideoTrack', () => {
       beforeEach(() => {
         setRenderHintsSpy.resetHistory();
       });
-      const allowManualSwitchOff = effectiveclientTrackSwitchOffControl === 'manual';
+      const allowManualSwitchOff = effectiveClientTrackSwitchOffControl === 'manual';
       if (allowManualSwitchOff) {
         it('calls _setRenderHint with enable = true', () => {
           track.switchOn();
@@ -230,7 +233,7 @@ describe('RemoteVideoTrack', () => {
       beforeEach(() => {
         setRenderHintsSpy.resetHistory();
       });
-      const allowManualSwitchOff = effectiveclientTrackSwitchOffControl === 'manual';
+      const allowManualSwitchOff = effectiveClientTrackSwitchOffControl === 'manual';
       if (allowManualSwitchOff) {
         it('calls _setRenderHint with enable = false', () => {
           track.switchOff();
@@ -308,14 +311,13 @@ describe('RemoteVideoTrack', () => {
       it('visible, _setRenderHint gets called with { enable: true }', () => {
         track._intersectionObserver.makeVisible(el);
         sinon.assert.calledWith(setRenderHintsSpy, sinon.match.has('enabled', true));
-        // sinon.assert.calledWith(setRenderHintsSpy, sinon.match.has('renderDimensions', { height: sinon.match.any, width: sinon.match.any }));
       });
 
-      it('invisible, _setRenderHint gets called with { enable: false }', () => {
+      it('invisible, _setRenderHint gets called with { enable: false } after some delay', async () => {
         track._intersectionObserver.makeInvisible(el);
+        await waitForSometime(1000);
         sinon.assert.calledWith(setRenderHintsSpy, { enabled: false });
       });
-
     });
   });
 


### PR DESCRIPTION
with client track switch off control set to auto - sdk request that track be turned off when it determines that track is not visible. However we found that sometimes react apps ends up causing elements to get hidden momentarily when layout changes. This results in  turn off and turn on request for the track in quick succession, causing a black screen momentarily. 

This fix delays requesting track turn off request by 50 ms. This required some refactoring as previously track switchOn/SwitchOff requests were clubbed together with render dimension changes. now they are handled separately.

 