### PR TITLE
VIDEO-7000: apply simulcast configuration only for safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 
 **Version 1.x will End of Life on September 8th, 2021.** Check [this guide](https://www.twilio.com/docs/video/migrating-1x-2x) to plan your migration to the latest 2.x version. Support for the 1.x version ended on December 4th, 2020.
 
+2.17.1 (In Progress)
+====================
+Bug Fixes
+---------
+
+- Fixed a bug which caused Chrome screen share tracks to receive lower resolution. (VIDEO-7000)
+
 2.17.0 (September 14, 2021)
 ===========================
 New Features

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1747,7 +1747,7 @@ function updateEncodingParameters(pcv2) {
       params.encodings[0].networkPriority = 'high';
     }
 
-    if (!isFirefox && sender.track.kind === 'video') {
+    if (isSafari && sender.track.kind === 'video') {
       const { width, height }  = sender.track.getSettings();
       pcv2._updateEncodings(width, height, params.encodings);
     }

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -1209,17 +1209,6 @@ describe('PeerConnectionV2', () => {
         }
       }
 
-      function itShouldSetResolutionScale() {
-        if (isRTCRtpSenderParamsSupported) {
-          it('should set RTCRtpEncodingParameters.scaleResolutionDownBy to 1 for all video senders', () => {
-            test.pc.getSenders().forEach(sender => {
-              if (sender.track.kind === 'video') {
-                sinon.assert.calledWith(sender.setParameters, sinon.match.hasNested('encodings[0].scaleResolutionDownBy', 1));
-              }
-            });
-          });
-        }
-      }
 
       // NOTE(mroberts): This test should really be extended. Instead of popping
       // arguments off of `setCodecPreferences`, we should validate that we
@@ -1266,7 +1255,6 @@ describe('PeerConnectionV2', () => {
 
         itShouldApplyBandwidthConstraints();
         itShouldApplyCodecPreferences();
-        itShouldSetResolutionScale();
         itShouldMaybeSetNetworkPriority();
       }
 

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -1211,12 +1211,11 @@ describe('PeerConnectionV2', () => {
 
       function itShouldNotSetResolutionScale() {
         if (isRTCRtpSenderParamsSupported) {
-          it('should set RTCRtpEncodingParameters.scaleResolutionDownBy for any video senders', () => {
+          it('should not set RTCRtpEncodingParameters.scaleResolutionDownBy for any video senders', () => {
             test.pc.getSenders().forEach(sender => {
               if (sender.track.kind === 'video') {
                 sinon.assert.calledWith(sender.setParameters, sinon.match(({ encodings }) => {
-                  const found = encodings.find(encoding => typeof encoding.scaleResolutionDownBy !== 'undefined');
-                  return !found;
+                  return !encodings.find(encoding => typeof encoding.scaleResolutionDownBy !== 'undefined');
                 }));
               }
             });

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -1209,6 +1209,20 @@ describe('PeerConnectionV2', () => {
         }
       }
 
+      function itShouldNotSetResolutionScale() {
+        if (isRTCRtpSenderParamsSupported) {
+          it('should set RTCRtpEncodingParameters.scaleResolutionDownBy for any video senders', () => {
+            test.pc.getSenders().forEach(sender => {
+              if (sender.track.kind === 'video') {
+                sinon.assert.calledWith(sender.setParameters, sinon.match(({ encodings }) => {
+                  const found = encodings.find(encoding => typeof encoding.scaleResolutionDownBy !== 'undefined');
+                  return !found;
+                }));
+              }
+            });
+          });
+        }
+      }
 
       // NOTE(mroberts): This test should really be extended. Instead of popping
       // arguments off of `setCodecPreferences`, we should validate that we
@@ -1255,6 +1269,7 @@ describe('PeerConnectionV2', () => {
 
         itShouldApplyBandwidthConstraints();
         itShouldApplyCodecPreferences();
+        itShouldNotSetResolutionScale();
         itShouldMaybeSetNetworkPriority();
       }
 


### PR DESCRIPTION
we [updated](https://github.com/twilio/twilio-video.js/pull/1560) simulcast configuration to address a safari issue. 
But this [regresses](https://github.com/twilio/twilio-video.js/issues/1575) chrome's screen share track handling. w/o any configuration looks like chrome creates 2 layers for screen share at highest resolution differing only in frameRate - which is good for screen share track. 

This fix lets chrome do its thing, and apply the simulcast configuration only for safari.  

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
