### PR TITLE
Preflight metrics

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -6,6 +6,8 @@ const createCancelableRoomPromise = require('./cancelableroompromise');
 const createLocalTracks = require('./createlocaltracks');
 const EncodingParametersImpl = require('./encodingparameters');
 const LocalParticipant = require('./localparticipant');
+const InsightsPublisher = require('./util/insightspublisher');
+const NullInsightsPublisher = require('./util/insightspublisher/null');
 
 const {
   LocalAudioTrack,
@@ -31,6 +33,8 @@ const {
   DEFAULT_REALM,
   DEFAULT_REGION,
   WS_SERVER,
+  SDK_NAME,
+  SDK_VERSION,
   typeErrors: E
 } = require('./util/constants');
 
@@ -246,10 +250,22 @@ function connect(token, options) {
   }, filterObject(options));
 
   /* eslint new-cap:0 */
-  const wsServer = WS_SERVER(options.environment, options.region);
-  const eventObserver = new EventObserver(Date.now(), log, options.eventListener);
-  options = Object.assign({ eventObserver, wsServer }, options);
+  const eventPublisherOptions = {};
+  if (typeof options.wsServerInsights === 'string') {
+    eventPublisherOptions.gateway = options.wsServerInsights;
+  }
+  const EventPublisher = options.insights ? InsightsPublisher : NullInsightsPublisher;
+  const eventPublisher = new EventPublisher(
+    token,
+    SDK_NAME,
+    SDK_VERSION,
+    options.environment,
+    options.realm,
+    eventPublisherOptions);
 
+  const wsServer = WS_SERVER(options.environment, options.region);
+  const eventObserver = new EventObserver(eventPublisher, Date.now(), log, options.eventListener);
+  options = Object.assign({ eventObserver, wsServer }, options);
   options.log = log;
 
   // NOTE(mroberts): Print the Safari warning once if the log-level is at least
@@ -366,11 +382,14 @@ function connect(token, options) {
     createRoom.bind(null, options));
 
   cancelableRoomPromise.then(room => {
+    eventPublisher.connect(room.sid, room.localParticipant.sid);
     log.info('Connected to Room:', room.toString());
     log.info('Room name:', room.name);
     log.debug('Room:', room);
+    room.once('disconnected', () => eventPublisher.disconnect());
     return room;
   }, error => {
+    eventPublisher.disconnect();
     if (cancelableRoomPromise._isCanceled) {
       log.info('Attempt to connect to a Room was canceled');
     } else {

--- a/lib/preflight/getturncredentials.ts
+++ b/lib/preflight/getturncredentials.ts
@@ -1,23 +1,13 @@
 const TwilioConnection = require('../twilioconnection.js');
-const { WS_SERVER, ICE_VERSION } = require('../util/constants');
+const { ICE_VERSION } = require('../util/constants');
 
 import { RTCIceServer, RTCStats } from './rtctypes';
 import { EventEmitter } from 'events';
-import { PreflightOptions } from '../../tsdef/PreflightTypes';
 
 
 export { RTCStats, RTCIceServer };
-export function getTurnCredentials(token: string, options: PreflightOptions): Promise<RTCIceServer[]> {
+export function getTurnCredentials(token: string, wsServer: string): Promise<RTCIceServer[]> {
   return new Promise((resolve, reject) => {
-    options = {
-      environment: 'prod',
-      region: 'gll',
-      ...options
-    };
-
-    // eslint-disable-next-line new-cap
-    const wsServer = WS_SERVER(options.environment, options.region);
-
     const eventObserver = new EventEmitter();
     const connectionOptions = {
       networkMonitor: null,

--- a/lib/preflight/makestat.ts
+++ b/lib/preflight/makestat.ts
@@ -6,8 +6,8 @@ import type { Stats } from '../../tsdef/PreflightTypes';
  * @param {Array<number>} values
  * @returns {{min: number, max: number: average: number}|null}
  */
-export function makeStat(values: number[]) : Stats|null {
-  if (values.length) {
+export function makeStat(values?: number[]|null) : Stats|null {
+  if (values && values.length) {
     const min = Math.min(...values);
     const max = Math.max(...values);
     const average = values.reduce((total, value) => total + value, 0) / values.length;

--- a/lib/preflight/preflighttest.ts
+++ b/lib/preflight/preflighttest.ts
@@ -272,6 +272,7 @@ export class PreflightTest extends EventEmitter {
           }
         };
         eventObserver.emit('event', insightsReport);
+        setTimeout(() => eventPublisher.disconnect(), 1000);
       }
     };
   }

--- a/lib/preflight/preflighttest.ts
+++ b/lib/preflight/preflighttest.ts
@@ -153,8 +153,7 @@ export class PreflightTest extends EventEmitter {
       },
       selectedIceCandidatePairStats: collectedStats ? collectedStats.selectedIceCandidatePairStats : null,
       iceCandidateStats: collectedStats ? collectedStats.iceCandidateStats : [],
-
-      // internal properties.
+      // NOTE(mpatwardhan): internal properties.
       error: error?.toString(),
       mos: makeStat(collectedStats?.mos),
     };
@@ -222,6 +221,7 @@ export class PreflightTest extends EventEmitter {
       });
     }
   }
+
   private _setupInsights({ token, environment = DEFAULT_ENVIRONMENT, realm = DEFAULT_REALM } : {
     token: string,
     environment?: string,

--- a/lib/signaling/v2/cancelableroomsignalingpromise.js
+++ b/lib/signaling/v2/cancelableroomsignalingpromise.js
@@ -57,8 +57,6 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
     };
 
     const {
-      InsightsPublisher,
-      NullInsightsPublisher,
       automaticSubscription,
       bandwidthProfile,
       dominantSpeaker,
@@ -69,10 +67,8 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
       name,
       networkMonitor,
       networkQuality,
-      insights,
       realm,
       sdpSemantics,
-      wsServerInsights
     } = options;
 
     // decide which msp channels to request
@@ -92,20 +88,13 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
       networkMonitor,
       networkQuality,
       iceServers,
-      insights,
       onIced,
       realm,
       renderHints,
       sdpSemantics,
       trackPriority,
       trackSwitchOff
-    }, typeof wsServerInsights === 'string' ? {
-      wsServerInsights
-    } : {}, InsightsPublisher ? {
-      InsightsPublisher
-    } : {}, NullInsightsPublisher ? {
-      NullInsightsPublisher
-    } : {}, bandwidthProfile ? {
+    }, bandwidthProfile ? {
       bandwidthProfile
     } : {});
 

--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -1,14 +1,12 @@
 'use strict';
 
 const { getSdpFormat } = require('@twilio/webrtc/lib/util/sdp');
-const packageInfo = require('../../../package.json');
-const InsightsPublisher = require('../../util/insightspublisher');
-const NullInsightsPublisher = require('../../util/insightspublisher/null');
 const StateMachine = require('../../statemachine');
 const TwilioConnection = require('../../twilioconnection');
 const DefaultBackoff = require('backoff');
 const { reconnectBackoffConfig } = require('../../util/constants');
 const Timeout = require('../../util/timeout');
+const { SDK_NAME, SDK_VERSION } = require('../../util/constants');
 
 const {
   createBandwidthProfilePayload,
@@ -27,8 +25,6 @@ const {
 
 const ICE_VERSION = 1;
 const RSP_VERSION = 2;
-const SDK_NAME = `${packageInfo.name}.js`;
-const SDK_VERSION = packageInfo.version;
 
 /*
 TwilioConnectionTransport States
@@ -90,8 +86,6 @@ class TwilioConnectionTransport extends StateMachine {
   constructor(name, accessToken, localParticipant, peerConnectionManager, wsServer, options) {
     options = Object.assign({
       Backoff: DefaultBackoff,
-      InsightsPublisher,
-      NullInsightsPublisher,
       TwilioConnection,
       iceServers: null,
       sdpFormat: getSdpFormat(options.sdpSemantics),
@@ -102,19 +96,6 @@ class TwilioConnectionTransport extends StateMachine {
     }, options);
     super('connecting', states);
 
-    const eventPublisherOptions = {};
-    if (options.wsServerInsights) {
-      eventPublisherOptions.gateway = options.wsServerInsights;
-    }
-
-    const EventPublisher = options.insights ? options.InsightsPublisher : options.NullInsightsPublisher;
-    const eventPublisher = new EventPublisher(
-      accessToken,
-      SDK_NAME,
-      SDK_VERSION,
-      options.environment,
-      options.realm,
-      eventPublisherOptions);
 
     Object.defineProperties(this, {
       _accessToken: {
@@ -125,9 +106,6 @@ class TwilioConnectionTransport extends StateMachine {
       },
       _bandwidthProfile: {
         value: options.bandwidthProfile
-      },
-      _disconnectEventPublisher: {
-        value: () => eventPublisher.disconnect()
       },
       _dominantSpeaker: {
         value: options.dominantSpeaker
@@ -198,16 +176,9 @@ class TwilioConnectionTransport extends StateMachine {
       }
     });
 
-    // eslint-disable-next-line no-warning-comments
-    // TODO(mmalavalli): Create and set EventPublisher outside this class, so
-    // that the EventPublisher constructor is no longer a dependency.
-    this._eventObserver.setPublisher(eventPublisher);
 
     setupTransport(this);
 
-    this.once('connected', ({ sid, participant }) => {
-      eventPublisher.connect(sid, participant.sid);
-    });
   }
 
   /**
@@ -315,7 +286,6 @@ class TwilioConnectionTransport extends StateMachine {
       this.preempt('disconnected', null, [error]);
       this._sendConnectOrSyncOrDisconnectMessage();
       this._twilioConnection.close();
-      this._disconnectEventPublisher();
       return true;
     }
     return false;

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -1,4 +1,7 @@
 'use strict';
+const packageInfo = require('../../package.json');
+module.exports.SDK_NAME = `${packageInfo.name}.js`;
+module.exports.SDK_VERSION = packageInfo.version;
 
 module.exports.DEFAULT_ENVIRONMENT = 'prod';
 module.exports.DEFAULT_REALM = 'us1';

--- a/lib/util/eventobserver.js
+++ b/lib/util/eventobserver.js
@@ -8,7 +8,8 @@ const VALID_GROUPS = [
   'room',
   'media',
   'quality',
-  'video-processor'
+  'video-processor',
+  'preflight'
 ];
 
 const VALID_LEVELS = [
@@ -35,20 +36,23 @@ class EventObserver extends EventEmitter {
   constructor(publisher, connectTimestamp, log, eventListener = null) {
     super();
     if (!publisher.publish) {
-      console.trace('makarand wrong publsher');
-      throw new Error('makarand wrong publsher');
+      throw new Error('makarand wrong publisher');
     }
-
+    console.warn('makarand: eventObserver constructor:');
     this.on('event', ({ name, group, level, payload }) => {
+      console.log('makarand: eventObserver received:', { name, group, level, payload });
       if (typeof name !== 'string') {
+        log.error('Unexpected name: ', name);
         throw new Error('Unexpected name: ', name);
       }
 
       if (!VALID_GROUPS.includes(group)) {
+        log.error('Unexpected group: ', group);
         throw new Error('Unexpected group: ', group);
       }
 
       if (!VALID_LEVELS.includes(level)) {
+        log.error('Unexpected level: ', level);
         throw new Error('Unexpected level: ', level);
       }
 
@@ -56,6 +60,7 @@ class EventObserver extends EventEmitter {
       const elapsedTime = timestamp - connectTimestamp;
 
       const publisherPayload = Object.assign({ elapsedTime, level }, payload ? payload : {});
+      console.log('makarand: publishing event:', group, name, publisherPayload);
       publisher.publish(group, name, publisherPayload);
 
       const event = Object.assign({

--- a/lib/util/eventobserver.js
+++ b/lib/util/eventobserver.js
@@ -35,12 +35,7 @@ class EventObserver extends EventEmitter {
    */
   constructor(publisher, connectTimestamp, log, eventListener = null) {
     super();
-    if (!publisher.publish) {
-      throw new Error('makarand wrong publisher');
-    }
-    console.warn('makarand: eventObserver constructor:');
     this.on('event', ({ name, group, level, payload }) => {
-      console.log('makarand: eventObserver received:', { name, group, level, payload });
       if (typeof name !== 'string') {
         log.error('Unexpected name: ', name);
         throw new Error('Unexpected name: ', name);
@@ -60,7 +55,6 @@ class EventObserver extends EventEmitter {
       const elapsedTime = timestamp - connectTimestamp;
 
       const publisherPayload = Object.assign({ elapsedTime, level }, payload ? payload : {});
-      console.log('makarand: publishing event:', group, name, publisherPayload);
       publisher.publish(group, name, publisherPayload);
 
       const event = Object.assign({

--- a/lib/util/eventobserver.js
+++ b/lib/util/eventobserver.js
@@ -27,19 +27,17 @@ const VALID_LEVELS = [
 class EventObserver extends EventEmitter {
   /**
    * Constructor.
+   * @param {InsightsPublisher} publisher
    * @param {number} connectTimestamp
    * @param {Log} log
    * @param {EventListener} [eventListener]
    */
-  constructor(connectTimestamp, log, eventListener = null) {
+  constructor(publisher, connectTimestamp, log, eventListener = null) {
     super();
-
-    Object.defineProperties(this, {
-      _publisher: {
-        value: null,
-        writable: true
-      }
-    });
+    if (!publisher.publish) {
+      console.trace('makarand wrong publsher');
+      throw new Error('makarand wrong publsher');
+    }
 
     this.on('event', ({ name, group, level, payload }) => {
       if (typeof name !== 'string') {
@@ -57,10 +55,9 @@ class EventObserver extends EventEmitter {
       const timestamp = Date.now();
       const elapsedTime = timestamp - connectTimestamp;
 
-      if (this._publisher) {
-        const publisherPayload = Object.assign({ elapsedTime, level }, payload ? payload : {});
-        this._publisher.publish(group, name, publisherPayload);
-      }
+      const publisherPayload = Object.assign({ elapsedTime, level }, payload ? payload : {});
+      publisher.publish(group, name, publisherPayload);
+
       const event = Object.assign({
         elapsedTime,
         group,
@@ -81,14 +78,6 @@ class EventObserver extends EventEmitter {
         eventListener.emit('event', event);
       }
     });
-  }
-
-  /**
-   * sets the publisher object. Once set events will be sent to publisher.
-   * @param {InsightsPublisher} publisher
-  */
-  setPublisher(publisher) {
-    this._publisher = publisher;
   }
 }
 

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -3,6 +3,7 @@
 const constants = require('./constants');
 const { typeErrors: E, trackPriority } = constants;
 const util = require('@twilio/webrtc/lib/util');
+const { sessionSID } = require('./sid');
 
 /**
  * Return the given {@link LocalTrack} or a new {@link LocalTrack} for the
@@ -572,6 +573,8 @@ function createRoomConnectEventPayload(connectOptions) {
     return val ? 'true' : 'false';
   }
   const payload = {
+    sessionSID,
+
     // arrays props converted to lengths.
     iceServers: (connectOptions.iceServers || []).length,
     audioTracks: (connectOptions.tracks || []).filter(track => track.kind === 'audio').length,

--- a/lib/util/sid.js
+++ b/lib/util/sid.js
@@ -1,0 +1,20 @@
+const SID_CHARS = '1234567890abcdef';
+const SID_CHAR_LENGTH = 32;
+// copied from: https://code.hq.twilio.com/flex/monkey/blob/0fdce2b6c52d6be0b17a5cdb92f0c54f119b8ea8/src/client/lib/sid.ts#L39
+
+/**
+ * Generates a random sid using given prefix.
+ * @param {string} prefix
+ * @returns string
+ */
+function createSID(prefix) {
+  let result = '';
+  for (let i = 0; i < SID_CHAR_LENGTH; i++) {
+    result += SID_CHARS.charAt(Math.floor(Math.random() * SID_CHARS.length));
+  }
+  return `${prefix}${result}`;
+}
+
+exports.sessionSID = createSID('SS');
+exports.createSID = createSID;
+

--- a/test/unit/spec/util/eventobserver.js
+++ b/test/unit/spec/util/eventobserver.js
@@ -1,12 +1,18 @@
 const assert = require('assert');
+const sinon = require('sinon');
 const { EventEmitter } = require('events');
 const EventObserver = require('../../../../lib/util/eventobserver');
 const log = require('../../../lib/fakelog');
 
+function makePublisher() {
+  return {
+    publish: sinon.spy()
+  };
+}
 describe('EventObserver', () => {
   describe('constructor', () => {
     it('should return an EventObserver', () => {
-      assert(new EventObserver(0, log, new EventEmitter()) instanceof EventObserver);
+      assert(new EventObserver(makePublisher(), 0, log, new EventEmitter()) instanceof EventObserver);
     });
   });
 
@@ -31,7 +37,7 @@ describe('EventObserver', () => {
         delete params.reason;
         connectTimestamp = Date.now();
         const eventListener = new EventEmitter();
-        eventObserver = new EventObserver(connectTimestamp, log, eventListener);
+        eventObserver = new EventObserver(makePublisher(), connectTimestamp, log, eventListener);
         eventListener.once('event', event => { eventParams = event; });
       });
 

--- a/test/unit/spec/util/index.js
+++ b/test/unit/spec/util/index.js
@@ -14,6 +14,7 @@ const {
   createRoomConnectEventPayload
 } = require('../../../../lib/util');
 
+const { sessionSID } = require('../../../../lib/util/sid');
 describe('util', () => {
   describe('createRoomConnectEventPayload', () => {
     [
@@ -145,6 +146,7 @@ describe('util', () => {
       it(testCase, () => {
         const event = createRoomConnectEventPayload(connectOptions);
         const defaultOptions = {
+          sessionSID,
           'audio': 'false',
           'audioTracks': 0,
           'automaticSubscription': 'false',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "checkJs": false,
     "declaration": false,
     "target": "es5",
-    "lib": ["es5", "es6", "es2016", "es2017.object", "es2018.promise", "dom"],
+    "lib": ["es5", "es6", "es2016", "es2019", "es2018.promise", "dom"],
     "downlevelIteration": true,
     "module": "commonjs",
     "noImplicitAny": true,

--- a/tsdef/PreflightTypes.d.ts
+++ b/tsdef/PreflightTypes.d.ts
@@ -1,6 +1,5 @@
 export interface PreflightOptions {
   duration?: number;
-  environment?: string;
   region?: string;
 }
 

--- a/tsdef/PreflightTypes.d.ts
+++ b/tsdef/PreflightTypes.d.ts
@@ -26,7 +26,7 @@ export interface RTCIceCandidateStats {
   candidateType?: string;
   priority?: number;
   url?: string;
-  relayProtocol?: number;
+  relayProtocol?: string;
 }
 
 export interface SelectedIceCandidatePairStats {


### PR DESCRIPTION
Sends preflight metrics to gateway. this uses schema defined [here](https://code.hq.twilio.com/client/rtc-insights-spec/pull/78)

Changes:
- [refactor](https://github.com/twilio/twilio-video.js/commit/9587e8e9644add110c4105bbb65057cbd87cc13b) insights reporting - instead of passing both eventBrowser/eventPublisher to `twilioconnectiontransport` now we hooks up eventPublisher with eventObserver, and only pass eventObserver to `twilioconnectiontransport`. This ended up reducing code complexity a bit: ![Screen Shot 2021-09-13 at 1 22 12 PM](https://user-images.githubusercontent.com/6174737/133151152-5d595bf7-797f-49e9-9040-46d88d73e15f.png) 

- update preflightTest to send preflight report to gateway at the end of the test using schema defined [here](https://code.hq.twilio.com/client/rtc-insights-spec/pull/78)

- update `connect` event (along with preflight event) to send sessionSID  that is client generated. This will help us map between prefiglith and subsequent rooms.
 
 
TODO :
- deploy sdki-ws-gateway to dev using https://code.hq.twilio.com/client/rtc-insights-spec/tree/preflight_event branch
- verify against dev with this branch.
- merge https://code.hq.twilio.com/client/rtc-insights-spec/pull/78
- release new version of https://code.hq.twilio.com/client/rtc-insights-spec
- redeploy sdki-ws-gateway to stage
- sdki-ws-gateway QA pass
- deploy sdki-ws-gateway to prod
- merge this change 
-
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
