### PR TITLE
doc update to mention browser limitation on networktimings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,6 @@ preflightTest.on('completed', (report: PreflightTestReport) => {
   console.log("Test completed in " + report.testTiming.duration + " milliseconds.");
   console.log(" It took " + report.networkTiming.connect?.duration + " milliseconds to connect");
   console.log(" It took " + report.networkTiming.media?.duration + " milliseconds to receive media");
-  console.log("rtt max: " + report.stats.rtt.max + ", rtt avg: " + report.stats.rtt.avg);
-
 });
 ```
 

--- a/lib/preflight/preflighttest.ts
+++ b/lib/preflight/preflighttest.ts
@@ -44,11 +44,13 @@ const PreflightProgress = {
 
   /**
    * established DTLS connection. This is measured from RTCDtlsTransport `connecting` to `connected` state.
+   * On Safari, Support for measuring this is missing, this event will be not be emitted on Safari.
    */
   dtlsConnected: 'dtlsConnected',
 
   /**
    * established a PeerConnection, This is measured from PeerConnection `connecting` to `connected` state.
+   * On Firefox, Support for measuring this is missing, this event will be not be emitted on Firefox.
    */
   peerConnectionConnected: 'peerConnectionConnected',
 
@@ -374,9 +376,9 @@ function initCollectedStats() : PreflightStats {
  * @typedef {object} NetworkTiming
  * @property {TimeMeasurement} [connect] - Time to establish signaling connection and acquire turn credentials
  * @property {TimeMeasurement} [media] - Time to start media. This is measured from calling connect to remote media getting started.
- * @property {TimeMeasurement} [dtls] - Time to establish dtls connection. This is measured from RTCDtlsTransport `connecting` to `connected` state.
+ * @property {TimeMeasurement} [dtls] - Time to establish dtls connection. This is measured from RTCDtlsTransport `connecting` to `connected` state. (Not available on Safari)
  * @property {TimeMeasurement} [ice] - Time to establish ice connectivity. This is measured from ICE connection `checking` to `connected` state.
- * @property {TimeMeasurement} [peerConnection] - Time to establish peer connectivity. This is measured from PeerConnection `connecting` to `connected` state.
+ * @property {TimeMeasurement} [peerConnection] - Time to establish peer connectivity. This is measured from PeerConnection `connecting` to `connected` state. (Not available on Firefox)
  */
 
 /**


### PR DESCRIPTION
<!-- Describe your Pull Request -->
Safari does not support [RTCDtlsTransport](https://developer.mozilla.org/en-US/docs/Web/API/RTCDtlsTransport#browser_compatibility), so `dtlsConnected` event will not be available.

firefox does not support [onconnectionstatechange](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/onconnectionstatechange#browser_compatibility), so `peerConnectionConnected` event will not be emitted on firefox.

Noted these issues in docs.


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
