### PR TITLE
VIDEO-6263: low fps from safari with simulcast enabled. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 
 **Version 1.x will End of Life on September 8th, 2021.** Check [this guide](https://www.twilio.com/docs/video/migrating-1x-2x) to plan your migration to the latest 2.x version. Support for the 1.x version ended on December 4th, 2020.
 
+2.17.0 (In Progress)
+====================
+Bug Fixes
+---------
+Fixed a bug that causes low framerate from Safari participants with simulcast enabled. (VIDEO-6263)
+
 2.16.0 (August 11, 2021)
 ========================
 **New Features**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 
 2.17.0 (In Progress)
 ====================
+
 Bug Fixes
 ---------
-Fixed a bug that causes low framerate from Safari participants with simulcast enabled. (VIDEO-6263)
+
+- Fixed a bug where the VideoTracks of Safari Participants with VP8 simulcast enabled sometimes had low frame rates. (VIDEO-6263)
 
 2.16.0 (August 11, 2021)
 ========================

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1717,6 +1717,14 @@ function updateEncodingParameters(pcv2) {
       params.encodings[0].networkPriority = 'high';
     }
 
+    if (sender.track.kind === 'video') {
+      let scale = 1;
+      params.encodings.forEach(encoding => {
+        encoding.scaleResolutionDownBy = scale;
+        scale *= 2;
+      });
+    }
+
     sender.setParameters(params).catch(error => {
       pcv2._log.warn(`Error while setting encodings parameters for ${sender.track.kind} Track ${sender.track.id}: ${error.message || error.name}`);
     });

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1722,7 +1722,7 @@ function updateEncodingParameters(pcv2) {
       // the same resolution. So, we make sure that the lower layers have
       // lower resolution, as seen in Chrome.
       params.encodings.forEach((encoding, i) => {
-        encoding.scaleResolutionDownBy = 1 << i;
+        encoding.scaleResolutionDownBy = 1 << (encodings.length - i - 1);
       });
     }
 

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -464,6 +464,38 @@ class PeerConnectionV2 extends StateMachine {
   }
 
   /**
+   * Updates scaleResolutionDownBy for encoding layers.
+   * @param {number} width
+   * @param {object} encodings
+   */
+  _updateEncodings(width, encodings) {
+    // NOTE(mpatwardhan): All the simulcast encodings in Safari have
+    // the same resolution. So, we make sure that the lower layers have
+    // lower resolution, as seen in Chrome.
+    // let maxScaleDown = 4;
+    // +=========+========================+
+    // |  width  | scaleResolutionDownBy  |
+    // +=========+========================+
+    // | 0-359   |  1, inactive, inactive |
+    // +---------+------------------------+
+    // | 360-719 |  2, 1, inactive        |
+    // +---------+------------------------+
+    // | 720+    |  4, 2, 1               |
+    // +---------+------------------------+
+
+    const activeLayers = Math.min(encodings.length, width <= 359 ? 1 : width <= 719 ? 2 : 3);
+    encodings.forEach((encoding, i) => {
+      if (i >= activeLayers) {
+        encoding.active = false;
+        this._log.debug(`Layer ${i} active = false`);
+      } else {
+        encoding.scaleResolutionDownBy = 1 << (activeLayers - i - 1);
+        this._log.debug(`Layer ${i} scaleResolutionDownBy = ${encoding.scaleResolutionDownBy}`);
+      }
+    });
+  }
+
+  /**
    * Add an ICE candidate to the {@link PeerConnectionV2}.
    * @private
    * @param {object} candidate
@@ -1718,12 +1750,9 @@ function updateEncodingParameters(pcv2) {
     }
 
     if (!isFirefox && sender.track.kind === 'video') {
-      // NOTE(mpatwardhan): All the simulcast encodings in Safari have
-      // the same resolution. So, we make sure that the lower layers have
-      // lower resolution, as seen in Chrome.
-      params.encodings.forEach((encoding, i) => {
-        encoding.scaleResolutionDownBy = 1 << (encodings.length - i - 1);
-      });
+      console.log('makarand: track = ', sender.track);
+      const { width }  = sender.track.getSettings();
+      pcv2._updateEncodings(width, params.encodings);
     }
 
     sender.setParameters(params).catch(error => {

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1717,7 +1717,7 @@ function updateEncodingParameters(pcv2) {
       params.encodings[0].networkPriority = 'high';
     }
 
-    if (sender.track.kind === 'video') {
+    if (!isFirefox && sender.track.kind === 'video') {
       let scale = 1;
       params.encodings.forEach(encoding => {
         encoding.scaleResolutionDownBy = scale;

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -466,32 +466,26 @@ class PeerConnectionV2 extends StateMachine {
   /**
    * Updates scaleResolutionDownBy for encoding layers.
    * @param {number} width
-   * @param {object} encodings
+   * @param {number} heights
+   * @param {Array<object>} encodings
    */
-  _updateEncodings(width, encodings) {
+  _updateEncodings(width, height, encodings) {
     // NOTE(mpatwardhan): All the simulcast encodings in Safari have
-    // the same resolution. So, we make sure that the lower layers have
+    // the same resolution. So, here we make sure that the lower layers have
     // lower resolution, as seen in Chrome.
-    // let maxScaleDown = 4;
-    // +=========+========================+
-    // |  width  | scaleResolutionDownBy  |
-    // +=========+========================+
-    // | 0-359   |  1, inactive, inactive |
-    // +---------+------------------------+
-    // | 360-719 |  2, 1, inactive        |
-    // +---------+------------------------+
-    // | 720+    |  4, 2, 1               |
-    // +---------+------------------------+
+    const simulcastLayerMap = [
+      { width: 960, height: 540, maxLayers: 3 },
+      { width: 480, height: 270, maxLayers: 2 },
+      { width: 0, height: 0, maxLayers: 1 }
+    ];
 
-    const activeLayers = Math.min(encodings.length, width <= 359 ? 1 : width <= 719 ? 2 : 3);
+    const activeLayers = Math.min(encodings.length, simulcastLayerMap.find(layer => (width * height) >= (layer.width * layer.height)).maxLayers);
     encodings.forEach((encoding, i) => {
-      if (i >= activeLayers) {
-        encoding.active = false;
-        this._log.debug(`Layer ${i} active = false`);
-      } else {
+      encoding.active = i < activeLayers;
+      if (encoding.active) {
         encoding.scaleResolutionDownBy = 1 << (activeLayers - i - 1);
-        this._log.debug(`Layer ${i} scaleResolutionDownBy = ${encoding.scaleResolutionDownBy}`);
       }
+      this._log.debug(`setting up simulcast layer ${i} with active = ${encoding.active}, scaleResolutionDownBy = ${encoding.scaleResolutionDownBy}`);
     });
   }
 
@@ -1750,8 +1744,8 @@ function updateEncodingParameters(pcv2) {
     }
 
     if (!isFirefox && sender.track.kind === 'video') {
-      const { width }  = sender.track.getSettings();
-      pcv2._updateEncodings(width, params.encodings);
+      const { width, height }  = sender.track.getSettings();
+      pcv2._updateEncodings(width, height, params.encodings);
     }
 
     sender.setParameters(params).catch(error => {

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -466,25 +466,28 @@ class PeerConnectionV2 extends StateMachine {
   /**
    * Updates scaleResolutionDownBy for encoding layers.
    * @param {number} width
-   * @param {number} heights
-   * @param {Array<object>} encodings
+   * @param {number} height
+   * @param {Array<RTCRtpEncodingParameters>} encodings
    */
   _updateEncodings(width, height, encodings) {
     // NOTE(mpatwardhan): All the simulcast encodings in Safari have
     // the same resolution. So, here we make sure that the lower layers have
     // lower resolution, as seen in Chrome.
-    const simulcastLayerMap = [
-      { pixels: 960 * 540, maxLayers: 3 },
-      { pixels: 480 * 270, maxLayers: 2 },
-      { pixels: 0, maxLayers: 1 }
+    const pixelsToMaxActiveLayers = [
+      { pixels: 960 * 540, maxActiveLayers: 3 },
+      { pixels: 480 * 270, maxActiveLayers: 2 },
+      { pixels: 0, maxActiveLayers: 1 }
     ];
 
     const trackPixels =  width * height;
-    const activeLayers = Math.min(encodings.length, simulcastLayerMap.find(layer => trackPixels >= layer.pixels).maxLayers);
+    const activeLayersInfo = simulcastLayerMap.find(layer => trackPixels >= layer.pixels);
+    const activeLayers = Math.min(encodings.length, activeLayersInfo.maxActiveLayers);
     encodings.forEach((encoding, i) => {
       encoding.active = i < activeLayers;
       if (encoding.active) {
         encoding.scaleResolutionDownBy = 1 << (activeLayers - i - 1);
+      } else {
+        delete encoding.scaleResolutionDownBy;
       }
       this._log.debug(`setting up simulcast layer ${i} with active = ${encoding.active}, scaleResolutionDownBy = ${encoding.scaleResolutionDownBy}`);
     });

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -480,7 +480,7 @@ class PeerConnectionV2 extends StateMachine {
     ];
 
     const trackPixels =  width * height;
-    const activeLayersInfo = simulcastLayerMap.find(layer => trackPixels >= layer.pixels);
+    const activeLayersInfo = pixelsToMaxActiveLayers.find(layer => trackPixels >= layer.pixels);
     const activeLayers = Math.min(encodings.length, activeLayersInfo.maxActiveLayers);
     encodings.forEach((encoding, i) => {
       encoding.active = i < activeLayers;

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1718,10 +1718,11 @@ function updateEncodingParameters(pcv2) {
     }
 
     if (!isFirefox && sender.track.kind === 'video') {
-      let scale = 1;
-      params.encodings.forEach(encoding => {
-        encoding.scaleResolutionDownBy = scale;
-        scale *= 2;
+      // NOTE(mpatwardhan): All the simulcast encodings in Safari have
+      // the same resolution. So, we make sure that the lower layers have
+      // lower resolution, as seen in Chrome.
+      params.encodings.forEach((encoding, i) => {
+        encoding.scaleResolutionDownBy = 1 << i;
       });
     }
 

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -474,12 +474,13 @@ class PeerConnectionV2 extends StateMachine {
     // the same resolution. So, here we make sure that the lower layers have
     // lower resolution, as seen in Chrome.
     const simulcastLayerMap = [
-      { width: 960, height: 540, maxLayers: 3 },
-      { width: 480, height: 270, maxLayers: 2 },
-      { width: 0, height: 0, maxLayers: 1 }
+      { pixels: 960 * 540, maxLayers: 3 },
+      { pixels: 480 * 270, maxLayers: 2 },
+      { pixels: 0, maxLayers: 1 }
     ];
 
-    const activeLayers = Math.min(encodings.length, simulcastLayerMap.find(layer => (width * height) >= (layer.width * layer.height)).maxLayers);
+    const trackPixels =  width * height;
+    const activeLayers = Math.min(encodings.length, simulcastLayerMap.find(layer => trackPixels >= layer.pixels).maxLayers);
     encodings.forEach((encoding, i) => {
       encoding.active = i < activeLayers;
       if (encoding.active) {

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1750,7 +1750,6 @@ function updateEncodingParameters(pcv2) {
     }
 
     if (!isFirefox && sender.track.kind === 'video') {
-      console.log('makarand: track = ', sender.track);
       const { width }  = sender.track.getSettings();
       pcv2._updateEncodings(width, params.encodings);
     }

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "tslint": "5.8.0",
     "twilio": "^3.49.0",
     "twilio-release-tool": "^1.0.2",
-    "typescript": "^4.0.5",
+    "typescript": "4.2.2",
     "uglify-js": "^2.8.22",
     "vinyl-fs": "^2.4.4",
     "vinyl-source-stream": "^1.1.0",

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -1161,6 +1161,18 @@ describe('PeerConnectionV2', () => {
         }
       }
 
+      function itShouldSetResolutionScale() {
+        if (isRTCRtpSenderParamsSupported) {
+          it('should set RTCRtpEncodingParameters.scaleResolutionDownBy to 1 for all video senders', () => {
+            test.pc.getSenders().forEach(sender => {
+              if (sender.track.kind === 'video') {
+                sinon.assert.calledWith(sender.setParameters, sinon.match.hasNested('encodings[0].scaleResolutionDownBy', 1));
+              }
+            });
+          });
+        }
+      }
+
       // NOTE(mroberts): This test should really be extended. Instead of popping
       // arguments off of `setCodecPreferences`, we should validate that we
       // apply transformed remote SDPs and emit transformed local SDPs.
@@ -1206,6 +1218,7 @@ describe('PeerConnectionV2', () => {
 
         itShouldApplyBandwidthConstraints();
         itShouldApplyCodecPreferences();
+        itShouldSetResolutionScale();
         itShouldMaybeSetNetworkPriority();
       }
 

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -80,6 +80,53 @@ describe('PeerConnectionV2', () => {
     });
   });
 
+  describe('._updateEncodings', () => {
+    [
+      {
+        testName: 'resolution >= 960x540',
+        width: 960,
+        height: 540,
+        encodings: [{}, {}, {}],
+        expectedEncodings: [{ active: true, scaleResolutionDownBy: 4 }, { active: true, scaleResolutionDownBy: 2 }, { active: true, scaleResolutionDownBy: 1 }]
+      },
+      {
+        testName: 'resolution >= 960x540 (no simulcast)',
+        width: 960,
+        height: 540,
+        encodings: [{}],
+        expectedEncodings: [{ active: true, scaleResolutionDownBy: 1 }]
+      },
+      {
+        testName: '960x540 > resolution >= 480x270',
+        width: 480,
+        height: 270,
+        encodings: [{}, {}, {}],
+        expectedEncodings: [{ active: true, scaleResolutionDownBy: 2 }, { active: true, scaleResolutionDownBy: 1 }, { active: false }]
+      },
+      {
+        testName: '960x540 > resolution >= 480x270 (no simulcast)',
+        width: 480,
+        height: 270,
+        encodings: [{}], // input encodings has only one layer
+        expectedEncodings: [{ active: true, scaleResolutionDownBy: 1 }]
+      },
+      {
+        testName: 'resolution <= 480x270',
+        width: 320,
+        height: 180,
+        encodings: [{}, {}, {}],
+        expectedEncodings: [{ active: true, scaleResolutionDownBy: 1 }, { active: false }, { active: false }]
+      }
+    ].forEach(({ width, height, encodings, expectedEncodings, testName }) => {
+      it(testName, () => {
+        const test = makeTest();
+        test.pcv2._updateEncodings(width, height, encodings);
+        assert.deepStrictEqual(encodings, expectedEncodings);
+      });
+    });
+  });
+
+
   describe('.iceConnectionState', () => {
     it('equals the underlying RTCPeerConnection\'s .iceConnectionState', () => {
       const test = makeTest();

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -960,7 +960,8 @@ describe('PeerConnectionV2', () => {
       async function setup() {
         let tracks;
         if (chromeScreenTrack) {
-          tracks = [{ id: 'foo', kind: 'video', label: 'screen:123' }];
+          const getSettings = () => { return { width: 1280, height: 720 }; };
+          tracks = [{ id: 'foo', kind: 'video', label: 'screen:123', getSettings }];
         }
         test = makeTest({
           offers: 3,
@@ -2290,7 +2291,8 @@ function makePeerConnectionV2(options) {
   options.id = options.id || makeId();
 
   const pc = options.pc || makePeerConnection(options);
-  const tracks = options.tracks || [{ kind: 'audio' }, { kind: 'video' }];
+  const getSettings = () => { return { width: 1280, height: 720 }; };
+  const tracks = options.tracks || [{ kind: 'audio' }, { kind: 'video', getSettings }];
   tracks.forEach(track => pc.addTrack(track));
 
   const Backoff = {


### PR DESCRIPTION
The default simulcast layers chosen by safari have same dimensions. This causes low framerate for tracks from safari. This 
change configures the layers with with `scaleResolutionDownBy` set to 1, 2, and 4. This is still pending design task: VIDEO-6730
  
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
