### PR TITLE
Small iOS Chrome Fixes

### DIFF
--- a/lib/media/track/localvideotrack.js
+++ b/lib/media/track/localvideotrack.js
@@ -3,6 +3,7 @@
 const { guessBrowser } = require('@twilio/webrtc/lib/util');
 
 const detectSilentVideo = require('../../util/detectsilentvideo');
+const { isChromeIOS } = require('../../util/browserdetection');
 const mixinLocalMediaTrack = require('./localmediatrack');
 const VideoTrack = require('./videotrack');
 
@@ -31,7 +32,7 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
    */
   constructor(mediaStreamTrack, options) {
     options = Object.assign({
-      workaroundSilentLocalVideo: guessBrowser() === 'safari'
+      workaroundSilentLocalVideo: guessBrowser() === 'safari' || isChromeIOS()
         && typeof document !== 'undefined'
         && typeof document.createElement === 'function'
     }, options);

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -3,6 +3,7 @@
 const { guessBrowser } = require('@twilio/webrtc/lib/util');
 const { MediaStream } = require('@twilio/webrtc');
 
+const { isChromeIOS } = require('../../util/browserdetection');
 const { waitForEvent, waitForSometime } = require('../../util');
 const localMediaRestartDeferreds = require('../../util/localmediarestartdeferreds');
 const Track = require('./');
@@ -32,7 +33,7 @@ class MediaTrack extends Track {
    */
   constructor(mediaTrackTransceiver, options) {
     options = Object.assign({
-      playPausedElementsIfNotBackgrounded: guessBrowser() === 'safari'
+      playPausedElementsIfNotBackgrounded: guessBrowser() === 'safari' || isChromeIOS()
         && typeof document === 'object'
         && typeof document.addEventListener === 'function'
         && typeof document.visibilityState === 'string'

--- a/lib/util/browserdetection.js
+++ b/lib/util/browserdetection.js
@@ -28,6 +28,15 @@ function isChromeIOS() {
 }
 
 /**
+ * Check whether the current OS version is 14_3 and above,
+ * used in conjunction with isChromeIOS and isMobile.
+ * @returns {boolean}
+ */
+function isChromeVersionSupported() {
+  return /14\_([3-9]|[1-9]\d+)|(1[5-9]|[2-9]\d+)_\d+/.test(navigator.userAgent);
+}
+
+/**
  * Check whether the current browser is a mobile browser
  * @returns {boolean}
  */
@@ -134,6 +143,7 @@ module.exports = {
   isAndroid,
   isIOS,
   isChromeIOS,
+  isChromeVersionSupported,
   isMobile,
   isNonChromiumEdge,
   mobileWebKitBrowser,

--- a/lib/util/browserdetection.js
+++ b/lib/util/browserdetection.js
@@ -33,7 +33,7 @@ function isChromeIOS() {
  * @returns {boolean}
  */
 function isChromeVersionSupported() {
-  return /14\_([3-9]|[1-9]\d+)|(1[5-9]|[2-9]\d+)_\d+/.test(navigator.userAgent);
+  return /14_([3-9]|[1-9]\d+)|(1[5-9]|[2-9]\d+)_\d+/.test(navigator.userAgent);
 }
 
 /**

--- a/lib/util/support.js
+++ b/lib/util/support.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { guessBrowser, support: isWebRTCSupported } = require('@twilio/webrtc/lib/util');
-const { isAndroid, isMobile, isNonChromiumEdge, rebrandedChromeBrowser, mobileWebKitBrowser } = require('./browserdetection');
+const { isAndroid, isChromeIOS, isChromeVersionSupported, isMobile, isNonChromiumEdge, rebrandedChromeBrowser, mobileWebKitBrowser } = require('./browserdetection');
 
 const SUPPORTED_CHROME_BASED_BROWSERS = [
   'crios',
@@ -32,6 +32,13 @@ function isSupported() {
   // to prevent unnecessary checks which could lead to errors
   if (!browser) {
     return false;
+  }
+
+  // NOTE (joma): Return if iOS chrome version is not 14.3 and above.
+  if (isChromeIOS()) {
+    if (!isChromeVersionSupported()) {
+      return false;
+    }
   }
 
   const rebrandedChrome = rebrandedChromeBrowser(browser);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "twilio-video",
   "title": "Twilio Video",
   "description": "Twilio Video JavaScript Library",
-  "version": "2.15.3-dev",
+  "version": "2.16.0-dev",
   "homepage": "https://twilio.com",
   "author": "Mark Andrus Roberts <mroberts@twilio.com>",
   "contributors": [

--- a/test/unit/spec/util/support.js
+++ b/test/unit/spec/util/support.js
@@ -156,6 +156,18 @@ describe('isSupported', () => {
       {}
     ],
     [
+      'Chrome on iPhone OS version 10.3',
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) CriOS/56.0.2924.75 Mobile/14E5239e Safari/602.1',
+      null,
+      {}
+    ],
+    [
+      'Chrome on iPad OS version 12.0',
+      'Mozilla/5.0 (iPad; CPU OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/71.0.3578.77 Mobile/15E148 Safari/605.1',
+      null,
+      {}
+    ],
+    [
       'Opera',
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36 OPR/56.0.3051.52'
     ],


### PR DESCRIPTION
This a relatively small PR:
1. Adding `isChromeIOS` to some other places I missed in the last PR to apply a few extra safari workarounds. 
2. Adding in an additional check to make sure that the browser is iOS Chrome 14.3+ since WebRTC WKWebView support didn't happen until iOS OS v14.3, and it does not seem that they will be fixing previous versions [as seen here](https://bugs.chromium.org/p/chromium/issues/detail?id=752458).
3. Failing Unit test cases added 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
