### PR TITLE
VIDEO-6891: remove deleted flag from preflight report.

### DIFF
--- a/lib/preflight/getCombinedConnectionStats.ts
+++ b/lib/preflight/getCombinedConnectionStats.ts
@@ -80,7 +80,6 @@ function makeStandardCandidateStats(input: any) : RTCIceCandidateStats {
     { key: 'priority', type: 'number' },
     { key: 'protocol', altKeys: ['transport'], type: 'string' },
     { key: 'url', type: 'string' },
-    { key: 'deleted', type: 'boolean' },
     { key: 'relayProtocol', type: 'string' },
   ];
 


### PR DESCRIPTION
preflight on Safari was sending boolean value 'deleted' in `RTCIceCandidateStats `. This was not part of the schema causing it to reject the payload.  Fixed this by removing this flag - It was not part of type definition anyways.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
