### PR TITLE
Video 7012 - wire up options to disable safari specific workarounds. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ Bug Fixes
 
 - Fixed a bug which caused Chrome screen share tracks to receive lower resolution. (VIDEO-7000)
 
+Change
+------
+
+- Added options to turn off Safari specific workarounds (VIDEO-7012).
+  Now you can turn off workarounds for `playPausedElementsIfNotBackgrounded`, `workaroundWebKitBug212780` for remote Tracks with,
+  ```ts
+  const { connect } = require('twilio-video');
+  const room = await connect(token, {
+    name: 'my-new-room',
+    playPausedElementsIfNotBackgrounded: false,
+    workaroundWebKitBug212780: false,
+  });
+  ```
+
+  To turn off the `playPausedElementsIfNotBackgrounded` for local Tracks you can specify
+  ```ts
+  const { createLocalVideoTrack } = require('twilio-video');
+  const localVideoTrack = await createLocalVideoTrack({
+    playPausedElementsIfNotBackgrounded: false
+  });
+  ```
+
+
 2.17.0 (September 14, 2021)
 ===========================
 New Features

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { MediaStreamTrack } = require('@twilio/webrtc');
-const { guessBrowser, guessBrowserVersion } = require('@twilio/webrtc/lib/util');
+const { isIOSChrome, guessBrowser, guessBrowserVersion } = require('@twilio/webrtc/lib/util');
 const createCancelableRoomPromise = require('./cancelableroompromise');
 const createLocalTracks = require('./createlocaltracks');
 const EncodingParametersImpl = require('./encodingparameters');
@@ -240,6 +240,15 @@ function connect(token, options) {
     networkQuality: false,
     preferredAudioCodecs: [],
     preferredVideoCodecs: [],
+
+    // NOTE(mmalavalli): To workaround webkit bug 213853, we play the inadvertently paused elements
+    // Bug: https://bugs.webkit.org/show_bug.cgi?id=213853
+    playPausedElementsIfNotBackgrounded: (guessBrowser() === 'safari' || isIOSChrome()),
+
+    // NOTE(mpatwardhan): WebKit bug: 212780 sometimes causes the audio/video elements to stay paused when safari
+    // regains foreground. To workaround it, when safari gains foreground - we will play any elements that were
+    // playing before safari lost foreground.
+    workaroundWebKitBug212780: (guessBrowser() === 'safari' || isIOSChrome()),
     realm: DEFAULT_REALM,
     region: DEFAULT_REGION,
     signaling: SignalingV2

--- a/lib/createlocaltracks.js
+++ b/lib/createlocaltracks.js
@@ -135,6 +135,14 @@ function createLocalTracks(options) {
     extraLocalTrackOptions.video.workaroundWebKitBug1208516 = options.video.workaroundWebKitBug1208516;
   }
 
+  if (options.audio && typeof options.audio.playPausedElementsIfNotBackgrounded === 'boolean') {
+    extraLocalTrackOptions.audio.playPausedElementsIfNotBackgrounded = options.audio.playPausedElementsIfNotBackgrounded;
+  }
+
+  if (options.video && typeof options.video.playPausedElementsIfNotBackgrounded === 'boolean') {
+    extraLocalTrackOptions.video.playPausedElementsIfNotBackgrounded = options.video.playPausedElementsIfNotBackgrounded;
+  }
+
   if (options.audio) {
     delete options.audio.name;
   }

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -28,16 +28,9 @@ class MediaTrack extends Track {
   /**
    * Construct a {@link MediaTrack}.
    * @param {MediaTrackTransceiver} mediaTrackTransceiver
-   * @param {{log: Log}} options
+   * @param {{log: Log, name: ?string, workaroundWebKitBug212780: boolean, playPausedElementsIfNotBackgrounded: boolean}} options
    */
   constructor(mediaTrackTransceiver, options) {
-    options = Object.assign({
-      playPausedElementsIfNotBackgrounded: (guessBrowser() === 'safari' || isIOSChrome())
-        && typeof document === 'object'
-        && typeof document.addEventListener === 'function'
-        && typeof document.visibilityState === 'string'
-    }, options);
-
     super(mediaTrackTransceiver.id, mediaTrackTransceiver.kind, options);
     let isStarted = false;
 
@@ -69,8 +62,7 @@ class MediaTrack extends Track {
         value: options.playPausedElementsIfNotBackgrounded
       },
       _shouldShimAttachedElements: {
-        value: options.workaroundWebKitBug212780
-          || options.playPausedElementsIfNotBackgrounded
+        value: options.workaroundWebKitBug212780 || options.playPausedElementsIfNotBackgrounded
       },
       _unprocessedTrack: {
         value: null,

--- a/lib/media/track/remotemediatrack.js
+++ b/lib/media/track/remotemediatrack.js
@@ -27,21 +27,10 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
      * @param {function(?Track.Priority): void} setPriority - Set or clear the subscribe
      *  {@link Track.Priority} of the {@link RemoteMediaTrack}
      * @param {function(ClientRenderHint): void} setRenderHint - Set render hints.
-     * @param {{log: Log, name: ?string}} options
+     * @param {{log: Log, name: ?string, workaroundWebKitBug212780: boolean, playPausedElementsIfNotBackgrounded: boolean}} options
      */
     constructor(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, setPriority, setRenderHint, options) {
-      options = Object.assign({
-        // NOTE(mpatwardhan): WebKit bug: 212780 sometimes causes the audio/video elements to stay paused when safari
-        // regains foreground. To workaround it, when safari gains foreground - we will play any elements that were
-        // playing before safari lost foreground.
-        workaroundWebKitBug212780: (guessBrowser() === 'safari' || isIOSChrome())
-          && typeof document === 'object'
-          && typeof document.addEventListener === 'function'
-          && typeof document.visibilityState === 'string'
-      }, options);
-
       super(mediaTrackReceiver, options);
-
       Object.defineProperties(this, {
         _isEnabled: {
           value: isEnabled,

--- a/lib/participant.js
+++ b/lib/participant.js
@@ -101,6 +101,12 @@ class Participant extends EventEmitter {
       _contentPreferencesMode: {
         value: options.contentPreferencesMode,
       },
+      _playPausedElementsIfNotBackgrounded: {
+        value: options.playPausedElementsIfNotBackgrounded,
+      },
+      _workaroundWebKitBug212780: {
+        value: options.workaroundWebKitBug212780,
+      },
       _log: {
         value: log
       },
@@ -262,7 +268,13 @@ class Participant extends EventEmitter {
    * @private
    */
   _handleTrackSignalingEvents() {
-    const { _log: log, _clientTrackSwitchOffControl: clientTrackSwitchOffControl, _contentPreferencesMode: contentPreferencesMode } = this;
+    const {
+      _log: log,
+      _clientTrackSwitchOffControl: clientTrackSwitchOffControl,
+      _contentPreferencesMode: contentPreferencesMode,
+      _playPausedElementsIfNotBackgrounded: playPausedElementsIfNotBackgrounded,
+      _workaroundWebKitBug212780: workaroundWebKitBug212780
+    } = this;
     const self = this;
 
     if (this.state === 'disconnected') {
@@ -337,7 +349,13 @@ class Participant extends EventEmitter {
         return;
       }
 
-      const options = { log, name, clientTrackSwitchOffControl, contentPreferencesMode };
+      const options = {
+        log, name,
+        clientTrackSwitchOffControl,
+        contentPreferencesMode,
+        playPausedElementsIfNotBackgrounded,
+        workaroundWebKitBug212780
+      };
       const setPriority = newPriority => participantSignaling.updateSubscriberTrackPriority(sid, newPriority);
       const setRenderHint = renderHint => {
         if (signaling.isSubscribed) {

--- a/lib/room.js
+++ b/lib/room.js
@@ -73,6 +73,12 @@ class Room extends EventEmitter {
       _contentPreferencesMode: {
         value: options.contentPreferencesMode || 'disabled'
       },
+      _playPausedElementsIfNotBackgrounded: {
+        value: options.playPausedElementsIfNotBackgrounded
+      },
+      _workaroundWebKitBug212780: {
+        value: options.workaroundWebKitBug212780
+      },
       _instanceId: {
         value: ++nInstances
       },
@@ -456,8 +462,20 @@ function rewriteLocalTrackIds(room, trackStats) {
  */
 
 function connectParticipant(room, participantSignaling) {
-  const { _log: log, _clientTrackSwitchOffControl: clientTrackSwitchOffControl, _contentPreferencesMode: contentPreferencesMode } = room;
-  const participant = new RemoteParticipant(participantSignaling, { log, clientTrackSwitchOffControl, contentPreferencesMode });
+  const {
+    _log: log,
+    _clientTrackSwitchOffControl: clientTrackSwitchOffControl,
+    _contentPreferencesMode: contentPreferencesMode,
+    _playPausedElementsIfNotBackgrounded: playPausedElementsIfNotBackgrounded,
+    _workaroundWebKitBug212780: workaroundWebKitBug212780
+  } = room;
+  const participant = new RemoteParticipant(participantSignaling, {
+    log,
+    clientTrackSwitchOffControl,
+    contentPreferencesMode,
+    playPausedElementsIfNotBackgrounded,
+    workaroundWebKitBug212780
+  });
 
   log.info('A new RemoteParticipant connected:', participant);
   room._participants.set(participant.sid, participant);

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -160,6 +160,7 @@ export interface CreateLocalTrackOptions extends MediaTrackConstraints {
   logLevel?: LogLevel | LogLevels;
   name?: string;
   workaroundWebKitBug180748?: boolean;
+  playPausedElementsIfNotBackgrounded?: boolean;
 }
 
 export interface ConnectOptions {
@@ -189,6 +190,9 @@ export interface ConnectOptions {
   region?: string;
   preferredAudioCodecs?: Array<AudioCodec | AudioCodecSettings | OpusCodecSettings>;
   preferredVideoCodecs?: Array<VideoCodec | VideoCodecSettings | VP8CodecSettings>;
+
+  playPausedRemoteElementsIfNotBackgrounded?: boolean;
+  workaroundWebKitBug212780?: boolean;
 
   /**
    * @deprecated use Video.Logger.


### PR DESCRIPTION
We have few safari specific workarounds that might not work well for newer version for iOS Safari. This PR wires up options to turn off those workarounds. 


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
