### PR TITLE
refactor eventpublisher

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -6,6 +6,8 @@ const createCancelableRoomPromise = require('./cancelableroompromise');
 const createLocalTracks = require('./createlocaltracks');
 const EncodingParametersImpl = require('./encodingparameters');
 const LocalParticipant = require('./localparticipant');
+const InsightsPublisher = require('./util/insightspublisher');
+const NullInsightsPublisher = require('./util/insightspublisher/null');
 
 const {
   LocalAudioTrack,
@@ -31,6 +33,8 @@ const {
   DEFAULT_REALM,
   DEFAULT_REGION,
   WS_SERVER,
+  SDK_NAME,
+  SDK_VERSION,
   typeErrors: E
 } = require('./util/constants');
 
@@ -246,10 +250,22 @@ function connect(token, options) {
   }, filterObject(options));
 
   /* eslint new-cap:0 */
-  const wsServer = WS_SERVER(options.environment, options.region);
-  const eventObserver = new EventObserver(Date.now(), log, options.eventListener);
-  options = Object.assign({ eventObserver, wsServer }, options);
+  const eventPublisherOptions = {};
+  if (typeof options.wsServerInsights === 'string') {
+    eventPublisherOptions.gateway = options.wsServerInsights;
+  }
+  const EventPublisher = options.insights ? InsightsPublisher : NullInsightsPublisher;
+  const eventPublisher = new EventPublisher(
+    token,
+    SDK_NAME,
+    SDK_VERSION,
+    options.environment,
+    options.realm,
+    eventPublisherOptions);
 
+  const wsServer = WS_SERVER(options.environment, options.region);
+  const eventObserver = new EventObserver(eventPublisher, Date.now(), log, options.eventListener);
+  options = Object.assign({ eventObserver, wsServer }, options);
   options.log = log;
 
   // NOTE(mroberts): Print the Safari warning once if the log-level is at least
@@ -366,11 +382,14 @@ function connect(token, options) {
     createRoom.bind(null, options));
 
   cancelableRoomPromise.then(room => {
+    eventPublisher.connect(room.sid, room.localParticipant.sid);
     log.info('Connected to Room:', room.toString());
     log.info('Room name:', room.name);
     log.debug('Room:', room);
+    room.once('disconnected', () => eventPublisher.disconnect());
     return room;
   }, error => {
+    eventPublisher.disconnect();
     if (cancelableRoomPromise._isCanceled) {
       log.info('Attempt to connect to a Room was canceled');
     } else {

--- a/lib/signaling/v2/cancelableroomsignalingpromise.js
+++ b/lib/signaling/v2/cancelableroomsignalingpromise.js
@@ -57,8 +57,6 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
     };
 
     const {
-      InsightsPublisher,
-      NullInsightsPublisher,
       automaticSubscription,
       bandwidthProfile,
       dominantSpeaker,
@@ -69,10 +67,8 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
       name,
       networkMonitor,
       networkQuality,
-      insights,
       realm,
       sdpSemantics,
-      wsServerInsights
     } = options;
 
     // decide which msp channels to request
@@ -92,20 +88,13 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
       networkMonitor,
       networkQuality,
       iceServers,
-      insights,
       onIced,
       realm,
       renderHints,
       sdpSemantics,
       trackPriority,
       trackSwitchOff
-    }, typeof wsServerInsights === 'string' ? {
-      wsServerInsights
-    } : {}, InsightsPublisher ? {
-      InsightsPublisher
-    } : {}, NullInsightsPublisher ? {
-      NullInsightsPublisher
-    } : {}, bandwidthProfile ? {
+    }, bandwidthProfile ? {
       bandwidthProfile
     } : {});
 

--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -1,14 +1,12 @@
 'use strict';
 
 const { getSdpFormat } = require('@twilio/webrtc/lib/util/sdp');
-const packageInfo = require('../../../package.json');
-const InsightsPublisher = require('../../util/insightspublisher');
-const NullInsightsPublisher = require('../../util/insightspublisher/null');
 const StateMachine = require('../../statemachine');
 const TwilioConnection = require('../../twilioconnection');
 const DefaultBackoff = require('backoff');
 const { reconnectBackoffConfig } = require('../../util/constants');
 const Timeout = require('../../util/timeout');
+const { SDK_NAME, SDK_VERSION } = require('../../util/constants');
 
 const {
   createBandwidthProfilePayload,
@@ -27,8 +25,6 @@ const {
 
 const ICE_VERSION = 1;
 const RSP_VERSION = 2;
-const SDK_NAME = `${packageInfo.name}.js`;
-const SDK_VERSION = packageInfo.version;
 
 /*
 TwilioConnectionTransport States
@@ -90,8 +86,6 @@ class TwilioConnectionTransport extends StateMachine {
   constructor(name, accessToken, localParticipant, peerConnectionManager, wsServer, options) {
     options = Object.assign({
       Backoff: DefaultBackoff,
-      InsightsPublisher,
-      NullInsightsPublisher,
       TwilioConnection,
       iceServers: null,
       sdpFormat: getSdpFormat(options.sdpSemantics),
@@ -102,19 +96,6 @@ class TwilioConnectionTransport extends StateMachine {
     }, options);
     super('connecting', states);
 
-    const eventPublisherOptions = {};
-    if (options.wsServerInsights) {
-      eventPublisherOptions.gateway = options.wsServerInsights;
-    }
-
-    const EventPublisher = options.insights ? options.InsightsPublisher : options.NullInsightsPublisher;
-    const eventPublisher = new EventPublisher(
-      accessToken,
-      SDK_NAME,
-      SDK_VERSION,
-      options.environment,
-      options.realm,
-      eventPublisherOptions);
 
     Object.defineProperties(this, {
       _accessToken: {
@@ -125,9 +106,6 @@ class TwilioConnectionTransport extends StateMachine {
       },
       _bandwidthProfile: {
         value: options.bandwidthProfile
-      },
-      _disconnectEventPublisher: {
-        value: () => eventPublisher.disconnect()
       },
       _dominantSpeaker: {
         value: options.dominantSpeaker
@@ -198,16 +176,9 @@ class TwilioConnectionTransport extends StateMachine {
       }
     });
 
-    // eslint-disable-next-line no-warning-comments
-    // TODO(mmalavalli): Create and set EventPublisher outside this class, so
-    // that the EventPublisher constructor is no longer a dependency.
-    this._eventObserver.setPublisher(eventPublisher);
 
     setupTransport(this);
 
-    this.once('connected', ({ sid, participant }) => {
-      eventPublisher.connect(sid, participant.sid);
-    });
   }
 
   /**
@@ -315,7 +286,6 @@ class TwilioConnectionTransport extends StateMachine {
       this.preempt('disconnected', null, [error]);
       this._sendConnectOrSyncOrDisconnectMessage();
       this._twilioConnection.close();
-      this._disconnectEventPublisher();
       return true;
     }
     return false;

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -1,4 +1,7 @@
 'use strict';
+const packageInfo = require('../../package.json');
+module.exports.SDK_NAME = `${packageInfo.name}.js`;
+module.exports.SDK_VERSION = packageInfo.version;
 
 module.exports.DEFAULT_ENVIRONMENT = 'prod';
 module.exports.DEFAULT_REALM = 'us1';

--- a/lib/util/eventobserver.js
+++ b/lib/util/eventobserver.js
@@ -27,19 +27,17 @@ const VALID_LEVELS = [
 class EventObserver extends EventEmitter {
   /**
    * Constructor.
+   * @param {InsightsPublisher} publisher
    * @param {number} connectTimestamp
    * @param {Log} log
    * @param {EventListener} [eventListener]
    */
-  constructor(connectTimestamp, log, eventListener = null) {
+  constructor(publisher, connectTimestamp, log, eventListener = null) {
     super();
-
-    Object.defineProperties(this, {
-      _publisher: {
-        value: null,
-        writable: true
-      }
-    });
+    if (!publisher.publish) {
+      console.trace('makarand wrong publsher');
+      throw new Error('makarand wrong publsher');
+    }
 
     this.on('event', ({ name, group, level, payload }) => {
       if (typeof name !== 'string') {
@@ -57,10 +55,9 @@ class EventObserver extends EventEmitter {
       const timestamp = Date.now();
       const elapsedTime = timestamp - connectTimestamp;
 
-      if (this._publisher) {
-        const publisherPayload = Object.assign({ elapsedTime, level }, payload ? payload : {});
-        this._publisher.publish(group, name, publisherPayload);
-      }
+      const publisherPayload = Object.assign({ elapsedTime, level }, payload ? payload : {});
+      publisher.publish(group, name, publisherPayload);
+
       const event = Object.assign({
         elapsedTime,
         group,
@@ -81,14 +78,6 @@ class EventObserver extends EventEmitter {
         eventListener.emit('event', event);
       }
     });
-  }
-
-  /**
-   * sets the publisher object. Once set events will be sent to publisher.
-   * @param {InsightsPublisher} publisher
-  */
-  setPublisher(publisher) {
-    this._publisher = publisher;
   }
 }
 

--- a/test/unit/spec/util/eventobserver.js
+++ b/test/unit/spec/util/eventobserver.js
@@ -1,12 +1,18 @@
 const assert = require('assert');
+const sinon = require('sinon');
 const { EventEmitter } = require('events');
 const EventObserver = require('../../../../lib/util/eventobserver');
 const log = require('../../../lib/fakelog');
 
+function makePublisher() {
+  return {
+    publish: sinon.spy()
+  };
+}
 describe('EventObserver', () => {
   describe('constructor', () => {
     it('should return an EventObserver', () => {
-      assert(new EventObserver(0, log, new EventEmitter()) instanceof EventObserver);
+      assert(new EventObserver(makePublisher(), 0, log, new EventEmitter()) instanceof EventObserver);
     });
   });
 
@@ -31,7 +37,7 @@ describe('EventObserver', () => {
         delete params.reason;
         connectTimestamp = Date.now();
         const eventListener = new EventEmitter();
-        eventObserver = new EventObserver(connectTimestamp, log, eventListener);
+        eventObserver = new EventObserver(makePublisher(), connectTimestamp, log, eventListener);
         eventListener.once('event', event => { eventParams = event; });
       });
 


### PR DESCRIPTION
This refactors insights - instead of passing both eventBrowser/eventPublisher to `twilioconnectiontransport` now we hooks up eventPublisher with eventObserver, and only pass eventObserver to `twilioconnectiontransport`

It ended up reducing code complexity a bit:
![Screen Shot 2021-09-13 at 1 22 12 PM](https://user-images.githubusercontent.com/6174737/133151152-5d595bf7-797f-49e9-9040-46d88d73e15f.png)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.

