### PR TITLE
feat(remotevideotrack): Prevent dynamic track switchoffs for PIP

### DIFF
--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -297,6 +297,18 @@ function setupDocumentVisibilityTurnOff(removeVideoTrack) {
   };
 }
 
+/**
+ * Determine if a track exists within a given video/audio element.
+ */
+function containsMediaStreamTrack(element, track) {
+  if (!element || !element.srcObject || !element.srcObject.getVideoTracks) { return false; }
+  const candidates = element.srcObject.getVideoTracks();
+
+  return candidates.find(candidate => {
+    return candidate.id === track.mediaStreamTrack.id;
+  });
+}
+
 function maybeUpdateEnabledHint(removeVideoTrack) {
   if (removeVideoTrack._clientTrackSwitchOffControl !== 'auto') {
     return;
@@ -308,7 +320,9 @@ function maybeUpdateEnabledHint(removeVideoTrack) {
   if (enabled === true) {
     removeVideoTrack._turnOffTimer.clear();
     removeVideoTrack._setRenderHint({ enabled: true });
-  } else if (!removeVideoTrack._turnOffTimer.isSet) {
+  // start the turn off timer if we have not already
+  // or if the track we are attempting to disable is currently being displayed in picture in picture mode
+  } else if (!removeVideoTrack._turnOffTimer.isSet && !containsMediaStreamTrack(document.pictureInPictureElement, removeVideoTrack)) {
     // set the track to be turned off after some delay.
     removeVideoTrack._turnOffTimer.start();
   }


### PR DESCRIPTION
### Description
There's a new utility function, `containsMediaStreamTrack` which can be given an element and a track and determine if the element is currently rendering the track.

We consult this function in `maybeUpdateEnabledHint` which is a key entrypoint into track switchOffs for remote video. If the track we are considering switching off is currently being rendered in the browser's picture-in-picture element, we don't switch it off.

### Motivation and Context
This fixes a bug where if pictureInPicture has been enabled, and a user changes tabs in their browser, the pictureInPicture video element will be switchedOff. Ultimately, there's no helpful visibility check for the picture in picture element. Relying on document.visibility is a bad check for knowing if all remote tracks should be switched off because some remote tracks may be rendered in the picture in picture element.

### How Has This Been Tested?
I've built the SDK locally and utilized it in a sample application. Using Chrome, I enable the picture-in-picture functionality in my sample application, while also enabling automatic switchoffs via the `contentPreferencesAPI`. When I change tabs, the picture in picture video element continues to play and is not switched off.

If I revert this change, rebuild, and test again, the picture-in-picture track is switchedOff in the scenario outlined above. Without any special UI treatment, the user just sees the "last" processed frame of the video track, frozen forever.

## Checklist:
- [ ] My change requires a change to the documentation. (maybe we document bugs, I leave that up to the maintainers).
- [x] All new and existing tests passed.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
