### PR TITLE
VIDEO-7790: safari replacetrack should reset layers per track dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 New Features
 ------------
 
-- This release introduces a new beta feature **Adaptive Simulcast**. This opt-in feature can be enabled by setting `preferredVideoCodecs="auto"` in ConnectOptions. When joining a group room with this feature enabled, the SDK will use VP8 simulcast, and will enable/disable simulcast layers dynamically, thus improving bandwidth and CPU usage. It works best when used along with `Client Track Switch Off Controls` and `Video Content Preferences`. These two flags allows the SFU to determine which simulcast layers are needed, thus allowing it to disable the layers not needed on publisher side. The beta currently does not support setting a max bitrate for your simulcast layers.
+- This release introduces a new beta feature **Adaptive Simulcast**. This opt-in feature can be enabled by setting `preferredVideoCodecs="auto"` in ConnectOptions. When joining a group room with this feature enabled, the SDK will use VP8 simulcast, and will enable/disable simulcast layers dynamically, thus improving bandwidth and CPU usage. It works best when used along with `Client Track Switch Off Control` and `Video Content Preferences`. These two flags allow the SFU to determine which simulcast layers are needed, thus allowing it to disable the layers not needed on publisher side. The beta currently does not support setting a max bitrate for your simulcast layers.
 
 If your application is currently using VP8 simulcast we recommend that you switch to this option.
 

--- a/lib/media/track/sender.js
+++ b/lib/media/track/sender.js
@@ -93,6 +93,11 @@ class MediaTrackSender extends MediaTrackTransceiver {
     return this;
   }
 
+  /**
+   * applies given encodings, or resets encodings if none specified.
+   * @param {Array<{enabled: boolean, layer_index: number}>|null} encodings
+   * @returns {Promise<string>}
+   */
   setPublisherHint(encodings) {
     // Note(mpatwardhan): since publisher hint applies only to group rooms we only look at 1st call callback.
     const [publisherHintCallback] = Array.from(this._senderToPublisherHintCallbacks.values());
@@ -101,15 +106,8 @@ class MediaTrackSender extends MediaTrackTransceiver {
 
   _replaceTrack(sender, mediaStreamTrack) {
     return sender.replaceTrack(mediaStreamTrack).then(replaceTrackResult => {
-      // clear any publisherHints set for the track.
-      this.setPublisherHint([
-        // eslint-disable-next-line camelcase
-        { enabled: true, layer_index: 0 },
-        // eslint-disable-next-line camelcase
-        { enabled: true, layer_index: 1 },
-        // eslint-disable-next-line camelcase
-        { enabled: true, layer_index: 2 }
-      ]).catch(() => {});
+      // clear any publisherHints and apply default encodings.
+      this.setPublisherHint(null).catch(() => {});
       this.emit('replaced');
       return replaceTrackResult;
     });

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1366,7 +1366,7 @@ class PeerConnectionV2 extends StateMachine {
     if (this._peerConnection.signalingState === 'stable') {
       this._mediaTrackSenderToPublisherHints.forEach(({ deferred, encodings }, mediaTrackSender) => {
         this._mediaTrackSenderToPublisherHints.delete(mediaTrackSender);
-        this._setPublisherHint(mediaTrackSender, encodings, true)
+        this._setPublisherHint(mediaTrackSender, encodings)
           .then(result => deferred.resolve(result))
           .catch(error => deferred.reject(error));
       });
@@ -1376,15 +1376,16 @@ class PeerConnectionV2 extends StateMachine {
   /**
    * updates encodings for simulcast layers of given sender.
    * @param {RTCRtpSender} sender
-   * @param {Array<{enabled: boolean, layer_index: number}>} encodings
+   * @param {Array<{enabled: boolean, layer_index: number}>|null} encodings
    * @returns {Promise<string>} string indicating result of the operation. can be one of
    *  "OK", "INVALID_HINT", "COULD_NOT_APPLY_HINT", "UNKNOWN_TRACK"
    */
-  _setPublisherHint(mediaTrackSender, encodings, _fromQueue) {
+  _setPublisherHint(mediaTrackSender, encodings) {
     if (isFirefox) {
       return Promise.resolve('COULD_NOT_APPLY_HINT');
     }
-    if (!_fromQueue && this._mediaTrackSenderToPublisherHints.has(mediaTrackSender)) {
+
+    if (this._mediaTrackSenderToPublisherHints.has(mediaTrackSender)) {
       // skip any stale hint associated with the mediaTrackSender.
       const queuedHint = this._mediaTrackSenderToPublisherHints.get(mediaTrackSender);
       queuedHint.deferred.resolve('REQUEST_SKIPPED');
@@ -1411,14 +1412,28 @@ class PeerConnectionV2 extends StateMachine {
     }
 
     const parameters = sender.getParameters();
-    encodings.forEach(({ enabled, layer_index: layerIndex }) => {
-      if (parameters.encodings.length > layerIndex) {
-        this._log.debug(`layer:${layerIndex}, active:${parameters.encodings[layerIndex].active} => ${enabled}`);
-        parameters.encodings[layerIndex].active = enabled;
+    if (encodings === null) {
+      // NOTE(mpatwardhan): we are asked to apply/enable default encodings
+      // in response to replaceTrack.
+      if (isSafari) {
+        const { width, height }  = sender.track.getSettings();
+        this._updateEncodings(width, height, parameters.encodings);
       } else {
-        this._log.warn(`invalid layer:${layerIndex}, active:${enabled}`);
+        // enable all encodings.
+        parameters.encodings.forEach(encoding => {
+          encoding.active = true;
+        });
       }
-    });
+    } else {
+      encodings.forEach(({ enabled, layer_index: layerIndex }) => {
+        if (parameters.encodings.length > layerIndex) {
+          this._log.debug(`layer:${layerIndex}, active:${parameters.encodings[layerIndex].active} => ${enabled}`);
+          parameters.encodings[layerIndex].active = enabled;
+        } else {
+          this._log.warn(`invalid layer:${layerIndex}, active:${enabled}`);
+        }
+      });
+    }
 
     return sender.setParameters(parameters).then(() => 'OK').catch(error => {
       this._log.error('Failed to apply publisher hints:', error);

--- a/test/unit/spec/media/track/sender.js
+++ b/test/unit/spec/media/track/sender.js
@@ -215,14 +215,7 @@ describe('MediaTrackSender', () => {
 
       if (publisherHintCallbackSet && replaceTrackSuccess) {
         it('sets default publisher hint', () => {
-          sinon.assert.calledWith(publisherHitCallBack, [
-            // eslint-disable-next-line camelcase
-            { enabled: true, layer_index: 0 },
-            // eslint-disable-next-line camelcase
-            { enabled: true, layer_index: 1 },
-            // eslint-disable-next-line camelcase
-            { enabled: true, layer_index: 2 }
-          ]);
+          sinon.assert.calledWith(publisherHitCallBack, null);
         });
       } else {
         it('does not set default publisher hint', () => {

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -484,8 +484,16 @@ describe('PeerConnectionV2', () => {
         });
       }
       if (signalingState === 'stable') {
-        it('applies given encodings', () => {
-          test.pcv2._setPublisherHint(trackSender, makePublisherHints(0, true));
+        it('applies given encodings if provided', () => {
+          test.pcv2._setPublisherHint(trackSender, makePublisherHints(0, false));
+          const rtpSender = test.pcv2._rtpSenders.get(trackSender);
+          sinon.assert.calledWith(rtpSender.setParameters, sinon.match(parameters => {
+            return parameters.encodings[0].active === false;
+          }));
+        });
+
+        it('resets hints in none provided', () => {
+          test.pcv2._setPublisherHint(trackSender, null);
           const rtpSender = test.pcv2._rtpSenders.get(trackSender);
           sinon.assert.calledWith(rtpSender.setParameters, sinon.match(parameters => {
             return parameters.encodings[0].active === true;


### PR DESCRIPTION
We re-enable simulcast layers (and let SFU know about it) when a track is replaced. 
However since we configure [simulcast layers  on safari depending on track dimensions](https://github.com/twilio/twilio-video.js/pull/1560) - the reset encodings need to reconfigure the layers based on replaced Tracks dimensions. This change ensures that replaceTrack does not enable layers that are were not supposed to be enabled to begin with.  

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
