### PR TITLE
Video-7401 fix setParameter error

### DIFF
--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -536,7 +536,7 @@ class LocalParticipant extends Participant {
     if (encodingParameters) {
       if (this._signaling.getParameters().adaptiveSimulcast && encodingParameters.maxVideoBitrate) {
         // eslint-disable-next-line new-cap
-        throw E.INVALID_TYPE('encodingParameters.maxVideoBitrate is not compatible with "preferredVideoCodecs=auto');
+        throw E.INVALID_TYPE('encodingParameters', 'encodingParameters.maxVideoBitrate is not compatible with "preferredVideoCodecs=auto"');
       }
 
       ['maxAudioBitrate', 'maxVideoBitrate'].forEach(prop => {

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -167,6 +167,7 @@ describe('connect', function() {
         errorThrown = error;
       }
       assert(errorThrown);
+      assert.equal(errorThrown.message, 'encodingParameters must be an encodingParameters.maxVideoBitrate is not compatible with "preferredVideoCodecs=auto"');
       assert(errorThrown instanceof TypeError);
     });
   });


### PR DESCRIPTION
fixes the error thrown from `localParticipant.setParameter`. 
also includes unit test fixes from (https://github.com/twilio/twilio-video.js/pull/1625)
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
