### PR TITLE
Update firefox stable node

### DIFF
--- a/.circleci/images/firefox/stable/Dockerfile
+++ b/.circleci/images/firefox/stable/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/node:10.0.0-stretch
+FROM circleci/node:lts-browsers
 
 #
 # Install Java 11 LTS / OpenJDK 11


### PR DESCRIPTION
It seems we forgot to update firefox-stable node version. All our images are using node 14/16. Firefox stable is still using node10. This PR fixes that.