### PR TITLE
Removing ESModuleInterop

### DIFF
--- a/test/unit/spec/createlocaltracks.ts
+++ b/test/unit/spec/createlocaltracks.ts
@@ -1,11 +1,9 @@
 'use strict';
 
-import { FakeMediaStreamTrack, fakeGetUserMedia } from '../../lib/fakemediastream';
+import * as assert from 'assert';
+import * as sinon from 'sinon';
 import { createLocalTracks } from '../../../lib/createlocaltracks';
-
-import assert from 'assert';
-import sinon from 'sinon';
-
+import { fakeGetUserMedia, FakeMediaStreamTrack } from '../../lib/fakemediastream';
 
 describe('createLocalTracks', () => {
   [

--- a/test/unit/spec/preflight.ts
+++ b/test/unit/spec/preflight.ts
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import * as assert from 'assert';
 import { runPreflight } from '../../../lib/preflight/preflighttest';
 
 describe('Preflight', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "allowJs": true,
     "checkJs": false,
     "declaration": false,
-    "esModuleInterop": true,
     "target": "es5",
     "lib": ["es2019", "dom"],
     "downlevelIteration": true,


### PR DESCRIPTION
Creating this small PR to fix some changes that that didn't get into the previous PR.

I've manually tested this and gone through all the places we call `createLocalTracks` and it looks good to go. Our integration and unit tests have the bases covered, just the TS Definition tests did not!

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

A description of what this PR does.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review
