### PR TITLE
Exponential backoff for render hint retries.

### DIFF
--- a/lib/signaling/v2/renderhintssignaling.js
+++ b/lib/signaling/v2/renderhintssignaling.js
@@ -20,6 +20,8 @@ class RenderHintsSignaling extends MediaSignaling {
       _responseTimer: {
         value: new Timeout(() => {
           this._sendAllHints();
+          // once timer fires, for next round double the delay.
+          this._responseTimer.setDelay(this._responseTimer.delay * 2);
         }, RENDER_HINT_RESPONSE_TIME_MS, false),
       }
     });
@@ -60,6 +62,7 @@ class RenderHintsSignaling extends MediaSignaling {
 
   _processHintResults(hintResults) {
     this._responseTimer.clear();
+    this._responseTimer.setDelay(RENDER_HINT_RESPONSE_TIME_MS);
     hintResults.forEach(hintResult => {
       if (hintResult.result !== 'OK') {
         this._log.debug('Server error processing hint:', hintResult);

--- a/test/integration/spec/audioonlyrooms.js
+++ b/test/integration/spec/audioonlyrooms.js
@@ -17,6 +17,7 @@ const {
   waitFor
 } = require('../../lib/util');
 
+// eslint-disable-next-line no-warning-comments
 // TODO(mmalavalli): Enable tests for firefox once VIDEO-7341 is fixed by the VMS team.
 (topology === 'group' && !isFirefox ? describe : describe.skip)('Audio Only Rooms', function() {
   // eslint-disable-next-line no-invalid-this

--- a/test/unit/spec/signaling/v2/renderhintssignaling.js
+++ b/test/unit/spec/signaling/v2/renderhintssignaling.js
@@ -220,7 +220,7 @@ describe('RenderHintsSignaling', () => {
 
       clock.tick(1000);
       await deferred.promise;
-      assert(publishCalls === 1);
+      assert.equal(publishCalls, 1);
       sinon.assert.calledWith(mst.publish, {
         type: 'render_hints',
         subscriber: {
@@ -266,12 +266,7 @@ describe('RenderHintsSignaling', () => {
         }
       });
 
-      // simulate bunch of clock ticks at 2 second intervals for 40 seconds.
-      let timeToWait = 40000;
-      while (timeToWait > 0) {
-        clock.tick(2000); // simulate 2 seconds
-        timeToWait -= 2000;
-      }
+      clock.tick(40000); // simulate 40 seconds
 
       // we expect 2nd retry to be made 2 second after 1st, and subsequent retries at exponential intervals.
       assert.equal(publishCalls, 6);

--- a/test/unit/spec/signaling/v2/renderhintssignaling.js
+++ b/test/unit/spec/signaling/v2/renderhintssignaling.js
@@ -148,7 +148,7 @@ describe('RenderHintsSignaling', () => {
 
       // wait for message to get published.
       await deferred.promise;
-      assert(publishCalls, 1);
+      assert.equal(publishCalls, 1);
       sinon.assert.calledWith(mst.publish, {
         type: 'render_hints',
         subscriber: {
@@ -166,7 +166,7 @@ describe('RenderHintsSignaling', () => {
       // send another hint
       subject.setTrackHint('bar', { enabled: true, renderDimensions: { width: 200, height: 200 } });
       await waitForSometime(10);
-      assert(publishCalls, 1);
+      assert.equal(publishCalls, 1);
 
       const serverMessage = {
         'type': 'render_hints',
@@ -188,7 +188,7 @@ describe('RenderHintsSignaling', () => {
       deferred = defer();
       mst.emit('message', serverMessage);
       await deferred.promise;
-      assert(publishCalls, 2);
+      assert.equal(publishCalls, 2);
       sinon.assert.calledWith(mst.publish, {
         type: 'render_hints',
         subscriber: {
@@ -202,24 +202,25 @@ describe('RenderHintsSignaling', () => {
       });
     });
 
-    it('re-sends all hints if server does not respond', async function() {
-      // eslint-disable-next-line no-invalid-this
-      this.timeout(10 * 1000); // this test takes more than 2 seconds.
+    it('re-sends all hints with exponential backoff until server responds', async function() {
+      let clock = sinon.useFakeTimers();
       const mst = makeTransport();
       const subject = makeTest(mst);
       subject.setTrackHint('foo', { enabled: true, renderDimensions: { width: 100, height: 100 } });
       subject.setTrackHint('boo', { enabled: false });
 
       let publishCalls = 0;
+      let publishTimes = [];
       let deferred = defer();
       mst.publish.callsFake(() => {
         publishCalls++;
+        publishTimes.push(Date.now());
         deferred.resolve();
       });
 
-      // wait for message to get published.
+      clock.tick(1000);
       await deferred.promise;
-      assert(publishCalls, 1);
+      assert(publishCalls === 1);
       sinon.assert.calledWith(mst.publish, {
         type: 'render_hints',
         subscriber: {
@@ -237,13 +238,12 @@ describe('RenderHintsSignaling', () => {
 
       // send another hint
       subject.setTrackHint('bar', { enabled: true, renderDimensions: { width: 200, height: 200 } });
-      await waitForSometime(50);
-      assert(publishCalls, 1);
+      assert.equal(publishCalls, 1);
 
-      // now wait longer w/o server response
-      deferred = defer();
-      await deferred.promise;
-      assert(publishCalls, 2);
+      clock.tick(2000); // simulate 2 seconds
+
+      // we should expect 1st retry  now.
+      assert.equal(publishCalls, 2);
 
       // expect publish to be called with all the hints.
       sinon.assert.calledWith(mst.publish, {
@@ -265,6 +265,48 @@ describe('RenderHintsSignaling', () => {
           }]
         }
       });
+
+      // simulate bunch of clock ticks at 2 second intervals for 40 seconds.
+      let timeToWait = 40000;
+      while (timeToWait > 0) {
+        clock.tick(2000); // simulate 2 seconds
+        timeToWait -= 2000;
+      }
+
+      // we expect 2nd retry to be made 2 second after 1st, and subsequent retries at exponential intervals.
+      assert.equal(publishCalls, 6);
+      assert.equal(publishTimes[2] - publishTimes[1], 2000);
+      assert.equal(publishTimes[3] - publishTimes[2], 4000);
+      assert.equal(publishTimes[4] - publishTimes[3], 8000);
+      assert.equal(publishTimes[5] - publishTimes[4], 16000);
+
+      // simulate a server response.
+      const serverMessage = {
+        'type': 'render_hints',
+        'subscriber': {
+          'id': 42,
+          'hints': [
+            {
+              'track': 'foo',
+              'result': 'OK'
+            },
+            {
+              'track': 'boo',
+              'result': 'INVALID_RENDER_HINT'
+            },
+            {
+              'track': 'bar',
+              'result': 'OK'
+            }
+          ]
+        }
+      };
+      mst.emit('message', serverMessage);
+
+      // simulate more time and verify that timer stops retrying.
+      clock.tick(100000); // simulate 100 seconds
+      assert.equal(publishCalls, 6);
+      clock.restore();
     });
   });
 


### PR DESCRIPTION
We add [retry logic](https://github.com/twilio/twilio-video.js/pull/1655) for render hint responses. This change makes this timer backoff exponentially...starting with 2 seconds, and then 4 and then 8 and so on.
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
