### PR TITLE
Video-3977: disable "reacquire track" workaround for screenshare track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Bug Fixes
 ---------
 
 - Fixed a bug where the VideoTracks of Safari Participants with VP8 simulcast enabled sometimes had low frame rates. (VIDEO-6263)
-- Fixed a bug which caused screen share track to get restarted as camera track if it was ended when gaining foreground. (VIDEO-3977)
+- Fixed a bug where the screen share track got restarted as a camera track if it was ended when the application was foreground. (VIDEO-3977)
 
 2.16.0 (August 11, 2021)
 ========================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Bug Fixes
 ---------
 
 - Fixed a bug where the VideoTracks of Safari Participants with VP8 simulcast enabled sometimes had low frame rates. (VIDEO-6263)
+- Fixed a bug which caused screen share track to get restarted as camera track if it was ended when gaining foreground. (VIDEO-3977)
 
 2.16.0 (August 11, 2021)
 ========================

--- a/lib/media/track/localmediatrack.js
+++ b/lib/media/track/localmediatrack.js
@@ -4,7 +4,7 @@
 const { getUserMedia } = require('@twilio/webrtc');
 const { guessBrowser, isIOSChrome } = require('@twilio/webrtc/lib/util');
 
-const { capitalize, defer, waitForSometime, waitForEvent } = require('../../util');
+const { capitalize, defer, isUserMediaTrack, waitForSometime, waitForEvent } = require('../../util');
 const { typeErrors: { ILLEGAL_INVOKE } } = require('../../util/constants');
 const detectSilentAudio = require('../../util/detectsilentaudio');
 const detectSilentVideo = require('../../util/detectsilentvideo');
@@ -33,7 +33,7 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
       // although the bug is seen  mainly on iOS devices, we do not have a reliable way to tell iOS from MacOs
       // userAgent on iOS pretends its macOs if Safari is set to request desktop pages.
       const workaroundWebKitBug1208516 = (guessBrowser() === 'safari' || isIOSChrome())
-        && typeof mediaStreamTrack.getSettings().deviceId === 'string' // we need to apply workaround only to microphone/camera tracks not screen shares.
+        && isUserMediaTrack(mediaStreamTrack)
         && typeof document === 'object'
         && typeof document.addEventListener === 'function'
         && typeof document.visibilityState === 'string';

--- a/lib/media/track/localmediatrack.js
+++ b/lib/media/track/localmediatrack.js
@@ -32,7 +32,8 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
       // NOTE(mpatwardhan): by default workaround for WebKitBug1208516 will be enabled on Safari browsers
       // although the bug is seen  mainly on iOS devices, we do not have a reliable way to tell iOS from MacOs
       // userAgent on iOS pretends its macOs if Safari is set to request desktop pages.
-      const workaroundWebKitBug1208516 = guessBrowser() === 'safari' || isIOSChrome()
+      const workaroundWebKitBug1208516 = (guessBrowser() === 'safari' || isIOSChrome())
+        && typeof mediaStreamTrack.getSettings().deviceId === 'string' // we need to apply workaround only to microphone/camera tracks not screen shares.
         && typeof document === 'object'
         && typeof document.addEventListener === 'function'
         && typeof document.visibilityState === 'string';
@@ -43,6 +44,8 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
         workaroundWebKitBug1208516,
         gUMSilentTrackWorkaround
       }, options);
+
+      console.log('makarand: isCreatedByCreateLocalTracks: ', options.isCreatedByCreateLocalTracks);
 
       const mediaTrackSender = new MediaTrackSender(mediaStreamTrack);
       const { kind } = mediaTrackSender;

--- a/lib/media/track/localmediatrack.js
+++ b/lib/media/track/localmediatrack.js
@@ -45,8 +45,6 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
         gUMSilentTrackWorkaround
       }, options);
 
-      console.log('makarand: isCreatedByCreateLocalTracks: ', options.isCreatedByCreateLocalTracks);
-
       const mediaTrackSender = new MediaTrackSender(mediaStreamTrack);
       const { kind } = mediaTrackSender;
 

--- a/lib/media/track/localvideotrack.js
+++ b/lib/media/track/localvideotrack.js
@@ -31,7 +31,7 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
    */
   constructor(mediaStreamTrack, options) {
     options = Object.assign({
-      workaroundSilentLocalVideo: guessBrowser() === 'safari' || isIOSChrome()
+      workaroundSilentLocalVideo: (guessBrowser() === 'safari' || isIOSChrome())
         && typeof document !== 'undefined'
         && typeof document.createElement === 'function'
     }, options);

--- a/lib/media/track/localvideotrack.js
+++ b/lib/media/track/localvideotrack.js
@@ -5,6 +5,7 @@ const { guessBrowser, isIOSChrome } = require('@twilio/webrtc/lib/util');
 const detectSilentVideo = require('../../util/detectsilentvideo');
 const mixinLocalMediaTrack = require('./localmediatrack');
 const VideoTrack = require('./videotrack');
+const { isUserMediaTrack } = require('../../util');
 
 const LocalMediaVideoTrack = mixinLocalMediaTrack(VideoTrack);
 
@@ -32,6 +33,7 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
   constructor(mediaStreamTrack, options) {
     options = Object.assign({
       workaroundSilentLocalVideo: (guessBrowser() === 'safari' || isIOSChrome())
+        && isUserMediaTrack(mediaStreamTrack)
         && typeof document !== 'undefined'
         && typeof document.createElement === 'function'
     }, options);

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -32,7 +32,7 @@ class MediaTrack extends Track {
    */
   constructor(mediaTrackTransceiver, options) {
     options = Object.assign({
-      playPausedElementsIfNotBackgrounded: guessBrowser() === 'safari' || isIOSChrome()
+      playPausedElementsIfNotBackgrounded: (guessBrowser() === 'safari' || isIOSChrome())
         && typeof document === 'object'
         && typeof document.addEventListener === 'function'
         && typeof document.visibilityState === 'string'

--- a/lib/media/track/remotemediatrack.js
+++ b/lib/media/track/remotemediatrack.js
@@ -34,7 +34,7 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
         // NOTE(mpatwardhan): WebKit bug: 212780 sometimes causes the audio/video elements to stay paused when safari
         // regains foreground. To workaround it, when safari gains foreground - we will play any elements that were
         // playing before safari lost foreground.
-        workaroundWebKitBug212780: guessBrowser() === 'safari' || isIOSChrome()
+        workaroundWebKitBug212780: (guessBrowser() === 'safari' || isIOSChrome())
           && typeof document === 'object'
           && typeof document.addEventListener === 'function'
           && typeof document.visibilityState === 'string'

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -797,6 +797,18 @@ function isChromeScreenShareTrack(track) {
   return isChrome && track.kind === 'video' && track.label && (/^screen:[0-9]+/.test(track.label) || /^web-contents-media-stream:[0-9/]+/.test(track.label) || /^window:[0-9]+/.test(track.label));
 }
 
+
+/**
+ * returns true if given MediaStreamTrack is a user media track
+ * @private
+ * @param {MediaStreamTrack} track
+ * @returns {boolean}
+ */
+function isUserMediaTrack(track) {
+  // NOTE(mpatwardhan): tracks obtained from getUserMedia have a deviceId in its settings.
+  return typeof track.getSettings().deviceId === 'string';
+}
+
 /**
  * Returns a promise that resolve after timeoutMS have passed.
  * @param {number} timeoutMS - time to wait in milliseconds.
@@ -852,5 +864,6 @@ exports.trackPublicationClass = trackPublicationClass;
 exports.valueToJSON = valueToJSON;
 exports.withJitter = withJitter;
 exports.isChromeScreenShareTrack = isChromeScreenShareTrack;
+exports.isUserMediaTrack = isUserMediaTrack;
 exports.waitForSometime = waitForSometime;
 exports.waitForEvent = waitForEvent;


### PR DESCRIPTION
This disables `workaroundWebKitBug1208516` for screen share track. I found that microphone and camera tracks have deviceId but screen share track does not. This fix uses this to determine if `workaroundWebKitBug1208516` needs to be applied. 

Also fixed a bug where introduction of `isIOSChrome` with lack of parenthesis was short-circuting checks after `if guessBrowser() === 'safari'`

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
