### PR TITLE
set active=true for default encodings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 Bug Fixes
 ---------
 
-- Fixed a bug that was introduced in 2.19.0 where `LocalVideoTrack` from older iOS devices (14.x) did not publish media (VIDEO-8770)
+- Fixed a bug that was introduced in 2.19.0 where the published LocalVideoTracks of Participants on older iOS versions 14.5 and below did not encode and transmit media. (VIDEO-8770)
 
 2.20.0 (February 10, 2022)
 ==========================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 
 **Version 1.x reached End of Life on September 8th, 2021.** See the changelog entry [here](https://www.twilio.com/changelog/end-of-life-complete-for-unsupported-versions-of-the-programmable-video-sdk). Support for the 1.x version ended on December 4th, 2020.
 
+2.20.1 (In Progress)
+====================
+Bug Fixes
+---------
+
+- Fixed a bug that was introduced in 2.19.0 where `LocalVideoTrack` from older iOS devices (14.x) did not publish media (VIDEO-8770)
+
 2.20.0 (February 10, 2022)
 ==========================
 

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -529,7 +529,7 @@ class PeerConnectionV2 extends StateMachine {
         if (enabled) {
           encoding.scaleResolutionDownBy = 1 << (activeLayers - i - 1);
           if (trackReplaced) {
-            delete encoding.active;
+            encoding.active = true;
           }
         } else {
           encoding.active = false;

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -126,12 +126,12 @@ describe('PeerConnectionV2', () => {
       },
       {
         browser: 'chrome',
-        testName: 'resolution <= 480x270 (trackReplaced removes active flag when trackReplaced)',
+        testName: 'resolution <= 480x270 (trackReplaced sets active flags)',
         width: 320,
         trackReplaced: true,
         height: 180,
         encodings: [{ scaleResolutionDownBy: 4, active: false }, { scaleResolutionDownBy: 2, active: true }, { scaleResolutionDownBy: 1, active: true }],
-        expectedEncodings: [{ scaleResolutionDownBy: 1 }, { active: false }, { active: false }]
+        expectedEncodings: [{ scaleResolutionDownBy: 1, active: true }, { active: false }, { active: false }]
       },
       {
         browser: 'chrome',
@@ -192,6 +192,25 @@ describe('PeerConnectionV2', () => {
         height: 270,
         encodings: [{}, {}, {}],
         expectedEncodings: [{ scaleResolutionDownBy: 2 }, { scaleResolutionDownBy: 1 }, { active: false }],
+        preferredCodecs: { audio: [], video: [{ codec: 'vp8', simulcast: true }] }
+      },
+      {
+        browser: 'safari',
+        testName: 'does not delete active property for safari',
+        width: 480,
+        height: 270,
+        encodings: [{}, {}, {}],
+        expectedEncodings: [{ scaleResolutionDownBy: 2 }, { scaleResolutionDownBy: 1 }, { active: false }],
+        preferredCodecs: { audio: [], video: [{ codec: 'vp8', simulcast: true }] }
+      },
+      {
+        browser: 'safari',
+        testName: 'sets active when trackReplaced',
+        trackReplaced: true,
+        width: 480,
+        height: 270,
+        encodings: [{}, {}, {}],
+        expectedEncodings: [{ scaleResolutionDownBy: 2, active: true }, { scaleResolutionDownBy: 1, active: true }, { active: false }],
         preferredCodecs: { audio: [], video: [{ codec: 'vp8', simulcast: true }] }
       },
       {


### PR DESCRIPTION
We apply default encodings for safari irrespective of adaptive simulcast. For default we remove any `active` flags from RTCRtpEncodingParameters. We found that on older iOS (14.x) devices missing `active` flag from is treated as false. causing the layer to get disabled. This change sets the active=true for default encodings (which are also applied during track replace operations)

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

released spec change: https://code.hq.twilio.com/client/sdk-frd/pull/97

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

A description of what this PR does.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
