### PR TITLE
Video 8391 reset layers after tranceiver reuse

### DIFF
--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -281,6 +281,9 @@ class PeerConnectionV2 extends StateMachine {
       _rtpSenders: {
         value: new Map()
       },
+      _rtpNewSenders: {
+        value: new Set()
+      },
       _iceConnectionMonitor: {
         value: new options.IceConnectionMonitor(peerConnection)
       },
@@ -1511,6 +1514,7 @@ class PeerConnectionV2 extends StateMachine {
       sender = transceiver.sender;
     }
     mediaTrackSender.addSender(sender, encodings => this._setPublisherHint(mediaTrackSender, encodings));
+    this._rtpNewSenders.add(sender);
     this._rtpSenders.set(mediaTrackSender, sender);
   }
 
@@ -1621,6 +1625,7 @@ class PeerConnectionV2 extends StateMachine {
       queuedHint.deferred.resolve('UNKNOWN_TRACK');
       this._mediaTrackSenderToPublisherHints.delete(mediaTrackSender);
     }
+    this._rtpNewSenders.delete(sender);
     this._rtpSenders.delete(mediaTrackSender);
   }
 
@@ -1917,7 +1922,10 @@ function updateEncodingParameters(pcv2) {
       params.encodings[0].networkPriority = 'high';
     }
 
-    pcv2._maybeUpdateEncodings(sender.track, params.encodings, false /* trackReplaced */);
+    // when a sender is reused, delete any active encodings set by server.
+    const trackReplaced = pcv2._rtpNewSenders.has(sender);
+    pcv2._maybeUpdateEncodings(sender.track, params.encodings, trackReplaced);
+    pcv2._rtpNewSenders.delete(sender);
 
     const promise = sender.setParameters(params).catch(error => {
       pcv2._log.warn(`Error while setting encodings parameters for ${sender.track.kind} Track ${sender.track.id}: ${error.message || error.name}`);

--- a/test/integration/spec/bandwidthprofile/publisherhints.js
+++ b/test/integration/spec/bandwidthprofile/publisherhints.js
@@ -35,6 +35,21 @@ async function getSimulcastLayerReport(room) {
   return ssrcToLocalVideoTrackStats;
 }
 
+// waits for active layers to match the condition, samples every incrementalWaitTime.
+// resolves when active layers matches the condition. rejects after totalWaitTimeMS
+async function waitForActiveLayers({ room, condition, incrementalWaitTime = 5 * SECOND, totalWaitTimeMS = 30 * SECOND }) {
+  let waitTime = 0;
+  while (totalWaitTimeMS > waitTime) {
+    // eslint-disable-next-line no-await-in-loop
+    const { activeLayers, inactiveLayers } = await getActiveLayers({ room, initialWaitMS: 0, activeTimeMS: incrementalWaitTime });
+    waitTime += incrementalWaitTime;
+    if (condition({ activeLayers, inactiveLayers })) {
+      return;
+    }
+  }
+  throw new Error('waitForActiveLayers failed');
+}
+
 // for a given room, returns array of simulcast layers that are active.
 // it checks for active layers by gathering layer stats activeTimeMS apart.
 async function getActiveLayers({ room, initialWaitMS = 15 * SECOND, activeTimeMS = 3 * SECOND }) {
@@ -198,9 +213,11 @@ if (defaults.topology !== 'peer-to-peer' && !isFirefox) {
           bandwidthProfile
         });
         console.log('room sid: ', aliceRoom.sid);
-        const { activeLayers, inactiveLayers } = await getActiveLayers({ room: aliceRoom, initialWaitMS: 2 * SECOND, activeTimeMS: 20 * SECOND });
-        assert.equal(activeLayers.length, expectedActive);
-        assert.equal(activeLayers.length + inactiveLayers.length, 3);
+
+        await waitForActiveLayers({ room: aliceRoom,  condition: ({ activeLayers, inactiveLayers }) => {
+          return activeLayers.length === expectedActive && activeLayers.length + inactiveLayers.length === 3;
+        } });
+
         aliceRoom.disconnect();
         completeRoom(roomSid);
       });
@@ -246,8 +263,18 @@ if (defaults.topology !== 'peer-to-peer' && !isFirefox) {
       describe('While Alice is alone in the room', () => {
         it('c1: all layers get turned off.', async () => {
           // initially SFU might take upto 30 seconds to turn off all layers.
-          const { activeLayers } = await getActiveLayers({ room: aliceRoom, initialWaitMS: 30 * SECOND });
-          assert(activeLayers.length === 0, `1) was expecting expectedActiveLayers=0 but found: ${activeLayers.length} in ${roomSid}`);
+          await waitForActiveLayers({ room: aliceRoom, condition: ({ activeLayers }) => activeLayers.length === 0 });
+        });
+
+        it('VIDEO-8391 track layers get reset when track is unpublished and published again', async () => {
+          const aliceVideoTrackPublication = [...aliceRoom.localParticipant.tracks.values()][0];
+          aliceVideoTrackPublication.unpublish();
+
+          await waitForSometime(2000);
+
+          await waitFor(aliceRoom.localParticipant.publishTrack(aliceLocalVideo), `alice to publish track again in ${roomSid}`);
+
+          await waitForActiveLayers({ room: aliceRoom, incrementalWaitTime: 3 * SECOND, condition: ({ activeLayers }) => activeLayers.length >= 2 });
         });
       });
 
@@ -307,8 +334,7 @@ if (defaults.topology !== 'peer-to-peer' && !isFirefox) {
           it(testCase, async () => {
             console.log(`executing ${testCase}`);
             await executeRemoteTrackActions(bob, aliceRemoteVideoForBob, 'Bob');
-            const { activeLayers } = await getActiveLayers({ room: aliceRoom });
-            assert(expectedActiveLayers(activeLayers.length), `unexpected activeLayers.length: ${activeLayers.length} in ${roomSid}`);
+            await waitForActiveLayers({ room: aliceRoom, condition: ({ activeLayers }) => expectedActiveLayers(activeLayers.length) });
           });
         });
         context('Charlie joins the room', () => {
@@ -379,35 +405,30 @@ if (defaults.topology !== 'peer-to-peer' && !isFirefox) {
               await executeRemoteTrackActions(bob, aliceRemoteVideoForBob, 'Bob');
               await executeRemoteTrackActions(charlie, aliceRemoteVideoForCharlie, 'Charlie');
 
-              const { activeLayers } = await getActiveLayers({ room: aliceRoom });
-              assert(expectedActiveLayers(activeLayers.length), `unexpected activeLayers.length: ${activeLayers.length} in ${roomSid}`);
+              await waitForActiveLayers({ room: aliceRoom, condition: ({ activeLayers }) => expectedActiveLayers(activeLayers.length) });
             });
           });
 
           it('subsequent negotiations does not cause layers to be enabled', async () => {
             await executeRemoteTrackActions({ switchOff: true }, aliceRemoteVideoForBob, 'Bob');
             await executeRemoteTrackActions({ switchOff: true }, aliceRemoteVideoForCharlie, 'Charlie');
-            let { activeLayers } = await getActiveLayers({ room: aliceRoom });
+            await waitForActiveLayers({ room: aliceRoom,  condition: ({ activeLayers }) => activeLayers.length === 0 });
 
-            assert(activeLayers.length === 0, `unexpected activeLayers.length after switch off: ${activeLayers.length} in ${roomSid}`);
-
+            // assert(activeLayers.length === 0, `unexpected activeLayers.length after switch off: ${activeLayers.length} in ${roomSid}`);
             const aliceLocalAudio = await waitFor(createLocalAudioTrack(), 'alice local audio track');
 
             // Bob publishes track
             await waitFor(aliceRoom.localParticipant.publishTrack(aliceLocalAudio), `Alice to publish audio track: ${roomSid}`);
-            await waitForSometime(5000);
 
-            ({ activeLayers } = (await getActiveLayers({ room: aliceRoom })));
-            assert(activeLayers.length === 0, `unexpected activeLayers.length after track publish: ${activeLayers.length} in ${roomSid}`);
+            await waitForActiveLayers({ room: aliceRoom, condition: ({ activeLayers }) => activeLayers.length === 0 });
           });
 
           it('adaptive simulcast continue to work after replace track', async () => {
             // have both bob and charlie turn off tracks.
             await executeRemoteTrackActions({ switchOff: true }, aliceRemoteVideoForBob, 'Bob');
             await executeRemoteTrackActions({ switchOff: true }, aliceRemoteVideoForCharlie, 'Charlie');
-            let { activeLayers } = await getActiveLayers({ room: aliceRoom });
 
-            assert(activeLayers.length === 0, `unexpected activeLayers.length after switch off #1: ${activeLayers.length} in ${roomSid}`);
+            await waitForActiveLayers({ room: aliceRoom,  condition: ({ activeLayers }) => activeLayers.length === 0 });
 
             // now restart the track
             console.log('restarting the track');
@@ -417,8 +438,7 @@ if (defaults.topology !== 'peer-to-peer' && !isFirefox) {
             await executeRemoteTrackActions({ switchOn: true }, aliceRemoteVideoForBob, 'Bob');
             await executeRemoteTrackActions({ switchOff: true }, aliceRemoteVideoForBob, 'Bob');
 
-            ({ activeLayers } = (await getActiveLayers({ room: aliceRoom })));
-            assert(activeLayers.length === 0, `unexpected activeLayers.length after switchOff #2: ${activeLayers.length} in ${roomSid}`);
+            await waitForActiveLayers({ room: aliceRoom,  condition: ({ activeLayers }) => activeLayers.length === 0 });
           });
         });
       });


### PR DESCRIPTION

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details
Fixes https://issues.corp.twilio.com/browse/VIDEO-8394


### Description

For adaptive simulcast we set default layer configuration every-time Peer Connection goes stable as described [here](https://code.hq.twilio.com/client/sdk-frd/blob/master/video/adaptive-simulcast.md#configuring-simulcast). This default configuration does not update any `active` fields that are meant to be set by SFU (publisher_hints). Later we  enable/disable layers as specified by publisher hints . 

The above scheme overlooked an issue about Recycled Transceiver. when a track is unpublished, and a new track is published, we reuse Transceivers when possible. In such cases we need to clear any layers that are  disabled by publisher hints on the track. Failing to do so causes publisher to never discover layers on the new tracks.

This change handles this case by keeping track of any new rtpSenders (`_rtpNewSenders`). For new sender we will now delete any active fields set by server - This uses same procedure that was used for trackReplaced case.

## Burndown

- https://github.com/twilio/twilio-video.js/commit/fb38ce94a0089f8e30732a26eefaebffcae10b69 added an integration test - and verified that it fails before the fix
- https://github.com/twilio/twilio-video.js/commit/b72ec8f79304322001750e6847f6ff0f27bc2fdf applied the fix


### Before review
* [x] Updated CHANGELOG.md if necessary (N/A)
* [x] Added unit tests if necessary
* [x] Updated affected documentation (N/A)
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Included screenshot as PR comment (if needed)
* [x] Ready for review
