### PR TITLE
VIDEO-6336 - Cleanup dummy audio element after start

### DIFF
--- a/lib/media/track/audiotrack.js
+++ b/lib/media/track/audiotrack.js
@@ -35,9 +35,7 @@ class AudioTrack extends MediaTrack {
     super._start();
     if (this._dummyEl) {
       // once started let go of dummy element
-      this._dummyEl.remove();
       this._dummyEl.srcObject = null;
-      this._dummyEl.oncanplay = null;
       this._dummyEl = null;
     }
   }

--- a/lib/media/track/audiotrack.js
+++ b/lib/media/track/audiotrack.js
@@ -34,7 +34,11 @@ class AudioTrack extends MediaTrack {
   _start() {
     super._start();
     if (this._dummyEl) {
-      this._detachElement(this._dummyEl);
+      // once started let go of dummy element
+      this._dummyEl.remove();
+      this._dummyEl.srcObject = null;
+      this._dummyEl.oncanplay = null;
+      this._dummyEl = null;
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "ts-node": "4.0.1",
     "tslint": "5.8.0",
     "twilio": "^3.49.0",
-    "twilio-release-tool": "^1.0.0",
+    "twilio-release-tool": "^1.0.2",
     "typescript": "^4.0.5",
     "uglify-js": "^2.8.22",
     "vinyl-fs": "^2.4.4",

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -23,6 +23,7 @@ require('./spec/data/receiver');
 require('./spec/data/transport');
 
 require('./spec/media/track/es5/localdatatrack');
+require('./spec/media/track/audiotrack');
 require('./spec/media/track/mediatrack');
 require('./spec/media/track/localdatatrack');
 require('./spec/media/track/localmediatrack');

--- a/test/unit/spec/media/track/audiotrack.js
+++ b/test/unit/spec/media/track/audiotrack.js
@@ -1,0 +1,117 @@
+'use strict';
+
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const sinon = require('sinon');
+const { inherits } = require('util');
+
+const AudioTrack = require('../../../../../lib/media/track/audiotrack');
+const MediaTrackTransceiver = require('../../../../../lib/media/track/transceiver');
+
+const log = require('../../../../lib/fakelog');
+const Document = require('../../../../lib/document');
+
+describe('AudioTrack', () => {
+  let _initialize;
+  let track;
+
+  before(() => {
+    _initialize = AudioTrack.prototype._initialize;
+    AudioTrack.prototype._initialize = sinon.spy();
+    global.document = global.document || new Document();
+  });
+
+  after(() => {
+    AudioTrack.prototype._initialize = _initialize;
+    if (global.document instanceof Document) {
+      delete global.document;
+    }
+  });
+
+  describe('_initialize', () => {
+    let dummyElement;
+
+    before(() => {
+      track = createAudioTrack('1', 'audio');
+      track._attach = sinon.spy();
+      track._detachElement = sinon.spy();
+      track._attachments.delete = sinon.spy();
+
+      dummyElement = { oncanplay: 'bar', remove: sinon.spy(), srcObject: 'something' };
+      track._createElement = sinon.spy(() => {
+        return dummyElement;
+      });
+
+      _initialize.call(track);
+    });
+
+    it('should call ._createElement', () => {
+      assert.equal(track._createElement.callCount, 1);
+    });
+
+    it('should call ._attach with the created element', () => {
+      assert(track._attach.calledWith(dummyElement));
+    });
+
+    it('should call .delete with the created element on the ._attachments Set', () => {
+      assert(track._attachments.delete.calledWith(dummyElement));
+    });
+
+    it('should set el.oncanplay to a function', () => {
+      assert.equal(typeof dummyElement.oncanplay, 'function');
+    });
+
+    it('should set el.muted to true', () => {
+      assert.equal(dummyElement.muted, true);
+    });
+
+    context('when the dummy element emits oncanplay event', () => {
+      it('should emit MediaTrack#started, passing the instance of MediaTrack', async () => {
+        _initialize.call(track);
+
+        const trackPromise = new Promise(resolve => track.on('started', resolve));
+
+        dummyElement.oncanplay();
+
+        const _track = await trackPromise;
+        assert.equal(track, _track);
+      });
+
+      it('should set .isStarted to true', () => {
+        assert(track.isStarted);
+      });
+
+      it('should set the element\'s oncanplay to null', () => {
+        assert.equal(dummyElement.oncanplay, null);
+      });
+
+      it('should set the element\'s srcObject to null', () => {
+        assert.equal(dummyElement.srcObject, null);
+      });
+    });
+  });
+
+});
+
+function createAudioTrack(id, kind, options) {
+  const mediaStreamTrack = new MediaStreamTrack(id, kind);
+  const mediaTrackTransceiver = new MediaTrackTransceiver(id, mediaStreamTrack);
+  const mediaTrack = new AudioTrack(mediaTrackTransceiver, Object.assign({ log: log }, options));
+  mediaTrack.tranceiver = mediaTrackTransceiver;
+  return mediaTrack;
+}
+
+function MediaStreamTrack(id, kind) {
+  EventEmitter.call(this);
+
+  Object.defineProperties(this, {
+    id: { value: id },
+    kind: { value: kind }
+  });
+}
+
+inherits(MediaStreamTrack, EventEmitter);
+
+MediaStreamTrack.prototype.addEventListener = MediaStreamTrack.prototype.addListener;
+
+MediaStreamTrack.prototype.removeEventListener = MediaStreamTrack.prototype.removeListener;


### PR DESCRIPTION
We create dummy element for audio only to generate 'started' event. Once started we were calling `_detachElement`, but that call is no-op for dummy element - Causing the audio element active until track ended. Fixed this by cleaning up dummy element specifically.


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
