### PR TITLE
VIDEO-7161 + VIDEO-7162 Simulcast API implementation + rollback support 

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -217,8 +217,12 @@ function connect(token, options) {
   // Additionally, the options that are no longer needed will be removed.
   deprecateOptions(options, log, deprecatedConnectOptionsProps);
 
+  if (options.preferredVideoCodecs === 'auto') {
+    // NOTE(mpatwardhan): enable adaptiveSimulcast.
+    options.preferredVideoCodecs = [{ codec: 'VP8', simulcast: true, adaptiveSimulcast: true }];
+  }
+
   options = Object.assign({
-    adaptiveSimulcast: true,
     automaticSubscription: true,
     createLocalTracks,
     dominantSpeaker: false,
@@ -389,10 +393,6 @@ function connect(token, options) {
  * @property {boolean|CreateLocalTrackOptions} [audio=true] - Whether or not to
  *   get local audio with <code>getUserMedia</code> when <code>tracks</code>
  *   are not provided.
- * @property {boolean} [adaptiveSimulcast=true] - Optional parameter that determines
- *    when to turn on the adaptive simulcast feature. Defaults to true if VP8 simulcast is
- *    enabled in <code>ConnectOptions.preferredVideoCodecs</code>. If set to true without
- *    enabling VP8 simulcast, then it is ignored.
  * @property {boolean} [automaticSubscription=true] - By default, you will subscribe
  *   to all RemoteTracks shared by other Participants in a Room. You can now override this
  *   behavior by setting this flag to <code>false</code>. It will make sure that you will
@@ -457,7 +457,8 @@ function connect(token, options) {
  * @property {Array<AudioCodec|AudioCodecSettings>} [preferredAudioCodecs=[]] - Preferred audio codecs;
  *  An empty array preserves the current audio codec preference order.
  * @property {Array<VideoCodec|VideoCodecSettings>} [preferredVideoCodecs=[]] -
- *  Preferred video codecs; An empty array preserves the current video codec
+ *  Preferred video codecs; If set to 'auto', sdk will use vp8 simulcast where ever applicable
+ *  An empty array preserves the current video codec
  *  preference order. If you want to set a preferred video codec on a Group Room,
  *  you will need to create the Room using the REST API and set the
  *  <code>VideoCodecs</code> property.

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -456,9 +456,9 @@ function connect(token, options) {
  *   for the list of supported signaling regions.
  * @property {Array<AudioCodec|AudioCodecSettings>} [preferredAudioCodecs=[]] - Preferred audio codecs;
  *  An empty array preserves the current audio codec preference order.
- * @property {Array<VideoCodec|VideoCodecSettings>} [preferredVideoCodecs=[]] -
- *  Preferred video codecs; If set to 'auto', sdk will use vp8 simulcast where ever applicable
- *  An empty array preserves the current video codec
+ * @property {Array<VideoCodec|VideoCodecSettings>|'auto'} [preferredVideoCodecs=[]] -
+ *  Preferred video codecs; If set to 'auto', VP8 simulcast will be used where ever applicable.
+ *  An empty array preserves the current video codec.
  *  preference order. If you want to set a preferred video codec on a Group Room,
  *  you will need to create the Room using the REST API and set the
  *  <code>VideoCodecs</code> property.

--- a/lib/signaling/v2/cancelableroomsignalingpromise.js
+++ b/lib/signaling/v2/cancelableroomsignalingpromise.js
@@ -19,6 +19,7 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
     Transport: DefaultTransport
   }, options);
 
+  const adaptiveSimulcast = preferredCodecs.video[0] &&  preferredCodecs.video[0].adaptiveSimulcast === true;
   const { PeerConnectionManager, RoomV2, Transport, iceServers, log } = options;
   const peerConnectionManager = new PeerConnectionManager(encodingParameters, preferredCodecs, options);
   const trackSenders = flatMap(localParticipant.tracks, trackV2 => [trackV2.trackTransceiver]);
@@ -59,7 +60,6 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
     const {
       InsightsPublisher,
       NullInsightsPublisher,
-      adaptiveSimulcast,
       automaticSubscription,
       bandwidthProfile,
       dominantSpeaker,

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -433,7 +433,7 @@ class PeerConnectionV2 extends StateMachine {
     });
   }
 
- get _shouldApplySimulcast() {
+  get _shouldApplySimulcast() {
     if (!isChrome && !isSafari) {
       return false;
     }
@@ -442,6 +442,7 @@ class PeerConnectionV2 extends StateMachine {
     const simulcast = this._preferredVideoCodecs.some(cs => {
       return cs.codec.toLowerCase() === 'vp8' && cs.simulcast && cs.adaptiveSimulcast !== false;
     });
+
     return simulcast;
   }
 

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -26,7 +26,7 @@ const {
   enableDtxForOpus,
   getMediaSections,
   removeSSRCAttributes,
-  revertSimulcastForNonVP8MediaSections,
+  revertSimulcast,
   setBitrateParameters,
   setCodecPreferences,
   setSimulcast,
@@ -125,7 +125,6 @@ class PeerConnectionV2 extends StateMachine {
   constructor(id, encodingParameters, preferredCodecs, options) {
     super('open', states);
     options = Object.assign({
-      adaptiveSimulcast: true,
       enableDscp: false,
       dummyAudioMediaStreamTrack: null,
       isChromeScreenShareTrack,
@@ -133,7 +132,7 @@ class PeerConnectionV2 extends StateMachine {
       isRTCRtpSenderParamsSupported,
       logLevel: DEFAULT_LOG_LEVEL,
       offerOptions: {},
-      revertSimulcastForNonVP8MediaSections,
+      revertSimulcast,
       sessionTimeout: DEFAULT_SESSION_TIMEOUT_SEC * 1000,
       setBitrateParameters,
       setCodecPreferences,
@@ -169,13 +168,6 @@ class PeerConnectionV2 extends StateMachine {
     }
 
     Object.defineProperties(this, {
-      _adaptiveSimulcast: {
-        value: options.adaptiveSimulcast
-      },
-      _effectiveAdaptiveSimulcast: {
-        value: options.effectiveAdaptiveSimulcast,
-        writable: true
-      },
       _appliedTrackIdsToAttributes: {
         value: new Map(),
         writable: true
@@ -329,10 +321,6 @@ class PeerConnectionV2 extends StateMachine {
         value: preferredCodecs.audio.every(({ codec }) => codec !== 'opus')
           || preferredCodecs.audio.some(({ codec, dtx }) => codec === 'opus' && dtx)
       },
-      _isVP8Preferred: {
-        value: (isChrome || isSafari) && preferredCodecs.video.some(
-          codecSettings => codecSettings.codec.toLowerCase() === 'vp8' && codecSettings.simulcast)
-      },
       _queuedDescription: {
         writable: true,
         value: null
@@ -374,8 +362,8 @@ class PeerConnectionV2 extends StateMachine {
       _setSimulcast: {
         value: options.setSimulcast
       },
-      _revertSimulcastForNonVP8MediaSections: {
-        value: options.revertSimulcastForNonVP8MediaSections
+      _revertSimulcast: {
+        value: options.revertSimulcast
       },
       _RTCIceCandidate: {
         value: options.RTCIceCandidate
@@ -436,48 +424,25 @@ class PeerConnectionV2 extends StateMachine {
   }
 
   setEffectiveAdaptiveSimulcast(effectiveAdaptiveSimulcast) {
-    this._log.debug('makarand PeerConnection!setEffectiveAdaptiveSimulcast: ', effectiveAdaptiveSimulcast);
-    this._effectiveAdaptiveSimulcast = effectiveAdaptiveSimulcast;
-  }
-
-  // returns 'vp8' 'all', 'none'
-  // indicating for which codecs should we revert simulcast.
-  shouldRevertSimulcast() {
-    if (!isChrome && !isSafari) {
-      return 'none';
-    }
-
-    if (!this._localDescriptionWithoutSimulcast) {
-      return 'none';
-    }
-
-    this._log.debug('makarand shouldRevertSimulcast adaptiveSimulcast:', this._adaptiveSimulcast, ' effectiveAdaptiveSimulcast:',  this._effectiveAdaptiveSimulcast);
-    if (this._adaptiveSimulcast && !this._effectiveAdaptiveSimulcast) {
-      return 'all';
-    }
-
-    if (this._isVP8Preferred) {
-      return 'nonVp8';
-    }
-
-    return 'none';
+    this._log.debug('Setting setEffectiveAdaptiveSimulcast: ', effectiveAdaptiveSimulcast);
+    // clear adaptive simulcast from codec preferences if it was set.
+    this._preferredVideoCodecs.forEach(cs => {
+      if ('adaptiveSimulcast' in cs) {
+        cs.adaptiveSimulcast = effectiveAdaptiveSimulcast;
+      }
+    });
   }
 
   shouldApplySimulcast() {
-    this._log.debug('makarand shouldApplySimulcast adaptiveSimulcast:', this._adaptiveSimulcast, ' effectiveAdaptiveSimulcast:',  this._effectiveAdaptiveSimulcast);
     if (!isChrome && !isSafari) {
       return false;
     }
 
-    if (this._isVP8Preferred) {
-      return true;
-    }
-
-    // adaptive simulcast case
-    if (this._adaptiveSimulcast && this._effectiveAdaptiveSimulcast) {
-      return true;
-    }
-    return false;
+    // adaptiveSimulcast is set to false after connected message is received if other party does not support it.
+    const simulcast = this._preferredVideoCodecs.some(cs => {
+      return cs.codec.toLowerCase() === 'vp8' && cs.simulcast && cs.adaptiveSimulcast !== false;
+    });
+    return simulcast;
   }
 
   /**
@@ -661,15 +626,11 @@ class PeerConnectionV2 extends StateMachine {
 
       if (this.shouldApplySimulcast()) {
         let sdpWithoutSimulcast = updatedSdp;
-        this._log.debug('makarand: setting simulcast 2 for ', answer.type);
         updatedSdp = this._setSimulcast(sdpWithoutSimulcast, this._sdpFormat, this._trackIdsToAttributes);
         // NOTE(syerrapragada): VMS does not support H264 simulcast. So,
         // unset simulcast for sections in local offer where corresponding
         // sections in answer doesn't have vp8 as preferred codec and reapply offer.
-        this._log.debug('makarand: reverting simulcast 2 for ', answer.type);
-
-        // Note(mpatwardhan): why are we reverting something that we just added ?
-        updatedSdp = this._revertSimulcastForNonVP8MediaSections(updatedSdp, sdpWithoutSimulcast, offer.sdp);
+        updatedSdp = this._revertSimulcast(updatedSdp, sdpWithoutSimulcast, offer.sdp);
       }
 
       // NOTE(mmalavalli): Work around Chromium bug 1074421.
@@ -1074,7 +1035,6 @@ class PeerConnectionV2 extends StateMachine {
           type: 'offer',
           sdp: updatedSdp
         };
-        this._log.debug('makarand: reverting simulcast 1 for ', 'offer');
         updatedSdp = this._setSimulcast(updatedSdp, this._sdpFormat, this._trackIdsToAttributes);
       }
       return this._setLocalDescription({
@@ -1154,7 +1114,6 @@ class PeerConnectionV2 extends StateMachine {
       });
     }
     return this._peerConnection.setLocalDescription(description).catch(error => {
-      this._log.debug('makarand: setLocalDescription error: ', error);
       this._log.warn(`Calling setLocalDescription with an RTCSessionDescription of type "${description.type}" failed with the error "${error.message}".`, error);
 
       const errorToThrow = new MediaClientLocalDescFailedError();
@@ -1245,13 +1204,12 @@ class PeerConnectionV2 extends StateMachine {
       // unset simulcast for sections in local offer where corresponding
       // sections in answer doesn't have vp8 as preferred codec and reapply offer.
       if (description.type === 'answer') {
-        const revert = this.shouldRevertSimulcast();
-        if (revert !== 'none') {
-          this._log.debug('makarand2: reverting simulcast 1 for ', this._localDescription.type, revert);
-
-          // if we had adaptive simulcast on, but was later turned off.
-          const revertForAll = revert === 'all';
-          const sdpWithoutSimulcastForNonVP8MediaSections = this._revertSimulcastForNonVP8MediaSections(
+        if (this._localDescriptionWithoutSimulcast) {
+          // NOTE(mpatwardhan):if we were using adaptive simulcast, and if its not supported by server
+          // revert simulcast even for vp8.
+          const adaptiveSimulcastEntry = this._preferredVideoCodecs.find(cs => 'adaptiveSimulcast' in cs);
+          const revertForAll = !!adaptiveSimulcastEntry && adaptiveSimulcastEntry.adaptiveSimulcast === false;
+          const sdpWithoutSimulcastForNonVP8MediaSections = this._revertSimulcast(
             this._localDescription.sdp,
             this._localDescriptionWithoutSimulcast.sdp,
             description.sdp, revertForAll);
@@ -1273,8 +1231,7 @@ class PeerConnectionV2 extends StateMachine {
         negotiationCompleted(this);
       }
     }, error => {
-      this._log.debug('makarand: error2: ', error);
-      this._log.warn(`Calling setRemoteDescription with an RTCSessionDescription of type "${description.type}" failed with the error "${error.message}".`);
+      this._log.warn(`Calling setRemoteDescription with an RTCSessionDescription of type "${description.type}" failed with the error "${error.message}".`, error);
       if (description.sdp) {
         this._log.warn(`The SDP was ${description.sdp}`);
       }

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -433,7 +433,7 @@ class PeerConnectionV2 extends StateMachine {
     });
   }
 
-  shouldApplySimulcast() {
+ get _shouldApplySimulcast() {
     if (!isChrome && !isSafari) {
       return false;
     }
@@ -624,7 +624,7 @@ class PeerConnectionV2 extends StateMachine {
       // this also helps reduce bytes on wires
       let updatedSdp = removeSSRCAttributes(answer.sdp, ['mslabel', 'label']);
 
-      if (this.shouldApplySimulcast()) {
+      if (this._shouldApplySimulcast) {
         let sdpWithoutSimulcast = updatedSdp;
         updatedSdp = this._setSimulcast(sdpWithoutSimulcast, this._sdpFormat, this._trackIdsToAttributes);
         // NOTE(syerrapragada): VMS does not support H264 simulcast. So,
@@ -1030,7 +1030,7 @@ class PeerConnectionV2 extends StateMachine {
         this._negotiationRole = 'offerer';
       }
 
-      if (this.shouldApplySimulcast()) {
+      if (this._shouldApplySimulcast) {
         this._localDescriptionWithoutSimulcast = {
           type: 'offer',
           sdp: updatedSdp

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -124,8 +124,8 @@ class PeerConnectionV2 extends StateMachine {
    */
   constructor(id, encodingParameters, preferredCodecs, options) {
     super('open', states);
-
     options = Object.assign({
+      adaptiveSimulcast: true,
       enableDscp: false,
       dummyAudioMediaStreamTrack: null,
       isChromeScreenShareTrack,
@@ -169,6 +169,13 @@ class PeerConnectionV2 extends StateMachine {
     }
 
     Object.defineProperties(this, {
+      _adaptiveSimulcast: {
+        value: options.adaptiveSimulcast
+      },
+      _effectiveAdaptiveSimulcast: {
+        value: options.effectiveAdaptiveSimulcast,
+        writable: true
+      },
       _appliedTrackIdsToAttributes: {
         value: new Map(),
         writable: true
@@ -322,7 +329,7 @@ class PeerConnectionV2 extends StateMachine {
         value: preferredCodecs.audio.every(({ codec }) => codec !== 'opus')
           || preferredCodecs.audio.some(({ codec, dtx }) => codec === 'opus' && dtx)
       },
-      _shouldApplySimulcast: {
+      _isVP8Preferred: {
         value: (isChrome || isSafari) && preferredCodecs.video.some(
           codecSettings => codecSettings.codec.toLowerCase() === 'vp8' && codecSettings.simulcast)
       },
@@ -426,6 +433,51 @@ class PeerConnectionV2 extends StateMachine {
 
   toString() {
     return `[PeerConnectionV2 #${this._instanceId}: ${this.id}]`;
+  }
+
+  setEffectiveAdaptiveSimulcast(effectiveAdaptiveSimulcast) {
+    this._log.debug('makarand PeerConnection!setEffectiveAdaptiveSimulcast: ', effectiveAdaptiveSimulcast);
+    this._effectiveAdaptiveSimulcast = effectiveAdaptiveSimulcast;
+  }
+
+  // returns 'vp8' 'all', 'none'
+  // indicating for which codecs should we revert simulcast.
+  shouldRevertSimulcast() {
+    if (!isChrome && !isSafari) {
+      return 'none';
+    }
+
+    if (!this._localDescriptionWithoutSimulcast) {
+      return 'none';
+    }
+
+    this._log.debug('makarand shouldRevertSimulcast adaptiveSimulcast:', this._adaptiveSimulcast, ' effectiveAdaptiveSimulcast:',  this._effectiveAdaptiveSimulcast);
+    if (this._adaptiveSimulcast && !this._effectiveAdaptiveSimulcast) {
+      return 'all';
+    }
+
+    if (this._isVP8Preferred) {
+      return 'nonVp8';
+    }
+
+    return 'none';
+  }
+
+  shouldApplySimulcast() {
+    this._log.debug('makarand shouldApplySimulcast adaptiveSimulcast:', this._adaptiveSimulcast, ' effectiveAdaptiveSimulcast:',  this._effectiveAdaptiveSimulcast);
+    if (!isChrome && !isSafari) {
+      return false;
+    }
+
+    if (this._isVP8Preferred) {
+      return true;
+    }
+
+    // adaptive simulcast case
+    if (this._adaptiveSimulcast && this._effectiveAdaptiveSimulcast) {
+      return true;
+    }
+    return false;
   }
 
   /**
@@ -607,12 +659,16 @@ class PeerConnectionV2 extends StateMachine {
       // this also helps reduce bytes on wires
       let updatedSdp = removeSSRCAttributes(answer.sdp, ['mslabel', 'label']);
 
-      if (this._shouldApplySimulcast) {
+      if (this.shouldApplySimulcast()) {
         let sdpWithoutSimulcast = updatedSdp;
+        this._log.debug('makarand: setting simulcast 2 for ', answer.type);
         updatedSdp = this._setSimulcast(sdpWithoutSimulcast, this._sdpFormat, this._trackIdsToAttributes);
         // NOTE(syerrapragada): VMS does not support H264 simulcast. So,
         // unset simulcast for sections in local offer where corresponding
         // sections in answer doesn't have vp8 as preferred codec and reapply offer.
+        this._log.debug('makarand: reverting simulcast 2 for ', answer.type);
+
+        // Note(mpatwardhan): why are we reverting something that we just added ?
         updatedSdp = this._revertSimulcastForNonVP8MediaSections(updatedSdp, sdpWithoutSimulcast, offer.sdp);
       }
 
@@ -1013,11 +1069,12 @@ class PeerConnectionV2 extends StateMachine {
         this._negotiationRole = 'offerer';
       }
 
-      if (this._shouldApplySimulcast) {
+      if (this.shouldApplySimulcast()) {
         this._localDescriptionWithoutSimulcast = {
           type: 'offer',
           sdp: updatedSdp
         };
+        this._log.debug('makarand: reverting simulcast 1 for ', 'offer');
         updatedSdp = this._setSimulcast(updatedSdp, this._sdpFormat, this._trackIdsToAttributes);
       }
       return this._setLocalDescription({
@@ -1097,7 +1154,8 @@ class PeerConnectionV2 extends StateMachine {
       });
     }
     return this._peerConnection.setLocalDescription(description).catch(error => {
-      this._log.warn(`Calling setLocalDescription with an RTCSessionDescription of type "${description.type}" failed with the error "${error.message}".`);
+      this._log.debug('makarand: setLocalDescription error: ', error);
+      this._log.warn(`Calling setLocalDescription with an RTCSessionDescription of type "${description.type}" failed with the error "${error.message}".`, error);
 
       const errorToThrow = new MediaClientLocalDescFailedError();
       const publishWarning = {
@@ -1186,16 +1244,24 @@ class PeerConnectionV2 extends StateMachine {
       // NOTE(syerrapragada): VMS does not support H264 simulcast. So,
       // unset simulcast for sections in local offer where corresponding
       // sections in answer doesn't have vp8 as preferred codec and reapply offer.
-      if (description.type === 'answer' && this._shouldApplySimulcast) {
-        const sdpWithoutSimulcastForNonVP8MediaSections = this._revertSimulcastForNonVP8MediaSections(
-          this._localDescription.sdp,
-          this._localDescriptionWithoutSimulcast.sdp,
-          description.sdp);
-        if (sdpWithoutSimulcastForNonVP8MediaSections !== this._localDescription.sdp) {
-          return this._rollbackAndApplyOffer({
-            type: this._localDescription.type,
-            sdp: sdpWithoutSimulcastForNonVP8MediaSections
-          });
+      if (description.type === 'answer') {
+        const revert = this.shouldRevertSimulcast();
+        if (revert !== 'none') {
+          this._log.debug('makarand2: reverting simulcast 1 for ', this._localDescription.type, revert);
+
+          // if we had adaptive simulcast on, but was later turned off.
+          const revertForAll = revert === 'all';
+          const sdpWithoutSimulcastForNonVP8MediaSections = this._revertSimulcastForNonVP8MediaSections(
+            this._localDescription.sdp,
+            this._localDescriptionWithoutSimulcast.sdp,
+            description.sdp, revertForAll);
+          this._localDescriptionWithoutSimulcast = null;
+          if (sdpWithoutSimulcastForNonVP8MediaSections !== this._localDescription.sdp) {
+            return this._rollbackAndApplyOffer({
+              type: this._localDescription.type,
+              sdp: sdpWithoutSimulcastForNonVP8MediaSections
+            });
+          }
         }
       }
     }).then(() => this._peerConnection.setRemoteDescription(description)).then(() => {
@@ -1207,6 +1273,7 @@ class PeerConnectionV2 extends StateMachine {
         negotiationCompleted(this);
       }
     }, error => {
+      this._log.debug('makarand: error2: ', error);
       this._log.warn(`Calling setRemoteDescription with an RTCSessionDescription of type "${description.type}" failed with the error "${error.message}".`);
       if (description.sdp) {
         this._log.warn(`The SDP was ${description.sdp}`);

--- a/lib/signaling/v2/peerconnectionmanager.js
+++ b/lib/signaling/v2/peerconnectionmanager.js
@@ -69,6 +69,13 @@ class PeerConnectionManager extends QueueingEventEmitter {
           ? new MediaTrackSender(createDummyAudioMediaStreamTrack(audioContext))
           : null
       },
+      _adaptiveSimulcast: {
+        value: options.adaptiveSimulcast,
+      },
+      _effectiveAdaptiveSimulcast: {
+        value: true, // initially we assume its true.
+        writable: true,
+      },
       _encodingParameters: {
         value: encodingParameters
       },
@@ -109,6 +116,11 @@ class PeerConnectionManager extends QueueingEventEmitter {
         value: options.PeerConnectionV2
       }
     });
+  }
+
+  setEffectiveAdaptiveSimulcast(effectiveAdaptiveSimulcast) {
+    this._effectiveAdaptiveSimulcast = effectiveAdaptiveSimulcast;
+    this._peerConnections.forEach(pc => pc.setEffectiveAdaptiveSimulcast(effectiveAdaptiveSimulcast));
   }
 
   /**
@@ -167,6 +179,8 @@ class PeerConnectionManager extends QueueingEventEmitter {
       const PeerConnectionV2 = this._PeerConnectionV2;
 
       const options = Object.assign({
+        adaptiveSimulcast: this._adaptiveSimulcast,
+        effectiveAdaptiveSimulcast: this._effectiveAdaptiveSimulcast,
         dummyAudioMediaStreamTrack: this._dummyAudioTrackSender
           ? this._dummyAudioTrackSender.track
           : null,

--- a/lib/signaling/v2/peerconnectionmanager.js
+++ b/lib/signaling/v2/peerconnectionmanager.js
@@ -69,13 +69,6 @@ class PeerConnectionManager extends QueueingEventEmitter {
           ? new MediaTrackSender(createDummyAudioMediaStreamTrack(audioContext))
           : null
       },
-      _adaptiveSimulcast: {
-        value: options.adaptiveSimulcast,
-      },
-      _effectiveAdaptiveSimulcast: {
-        value: true, // initially we assume its true.
-        writable: true,
-      },
       _encodingParameters: {
         value: encodingParameters
       },
@@ -119,8 +112,12 @@ class PeerConnectionManager extends QueueingEventEmitter {
   }
 
   setEffectiveAdaptiveSimulcast(effectiveAdaptiveSimulcast) {
-    this._effectiveAdaptiveSimulcast = effectiveAdaptiveSimulcast;
     this._peerConnections.forEach(pc => pc.setEffectiveAdaptiveSimulcast(effectiveAdaptiveSimulcast));
+    this._preferredCodecs.video.forEach(cs => {
+      if ('adaptiveSimulcast' in cs) {
+        cs.adaptiveSimulcast = effectiveAdaptiveSimulcast;
+      }
+    });
   }
 
   /**
@@ -179,8 +176,6 @@ class PeerConnectionManager extends QueueingEventEmitter {
       const PeerConnectionV2 = this._PeerConnectionV2;
 
       const options = Object.assign({
-        adaptiveSimulcast: this._adaptiveSimulcast,
-        effectiveAdaptiveSimulcast: this._effectiveAdaptiveSimulcast,
         dummyAudioMediaStreamTrack: this._dummyAudioTrackSender
           ? this._dummyAudioTrackSender.track
           : null,

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -149,9 +149,8 @@ class RoomV2 extends RoomSignaling {
 
     this._update(initialState);
 
-    // after initial state is received we know if publisher_hints are enabled or not
-    // if they are not enabled. we need to revert simulcast even for vp8
-    this._log.debug('makarand PeerConnectionManager!setEffectiveAdaptiveSimulcast: ', this._publisherHintsSignaling.isSetup);
+    // NOTE(mpatwardhan) after initial state we know if publisher_hints are enabled or not
+    // if they are not enabled. we need to undo simulcast that if it was enabled with initial offer.
     this._peerConnectionManager.setEffectiveAdaptiveSimulcast(this._publisherHintsSignaling.isSetup);
   }
 

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -148,6 +148,11 @@ class RoomV2 extends RoomSignaling {
     periodicallyPublishStats(this, transport, options.statsPublishIntervalMs);
 
     this._update(initialState);
+
+    // after initial state is received we know if publisher_hints are enabled or not
+    // if they are not enabled. we need to revert simulcast even for vp8
+    this._log.debug('makarand PeerConnectionManager!setEffectiveAdaptiveSimulcast: ', this._publisherHintsSignaling.isSetup);
+    this._peerConnectionManager.setEffectiveAdaptiveSimulcast(this._publisherHintsSignaling.isSetup);
   }
 
   /**

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -1,6 +1,8 @@
+/* eslint-disable no-console */
 'use strict';
 
 const { difference, flatMap } = require('../');
+const Diff = require('diff');
 const setSimulcastInMediaSection = require('./simulcast');
 
 const ptToFixedBitrateAudioCodecName = {
@@ -408,9 +410,10 @@ function unifiedPlanFilterLocalCodecs(localSdp, remoteSdp) {
  * @param localSdp - simulcast enabled local sdp
  * @param localSdpWithoutSimulcast - local sdp before simulcast was set
  * @param remoteSdp - remote sdp
+ * @param revertForAll - should we revert simulcast for all codes. if set to false it will be reverted only for non-vp8
  * @return {string} Updated SDP string
  */
-function revertSimulcastForNonVP8MediaSections(localSdp, localSdpWithoutSimulcast, remoteSdp) {
+function revertSimulcastForNonVP8MediaSections(localSdp, localSdpWithoutSimulcast, remoteSdp, revertForAll = false) {
   const remoteMidToMediaSections = createMidToMediaSectionMap(remoteSdp);
   const localMidToMediaSectionsWithoutSimulcast = createMidToMediaSectionMap(localSdpWithoutSimulcast);
   const mediaSections = getMediaSections(localSdp);
@@ -430,8 +433,28 @@ function revertSimulcastForNonVP8MediaSections(localSdp, localSdpWithoutSimulcas
     const remotePtToCodecs = createPtToCodecName(remoteSection);
     const remotePayloadTypes = getPayloadTypesInMediaSection(remoteSection);
 
-    const isVP8ThePreferredCodec = remotePayloadTypes.length && remotePtToCodecs.get(remotePayloadTypes[0]) === 'vp8';
-    return isVP8ThePreferredCodec ? section : localMidToMediaSectionsWithoutSimulcast.get(mid).replace(/\r\n$/, '');
+    const shouldRevertSimulcast = revertForAll || (remotePayloadTypes.length && remotePtToCodecs.get(remotePayloadTypes[0]) === 'vp8');
+    if (!shouldRevertSimulcast) {
+      return section;
+    }
+
+    const newSection = localMidToMediaSectionsWithoutSimulcast.get(mid).replace(/\r\n$/, '');
+    console.log('%c makarand: reverting simulcast ', `background: ${'yellow'}`);
+    // const newSection = localMidToMediaSectionsWithoutSimulcast.get(mid).replace(/\r\n$/, '');
+    try {
+      const diff = Diff.diffLines(section, newSection);
+      diff.forEach(part => {
+        // green for additions, red for deletions
+        // grey for common parts
+        const color = part.added ? 'lightgreen' : part.removed ? 'red' : 'grey';
+        console.log(`%c${part.value}`, `background: ${color}`);
+      });
+    } catch (ex) {
+      console.log('makarand: error diffing ', ex);
+    }
+    console.log('%c makarand: done reverting simulcast ', `background: ${'yellow'}`);
+    return newSection;
+
   })).concat('').join('\r\n');
 }
 

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 'use strict';
 
 const { difference, flatMap } = require('../');
@@ -409,7 +408,8 @@ function unifiedPlanFilterLocalCodecs(localSdp, remoteSdp) {
  * @param localSdp - simulcast enabled local sdp
  * @param localSdpWithoutSimulcast - local sdp before simulcast was set
  * @param remoteSdp - remote sdp
- * @param revertForAll - should we revert simulcast for all codecs? if set to false(default) it will be reverted ffor non-vp8 codecs only
+ * @param revertForAll - when true simulcast will be reverted for all codecs. when false it will be reverted
+ *  only for non-vp8 codecs.
  * @return {string} Updated SDP string
  */
 function revertSimulcast(localSdp, localSdpWithoutSimulcast, remoteSdp, revertForAll = false) {

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -2,7 +2,6 @@
 'use strict';
 
 const { difference, flatMap } = require('../');
-const Diff = require('diff');
 const setSimulcastInMediaSection = require('./simulcast');
 
 const ptToFixedBitrateAudioCodecName = {
@@ -410,10 +409,10 @@ function unifiedPlanFilterLocalCodecs(localSdp, remoteSdp) {
  * @param localSdp - simulcast enabled local sdp
  * @param localSdpWithoutSimulcast - local sdp before simulcast was set
  * @param remoteSdp - remote sdp
- * @param revertForAll - should we revert simulcast for all codes. if set to false it will be reverted only for non-vp8
+ * @param revertForAll - should we revert simulcast for all codecs? if set to false(default) it will be reverted ffor non-vp8 codecs only
  * @return {string} Updated SDP string
  */
-function revertSimulcastForNonVP8MediaSections(localSdp, localSdpWithoutSimulcast, remoteSdp, revertForAll = false) {
+function revertSimulcast(localSdp, localSdpWithoutSimulcast, remoteSdp, revertForAll = false) {
   const remoteMidToMediaSections = createMidToMediaSectionMap(remoteSdp);
   const localMidToMediaSectionsWithoutSimulcast = createMidToMediaSectionMap(localSdpWithoutSimulcast);
   const mediaSections = getMediaSections(localSdp);
@@ -433,28 +432,9 @@ function revertSimulcastForNonVP8MediaSections(localSdp, localSdpWithoutSimulcas
     const remotePtToCodecs = createPtToCodecName(remoteSection);
     const remotePayloadTypes = getPayloadTypesInMediaSection(remoteSection);
 
-    const shouldRevertSimulcast = revertForAll || (remotePayloadTypes.length && remotePtToCodecs.get(remotePayloadTypes[0]) === 'vp8');
-    if (!shouldRevertSimulcast) {
-      return section;
-    }
-
-    const newSection = localMidToMediaSectionsWithoutSimulcast.get(mid).replace(/\r\n$/, '');
-    console.log('%c makarand: reverting simulcast ', `background: ${'yellow'}`);
-    // const newSection = localMidToMediaSectionsWithoutSimulcast.get(mid).replace(/\r\n$/, '');
-    try {
-      const diff = Diff.diffLines(section, newSection);
-      diff.forEach(part => {
-        // green for additions, red for deletions
-        // grey for common parts
-        const color = part.added ? 'lightgreen' : part.removed ? 'red' : 'grey';
-        console.log(`%c${part.value}`, `background: ${color}`);
-      });
-    } catch (ex) {
-      console.log('makarand: error diffing ', ex);
-    }
-    console.log('%c makarand: done reverting simulcast ', `background: ${'yellow'}`);
-    return newSection;
-
+    const isVP8ThePreferredCodec = remotePayloadTypes.length && remotePtToCodecs.get(remotePayloadTypes[0]) === 'vp8';
+    const shouldRevertSimulcast = revertForAll || !isVP8ThePreferredCodec;
+    return shouldRevertSimulcast ? localMidToMediaSectionsWithoutSimulcast.get(mid).replace(/\r\n$/, '') : section;
   })).concat('').join('\r\n');
 }
 
@@ -658,7 +638,7 @@ exports.disableRtx = disableRtx;
 exports.enableDtxForOpus = enableDtxForOpus;
 exports.getMediaSections = getMediaSections;
 exports.removeSSRCAttributes = removeSSRCAttributes;
-exports.revertSimulcastForNonVP8MediaSections = revertSimulcastForNonVP8MediaSections;
+exports.revertSimulcast = revertSimulcast;
 exports.setBitrateParameters = setBitrateParameters;
 exports.setCodecPreferences = setCodecPreferences;
 exports.setSimulcast = setSimulcast;

--- a/lib/util/sdp/simulcast.js
+++ b/lib/util/sdp/simulcast.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 'use strict';
 
 const difference = require('../').difference;

--- a/lib/util/sdp/simulcast.js
+++ b/lib/util/sdp/simulcast.js
@@ -3,7 +3,6 @@
 
 const difference = require('../').difference;
 const flatMap = require('../').flatMap;
-const Diff = require('diff');
 /**
  * Create a random {@link SSRC}.
  * @returns {SSRC}
@@ -271,21 +270,7 @@ function setSimulcastInMediaSection(section, sdpFormat, trackIdsToAttributes) {
     sectionLines.push(xGoogleFlagConference);
   }
 
-  console.log('%c makarand: applying simulcast ', `background: ${'yellow'}`);
-  const newSection = sectionLines.join('\r\n');
-  try {
-    const diff = Diff.diffLines(section, newSection);
-    diff.forEach(part => {
-      // green for additions, red for deletions
-      // grey for common parts
-      const color = part.added ? 'green' : part.removed ? 'red' : 'grey';
-      console.log(`%c${part.value}`, `background: ${color}`);
-    });
-  } catch (ex) {
-    console.log('makarand: error diffing ', ex);
-  }
-  console.log('%c makarand: done applying simulcast ', `background: ${'yellow'}`);
-  return newSection;
+  return sectionLines.join('\r\n');
 }
 
 /**

--- a/lib/util/sdp/simulcast.js
+++ b/lib/util/sdp/simulcast.js
@@ -1,8 +1,9 @@
+/* eslint-disable no-console */
 'use strict';
 
 const difference = require('../').difference;
 const flatMap = require('../').flatMap;
-
+const Diff = require('diff');
 /**
  * Create a random {@link SSRC}.
  * @returns {SSRC}
@@ -270,7 +271,21 @@ function setSimulcastInMediaSection(section, sdpFormat, trackIdsToAttributes) {
     sectionLines.push(xGoogleFlagConference);
   }
 
-  return sectionLines.join('\r\n');
+  console.log('%c makarand: applying simulcast ', `background: ${'yellow'}`);
+  const newSection = sectionLines.join('\r\n');
+  try {
+    const diff = Diff.diffLines(section, newSection);
+    diff.forEach(part => {
+      // green for additions, red for deletions
+      // grey for common parts
+      const color = part.added ? 'green' : part.removed ? 'red' : 'grey';
+      console.log(`%c${part.value}`, `background: ${color}`);
+    });
+  } catch (ex) {
+    console.log('makarand: error diffing ', ex);
+  }
+  console.log('%c makarand: done applying simulcast ', `background: ${'yellow'}`);
+  return newSection;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
   "dependencies": {
     "@twilio/webrtc": "4.5.1",
     "backoff": "^2.5.0",
+    "diff": "^5.0.0",
     "ws": "^7.4.6",
     "xmlhttprequest": "^1.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -147,7 +147,6 @@
   "dependencies": {
     "@twilio/webrtc": "4.5.1",
     "backoff": "^2.5.0",
-    "diff": "^5.0.0",
     "ws": "^7.4.6",
     "xmlhttprequest": "^1.8.0"
   },

--- a/test/unit/spec/signaling/v2/peerconnectionmanager.js
+++ b/test/unit/spec/signaling/v2/peerconnectionmanager.js
@@ -1046,6 +1046,8 @@ function makePeerConnectionV2Constructor(testOptions) {
 
     peerConnectionV2.removeMediaTrackSender = sinon.spy();
 
+    peerConnectionV2.setEffectiveAdaptiveSimulcast = sinon.spy();
+
     peerConnectionV2.setConfiguration = sinon.spy(configuration => {
       peerConnectionV2.configuration = configuration;
     });

--- a/test/unit/spec/signaling/v2/room.js
+++ b/test/unit/spec/signaling/v2/room.js
@@ -1875,6 +1875,7 @@ function makePeerConnectionManager(getRoom) {
   peerConnectionManager.setTrackSenders = sinon.spy(() => {});
   peerConnectionManager.getTrackReceivers = sinon.spy(() => []);
   peerConnectionManager.setIceReconnectTimeout = sinon.spy(() => {});
+  peerConnectionManager.setEffectiveAdaptiveSimulcast = sinon.spy(() => {});
 
   // eslint-disable-next-line require-await
   peerConnectionManager.getStats = async () => {

--- a/test/unit/spec/util/browserdetection.js
+++ b/test/unit/spec/util/browserdetection.js
@@ -3,6 +3,7 @@
 const assert = require('assert');
 const { isIOSChrome } = require('@twilio/webrtc/lib/util');
 
+// eslint-disable-next-line no-warning-comments
 // TODO(joma): Move the contents of this file to twilio-webrtc.js.
 describe('isIOSChrome', () => {
   let oldAgent;

--- a/tsdef/twilio-video-tests.ts
+++ b/tsdef/twilio-video-tests.ts
@@ -344,6 +344,12 @@ function useConnectionOptions() {
   return connectionOptions;
 }
 
+function useAdaptiveSimulcast() {
+  const connectionOptions: Video.ConnectOptions = {
+    preferredVideoCodecs: 'auto',
+  };
+}
+
 function runPreflight() {
   const preflight: Video.PreflightTest = Video.runPreflight('token', { region: 'us1' });
   preflight.on('completed', (report: Video.PreflightTestReport) => {

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -164,7 +164,6 @@ export interface CreateLocalTrackOptions extends MediaTrackConstraints {
 
 export interface ConnectOptions {
   audio?: boolean | CreateLocalTrackOptions;
-  adaptiveSimulcast?: boolean,
   automaticSubscription?: boolean;
   bandwidthProfile?: BandwidthProfileOptions;
   dominantSpeaker?: boolean;
@@ -189,7 +188,7 @@ export interface ConnectOptions {
   networkQuality?: boolean | NetworkQualityConfiguration;
   region?: string;
   preferredAudioCodecs?: Array<AudioCodec | AudioCodecSettings | OpusCodecSettings>;
-  preferredVideoCodecs?: Array<VideoCodec | VideoCodecSettings | VP8CodecSettings>;
+  preferredVideoCodecs?: Array<VideoCodec | VideoCodecSettings | VP8CodecSettings> | 'auto';
 
   /**
    * @deprecated use Video.Logger.


### PR DESCRIPTION
This change implements the proposed API for adaptive simulcast.

Now  `connect` will accept a new value 'auto' for preferredVideoCodecs. This new values would enable adaptive simulcast  and request for 'publisher_hints' msp channel in initial connect message.

To handle the case for P2P room (where we do not want to enable simulcast) SDK will check for availability of publisher_hints msp in `connected` message, and if not available then rollback the offer that was sent with simulcast enabled.


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
