### PR TITLE
VIDEO-7928: configure chrome simulcast layers

### DIFF
--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -505,16 +505,17 @@ class PeerConnectionV2 extends StateMachine {
    *
    * @param {MediaStreamTrack} track
    * @param {Array<RTCRtpEncodingParameters>} encodings
+   * @param {boolean} disableOnly - if true, the function will only disable encoding as needed.
    * @returns {boolean} true if encodings were updated.
    */
-  _maybeUpdateEncodings(track, encodings) {
+  _maybeUpdateEncodings(track, encodings, disableOnly = false) {
     const shouldUpdate = this._shouldUpdateEncodings(track);
     if (!shouldUpdate) {
       return false;
     }
 
     const { width, height }  = track.getSettings();
-    this._updateEncodings(width, height, encodings);
+    this._updateEncodings(width, height, encodings, disableOnly);
     return true;
   }
   /**
@@ -522,8 +523,9 @@ class PeerConnectionV2 extends StateMachine {
    * @param {number} width
    * @param {number} height
    * @param {Array<RTCRtpEncodingParameters>} encodings
+   * @param {boolean} disableOnly - if true, the function will only disable encoding as needed.
    */
-  _updateEncodings(width, height, encodings) {
+  _updateEncodings(width, height, encodings, disableOnly) {
     // NOTE(mpatwardhan): All the simulcast encodings in Safari have
     // the same resolution. So, here we make sure that the lower layers have
     // lower resolution, as seen in Chrome.
@@ -537,7 +539,10 @@ class PeerConnectionV2 extends StateMachine {
     const activeLayersInfo = pixelsToMaxActiveLayers.find(layer => trackPixels >= layer.pixels);
     const activeLayers = Math.min(encodings.length, activeLayersInfo.maxActiveLayers);
     encodings.forEach((encoding, i) => {
-      encoding.active = i < activeLayers;
+      const enabled  = i < activeLayers;
+      if (!disableOnly || !enabled) {
+        encoding.active = enabled;
+      }
       if (encoding.active) {
         encoding.scaleResolutionDownBy = 1 << (activeLayers - i - 1);
       } else {
@@ -1462,6 +1467,9 @@ class PeerConnectionV2 extends StateMachine {
           this._log.warn(`invalid layer:${layerIndex}, active:${enabled}`);
         }
       });
+
+      // disable any encoding that shouldn't have been enabled by publisher_hints.
+      this._maybeUpdateEncodings(sender.track, parameters.encodings, true /* disableOnly */);
     }
 
     return sender.setParameters(parameters).then(() => 'OK').catch(error => {

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -498,10 +498,10 @@ class PeerConnectionV2 extends StateMachine {
   /**
    * @param {MediaStreamTrack} track
    * @param {Array<RTCRtpEncodingParameters>} encodings
-   * @param {boolean} disableOnly - if true, the function will only disable encoding as needed.
+   * @param {boolean} trackReplaced
    * @returns {boolean} true if encodings were updated.
    */
-  _maybeUpdateEncodings(track, encodings, disableOnly = false) {
+  _maybeUpdateEncodings(track, encodings, trackReplaced = false) {
     if (track.kind !== 'video') {
       return false;
     }
@@ -510,18 +510,21 @@ class PeerConnectionV2 extends StateMachine {
     // Note(mpatwardhan): always configure encodings  always for safari.
     // for chrome only when adaptive simulcast enabled.
     if (browser === 'safari' || (browser === 'chrome' && this._isAdaptiveSimulcastEnabled())) {
-      return this._updateEncodings(track, encodings, disableOnly);
+      return this._updateEncodings(track, encodings, trackReplaced);
     }
     return false;
   }
 
   /**
-   * Updates simulcast layer encodings
+   * Configures with default encodings depending on track type and resolution.
+   * Default configuration sets some encodings to disabled, and for others set scaleResolutionDownBy
+   * values. When trackReplaced is set to true, it will clear 'active' for any encodings that
+   * needs to be enabled.
    * @param {MediaStreamTrack} track
    * @param {Array<RTCRtpEncodingParameters>} encodings
-   * @param {boolean} disableOnly - if true, the function will only disable encoding as needed.
+   * @param {boolean} trackReplaced
    */
-  _updateEncodings(track, encodings, disableOnly) {
+  _updateEncodings(track, encodings, trackReplaced) {
     if (this._isChromeScreenShareTrack(track)) {
       // for screen share track only enable 2 layers.
       const screenShareActiveLayerConfig = [
@@ -530,12 +533,13 @@ class PeerConnectionV2 extends StateMachine {
       ];
       encodings.forEach((encoding, i) => {
         const activeLayerConfig = screenShareActiveLayerConfig[i];
-        if (!disableOnly || !activeLayerConfig) {
-          encoding.active = !!activeLayerConfig;
-        }
-        if (encoding.active) {
+        if (activeLayerConfig) {
           encoding.scaleResolutionDownBy = activeLayerConfig.scaleResolutionDownBy;
+          if (trackReplaced) {
+            delete encoding.active;
+          }
         } else {
+          encoding.active = false;
           delete encoding.scaleResolutionDownBy;
         }
       });
@@ -554,17 +558,18 @@ class PeerConnectionV2 extends StateMachine {
       const activeLayers = Math.min(encodings.length, activeLayersInfo.maxActiveLayers);
       encodings.forEach((encoding, i) => {
         const enabled  = i < activeLayers;
-        if (!disableOnly || !enabled) {
-          encoding.active = enabled;
-        }
-        if (encoding.active) {
+        if (enabled) {
           encoding.scaleResolutionDownBy = 1 << (activeLayers - i - 1);
+          if (trackReplaced) {
+            delete encoding.active;
+          }
         } else {
+          encoding.active = false;
           delete encoding.scaleResolutionDownBy;
         }
       });
     }
-    this._log.warn('_updateEncodings:', encodings.map(({ active, scaleResolutionDownBy }, i) => `[${i}: ${active}, ${scaleResolutionDownBy || 0}]`).join(', '));
+    this._log.debug('_updateEncodings:', encodings.map(({ active, scaleResolutionDownBy }, i) => `[${i}: ${active}, ${scaleResolutionDownBy || 0}]`).join(', '));
     return true;
   }
 
@@ -1465,16 +1470,7 @@ class PeerConnectionV2 extends StateMachine {
     }
 
     const parameters = sender.getParameters();
-    if (encodings === null) {
-      // NOTE(mpatwardhan): we are asked to apply/enable default encodings
-      // in response to replaceTrack.
-      if (!this._maybeUpdateEncodings(sender.track, parameters.encodings)) {
-        // enable all encodings.
-        parameters.encodings.forEach(encoding => {
-          encoding.active = true;
-        });
-      }
-    } else {
+    if (encodings !== null) {
       encodings.forEach(({ enabled, layer_index: layerIndex }) => {
         if (parameters.encodings.length > layerIndex) {
           this._log.debug(`layer:${layerIndex}, active:${parameters.encodings[layerIndex].active} => ${enabled}`);
@@ -1483,10 +1479,13 @@ class PeerConnectionV2 extends StateMachine {
           this._log.warn(`invalid layer:${layerIndex}, active:${enabled}`);
         }
       });
-
-      // disable any encoding that shouldn't have been enabled by publisher_hints.
-      this._maybeUpdateEncodings(sender.track, parameters.encodings, true /* disableOnly */);
     }
+
+    // Note(mpatwardhan): after publisher hints are applied, overwrite with default encodings
+    // to disable any encoding that shouldn't have been enabled by publisher_hints.
+    // When encodings===null (that is we are asked to reset encodings for replaceTrack)
+    // along with disabling encodings, clear active flag for encodings that should not be disabled
+    this._maybeUpdateEncodings(sender.track, parameters.encodings, encodings === null /* trackReplaced */);
 
     return sender.setParameters(parameters).then(() => 'OK').catch(error => {
       this._log.error('Failed to apply publisher hints:', error);
@@ -1918,7 +1917,7 @@ function updateEncodingParameters(pcv2) {
       params.encodings[0].networkPriority = 'high';
     }
 
-    pcv2._maybeUpdateEncodings(sender.track, params.encodings);
+    pcv2._maybeUpdateEncodings(sender.track, params.encodings, false /* trackReplaced */);
 
     const promise = sender.setParameters(params).catch(error => {
       pcv2._log.warn(`Error while setting encodings parameters for ${sender.track.kind} Track ${sender.track.id}: ${error.message || error.name}`);

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -507,11 +507,13 @@ class PeerConnectionV2 extends StateMachine {
     }
     const browser = util.guessBrowser();
 
-    // Note(mpatwardhan): always configure encodings  always for safari.
+    // Note(mpatwardhan): always configure encodings for safari.
     // for chrome only when adaptive simulcast enabled.
     if (browser === 'safari' || (browser === 'chrome' && this._isAdaptiveSimulcastEnabled())) {
-      return this._updateEncodings(track, encodings, trackReplaced);
+      this._updateEncodings(track, encodings, trackReplaced);
+      return true;
     }
+
     return false;
   }
 
@@ -570,7 +572,6 @@ class PeerConnectionV2 extends StateMachine {
       });
     }
     this._log.debug('_updateEncodings:', encodings.map(({ active, scaleResolutionDownBy }, i) => `[${i}: ${active}, ${scaleResolutionDownBy || 0}]`).join(', '));
-    return true;
   }
 
   /**

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -487,8 +487,8 @@ class PeerConnectionV2 extends StateMachine {
   }
 
   /**
-   *
-   * @returns true if adaptive simulcast is effective.
+   * Whether adaptive simulcast is enabled.
+   * @returns {boolean}
    */
   _isAdaptiveSimulcastEnabled() {
     const adaptiveSimulcastEntry = this._preferredVideoCodecs.find(cs => 'adaptiveSimulcast' in cs);
@@ -528,7 +528,6 @@ class PeerConnectionV2 extends StateMachine {
    */
   _updateEncodings(track, encodings, trackReplaced) {
     if (this._isChromeScreenShareTrack(track)) {
-      // for screen share track only enable 2 layers.
       const screenShareActiveLayerConfig = [
         { scaleResolutionDownBy: 1 },
         { scaleResolutionDownBy: 1 }

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -10,7 +10,8 @@ const {
   getStats: getStatistics
 } = require('@twilio/webrtc');
 
-const { guessBrowser } = require('@twilio/webrtc/lib/util');
+const util = require('@twilio/webrtc/lib/util');
+const { guessBrowser } = util;
 const { getSdpFormat } = require('@twilio/webrtc/lib/util/sdp');
 
 const {
@@ -485,6 +486,37 @@ class PeerConnectionV2 extends StateMachine {
     return true;
   }
 
+  _shouldUpdateEncodings(track) {
+    if (track.kind !== 'video') {
+      return false;
+    }
+
+    if (util.guessBrowser() === 'safari') {
+      return true;
+    }
+
+    // NOTE(mpatwardhan):for chrome, update only non-screen share tracks, and only if adaptiveSimulcast is enabled.
+    const adaptiveSimulcastEntry = this._preferredVideoCodecs.find(cs => 'adaptiveSimulcast' in cs);
+    const adaptiveSimulcastEnabled = adaptiveSimulcastEntry && adaptiveSimulcastEntry.adaptiveSimulcast === true;
+    return util.guessBrowser() === 'chrome' && adaptiveSimulcastEnabled && !this._isChromeScreenShareTrack(track);
+  }
+
+  /**
+   *
+   * @param {MediaStreamTrack} track
+   * @param {Array<RTCRtpEncodingParameters>} encodings
+   * @returns {boolean} true if encodings were updated.
+   */
+  _maybeUpdateEncodings(track, encodings) {
+    const shouldUpdate = this._shouldUpdateEncodings(track);
+    if (!shouldUpdate) {
+      return false;
+    }
+
+    const { width, height }  = track.getSettings();
+    this._updateEncodings(width, height, encodings);
+    return true;
+  }
   /**
    * Updates scaleResolutionDownBy for encoding layers.
    * @param {number} width
@@ -1415,10 +1447,7 @@ class PeerConnectionV2 extends StateMachine {
     if (encodings === null) {
       // NOTE(mpatwardhan): we are asked to apply/enable default encodings
       // in response to replaceTrack.
-      if (isSafari) {
-        const { width, height }  = sender.track.getSettings();
-        this._updateEncodings(width, height, parameters.encodings);
-      } else {
+      if (!this._maybeUpdateEncodings(sender.track, parameters.encodings)) {
         // enable all encodings.
         parameters.encodings.forEach(encoding => {
           encoding.active = true;
@@ -1865,11 +1894,7 @@ function updateEncodingParameters(pcv2) {
       params.encodings[0].networkPriority = 'high';
     }
 
-    if (isSafari && sender.track.kind === 'video') {
-      const { width, height }  = sender.track.getSettings();
-      pcv2._updateEncodings(width, height, params.encodings);
-    }
-
+    pcv2._maybeUpdateEncodings(sender.track, params.encodings);
 
     const promise = sender.setParameters(params).catch(error => {
       pcv2._log.warn(`Error while setting encodings parameters for ${sender.track.kind} Track ${sender.track.id}: ${error.message || error.name}`);

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -486,70 +486,86 @@ class PeerConnectionV2 extends StateMachine {
     return true;
   }
 
-  _shouldUpdateEncodings(track) {
-    if (track.kind !== 'video') {
-      return false;
-    }
-
-    if (util.guessBrowser() === 'safari') {
-      return true;
-    }
-
-    // NOTE(mpatwardhan):for chrome, update only non-screen share tracks, and only if adaptiveSimulcast is enabled.
+  /**
+   *
+   * @returns true if adaptive simulcast is effective.
+   */
+  _isAdaptiveSimulcastEnabled() {
     const adaptiveSimulcastEntry = this._preferredVideoCodecs.find(cs => 'adaptiveSimulcast' in cs);
-    const adaptiveSimulcastEnabled = adaptiveSimulcastEntry && adaptiveSimulcastEntry.adaptiveSimulcast === true;
-    return util.guessBrowser() === 'chrome' && adaptiveSimulcastEnabled && !this._isChromeScreenShareTrack(track);
+    return adaptiveSimulcastEntry && adaptiveSimulcastEntry.adaptiveSimulcast === true;
   }
 
   /**
-   *
    * @param {MediaStreamTrack} track
    * @param {Array<RTCRtpEncodingParameters>} encodings
    * @param {boolean} disableOnly - if true, the function will only disable encoding as needed.
    * @returns {boolean} true if encodings were updated.
    */
   _maybeUpdateEncodings(track, encodings, disableOnly = false) {
-    const shouldUpdate = this._shouldUpdateEncodings(track);
-    if (!shouldUpdate) {
+    if (track.kind !== 'video') {
       return false;
     }
+    const browser = util.guessBrowser();
 
-    const { width, height }  = track.getSettings();
-    this._updateEncodings(width, height, encodings, disableOnly);
-    return true;
+    // Note(mpatwardhan): always configure encodings  always for safari.
+    // for chrome only when adaptive simulcast enabled.
+    if (browser === 'safari' || (browser === 'chrome' && this._isAdaptiveSimulcastEnabled())) {
+      return this._updateEncodings(track, encodings, disableOnly);
+    }
+    return false;
   }
+
   /**
-   * Updates scaleResolutionDownBy for encoding layers.
-   * @param {number} width
-   * @param {number} height
+   * Updates simulcast layer encodings
+   * @param {MediaStreamTrack} track
    * @param {Array<RTCRtpEncodingParameters>} encodings
    * @param {boolean} disableOnly - if true, the function will only disable encoding as needed.
    */
-  _updateEncodings(width, height, encodings, disableOnly) {
-    // NOTE(mpatwardhan): All the simulcast encodings in Safari have
-    // the same resolution. So, here we make sure that the lower layers have
-    // lower resolution, as seen in Chrome.
-    const pixelsToMaxActiveLayers = [
-      { pixels: 960 * 540, maxActiveLayers: 3 },
-      { pixels: 480 * 270, maxActiveLayers: 2 },
-      { pixels: 0, maxActiveLayers: 1 }
-    ];
+  _updateEncodings(track, encodings, disableOnly) {
+    if (this._isChromeScreenShareTrack(track)) {
+      // for screen share track only enable 2 layers.
+      const screenShareActiveLayerConfig = [
+        { scaleResolutionDownBy: 1 },
+        { scaleResolutionDownBy: 1 }
+      ];
+      encodings.forEach((encoding, i) => {
+        const activeLayerConfig = screenShareActiveLayerConfig[i];
+        if (!disableOnly || !activeLayerConfig) {
+          encoding.active = !!activeLayerConfig;
+        }
+        if (encoding.active) {
+          encoding.scaleResolutionDownBy = activeLayerConfig.scaleResolutionDownBy;
+        } else {
+          delete encoding.scaleResolutionDownBy;
+        }
+      });
+    } else {
+      const { width, height }  = track.getSettings();
+      // NOTE(mpatwardhan): for non-screen share tracks
+      // enable layers depending on track resolutions
+      const pixelsToMaxActiveLayers = [
+        { pixels: 960 * 540, maxActiveLayers: 3 },
+        { pixels: 480 * 270, maxActiveLayers: 2 },
+        { pixels: 0, maxActiveLayers: 1 }
+      ];
 
-    const trackPixels =  width * height;
-    const activeLayersInfo = pixelsToMaxActiveLayers.find(layer => trackPixels >= layer.pixels);
-    const activeLayers = Math.min(encodings.length, activeLayersInfo.maxActiveLayers);
-    encodings.forEach((encoding, i) => {
-      const enabled  = i < activeLayers;
-      if (!disableOnly || !enabled) {
-        encoding.active = enabled;
-      }
-      if (encoding.active) {
-        encoding.scaleResolutionDownBy = 1 << (activeLayers - i - 1);
-      } else {
-        delete encoding.scaleResolutionDownBy;
-      }
-      this._log.debug(`setting up simulcast layer ${i} with active = ${encoding.active}, scaleResolutionDownBy = ${encoding.scaleResolutionDownBy}`);
-    });
+      const trackPixels =  width * height;
+      const activeLayersInfo = pixelsToMaxActiveLayers.find(layer => trackPixels >= layer.pixels);
+      const activeLayers = Math.min(encodings.length, activeLayersInfo.maxActiveLayers);
+      encodings.forEach((encoding, i) => {
+        const enabled  = i < activeLayers;
+        if (!disableOnly || !enabled) {
+          encoding.active = enabled;
+        }
+        if (encoding.active) {
+          encoding.scaleResolutionDownBy = 1 << (activeLayers - i - 1);
+        } else {
+          delete encoding.scaleResolutionDownBy;
+        }
+      });
+    }
+    this._log.warn('_updateEncodings:', encodings.map(({ active, scaleResolutionDownBy }, i) => `[${i}: ${active}, ${scaleResolutionDownBy || 0}]`).join(', '));
+    return true;
   }
 
   /**

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -490,7 +490,7 @@ class PeerConnectionV2 extends StateMachine {
    * Whether adaptive simulcast is enabled.
    * @returns {boolean}
    */
-  _isAdaptiveSimulcastEnabled() {
+  get _isAdaptiveSimulcastEnabled() {
     const adaptiveSimulcastEntry = this._preferredVideoCodecs.find(cs => 'adaptiveSimulcast' in cs);
     return adaptiveSimulcastEntry && adaptiveSimulcastEntry.adaptiveSimulcast === true;
   }
@@ -509,7 +509,7 @@ class PeerConnectionV2 extends StateMachine {
 
     // Note(mpatwardhan): always configure encodings for safari.
     // for chrome only when adaptive simulcast enabled.
-    if (browser === 'safari' || (browser === 'chrome' && this._isAdaptiveSimulcastEnabled())) {
+    if (browser === 'safari' || (browser === 'chrome' && this._isAdaptiveSimulcastEnabled)) {
       this._updateEncodings(track, encodings, trackReplaced);
       return true;
     }

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -812,8 +812,7 @@ function inRange(num, min, max) {
 function isChromeScreenShareTrack(track) {
   // NOTE(mpatwardhan): Chrome creates screen share tracks with label like: "screen:69734272*"
   // we will check for label that starts with "screen:D" where D being a digit.
-  const isChrome = util.guessBrowser() === 'chrome';
-  return isChrome && track.kind === 'video' && track.label && (/^screen:[0-9]+/.test(track.label) || /^web-contents-media-stream:[0-9/]+/.test(track.label) || /^window:[0-9]+/.test(track.label));
+  return util.guessBrowser() === 'chrome' && track.kind === 'video' && 'displaySurface' in track.getSettings();
 }
 
 

--- a/lib/util/sdp/simulcast.js
+++ b/lib/util/sdp/simulcast.js
@@ -64,7 +64,14 @@ class TrackAttributes {
     if (this.isSimulcastEnabled) {
       return;
     }
-    const simulcastSSRCs = [createSSRC(), createSSRC()];
+
+    const originalSSRCs = Array.from(this.primarySSRCs.values());
+    let previousSSRC = 0;
+    if (originalSSRCs.length) {
+      // we will use original ssrc value to generate new values.
+      previousSSRC = Number(originalSSRCs[originalSSRCs.length - 1]);
+    }
+    const simulcastSSRCs = previousSSRC ? [String(previousSSRC + 1), String(previousSSRC + 2)] : [createSSRC(), createSSRC()];
     simulcastSSRCs.forEach(function(ssrc) {
       this.primarySSRCs.add(ssrc);
     }, this);

--- a/lib/util/sdp/simulcast.js
+++ b/lib/util/sdp/simulcast.js
@@ -64,14 +64,7 @@ class TrackAttributes {
     if (this.isSimulcastEnabled) {
       return;
     }
-
-    const originalSSRCs = Array.from(this.primarySSRCs.values());
-    let previousSSRC = 0;
-    if (originalSSRCs.length) {
-      // we will use original ssrc value to generate new values.
-      previousSSRC = Number(originalSSRCs[originalSSRCs.length - 1]);
-    }
-    const simulcastSSRCs = previousSSRC ? [String(previousSSRC + 1), String(previousSSRC + 2)] : [createSSRC(), createSSRC()];
+    const simulcastSSRCs = [createSSRC(), createSSRC()];
     simulcastSSRCs.forEach(function(ssrc) {
       this.primarySSRCs.add(ssrc);
     }, this);

--- a/test/integration/spec/bandwidthprofile/publisherhints.js
+++ b/test/integration/spec/bandwidthprofile/publisherhints.js
@@ -175,7 +175,6 @@ if (defaults.topology !== 'peer-to-peer' && !isFirefox) {
     [
       { width: 1280, height: 720, expectedActive: 3 },
       { width: 640, height: 480, expectedActive: 2 },
-      { width: 480, height: 270, expectedActive: 2 },
       { width: 320, height: 180, expectedActive: 1 },
     ].forEach(({ width, height, expectedActive }) => {
       it(`are configured correctly for ${width}x${height}`, async () => {
@@ -186,13 +185,11 @@ if (defaults.topology !== 'peer-to-peer' && !isFirefox) {
           ...defaults,
           tracks: [aliceLocalVideo],
           name: roomSid,
-          loggerName: 'AliceLogger',
           preferredVideoCodecs: 'auto',
           bandwidthProfile
         });
         console.log('room sid: ', aliceRoom.sid);
-        Logger.getLogger('AliceLogger').setLevel('WARN');
-        const { activeLayers, inactiveLayers } = await getActiveLayers({ room: aliceRoom, initialWaitMS: 1000, activeTimeMS: 20000 });
+        const { activeLayers, inactiveLayers } = await getActiveLayers({ room: aliceRoom, initialWaitMS: 0, activeTimeMS: 30000 });
         assert.equal(activeLayers.length, expectedActive);
         assert.equal(activeLayers.length + inactiveLayers.length, 3);
         aliceRoom.disconnect();

--- a/test/integration/spec/bandwidthprofile/publisherhints.js
+++ b/test/integration/spec/bandwidthprofile/publisherhints.js
@@ -37,32 +37,11 @@ async function getSimulcastLayerReport(room) {
 
 // for a given room, returns array of simulcast layers that are active.
 // it checks for active layers by gathering layer stats activeTimeMS apart.
-async function getActiveLayers({ room, initialWaitMS = 15 * SECOND, activeTimeMS = 3 * SECOND, intermediatePrefix = '' }) {
+async function getActiveLayers({ room, initialWaitMS = 15 * SECOND, activeTimeMS = 3 * SECOND }) {
   await waitForSometime(initialWaitMS);
   const layersBefore = await getSimulcastLayerReport(room);
   await waitForSometime(activeTimeMS);
   const layersAfter = await getSimulcastLayerReport(room);
-  // debug code.
-  // if (intermediatePrefix) {
-  //   await waitForSometime(initialWaitMS);
-  // } else {
-  //   for (let i = 0; i < initialWaitMS / 1000; i++) {
-  //     // eslint-disable-next-line no-await-in-loop
-  //     await getActiveLayers({ room, initialWaitMS: 0, activeTimeMS: 1 * SECOND, intermediatePrefix: `initial ${i}/${initialWaitMS / 1000}` });
-  //   }
-  // }
-
-  // const layersBefore = await getSimulcastLayerReport(room);
-
-  // if (intermediatePrefix) {
-  //   await waitForSometime(activeTimeMS);
-  // } else {
-  //   for (let i = 0; i < activeTimeMS / 1000; i++) {
-  //     // eslint-disable-next-line no-await-in-loop
-  //     await getActiveLayers({ room, initialWaitMS: 0, activeTimeMS: 1 * SECOND, intermediatePrefix: `${i}/${activeTimeMS / 1000}` });
-  //   }
-  // }
-  // const layersAfter = await getSimulcastLayerReport(room);
 
   const activeLayers = [];
   const inactiveLayers = [];
@@ -86,7 +65,7 @@ async function getActiveLayers({ room, initialWaitMS = 15 * SECOND, activeTimeMS
     return layers.map(({ ssrc, width, height }) => `${ssrc}: ${width}x${height}`).join(', ');
   }
 
-  console.log(`${intermediatePrefix || ' *** '}: active: ${layersToString(activeLayers)}, inactive: ${layersToString(inactiveLayers)}`);
+  console.log(`active: ${layersToString(activeLayers)}, inactive: ${layersToString(inactiveLayers)}`);
   return { activeLayers, inactiveLayers };
 }
 

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -117,15 +117,8 @@ describe('PeerConnectionV2', () => {
         height: 180,
         encodings: [{}, {}, {}],
         expectedEncodings: [{ active: true, scaleResolutionDownBy: 1 }, { active: false }, { active: false }]
-      },
-      {
-        testName: 'resolution <= 480x270',
-        width: 320,
-        height: 180,
-        encodings: [{}, {}, {}],
-        expectedEncodings: [{ active: true, scaleResolutionDownBy: 1 }, { active: false }, { active: false }]
-      },
-    ].forEach(({ width, height, encodings, expectedEncodings, testName, browser }) => {
+      }
+    ].forEach(({ width, height, encodings, expectedEncodings, testName }) => {
       it(testName, () => {
         const test = makeTest();
         test.pcv2._updateEncodings(width, height, encodings);

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -81,69 +81,6 @@ describe('PeerConnectionV2', () => {
     });
   });
 
-  describe('._updateEncodings', () => {
-    [
-      {
-        testName: 'resolution >= 960x540',
-        width: 960,
-        height: 540,
-        encodings: [{}, {}, {}],
-        expectedEncodings: [{ active: true, scaleResolutionDownBy: 4 }, { active: true, scaleResolutionDownBy: 2 }, { active: true, scaleResolutionDownBy: 1 }]
-      },
-      {
-        testName: 'resolution >= 960x540 (no simulcast)',
-        width: 960,
-        height: 540,
-        encodings: [{}],
-        expectedEncodings: [{ active: true, scaleResolutionDownBy: 1 }]
-      },
-      {
-        testName: '960x540 > resolution >= 480x270',
-        width: 480,
-        height: 270,
-        encodings: [{}, {}, {}],
-        expectedEncodings: [{ active: true, scaleResolutionDownBy: 2 }, { active: true, scaleResolutionDownBy: 1 }, { active: false }]
-      },
-      {
-        testName: '960x540 > resolution >= 480x270 (disableOnly)',
-        disableOnly: true,
-        width: 480,
-        height: 270,
-        encodings: [{}, {}, {}],
-        expectedEncodings: [{}, {}, { active: false }]
-      },
-      {
-        testName: '960x540 > resolution >= 480x270 (no simulcast)',
-        width: 480,
-        height: 270,
-        encodings: [{}], // input encodings has only one layer
-        expectedEncodings: [{ active: true, scaleResolutionDownBy: 1 }]
-      },
-      {
-        testName: 'resolution <= 480x270',
-        width: 320,
-        height: 180,
-        encodings: [{}, {}, {}],
-        expectedEncodings: [{ active: true, scaleResolutionDownBy: 1 }, { active: false }, { active: false }]
-      },
-      {
-        testName: 'resolution <= 480x270 (disable only)',
-        disableOnly: true,
-        width: 320,
-        height: 180,
-        encodings: [{}, {}, {}],
-        expectedEncodings: [{}, { active: false }, { active: false }]
-      }
-
-    ].forEach(({ width, height, encodings, expectedEncodings, testName, disableOnly }) => {
-      it(testName, () => {
-        const test = makeTest();
-        test.pcv2._updateEncodings(width, height, encodings, disableOnly);
-        assert.deepStrictEqual(encodings, expectedEncodings);
-      });
-    });
-  });
-
   describe('._maybeUpdateEncodings', () => {
     let stub;
     beforeEach(() => {
@@ -157,21 +94,80 @@ describe('PeerConnectionV2', () => {
     [
       {
         browser: 'chrome',
-        testName: 'updates encoding for chrome user media track',
+        testName: 'video, resolution >= 960x540',
         width: 960,
         height: 540,
         encodings: [{}, {}, {}],
-        expectedEncodings: [{ active: true, scaleResolutionDownBy: 4 }, { active: true, scaleResolutionDownBy: 2 }, { active: true, scaleResolutionDownBy: 1 }],
-        preferredCodecs: { audio: [], video: [{ codec: 'vp8', simulcast: true, adaptiveSimulcast: true }] }
+        expectedEncodings: [{ active: true, scaleResolutionDownBy: 4 }, { active: true, scaleResolutionDownBy: 2 }, { active: true, scaleResolutionDownBy: 1 }]
       },
       {
         browser: 'chrome',
-        testName: 'does not update encodings for chrome screen share track',
+        testName: '960x540 > resolution >= 480x270',
+        width: 480,
+        height: 270,
+        encodings: [{}, {}, {}],
+        expectedEncodings: [{ active: true, scaleResolutionDownBy: 2 }, { active: true, scaleResolutionDownBy: 1 }, { active: false }]
+      },
+      {
+        browser: 'chrome',
+        testName: 'resolution <= 480x270',
+        width: 320,
+        height: 180,
+        encodings: [{}, {}, {}],
+        expectedEncodings: [{ active: true, scaleResolutionDownBy: 1 }, { active: false }, { active: false }]
+      },
+      {
+        browser: 'chrome',
+        testName: '960x540 > resolution >= 480x270 (disableOnly only disables layers)',
+        disableOnly: true,
+        width: 480,
+        height: 270,
+        encodings: [{}, {}, {}],
+        expectedEncodings: [{}, {}, { active: false }]
+      },
+      {
+        browser: 'chrome',
+        testName: '960x540 > resolution >= 480x270 (no simulcast)',
+        width: 480,
+        height: 270,
+        encodings: [{}], // input encodings has only one layer
+        expectedEncodings: [{ active: true, scaleResolutionDownBy: 1 }]
+      },
+      {
+        browser: 'chrome',
+        testName: 'video, resolution >= 960x540 (no simulcast)',
+        width: 960,
+        height: 540,
+        encodings: [{}],
+        expectedEncodings: [{ active: true, scaleResolutionDownBy: 1 }]
+      },
+      {
+        browser: 'chrome',
+        testName: 'resolution <= 480x270 (disable only)',
+        disableOnly: true,
+        width: 320,
+        height: 180,
+        encodings: [{}, {}, {}],
+        expectedEncodings: [{}, { active: false }, { active: false }]
+      },
+      {
+        browser: 'chrome',
+        testName: 'screen share track: only two layers are enabled',
         isScreenShare: true,
         width: 960,
         height: 540,
         encodings: [{}, {}, {}],
-        preferredCodecs: { audio: [], video: [{ codec: 'vp8', simulcast: true, adaptiveSimulcast: true }] }
+        expectedEncodings: [{ active: true, scaleResolutionDownBy: 1 }, { active: true, scaleResolutionDownBy: 1 }, { active: false }],
+      },
+      {
+        browser: 'chrome',
+        testName: 'screen share track: disableOnly only disables layers',
+        disableOnly: true,
+        isScreenShare: true,
+        width: 960,
+        height: 540,
+        encodings: [{}, {}, {}],
+        expectedEncodings: [{}, {}, { active: false }],
       },
       {
         browser: 'chrome',
@@ -184,7 +180,6 @@ describe('PeerConnectionV2', () => {
       {
         browser: 'safari',
         testName: 'updates encoding for safari (irrespective of adaptiveSimulcast) ',
-        isScreenShare: true,
         width: 480,
         height: 270,
         encodings: [{}, {}, {}],
@@ -206,9 +201,8 @@ describe('PeerConnectionV2', () => {
         width: 480,
         height: 270,
         encodings: [{}, {}, {}],
-        preferredCodecs: { audio: [], video: [{ codec: 'vp8', simulcast: true }] }
-      },
-    ].forEach(({ width, height, encodings, testName, browser, preferredCodecs, expectedEncodings = null, isScreenShare = false, kind = 'video' }) => {
+      }
+    ].forEach(({ width, height, encodings, testName, browser, preferredCodecs, disableOnly = false, expectedEncodings = null, isScreenShare = false, kind = 'video' }) => {
       it(`${browser}:${testName}`, () => {
         stub = stub.returns(browser);
         const trackSettings = { width, height };
@@ -220,8 +214,9 @@ describe('PeerConnectionV2', () => {
           getSettings: () => trackSettings
         };
 
+        preferredCodecs = preferredCodecs || { audio: [], video: [{ codec: 'vp8', simulcast: true, adaptiveSimulcast: true }] };
         const test = makeTest({ preferredCodecs, isChromeScreenShareTrack: () => isScreenShare });
-        const updated = test.pcv2._maybeUpdateEncodings(mediaStreamTrack, encodings);
+        const updated = test.pcv2._maybeUpdateEncodings(mediaStreamTrack, encodings, disableOnly);
         const shouldUpdate = !!expectedEncodings;
         assert(updated === shouldUpdate, `_maybeUpdateEncodings returned unexpected: ${updated}`);
         if (expectedEncodings) {
@@ -229,6 +224,7 @@ describe('PeerConnectionV2', () => {
         }
         stub.resetHistory();
       });
+      return true;
     });
   });
 

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -605,7 +605,7 @@ describe('PeerConnectionV2', () => {
           test.pcv2._setPublisherHint(trackSender, null);
           const rtpSender = test.pcv2._rtpSenders.get(trackSender);
           sinon.assert.calledWith(rtpSender.setParameters, sinon.match(parameters => {
-            return parameters.encodings[0].active === true;
+            return !('active' in parameters.encodings[0]);
           }));
         });
 

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -94,36 +94,44 @@ describe('PeerConnectionV2', () => {
     [
       {
         browser: 'chrome',
-        testName: 'video, resolution >= 960x540',
+        testName: 'video, resolution >= 960x540 (defaults)',
         width: 960,
         height: 540,
         encodings: [{}, {}, {}],
-        expectedEncodings: [{ active: true, scaleResolutionDownBy: 4 }, { active: true, scaleResolutionDownBy: 2 }, { active: true, scaleResolutionDownBy: 1 }]
+        expectedEncodings: [{ scaleResolutionDownBy: 4 }, { scaleResolutionDownBy: 2 }, { scaleResolutionDownBy: 1 }]
       },
       {
         browser: 'chrome',
-        testName: '960x540 > resolution >= 480x270',
+        testName: '960x540 > resolution >= 480x270 (defaults)',
         width: 480,
         height: 270,
         encodings: [{}, {}, {}],
-        expectedEncodings: [{ active: true, scaleResolutionDownBy: 2 }, { active: true, scaleResolutionDownBy: 1 }, { active: false }]
+        expectedEncodings: [{ scaleResolutionDownBy: 2 }, { scaleResolutionDownBy: 1 }, { active: false }]
       },
       {
         browser: 'chrome',
-        testName: 'resolution <= 480x270',
+        testName: 'resolution <= 480x270 (defaults)',
         width: 320,
         height: 180,
         encodings: [{}, {}, {}],
-        expectedEncodings: [{ active: true, scaleResolutionDownBy: 1 }, { active: false }, { active: false }]
+        expectedEncodings: [{ scaleResolutionDownBy: 1 }, { active: false }, { active: false }]
       },
       {
         browser: 'chrome',
-        testName: '960x540 > resolution >= 480x270 (disableOnly only disables layers)',
-        disableOnly: true,
+        testName: '960x540 > resolution >= 480x270 (keeps layers disabled if disabled originally)',
         width: 480,
         height: 270,
-        encodings: [{}, {}, {}],
-        expectedEncodings: [{}, {}, { active: false }]
+        encodings: [{ scaleResolutionDownBy: 2, active: true }, { scaleResolutionDownBy: 1, active: false }, { active: true }],
+        expectedEncodings: [{ scaleResolutionDownBy: 2, active: true }, { scaleResolutionDownBy: 1, active: false }, { active: false }]
+      },
+      {
+        browser: 'chrome',
+        testName: 'resolution <= 480x270 (trackReplaced removes active flag when trackReplaced)',
+        width: 320,
+        trackReplaced: true,
+        height: 180,
+        encodings: [{ scaleResolutionDownBy: 4, active: false }, { scaleResolutionDownBy: 2, active: true }, { scaleResolutionDownBy: 1, active: true }],
+        expectedEncodings: [{ scaleResolutionDownBy: 1 }, { active: false }, { active: false }]
       },
       {
         browser: 'chrome',
@@ -131,7 +139,7 @@ describe('PeerConnectionV2', () => {
         width: 480,
         height: 270,
         encodings: [{}], // input encodings has only one layer
-        expectedEncodings: [{ active: true, scaleResolutionDownBy: 1 }]
+        expectedEncodings: [{ scaleResolutionDownBy: 1 }]
       },
       {
         browser: 'chrome',
@@ -139,35 +147,35 @@ describe('PeerConnectionV2', () => {
         width: 960,
         height: 540,
         encodings: [{}],
-        expectedEncodings: [{ active: true, scaleResolutionDownBy: 1 }]
+        expectedEncodings: [{ scaleResolutionDownBy: 1 }]
       },
       {
         browser: 'chrome',
-        testName: 'resolution <= 480x270 (disable only)',
-        disableOnly: true,
-        width: 320,
-        height: 180,
-        encodings: [{}, {}, {}],
-        expectedEncodings: [{}, { active: false }, { active: false }]
-      },
-      {
-        browser: 'chrome',
-        testName: 'screen share track: only two layers are enabled',
+        testName: 'screen share track (defaults)',
         isScreenShare: true,
         width: 960,
         height: 540,
         encodings: [{}, {}, {}],
-        expectedEncodings: [{ active: true, scaleResolutionDownBy: 1 }, { active: true, scaleResolutionDownBy: 1 }, { active: false }],
+        expectedEncodings: [{ scaleResolutionDownBy: 1 }, { scaleResolutionDownBy: 1 }, { active: false }],
       },
       {
         browser: 'chrome',
-        testName: 'screen share track: disableOnly only disables layers',
-        disableOnly: true,
+        testName: 'screen share track (keeps layers disabled if disabled originally)',
         isScreenShare: true,
         width: 960,
         height: 540,
-        encodings: [{}, {}, {}],
-        expectedEncodings: [{}, {}, { active: false }],
+        encodings: [{ scaleResolutionDownBy: 1, active: true }, { scaleResolutionDownBy: 1, active: false }, { scaleResolutionDownBy: 1, active: true }],
+        expectedEncodings: [{ scaleResolutionDownBy: 1, active: true }, { scaleResolutionDownBy: 1, active: false }, { active: false }],
+      },
+      {
+        browser: 'chrome',
+        testName: 'screen share track (trackReplaced)',
+        isScreenShare: true,
+        trackReplaced: true,
+        width: 960,
+        height: 540,
+        encodings: [{ scaleResolutionDownBy: 1, active: true }, { scaleResolutionDownBy: 1, active: false }, { scaleResolutionDownBy: 1, active: true }],
+        expectedEncodings: [{ scaleResolutionDownBy: 1 }, { scaleResolutionDownBy: 1 }, { active: false }],
       },
       {
         browser: 'chrome',
@@ -183,7 +191,7 @@ describe('PeerConnectionV2', () => {
         width: 480,
         height: 270,
         encodings: [{}, {}, {}],
-        expectedEncodings: [{ active: true, scaleResolutionDownBy: 2 }, { active: true, scaleResolutionDownBy: 1 }, { active: false }],
+        expectedEncodings: [{ scaleResolutionDownBy: 2 }, { scaleResolutionDownBy: 1 }, { active: false }],
         preferredCodecs: { audio: [], video: [{ codec: 'vp8', simulcast: true }] }
       },
       {
@@ -202,7 +210,7 @@ describe('PeerConnectionV2', () => {
         height: 270,
         encodings: [{}, {}, {}],
       }
-    ].forEach(({ width, height, encodings, testName, browser, preferredCodecs, disableOnly = false, expectedEncodings = null, isScreenShare = false, kind = 'video' }) => {
+    ].forEach(({ width, height, encodings, testName, browser, preferredCodecs, trackReplaced = false, expectedEncodings = null, isScreenShare = false, kind = 'video' }) => {
       it(`${browser}:${testName}`, () => {
         stub = stub.returns(browser);
         const trackSettings = { width, height };
@@ -216,7 +224,7 @@ describe('PeerConnectionV2', () => {
 
         preferredCodecs = preferredCodecs || { audio: [], video: [{ codec: 'vp8', simulcast: true, adaptiveSimulcast: true }] };
         const test = makeTest({ preferredCodecs, isChromeScreenShareTrack: () => isScreenShare });
-        const updated = test.pcv2._maybeUpdateEncodings(mediaStreamTrack, encodings, disableOnly);
+        const updated = test.pcv2._maybeUpdateEncodings(mediaStreamTrack, encodings, trackReplaced);
         const shouldUpdate = !!expectedEncodings;
         assert(updated === shouldUpdate, `_maybeUpdateEncodings returned unexpected: ${updated}`);
         if (expectedEncodings) {

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -105,6 +105,14 @@ describe('PeerConnectionV2', () => {
         expectedEncodings: [{ active: true, scaleResolutionDownBy: 2 }, { active: true, scaleResolutionDownBy: 1 }, { active: false }]
       },
       {
+        testName: '960x540 > resolution >= 480x270 (disableOnly)',
+        disableOnly: true,
+        width: 480,
+        height: 270,
+        encodings: [{}, {}, {}],
+        expectedEncodings: [{}, {}, { active: false }]
+      },
+      {
         testName: '960x540 > resolution >= 480x270 (no simulcast)',
         width: 480,
         height: 270,
@@ -117,11 +125,20 @@ describe('PeerConnectionV2', () => {
         height: 180,
         encodings: [{}, {}, {}],
         expectedEncodings: [{ active: true, scaleResolutionDownBy: 1 }, { active: false }, { active: false }]
+      },
+      {
+        testName: 'resolution <= 480x270 (disable only)',
+        disableOnly: true,
+        width: 320,
+        height: 180,
+        encodings: [{}, {}, {}],
+        expectedEncodings: [{}, { active: false }, { active: false }]
       }
-    ].forEach(({ width, height, encodings, expectedEncodings, testName }) => {
+
+    ].forEach(({ width, height, encodings, expectedEncodings, testName, disableOnly }) => {
       it(testName, () => {
         const test = makeTest();
-        test.pcv2._updateEncodings(width, height, encodings);
+        test.pcv2._updateEncodings(width, height, encodings, disableOnly);
         assert.deepStrictEqual(encodings, expectedEncodings);
       });
     });

--- a/test/unit/spec/util/index.js
+++ b/test/unit/spec/util/index.js
@@ -275,9 +275,7 @@ describe('util', () => {
   });
 
   describe('chromeScreenShare', () => {
-    const validLabels = ['web-contents-media-stream://1174:3', 'window:1561:0', 'screen:2077749241:0'];
-    const invalidLabels = ['foo:bar:12356', 'fizz:123456:78901', 'fakelabel://123456'];
-    const mediaStreamTrack = {
+    const userMediaTrack = {
       kind: 'video',
       id: '1aaadf6e-6a4f-465b-96bf-1a35a2d3ac2b',
       enabled: true,
@@ -286,8 +284,30 @@ describe('util', () => {
       onunmute: null,
       readyState: 'live',
       onended: null,
-      contentHint: ''
+      contentHint: '',
+      getSettings: () => {
+        return {
+        };
+      }
     };
+
+    const screenShareTrack = {
+      kind: 'video',
+      id: '1aaadf6e-6a4f-465b-96bf-1a35a2d3ac2b',
+      enabled: true,
+      muted: true,
+      onmute: null,
+      onunmute: null,
+      readyState: 'live',
+      onended: null,
+      contentHint: '',
+      getSettings: () => {
+        return {
+          displaySurface: 'monitor'
+        };
+      }
+    };
+
     let stub;
 
     beforeEach(() => {
@@ -299,26 +319,20 @@ describe('util', () => {
     });
 
     [['chrome', true], ['firefox', false], ['safari', false]].forEach(([browser, expectedBool]) => {
-      it(`valid labels should return ${expectedBool} for ${browser}`, () => {
+      it(`screen share track should return ${expectedBool} for ${browser}`, () => {
         stub = stub.returns(browser);
-        validLabels.forEach(label => {
-          mediaStreamTrack.label = label;
-          const screenShare = isChromeScreenShareTrack(mediaStreamTrack);
-          assert.equal(expectedBool, screenShare);
-          stub.resetHistory();
-        });
+        const screenShare = isChromeScreenShareTrack(screenShareTrack);
+        assert.equal(expectedBool, screenShare);
+        stub.resetHistory();
       });
     });
 
     [['chrome', false], ['firefox', false], ['safari', false]].forEach(([browser, expectedBool]) => {
-      it(`invalid labels should return ${expectedBool} for ${browser}`, () => {
+      it(`user Media Track track should return ${expectedBool} for ${browser}`, () => {
         stub = stub.returns(browser);
-        invalidLabels.forEach(label => {
-          mediaStreamTrack.label = label;
-          const screenShare = isChromeScreenShareTrack(mediaStreamTrack);
-          assert.equal(expectedBool, screenShare);
-          stub.resetHistory();
-        });
+        const screenShare = isChromeScreenShareTrack(userMediaTrack);
+        assert.equal(expectedBool, screenShare);
+        stub.resetHistory();
       });
     });
   });


### PR DESCRIPTION
This change configures simulcast layers as described in https://code.hq.twilio.com/client/sdk-frd/pull/96. 
- configure video and chrome screen-share track layers when adaptive simulcast is effective
- only set 'active: false' during default configuration
- apply default configuration after publisher hints are applied.
- after replaceTrack remove active flags for the layers that should be enabled.
- added bunch of tests

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
