### PR TITLE
use audio jitter only

### DIFF
--- a/lib/preflight/getCombinedConnectionStats.ts
+++ b/lib/preflight/getCombinedConnectionStats.ts
@@ -39,7 +39,8 @@ export async function getCombinedConnectionStats({ publisher, subscriber }: { pu
 
   // jitter: subscriber, inbound-rtp, audio
   //         Note: chrome has jitter for video, but not Safari.
-  const jitter = getStatValues(subscriberStats, 'jitter', ['audio', 'video'], ['inbound-rtp']).reduce((a, b) => Math.max(a, b), 0);
+  //         Note: also jitter values are in seconds, but chrome's video jitter values were found to be are too big to be in seconds.
+  const jitter = getStatValues(subscriberStats, 'jitter', ['audio'], ['inbound-rtp']).reduce((a, b) => Math.max(a, b), 0);
 
   // packets, packetsLost:
   //              subscriber, audio, inbound-rtp,

--- a/lib/preflight/preflighttest.ts
+++ b/lib/preflight/preflighttest.ts
@@ -317,8 +317,9 @@ export class PreflightTest extends EventEmitter {
     this._receivedBytesMovingAverage.putSample(bytesReceived, timestamp);
     this._packetLossMovingAverage.putSample(packetsLost, packets);
     if (hasLastData) {
-      collectedStats.outgoingBitrate.push(this._sentBytesMovingAverage.get());
-      collectedStats.incomingBitrate.push(this._receivedBytesMovingAverage.get());
+      // convert BytesMovingAverage which is in bytes/millisecond to bits/second
+      collectedStats.outgoingBitrate.push(this._sentBytesMovingAverage.get() * 1000 * 8);
+      collectedStats.incomingBitrate.push(this._receivedBytesMovingAverage.get() * 1000 * 8);
       const fractionPacketLost = this._packetLossMovingAverage.get();
       const percentPacketsLost = Math.min(100, fractionPacketLost * 100);
 
@@ -362,8 +363,6 @@ export interface InternalStatsReport extends StatsReport {
     timestamp: number;
     bytesSent: number;
     bytesReceived: number;
-    availableOutgoingBitrate?: number;
-    availableIncomingBitrate?: number;
     currentRoundTripTime?: number;
     localCandidate: RTCIceCandidateStats;
     remoteCandidate: RTCIceCandidateStats;
@@ -411,7 +410,7 @@ function initCollectedStats() : PreflightStats {
 /**
  * Represents RTC related stats that were observed during preflight test
  * @typedef {object} PreflightReportStats
- * @property {Stats} [jitter] - Packet delay variation
+ * @property {Stats} [jitter] - Packet delay variation in seconds
  * @property {Stats} [rtt] - Round trip time, to the server back to the client in milliseconds.
  * @property {Stats} [mos] - mos score (1 to 5)
  * @property {Stats} [outgoingBitrate] - Outgoing bitrate in bits per second.


### PR DESCRIPTION
although chrome reports jitter values for video tracks, they does not seem correct - they are too large to be in seconds. 
For now just use jitter from audio tracks.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
