### PR TITLE
no more unhandled rejections in unit tests

### DIFF
--- a/lib/signaling/v2/mediasignaling.js
+++ b/lib/signaling/v2/mediasignaling.js
@@ -50,19 +50,16 @@ class MediaSignaling extends EventEmitter {
     const receiverPromise = this._getReceiver(id).then(receiver => {
       if (receiver.kind !== 'data') {
         this._log.error('Expected a DataTrackReceiver');
-        throw new Error('Expected a DataTrackReceiver');
       } if (this._receiverPromise !== receiverPromise) {
         return;
       }
 
       try {
         this._transport = receiver.toDataTransport();
+        this.emit('ready', this._transport);
       } catch (ex) {
         this._log.error('Failed to toDataTransport');
-        throw new Error('Failed to toDataTransport');
       }
-      this.emit('ready', this._transport);
-
       receiver.once('close', () => this._teardown());
     });
     this._receiverPromise = receiverPromise;

--- a/lib/signaling/v2/mediasignaling.js
+++ b/lib/signaling/v2/mediasignaling.js
@@ -58,7 +58,7 @@ class MediaSignaling extends EventEmitter {
         this._transport = receiver.toDataTransport();
         this.emit('ready', this._transport);
       } catch (ex) {
-        this._log.error('Failed to toDataTransport');
+        this._log.error(`Failed to toDataTransport: ${ex.message}`);
       }
       receiver.once('close', () => this._teardown());
     });

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -904,7 +904,9 @@ class PeerConnectionV2 extends StateMachine {
       log.debug(`Starting ICE reconnect timeout: ${delay}`);
       this._iceReconnectTimeout.start();
     }
-    this.offer();
+    this.offer().catch(ex => {
+      log.error(`offer failed in _initiateIceRestart with: ${ex.message}`);
+    });
   }
 
   /**


### PR DESCRIPTION
CircleCI updated to node version 16.13.0, which handles unhandled promise rejections differently. We need to fix any code rejections that are unhandled.

This rejection was unhandled, but looking closely this rejection was more like assert. Removed the rejection code  (throws) in this case.
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
