### PR TITLE
VIDEO-7831 Fix Connect to return CancelablePromise on Type Definitions

### DIFF
--- a/lib/util/cancelablepromise.js
+++ b/lib/util/cancelablepromise.js
@@ -110,6 +110,18 @@ class CancelablePromise {
       promise.then(...args).then(resolve, reject);
     }, this._onCancel);
   }
+
+  /**
+ * @param {?function} onResolved
+ * @returns {CancelablePromise}
+ */
+  finally() {
+    const args = [].slice.call(arguments);
+    const promise = this._promise;
+    return new CancelablePromise(function onCreate() {
+      promise.finally(...args);
+    }, this._onCancel);
+  }
 }
 
 module.exports = CancelablePromise;

--- a/lib/util/cancelablepromise.js
+++ b/lib/util/cancelablepromise.js
@@ -112,7 +112,7 @@ class CancelablePromise {
   }
 
   /**
- * @param {?function} onResolved
+ * @param {?function} onFinally
  * @returns {CancelablePromise}
  */
   finally() {

--- a/lib/util/cancelablepromise.js
+++ b/lib/util/cancelablepromise.js
@@ -118,8 +118,8 @@ class CancelablePromise {
   finally() {
     const args = [].slice.call(arguments);
     const promise = this._promise;
-    return new CancelablePromise(function onCreate() {
-      promise.finally(...args);
+    return new CancelablePromise(function onCreate(resolve, reject) {
+      promise.finally(...args).then(resolve, reject);
     }, this._onCancel);
   }
 }

--- a/lib/util/cancelablepromise.js
+++ b/lib/util/cancelablepromise.js
@@ -110,18 +110,6 @@ class CancelablePromise {
       promise.then(...args).then(resolve, reject);
     }, this._onCancel);
   }
-
-  /**
-   * @param {?function} onResolved
-   * @returns {CancelablePromise}
-   */
-  finally() {
-    const args = [].slice.call(arguments);
-    const promise = this._promise;
-    return new CancelablePromise(function onCreate() {
-      promise.finally(...args);
-    }, this._onCancel);
-  }
 }
 
 module.exports = CancelablePromise;

--- a/lib/util/cancelablepromise.js
+++ b/lib/util/cancelablepromise.js
@@ -110,6 +110,18 @@ class CancelablePromise {
       promise.then(...args).then(resolve, reject);
     }, this._onCancel);
   }
+
+  /**
+   * @param {?function} onResolved
+   * @returns {CancelablePromise}
+   */
+  finally() {
+    const args = [].slice.call(arguments);
+    const promise = this._promise;
+    return new CancelablePromise(function onCreate() {
+      promise.finally(...args);
+    }, this._onCancel);
+  }
 }
 
 module.exports = CancelablePromise;

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "test:framework:install": "npm install chromedriver && npm install selenium-webdriver && npm install geckodriver && npm install puppeteer",
     "test:framework": "npm-run-all test:framework:install test:framework:no-framework test:framework:react",
     "test": "npm-run-all test:unit test:integration",
-    "build:es5": "rimraf ./es5 && tsc tsdef/twilio-video-tests.ts --noEmit && tsc",
+    "build:es5": "rimraf ./es5 && tsc tsdef/twilio-video-tests.ts --noEmit --lib es2018,dom && tsc ",
     "build:js": "node ./scripts/build.js ./src/twilio-video.js ./LICENSE.md ./dist/twilio-video.js",
     "build:min.js": "uglifyjs ./dist/twilio-video.js -o ./dist/twilio-video.min.js --comments \"/^! twilio-video.js/\" -b beautify=false,ascii_only=true",
     "build": "npm-run-all clean lint docs test:unit test:integration build:es5 build:js build:min.js test:umd",

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -744,11 +744,10 @@ describe('connect', function() {
       let room;
       let errorThrown = null;
       try {
-        room = await cancelablePromise;
+        room = await cancelablePromise.finally(onFinally);
       } catch (error) {
         errorThrown = error;
       }
-      await cancelablePromise.finally(onFinally);
       sinon.assert.calledOnce(onFinally);
       assert(!errorThrown);
       assert(room instanceof Room);
@@ -756,13 +755,14 @@ describe('connect', function() {
 
     it('should reject and finally is called', async () => {
       const onFinally = sinon.stub();
+      let err;
       try {
-        await cancelablePromise;
+        await cancelablePromise.finally(onFinally);
         throw new Error('Connecting to room, but expecting to cancel');
       } catch (error) {
-        assert(error);
+        err = error;
       }
-      await cancelablePromise.finally(onFinally);
+      assert(err);
       sinon.assert.calledOnce(onFinally);
     });
   });

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -720,6 +720,27 @@ describe('connect', function() {
     });
   });
 
+  describe('called with a Room name and', () => {
+    let sid;
+    let cancelablePromise;
+
+    before(async () => {
+      sid = await createRoom(randomName(), defaults.topology);
+      const options = Object.assign({ name: sid, tracks: [] }, defaults);
+      cancelablePromise = connect(getToken(randomName()), options);
+    });
+
+    after(() => completeRoom(sid));
+
+    it('should return a promise that resolves to a room', async () => {
+      let finallyCalled = false;
+      await cancelablePromise.finally(() => {
+        finallyCalled = true;
+      });
+      assert(finallyCalled);
+    });
+  });
+
   (isRTCRtpSenderParamsSupported ? describe : describe.skip)('DSCP tagging', () => {
     combinationContext([
       [

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -4,6 +4,7 @@
 const assert = require('assert');
 const { EventEmitter } = require('events');
 const { getUserMedia } = require('@twilio/webrtc');
+const sinon = require('sinon');
 
 const connect = require('../../../es5/connect');
 const { audio: createLocalAudioTrack, video: createLocalVideoTrack } = require('../../../es5/createlocaltrack');
@@ -733,15 +734,13 @@ describe('connect', function() {
     after(() => completeRoom(sid));
 
     it('should return a promise', async () => {
-      let finallyCalled = false;
-      await cancelablePromise.finally(() => {
-        finallyCalled = true;
-      });
-      assert(finallyCalled);
+      const onFinally = sinon.stub();
+      await cancelablePromise.finally(onFinally);
+      sinon.assert.calledOnce(onFinally);
     });
 
     it('should resolve with a room and finally is called', async () => {
-      let finallyCalled = false;
+      const onFinally = sinon.stub();
       let room;
       let errorThrown = null;
       try {
@@ -749,26 +748,22 @@ describe('connect', function() {
       } catch (error) {
         errorThrown = error;
       }
-      await cancelablePromise.finally(() => {
-        finallyCalled = true;
-      });
-      assert(finallyCalled);
+      await cancelablePromise.finally(onFinally);
+      sinon.assert.calledOnce(onFinally);
       assert(!errorThrown);
       assert(room instanceof Room);
     });
 
     it('should reject and finally is called', async () => {
-      let finallyCalled = false;
+      const onFinally = sinon.stub();
       try {
         await cancelablePromise;
         throw new Error('Connecting to room, but expecting to cancel');
       } catch (error) {
         assert(error);
       }
-      await cancelablePromise.finally(() => {
-        finallyCalled = true;
-      });
-      assert(finallyCalled);
+      await cancelablePromise.finally(onFinally);
+      sinon.assert.calledOnce(onFinally);
     });
   });
 

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -720,7 +720,7 @@ describe('connect', function() {
     });
   });
 
-  describe('called with a Room name and', () => {
+  describe.only('called with a Room name and', () => {
     let sid;
     let cancelablePromise;
 
@@ -732,8 +732,39 @@ describe('connect', function() {
 
     after(() => completeRoom(sid));
 
-    it('should return a promise that resolves to a room', async () => {
+    it('should return a promise', async () => {
       let finallyCalled = false;
+      await cancelablePromise.finally(() => {
+        finallyCalled = true;
+      });
+      assert(finallyCalled);
+    });
+
+    it('should resolve with a room and finally is called', async () => {
+      let finallyCalled = false;
+      let room;
+      let errorThrown = null;
+      try {
+        room = await cancelablePromise;
+      } catch (error) {
+        errorThrown = error;
+      }
+      await cancelablePromise.finally(() => {
+        finallyCalled = true;
+      });
+      assert(finallyCalled);
+      assert(!errorThrown);
+      assert(room instanceof Room);
+    });
+
+    it('should reject and finally is called', async () => {
+      let finallyCalled = false;
+      try {
+        await cancelablePromise;
+        throw new Error('Connecting to room, but expecting to cancel');
+      } catch (error) {
+        assert(error);
+      }
       await cancelablePromise.finally(() => {
         finallyCalled = true;
       });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "checkJs": false,
     "declaration": false,
     "target": "es5",
-    "lib": ["es5", "es6", "es2016", "es2019", "es2018.promise", "dom"],
+    "lib": ["es2019", "dom"],
     "downlevelIteration": true,
     "module": "commonjs",
     "noImplicitAny": true,

--- a/tsdef/index.d.ts
+++ b/tsdef/index.d.ts
@@ -1,4 +1,4 @@
-import { ConnectOptions, CreateLocalTrackOptions, CreateLocalTracksOptions, LocalTrack } from './types';
+import { CancelablePromise, ConnectOptions, CreateLocalTrackOptions, CreateLocalTracksOptions, LocalTrack } from './types';
 import { PreflightOptions, PreflightTestReport } from './PreflightTypes';
 import { LocalAudioTrack } from './LocalAudioTrack';
 import { LocalVideoTrack } from './LocalVideoTrack';

--- a/tsdef/index.d.ts
+++ b/tsdef/index.d.ts
@@ -10,7 +10,7 @@ import { Room } from './Room';
 export const isSupported: boolean;
 export const version:string;
 export const Logger: Log.RootLogger;
-export function connect(token: string, options?: ConnectOptions): Promise<Room>;
+export function connect(token: string, options?: ConnectOptions): CancelablePromise<Room>;
 export function createLocalAudioTrack(options?: CreateLocalTrackOptions): Promise<LocalAudioTrack>;
 export function createLocalTracks(options?: CreateLocalTracksOptions): Promise<LocalTrack[]>;
 export function createLocalVideoTrack(options?: CreateLocalTrackOptions): Promise<LocalVideoTrack>;

--- a/tsdef/twilio-video-tests.ts
+++ b/tsdef/twilio-video-tests.ts
@@ -230,6 +230,15 @@ let room: Video.Room | null = null;
 let localVideoTrack: Video.LocalVideoTrack | null = null;
 let localAudioTrack: Video.LocalAudioTrack | null = null;
 
+// Testing finally method
+Video.connect('$TOKEN', {
+  name: 'room-name',
+  video: false,
+  audio: false
+}).finally(() => {
+  return 'Finally Connected to a Room!';
+});
+
 async function initRoom() {
   room = await Video.connect('$TOKEN', {
     name: 'room-name',

--- a/tsdef/twilio-video-tests.ts
+++ b/tsdef/twilio-video-tests.ts
@@ -231,12 +231,16 @@ let localVideoTrack: Video.LocalVideoTrack | null = null;
 let localAudioTrack: Video.LocalAudioTrack | null = null;
 
 // Testing finally method
-Video.connect('$TOKEN', {
+const maybeRoom = Video.connect('$TOKEN', {
   name: 'room-name',
   video: false,
   audio: false
+}).then(room => {
+  return room;
+}).catch(err => {
+  throw new Error(err);
 }).finally(() => {
-  return 'Finally Connected to a Room!';
+  return 'Finally happened!';
 });
 
 async function initRoom() {

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -258,6 +258,7 @@ export class StatsReport {
   remoteAudioTrackStats: RemoteAudioTrackStats[];
   remoteVideoTrackStats: RemoteVideoTrackStats[];
 }
-interface CancelablePromise<T> extends Promise<T> {
+export interface CancelablePromise<T> extends Promise<T> {
   cancel: () => void;
+  finally(onfinally?: (() => void) | undefined | null): Promise<T>;
 }

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -258,3 +258,6 @@ export class StatsReport {
   remoteAudioTrackStats: RemoteAudioTrackStats[];
   remoteVideoTrackStats: RemoteVideoTrackStats[];
 }
+interface CancelablePromise<T> extends Promise<T> {
+  cancel: () => void;
+}

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -260,5 +260,4 @@ export class StatsReport {
 }
 export interface CancelablePromise<T> extends Promise<T> {
   cancel: () => void;
-  finally(onfinally?: (() => void) | undefined | null): Promise<T>;
 }

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -260,4 +260,5 @@ export class StatsReport {
 }
 interface CancelablePromise<T> extends Promise<T> {
   cancel: () => void;
+  finally(onfinally?: (() => void) | undefined | null): Promise<T>
 }

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -260,5 +260,4 @@ export class StatsReport {
 }
 interface CancelablePromise<T> extends Promise<T> {
   cancel: () => void;
-  finally(onfinally?: (() => void) | undefined | null): Promise<T>
 }


### PR DESCRIPTION
This PR fixes an [issue](https://github.com/twilio/twilio-video.js/issues/1647) that was reported by a user. Currently our `connect` method returns a `Promise`, but it's supposed to return a `CancelablePromise`.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
