### PR TITLE
video-6336: media element leak causes error on chrome 92 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 
 **Version 1.x will End of Life on September 8th, 2021.** Check [this guide](https://www.twilio.com/docs/video/migrating-1x-2x) to plan your migration to the latest 2.x version. Support for the 1.x version ended on December 4th, 2020.
 
+2.15.3 (In Progress)
+====================
+
+Bug Fixes
+---------
+Chrome 92 [started enforcing](https://chromium-review.googlesource.com/c/chromium/src/+/2816118) limit on number of WebMediaPlayers. This blocks creation of further WebMediaPlayers once there are already 75 (desktop) or 40 (mobile) players. Fixed a related bug where the SDK was not cleaning up an internally maintained media elements.
+Please ensure that your application cleans up media elements as well after they are detached.
+```js
+  const elements = track.detach();
+  elements.forEach(el => {
+    el.remove();
+    el.srcObject = null;
+  });
+```
+
 2.15.2 (July 15, 2021)
 ======================
 

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 'use strict';
 
 const { guessBrowser } = require('@twilio/webrtc/lib/util');
@@ -145,8 +146,11 @@ class MediaTrack extends Track {
   _end() {
     this._log.debug('Ended');
     if (this._dummyEl) {
-      this._detachElement(this._dummyEl);
+      this._detachElementInternal(this._dummyEl);
+      this._dummyEl.remove();
+      this._dummyEl.srcObject = null;
       this._dummyEl.oncanplay = null;
+      this._dummyEl = null;
     }
   }
 
@@ -259,6 +263,13 @@ class MediaTrack extends Track {
     return elements.map(this._detachElement.bind(this));
   }
 
+  _detachElementInternal(el) {
+    const mediaStream = el.srcObject;
+    if (mediaStream instanceof this._MediaStream) {
+      mediaStream.removeTrack(this.processedTrack || this.mediaStreamTrack);
+    }
+  }
+
   /**
    * @private
    */
@@ -266,12 +277,7 @@ class MediaTrack extends Track {
     if (!this._attachments.has(el)) {
       return el;
     }
-
-    const mediaStream = el.srcObject;
-    if (mediaStream instanceof this._MediaStream) {
-      mediaStream.removeTrack(this.processedTrack || this.mediaStreamTrack);
-    }
-
+    this._detachElementInternal(el);
     this._attachments.delete(el);
 
     if (this._shouldShimAttachedElements && this._elShims.has(el)) {

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -119,24 +119,29 @@ class MediaTrack extends Track {
    * @private
    */
   _initialize() {
-    const self = this;
+    try {
+      const self = this;
 
-    this._log.debug('Initializing');
-    this._dummyEl = this._createElement();
+      this._log.debug('Initializing');
+      this._dummyEl = this._createElement();
 
-    this.mediaStreamTrack.addEventListener('ended', function onended() {
-      self._end();
-      self.mediaStreamTrack.removeEventListener('ended', onended);
-    });
+      this.mediaStreamTrack.addEventListener('ended', function onended() {
+        self._end();
+        self.mediaStreamTrack.removeEventListener('ended', onended);
+      });
 
-    if (this._dummyEl) {
-      this._dummyEl.muted = true;
-      this._dummyEl.oncanplay = this._start.bind(this, this._dummyEl);
+      if (this._dummyEl) {
+        this._dummyEl.muted = true;
+        this._dummyEl.oncanplay = this._start.bind(this, this._dummyEl);
 
-      // NOTE(csantos): We always want to attach the original mediaStreamTrack for dummyEl
-      this._attach(this._dummyEl, this.mediaStreamTrack);
+        // NOTE(csantos): We always want to attach the original mediaStreamTrack for dummyEl
+        this._attach(this._dummyEl, this.mediaStreamTrack);
 
-      this._attachments.delete(this._dummyEl);
+        this._attachments.delete(this._dummyEl);
+      }
+    } catch (e) {
+      console.log('error in _initialize:', e);
+      throw e;
     }
   }
 
@@ -155,21 +160,26 @@ class MediaTrack extends Track {
   }
 
   attach(el) {
-    if (typeof el === 'string') {
-      el = this._selectElement(el);
-    } else if (!el) {
-      el = this._createElement();
-    }
-    this._log.debug('Attempting to attach to element:', el);
-    el = this._attach(el);
+    try {
+      if (typeof el === 'string') {
+        el = this._selectElement(el);
+      } else if (!el) {
+        el = this._createElement();
+      }
+      this._log.debug('Attempting to attach to element:', el);
+      el = this._attach(el);
 
-    if (this._shouldShimAttachedElements && !this._elShims.has(el)) {
-      const onUnintentionallyPaused = this._playPausedElementsIfNotBackgrounded
-        ? () => playIfPausedAndNotBackgrounded(el, this._log)
-        : null;
-      this._elShims.set(el, shimMediaElement(el, onUnintentionallyPaused));
+      if (this._shouldShimAttachedElements && !this._elShims.has(el)) {
+        const onUnintentionallyPaused = this._playPausedElementsIfNotBackgrounded
+          ? () => playIfPausedAndNotBackgrounded(el, this._log)
+          : null;
+        this._elShims.set(el, shimMediaElement(el, onUnintentionallyPaused));
+      }
+    } catch (e) {
+      console.log('error in attach:', e);
+      this._log.warn('error in attach:', e);
+      throw e;
     }
-
     return el;
   }
 

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 'use strict';
 
 const { guessBrowser } = require('@twilio/webrtc/lib/util');
@@ -119,29 +118,24 @@ class MediaTrack extends Track {
    * @private
    */
   _initialize() {
-    try {
-      const self = this;
+    const self = this;
 
-      this._log.debug('Initializing');
-      this._dummyEl = this._createElement();
+    this._log.debug('Initializing');
+    this._dummyEl = this._createElement();
 
-      this.mediaStreamTrack.addEventListener('ended', function onended() {
-        self._end();
-        self.mediaStreamTrack.removeEventListener('ended', onended);
-      });
+    this.mediaStreamTrack.addEventListener('ended', function onended() {
+      self._end();
+      self.mediaStreamTrack.removeEventListener('ended', onended);
+    });
 
-      if (this._dummyEl) {
-        this._dummyEl.muted = true;
-        this._dummyEl.oncanplay = this._start.bind(this, this._dummyEl);
+    if (this._dummyEl) {
+      this._dummyEl.muted = true;
+      this._dummyEl.oncanplay = this._start.bind(this, this._dummyEl);
 
-        // NOTE(csantos): We always want to attach the original mediaStreamTrack for dummyEl
-        this._attach(this._dummyEl, this.mediaStreamTrack);
+      // NOTE(csantos): We always want to attach the original mediaStreamTrack for dummyEl
+      this._attach(this._dummyEl, this.mediaStreamTrack);
 
-        this._attachments.delete(this._dummyEl);
-      }
-    } catch (e) {
-      console.log('error in _initialize:', e);
-      throw e;
+      this._attachments.delete(this._dummyEl);
     }
   }
 
@@ -151,7 +145,6 @@ class MediaTrack extends Track {
   _end() {
     this._log.debug('Ended');
     if (this._dummyEl) {
-      this._detachElementInternal(this._dummyEl);
       this._dummyEl.remove();
       this._dummyEl.srcObject = null;
       this._dummyEl.oncanplay = null;
@@ -160,25 +153,19 @@ class MediaTrack extends Track {
   }
 
   attach(el) {
-    try {
-      if (typeof el === 'string') {
-        el = this._selectElement(el);
-      } else if (!el) {
-        el = this._createElement();
-      }
-      this._log.debug('Attempting to attach to element:', el);
-      el = this._attach(el);
+    if (typeof el === 'string') {
+      el = this._selectElement(el);
+    } else if (!el) {
+      el = this._createElement();
+    }
+    this._log.debug('Attempting to attach to element:', el);
+    el = this._attach(el);
 
-      if (this._shouldShimAttachedElements && !this._elShims.has(el)) {
-        const onUnintentionallyPaused = this._playPausedElementsIfNotBackgrounded
-          ? () => playIfPausedAndNotBackgrounded(el, this._log)
-          : null;
-        this._elShims.set(el, shimMediaElement(el, onUnintentionallyPaused));
-      }
-    } catch (e) {
-      console.log('error in attach:', e);
-      this._log.warn('error in attach:', e);
-      throw e;
+    if (this._shouldShimAttachedElements && !this._elShims.has(el)) {
+      const onUnintentionallyPaused = this._playPausedElementsIfNotBackgrounded
+        ? () => playIfPausedAndNotBackgrounded(el, this._log)
+        : null;
+      this._elShims.set(el, shimMediaElement(el, onUnintentionallyPaused));
     }
     return el;
   }
@@ -273,13 +260,6 @@ class MediaTrack extends Track {
     return elements.map(this._detachElement.bind(this));
   }
 
-  _detachElementInternal(el) {
-    const mediaStream = el.srcObject;
-    if (mediaStream instanceof this._MediaStream) {
-      mediaStream.removeTrack(this.processedTrack || this.mediaStreamTrack);
-    }
-  }
-
   /**
    * @private
    */
@@ -287,7 +267,10 @@ class MediaTrack extends Track {
     if (!this._attachments.has(el)) {
       return el;
     }
-    this._detachElementInternal(el);
+    const mediaStream = el.srcObject;
+    if (mediaStream instanceof this._MediaStream) {
+      mediaStream.removeTrack(this.processedTrack || this.mediaStreamTrack);
+    }
     this._attachments.delete(el);
 
     if (this._shouldShimAttachedElements && this._elShims.has(el)) {

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -7,6 +7,7 @@ require('./spec/bandwidthprofile/regressions');
 require('./spec/bandwidthprofile/renderhints');
 require('./spec/bandwidthprofile/video');
 require('./spec/connect');
+require('./spec/leaktests');
 require('./spec/logger');
 require('./spec/localparticipant/networkqualitylevel');
 require('./spec/localparticipant/publishunpublishtrack');

--- a/test/integration/spec/leaktests.js
+++ b/test/integration/spec/leaktests.js
@@ -40,6 +40,8 @@ function getTracksOfKind(participant, kind) {
 
     const aliceRoom = await waitFor(connect(getToken('Alice'), connectOptions), 'Alice to connect to room');
     async function joinRoomAndEnsureTracksStarted(i) {
+      // eslint-disable-next-line no-console
+      console.log(`${i}] connecting to room ${aliceRoom.sid}`);
       const bobRoom = await waitFor(connect(getToken('Bob'), connectOptions), `${i}] Bob to join room: ${aliceRoom.sid}`);
 
       // wait for Bob to see alice connected.
@@ -62,7 +64,7 @@ function getTracksOfKind(participant, kind) {
     // Alice joins room first.
     for (let i = 0; i < 50; i++) {
       // eslint-disable-next-line no-await-in-loop
-      await joinRoomAndEnsureTracksStarted();
+      await joinRoomAndEnsureTracksStarted(i);
     }
 
     aliceRoom.disconnect();

--- a/test/integration/spec/leaktests.js
+++ b/test/integration/spec/leaktests.js
@@ -25,7 +25,9 @@ function getTracksOfKind(participant, kind) {
   return [...participant.tracks.values()].filter(remoteTrack => remoteTrack.kind === kind).map(({ track }) => track);
 }
 
-(isChrome ? describe : describe.skip)('VIDEO-6336: media element leak detection', function() {
+// eslint-disable-next-line no-warning-comments
+// TODO(mpatwardhan): Fix VIDEO-6356 and enable this test for p2p rooms.
+(isChrome && defaults.topology !== 'peer-to-peer' ? describe : describe.skip)('VIDEO-6336: media element leak detection', function() {
   // eslint-disable-next-line no-invalid-this
   this.timeout(5 * 60 * 1000);
 

--- a/test/integration/spec/leaktests.js
+++ b/test/integration/spec/leaktests.js
@@ -1,0 +1,71 @@
+/* eslint-disable no-undefined */
+'use strict';
+
+const assert = require('assert');
+const defaults = require('../../lib/defaults');
+const { completeRoom, createRoom } = require('../../lib/rest');
+const { audio: createLocalAudioTrack, video: createLocalVideoTrack } = require('../../../lib/createlocaltrack');
+const connect = require('../../../lib/connect');
+const getToken = require('../../lib/token');
+const { isChrome } = require('../../lib/guessbrowser');
+
+const {
+  smallVideoConstraints,
+  randomName,
+  participantsConnected,
+  tracksSubscribed,
+  waitForSometime,
+  waitFor,
+  trackStarted
+} = require('../../lib/util');
+
+
+function getTracksOfKind(participant, kind) {
+  return [...participant.tracks.values()].filter(remoteTrack => remoteTrack.kind === kind).map(({ track }) => track);
+}
+
+(isChrome ? describe : describe.skip)('VIDEO-6336: media element leak detection', function() {
+  // eslint-disable-next-line no-invalid-this
+  this.timeout(5 * 60 * 1000);
+
+  it(' tracks works even after 50 connect disconnects ', async () => {
+    const localAudioTrack = await createLocalAudioTrack({ fake: true });
+    const localVideoTrack = await createLocalVideoTrack(smallVideoConstraints);
+    const roomName = await createRoom(randomName(), defaults.topology);
+    const connectOptions = Object.assign({
+      name: roomName,
+      tracks: [localAudioTrack, localVideoTrack],
+      logLevel: 'warn',
+    }, defaults);
+
+    const aliceRoom = await waitFor(connect(getToken('Alice'), connectOptions), 'Alice to connect to room');
+    async function joinRoomAndEnsureTracksStarted(i) {
+      const bobRoom = await waitFor(connect(getToken('Bob'), connectOptions), `${i}] Bob to join room: ${aliceRoom.sid}`);
+
+      // wait for Bob to see alice connected.
+      await waitFor(participantsConnected(bobRoom, 1), `${i}] Bob to see Alice connected: ${aliceRoom.sid}`);
+
+      const aliceRemote = bobRoom.participants.get(aliceRoom.localParticipant.sid);
+      await waitFor(tracksSubscribed(aliceRemote, 2), `${i}] Bob to see Alice's track: ${aliceRoom.sid}`);
+
+      const remoteVideoTracks = getTracksOfKind(aliceRemote, 'video');
+      const remoteAudioTracks = getTracksOfKind(aliceRemote, 'audio');
+      assert.strictEqual(remoteVideoTracks.length, 1);
+      assert.strictEqual(remoteAudioTracks.length, 1);
+
+      await waitFor(trackStarted(remoteVideoTracks[0]), `${i}] Bob to see Alice's video track started: ${aliceRoom.sid}`);
+      await waitFor(trackStarted(remoteAudioTracks[0]), `${i}] Bob to see Alice's audio track started: ${aliceRoom.sid}`);
+      bobRoom.disconnect();
+      await waitForSometime(1000);
+    }
+
+    // Alice joins room first.
+    for (let i = 0; i < 50; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await joinRoomAndEnsureTracksStarted();
+    }
+
+    aliceRoom.disconnect();
+    await completeRoom(aliceRoom.sid);
+  });
+});

--- a/test/lib/document.js
+++ b/test/lib/document.js
@@ -22,6 +22,10 @@ class HTMLElement {
     return this;
   }
 
+  remove() {
+
+  }
+
   play() {
     return Promise.resolve();
   }

--- a/test/unit/spec/media/track/localmediatrack.js
+++ b/test/unit/spec/media/track/localmediatrack.js
@@ -117,7 +117,7 @@ const { defer } = require('../../../../../lib/util');
     describe('#_setMediaStreamTrack', () => {
       let dummyElement;
       beforeEach(() => {
-        dummyElement = { oncanplay: 'bar' };
+        dummyElement = { oncanplay: 'bar', remove: sinon.spy() };
         document.createElement = sinon.spy(() => {
           return dummyElement;
         });
@@ -340,7 +340,8 @@ const { defer } = require('../../../../../lib/util');
       const dummyElement = {
         oncanplay: null,
         videoWidth: 320,
-        videoHeight: 240
+        videoHeight: 240,
+        remove: sinon.spy()
       };
 
       before(() => {

--- a/test/unit/spec/media/track/mediatrack.js
+++ b/test/unit/spec/media/track/mediatrack.js
@@ -56,7 +56,7 @@ describe('MediaTrack', () => {
       track._detachElement = sinon.spy();
       track._attachments.delete = sinon.spy();
 
-      dummyElement = { oncanplay: 'bar' };
+      dummyElement = { oncanplay: 'bar', remove: sinon.spy() };
       track._createElement = sinon.spy(() => {
         return dummyElement;
       });


### PR DESCRIPTION
chrome 92 started [limiting](https://chromium-review.googlesource.com/c/chromium/src/+/2816118) the WebMediaPlayers. This [breaks](https://bugs.chromium.org/p/chromium/issues/detail?id=1232649) lot of webrtc applications. This fix ensures that 1) we do not leak media elements created internally and 2) we clear the `srcObject` before removing media elements.

The application that use `RemoteAudioTrack.detach`() method need to ensure that they clear srcObject on the returned elements as well.

related github issues: https://github.com/twilio/twilio-video.js/issues/1367 & https://github.com/twilio/twilio-video.js/issues/1528
  
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
