### PR TITLE
VIDEO-8535 - Reverting TSDef Changes from CreateLocalTracks PR

### DIFF
--- a/lib/createlocaltracks.ts
+++ b/lib/createlocaltracks.ts
@@ -133,10 +133,6 @@ export async function createLocalTracks(options?: CreateLocalTracksOptions): Pro
     return fullOptions.tracks;
   }
 
-  if (typeof fullOptions.audio === 'object') {
-    fullOptions.audio.name;
-  }
-
   const extraLocalTrackOptions: ExtraLocalTrackOptions = {
     audio: typeof fullOptions.audio === 'object' && fullOptions.audio.name
       ? { name: fullOptions.audio.name }

--- a/lib/createlocaltracks.ts
+++ b/lib/createlocaltracks.ts
@@ -24,6 +24,15 @@ let createLocalTrackCalls = 0;
 type ExtraLocalTrackOption = CreateLocalTrackOptions & { isCreatedByCreateLocalTracks?: boolean };
 type ExtraLocalTrackOptions = { audio: ExtraLocalTrackOption; video: ExtraLocalTrackOption; };
 
+interface InternalOptions extends CreateLocalTracksOptions {
+  getUserMedia: any;
+  LocalAudioTrack: any;
+  LocalDataTrack: any;
+  LocalVideoTrack: any;
+  MediaStreamTrack: any;
+  Log: any;
+};
+
 /**
  * Request {@link LocalTrack}s. By default, it requests a
  * {@link LocalAudioTrack} and a {@link LocalVideoTrack}.
@@ -85,7 +94,7 @@ export async function createLocalTracks(options?: CreateLocalTracksOptions): Pro
   const isAudioVideoAbsent =
     !(options && ('audio' in options || 'video' in options));
 
-  const fullOptions = Object.assign({
+  const fullOptions: InternalOptions = {
     audio: isAudioVideoAbsent,
     getUserMedia,
     loggerName: DEFAULT_LOGGER_NAME,
@@ -96,7 +105,8 @@ export async function createLocalTracks(options?: CreateLocalTracksOptions): Pro
     MediaStreamTrack,
     Log,
     video: isAudioVideoAbsent,
-  }, options);
+    ...options,
+  };
 
   const logComponentName = `[createLocalTracks #${++createLocalTrackCalls}]`;
   const logLevels = buildLogLevels(fullOptions.logLevel);
@@ -123,11 +133,15 @@ export async function createLocalTracks(options?: CreateLocalTracksOptions): Pro
     return fullOptions.tracks;
   }
 
+  if (typeof fullOptions.audio === 'object') {
+    fullOptions.audio.name;
+  }
+
   const extraLocalTrackOptions: ExtraLocalTrackOptions = {
-    audio: fullOptions.audio && fullOptions.audio.name
+    audio: typeof fullOptions.audio === 'object' && fullOptions.audio.name
       ? { name: fullOptions.audio.name }
       : {},
-    video: fullOptions.video && fullOptions.video.name
+    video: typeof fullOptions.video === 'object' && fullOptions.video.name
       ? { name: fullOptions.video.name }
       : {}
   };
@@ -135,18 +149,18 @@ export async function createLocalTracks(options?: CreateLocalTracksOptions): Pro
   extraLocalTrackOptions.audio.isCreatedByCreateLocalTracks = true;
   extraLocalTrackOptions.video.isCreatedByCreateLocalTracks = true;
 
-  if (fullOptions.audio && typeof fullOptions.audio.workaroundWebKitBug1208516 === 'boolean') {
+  if (typeof fullOptions.audio === 'object' && typeof fullOptions.audio.workaroundWebKitBug1208516 === 'boolean') {
     extraLocalTrackOptions.audio.workaroundWebKitBug1208516 = fullOptions.audio.workaroundWebKitBug1208516;
   }
 
-  if (fullOptions.video && typeof fullOptions.video.workaroundWebKitBug1208516 === 'boolean') {
+  if (typeof fullOptions.video === 'object' && typeof fullOptions.video.workaroundWebKitBug1208516 === 'boolean') {
     extraLocalTrackOptions.video.workaroundWebKitBug1208516 = fullOptions.video.workaroundWebKitBug1208516;
   }
 
-  if (fullOptions.audio) {
+  if (typeof fullOptions.audio === 'object') {
     delete fullOptions.audio.name;
   }
-  if (fullOptions.video) {
+  if (typeof fullOptions.video === 'object') {
     delete fullOptions.video.name;
   }
 
@@ -155,7 +169,7 @@ export async function createLocalTracks(options?: CreateLocalTracksOptions): Pro
     video: fullOptions.video
   };
 
-  const workaroundWebKitBug180748 = fullOptions.audio && fullOptions.audio.workaroundWebKitBug180748;
+  const workaroundWebKitBug180748 = typeof fullOptions.audio === 'object' && fullOptions.audio.workaroundWebKitBug180748;
 
   try {
     const mediaStream = await (workaroundWebKitBug180748

--- a/tsdef/twilio-video-tests.ts
+++ b/tsdef/twilio-video-tests.ts
@@ -294,7 +294,8 @@ async function initRoom() {
   room.localParticipant.publishTrack(localAudioTrack);
   room.participants.forEach(participantConnected);
 
-  localTracks = await Video.createLocalTracks();
+  localTracks = await Video.createLocalTracks({ audio: true, video: false });
+  await Video.createLocalTracks({ audio: true });
   await Video.connect('$TOKEN', {
     name: 'my-cool-room',
     tracks: localTracks

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -202,14 +202,14 @@ export interface ConnectOptions {
 }
 
 export interface CreateLocalTracksOptions {
-  audio?: CreateLocalTrackOptions;
+  audio?: boolean | CreateLocalTrackOptions;
   /**
    * @deprecated
    */
   logLevel?: LogLevel | LogLevels;
   loggerName?: string;
   tracks?: LocalTrack[];
-  video?: CreateLocalTrackOptions;
+  video?: boolean | CreateLocalTrackOptions;
 }
 
 export class TrackStats {


### PR DESCRIPTION
[VIDEO-8535](https://issues.corp.twilio.com/browse/VIDEO-8535)

There were some changes done to the `tsdef` file that broke how customers utilized  `createLocalTracks` by passing in a `boolean` value for `audio` and `video`. This change has been reverted and some build tests have been added to the definitions test file to catch this. 

I've verified that the react app is able to build successfully and our tests are passing locally as well. 

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details
[VIDEO-8535](https://issues.corp.twilio.com/browse/VIDEO-8535)

### Description

A description of what this PR does.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review
