### PR TITLE
Video-6677 consider PIP windows for render hints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ Known Limitations
   - Peer-to-Peer Rooms
 - When the Room is being recorded, the SFU will not disable any simulcast layers of the publisher's VideoTrack.
 
+Bug Fixes
+---------
+
+- Fixed a bug where setting clientTrackSwitchOffControl to `auto` caused the RemoteVideoTrack's to get switched off even while playing in picture-in-picture window. (VIDEO-6677)
+  Note that this fix does not work on firefox because firefox does not yet implement [picture-in-picture](https://developer.mozilla.org/en-US/docs/Web/API/Picture-in-Picture_API) APIs.
 
 2.18.1 (October 29, 2021)
 =========================

--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -171,7 +171,7 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
     return this;
   }
 
-  unObserverPIP(el) {
+  _unObservePip(el) {
     const pipCallbacks = this._elToPipCallbacks.get(el);
     if (pipCallbacks) {
       el.removeEventListener('enterpictureinpicture', pipCallbacks.onEnterPip);
@@ -180,12 +180,12 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
     }
   }
 
-  observerPIP(el) {
+  _observePip(el) {
     const pipCallbacks = this._elToPipCallbacks.get(el);
     if (!pipCallbacks) {
-      const onEnterPip = event => this.onEnterPip(event, el);
-      const onLeavePip = event => this.onLeavePip(event, el);
-      const onResizePip = event => this.onResizePip(event, el);
+      const onEnterPip = event => this._onEnterPip(event, el);
+      const onLeavePip = event => this._onLeavePip(event, el);
+      const onResizePip = event => this._onResizePip(event, el);
 
       el.addEventListener('enterpictureinpicture', onEnterPip);
       el.addEventListener('leavepictureinpicture', onLeavePip);
@@ -193,16 +193,16 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
     }
   }
 
-  onEnterPip(event, videoEl) {
+  _onEnterPip(event, videoEl) {
     this._log.debug('onEnterPip');
-    this._elToPipWindows.set(videoEl, event.pictureInPictureWindow);
-    const { onResizePip } = this._elToPipCallbacks.get(videoEl);
     const pipWindow = event.pictureInPictureWindow;
+    this._elToPipWindows.set(videoEl, pipWindow);
+    const { onResizePip } = this._elToPipCallbacks.get(videoEl);
     pipWindow.addEventListener('resize', onResizePip);
     maybeUpdateEnabledHint(this);
   }
 
-  onLeavePip(event, videoEl) {
+  _onLeavePip(event, videoEl) {
     this._log.debug('onLeavePip');
     this._elToPipWindows.delete(videoEl);
     const { onResizePip } = this._elToPipCallbacks.get(videoEl);
@@ -211,7 +211,7 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
     maybeUpdateEnabledHint(this);
   }
 
-  onResizePip() {
+  _onResizePip() {
     maybeUpdateDimensionHint(this);
   }
 
@@ -231,7 +231,7 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
       this._documentVisibilityTurnOffCleanup = this._documentVisibilityTurnOffCleanup || setupDocumentVisibilityTurnOff(this);
     }
 
-    this.observerPIP(result);
+    this._observePip(result);
     return result;
   }
 
@@ -242,7 +242,7 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
       this._intersectionObserver.unobserve(element);
       this._resizeObserver.unobserve(element);
       this._invisibleElements.delete(element);
-      this.unObserverPIP(element);
+      this._unObservePip(element);
     });
 
     if (this._attachments.size === 0) {

--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -67,6 +67,12 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
       _invisibleElements: {
         value: new WeakSet(),
       },
+      _elToPipCallbacks: {
+        value: new WeakMap(),
+      },
+      _elToPipWindows: {
+        value: new WeakMap(),
+      },
       _turnOffTimer: {
         value: new Timeout(() => {
           this._setRenderHint({ enabled: false });
@@ -165,6 +171,50 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
     return this;
   }
 
+  unObserverPIP(el) {
+    const pipCallbacks = this._elToPipCallbacks.get(el);
+    if (pipCallbacks) {
+      el.removeEventListener('enterpictureinpicture', pipCallbacks.onEnterPip);
+      el.removeEventListener('leavepictureinpicture', pipCallbacks.onLeavePip);
+      this._elToPipCallbacks.delete(el);
+    }
+  }
+
+  observerPIP(el) {
+    const pipCallbacks = this._elToPipCallbacks.get(el);
+    if (!pipCallbacks) {
+      const onEnterPip = event => this.onEnterPip(event, el);
+      const onLeavePip = event => this.onLeavePip(event, el);
+      const onResizePip = event => this.onResizePip(event, el);
+
+      el.addEventListener('enterpictureinpicture', onEnterPip);
+      el.addEventListener('leavepictureinpicture', onLeavePip);
+      this._elToPipCallbacks.set(el, { onEnterPip, onLeavePip, onResizePip });
+    }
+  }
+
+  onEnterPip(event, videoEl) {
+    this._log.debug('onEnterPip');
+    this._elToPipWindows.set(videoEl, event.pictureInPictureWindow);
+    const { onResizePip } = this._elToPipCallbacks.get(videoEl);
+    const pipWindow = event.pictureInPictureWindow;
+    pipWindow.addEventListener('resize', onResizePip);
+    maybeUpdateEnabledHint(this);
+  }
+
+  onLeavePip(event, videoEl) {
+    this._log.debug('onLeavePip');
+    this._elToPipWindows.delete(videoEl);
+    const { onResizePip } = this._elToPipCallbacks.get(videoEl);
+    const pipWindow = event.pictureInPictureWindow;
+    pipWindow.removeEventListener('resize', onResizePip);
+    maybeUpdateEnabledHint(this);
+  }
+
+  onResizePip() {
+    maybeUpdateDimensionHint(this);
+  }
+
   attach(el) {
     const result = super.attach(el);
 
@@ -181,6 +231,7 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
       this._documentVisibilityTurnOffCleanup = this._documentVisibilityTurnOffCleanup || setupDocumentVisibilityTurnOff(this);
     }
 
+    this.observerPIP(result);
     return result;
   }
 
@@ -191,6 +242,7 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
       this._intersectionObserver.unobserve(element);
       this._resizeObserver.unobserve(element);
       this._invisibleElements.delete(element);
+      this.unObserverPIP(element);
     });
 
     if (this._attachments.size === 0) {
@@ -297,34 +349,42 @@ function setupDocumentVisibilityTurnOff(removeVideoTrack) {
   };
 }
 
-function maybeUpdateEnabledHint(removeVideoTrack) {
-  if (removeVideoTrack._clientTrackSwitchOffControl !== 'auto') {
+function maybeUpdateEnabledHint(remoteVideoTrack) {
+  if (remoteVideoTrack._clientTrackSwitchOffControl !== 'auto') {
     return;
   }
 
-  const visibleElements = removeVideoTrack._getAllAttachedElements().filter(el => !removeVideoTrack._invisibleElements.has(el));
-  const enabled = document.visibilityState === 'visible' && visibleElements.length > 0;
+  const visibleElements = remoteVideoTrack._getAllAttachedElements().filter(el => !remoteVideoTrack._invisibleElements.has(el));
+  const pipWindows = remoteVideoTrack._getAllAttachedElements().filter(el => remoteVideoTrack._elToPipWindows.has(el));
+
+  // even when document is invisible we may have track playing in pip window.
+  const enabled = pipWindows.length > 0 || (document.visibilityState === 'visible' && visibleElements.length > 0);
 
   if (enabled === true) {
-    removeVideoTrack._turnOffTimer.clear();
-    removeVideoTrack._setRenderHint({ enabled: true });
-  } else if (!removeVideoTrack._turnOffTimer.isSet) {
+    remoteVideoTrack._turnOffTimer.clear();
+    remoteVideoTrack._setRenderHint({ enabled: true });
+  } else if (!remoteVideoTrack._turnOffTimer.isSet) {
     // set the track to be turned off after some delay.
-    removeVideoTrack._turnOffTimer.start();
+    remoteVideoTrack._turnOffTimer.start();
   }
 }
 
-function maybeUpdateDimensionHint(removeVideoTrack) {
-  if (removeVideoTrack._contentPreferencesMode !== 'auto') {
+function maybeUpdateDimensionHint(remoteVideoTrack) {
+  if (remoteVideoTrack._contentPreferencesMode !== 'auto') {
     return;
   }
 
-  const visibleElements = removeVideoTrack._getAllAttachedElements().filter(el => !removeVideoTrack._invisibleElements.has(el));
-  if (visibleElements.length > 0) {
-    const [{ clientHeight, clientWidth }] = visibleElements.sort((el1, el2) =>
+  const visibleElements = remoteVideoTrack._getAllAttachedElements().filter(el => !remoteVideoTrack._invisibleElements.has(el));
+  const pipElements = remoteVideoTrack._getAllAttachedElements().map(el => {
+    const pipWindow = remoteVideoTrack._elToPipWindows.get(el);
+    return pipWindow ? { clientHeight: pipWindow.height, clientWidth: pipWindow.width } : { clientHeight: 0, clientWidth: 0 };
+  });
+  const totalElements = visibleElements.concat(pipElements);
+  if (totalElements.length > 0) {
+    const [{ clientHeight, clientWidth }] = totalElements.sort((el1, el2) =>
       el2.clientHeight + el2.clientWidth - el1.clientHeight - el1.clientWidth - 1);
     const renderDimensions = { height: clientHeight, width: clientWidth };
-    removeVideoTrack._setRenderHint({ renderDimensions });
+    remoteVideoTrack._setRenderHint({ renderDimensions });
   }
 }
 

--- a/test/lib/document.js
+++ b/test/lib/document.js
@@ -33,6 +33,9 @@ class HTMLElement {
   pause() {
     return Promise.resolve();
   }
+
+  addEventListener() {}
+  removeEventListener() {}
 }
 
 class HTMLBodyElement extends HTMLElement {

--- a/test/unit/spec/media/track/remotemediatrack.js
+++ b/test/unit/spec/media/track/remotemediatrack.js
@@ -253,7 +253,10 @@ const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserv
         track._createElement = sinon.spy(() => {
           // return a unique element.
           return {
-            internalId: Date()
+            internalId: Date(),
+            addEventListener: sinon.spy(),
+            removeEventListener: sinon.spy()
+
           };
         });
       });
@@ -298,7 +301,9 @@ const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserv
         track._createElement = sinon.spy(() => {
           // return a unique element.
           return {
-            internalId: Date()
+            internalId: Date(),
+            addEventListener: sinon.spy(),
+            removeEventListener: sinon.spy()
           };
         });
 

--- a/test/unit/spec/media/track/remotevideotrack.js
+++ b/test/unit/spec/media/track/remotevideotrack.js
@@ -58,7 +58,7 @@ describe('RemoteVideoTrack', () => {
       addEventListenerStub = sinon.spy(document, 'addEventListener');
       removeEventListenerStub = sinon.spy(document, 'removeEventListener');
 
-      const dummyElement = { oncanplay: sinon.spy() };
+      const dummyElement = { oncanplay: sinon.spy(), addEventListener: sinon.spy(), removeEventListener: sinon.spy() };
       document.createElement = sinon.spy(() => {
         return dummyElement;
       });

--- a/test/unit/spec/media/track/remotevideotrack.js
+++ b/test/unit/spec/media/track/remotevideotrack.js
@@ -136,6 +136,11 @@ describe('RemoteVideoTrack', () => {
         sinon.assert.calledWith(resizeObserveSpy, el);
       });
 
+      it('pip events are hooked up', () => {
+        sinon.assert.calledWith(el.addEventListener, 'enterpictureinpicture');
+        sinon.assert.calledWith(el.addEventListener, 'leavepictureinpicture');
+      });
+
       if (effectiveDocVisibility) {
         it('listens for document visibility change', () => {
           sinon.assert.callCount(document.addEventListener, 1);
@@ -188,6 +193,11 @@ describe('RemoteVideoTrack', () => {
       it('ResizeObserver unobserve is called', () => {
         sinon.assert.callCount(resizeUnobserveSpy, 1);
         sinon.assert.calledWith(resizeUnobserveSpy, el);
+      });
+
+      it('pip events are unhooked', () => {
+        sinon.assert.calledWith(el.removeEventListener, 'enterpictureinpicture');
+        sinon.assert.calledWith(el.removeEventListener, 'leavepictureinpicture');
       });
 
       if (effectiveDocVisibility) {


### PR DESCRIPTION
SDK sends hints about video elements considering their visibility and dimensions to SFU. Those hints were not considering picture-in-picture windows. So if PIP window is open and a tab is switched or video element becomes invisible, the track would get switched off. This PIP handling fixes that. 
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
