### PR TITLE
VIDEO-6192 / 6188 - Rollbar error fixes

### DIFF
--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -588,11 +588,23 @@ function createRoomConnectEventPayload(connectOptions) {
     payload[eventProp] = boolToString(!!connectOptions[prop]);
   });
 
-  // numbers and string properties.
-  [['maxVideoBitrate'], ['maxAudioBitrate'], ['iceTransportPolicy'], ['region'], ['name', 'roomName']].forEach(([prop, eventProp]) => {
+  // numbers properties.
+  [['maxVideoBitrate'], ['maxAudioBitrate']].forEach(([prop, eventProp]) => {
     eventProp = eventProp || prop;
-    if (typeof connectOptions[prop] === 'number' || typeof connectOptions[prop] === 'string') {
+    if (typeof connectOptions[prop] === 'number') {
       payload[eventProp] = connectOptions[prop];
+    } else if (typeof connectOptions[prop] === 'string') {
+      payload[eventProp] = Number(connectOptions[prop]);
+    }
+  });
+
+  // string properties.
+  [['iceTransportPolicy'], ['region'], ['name', 'roomName']].forEach(([prop, eventProp]) => {
+    eventProp = eventProp || prop;
+    if (typeof connectOptions[prop] === 'string') {
+      payload[eventProp] = connectOptions[prop];
+    } else if (typeof connectOptions[prop] === 'number' && prop === 'name') {
+      payload[eventProp] = connectOptions[prop].toString();
     }
   });
 

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -593,7 +593,7 @@ function createRoomConnectEventPayload(connectOptions) {
     eventProp = eventProp || prop;
     if (typeof connectOptions[prop] === 'number') {
       payload[eventProp] = connectOptions[prop];
-    } else if (typeof connectOptions[prop] === 'string') {
+    } else if (!isNaN(Number(connectOptions[prop]))) {
       payload[eventProp] = Number(connectOptions[prop]);
     }
   });

--- a/test/unit/spec/util/index.js
+++ b/test/unit/spec/util/index.js
@@ -99,6 +99,11 @@ describe('util', () => {
         expectedPayload: { maxVideoBitrate: 100 },
       },
       {
+        testCase: 'maxVideoBitrate specified as non-number string',
+        connectOptions: { maxVideoBitrate: 'foo' },
+        expectedPayload: {},
+      },
+      {
         testCase: 'maxAudioBitrate specified as number',
         connectOptions: { maxAudioBitrate: 100 },
         expectedPayload: { maxAudioBitrate: 100 },
@@ -107,6 +112,11 @@ describe('util', () => {
         testCase: 'maxAudioBitrate specified as string',
         connectOptions: { maxAudioBitrate: '100' },
         expectedPayload: { maxAudioBitrate: 100 },
+      },
+      {
+        testCase: 'maxAudioBitrate specified as non-number string',
+        connectOptions: { maxAudioBitrate: 'foo' },
+        expectedPayload: {},
       },
       {
         testCase: 'networkQuality true',

--- a/test/unit/spec/util/index.js
+++ b/test/unit/spec/util/index.js
@@ -74,9 +74,14 @@ describe('util', () => {
         expectedPayload: { preferredAudioCodecs: JSON.stringify([{ codec: 'VP8', simulcast: true }]) },
       },
       {
-        testCase: 'name specified',
+        testCase: 'name specified as string',
         connectOptions: { name: 'room name goes here' },
         expectedPayload: { roomName: 'room name goes here' },
+      },
+      {
+        testCase: 'name specified as number',
+        connectOptions: { name: 1234 },
+        expectedPayload: { roomName: '1234' },
       },
       {
         testCase: 'region specified',
@@ -84,13 +89,23 @@ describe('util', () => {
         expectedPayload: { region: 'in1' },
       },
       {
-        testCase: 'maxVideoBitrate specified',
+        testCase: 'maxVideoBitrate specified as number',
         connectOptions: { maxVideoBitrate: 100 },
         expectedPayload: { maxVideoBitrate: 100 },
       },
       {
-        testCase: 'maxAudioBitrate specified',
+        testCase: 'maxVideoBitrate specified as string',
+        connectOptions: { maxVideoBitrate: '100' },
+        expectedPayload: { maxVideoBitrate: 100 },
+      },
+      {
+        testCase: 'maxAudioBitrate specified as number',
         connectOptions: { maxAudioBitrate: 100 },
+        expectedPayload: { maxAudioBitrate: 100 },
+      },
+      {
+        testCase: 'maxAudioBitrate specified as string',
+        connectOptions: { maxAudioBitrate: '100' },
         expectedPayload: { maxAudioBitrate: 100 },
       },
       {


### PR DESCRIPTION
JIRA Tickets:
[VIDEO-6188](https://issues.corp.twilio.com/browse/VIDEO-6188)
[VIDEO-6192](https://issues.corp.twilio.com/browse/VIDEO-6192)

Addresses some of the errors we're seeing in rollbar. Some types (name/roomName) that were meant to be a string came in as integers and others (maxAudioBitrate/maxVideoBitrate) that were meant to be integers could come in as strings. Also added in some extra unit tests to capture and verify these changes.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
