### PR TITLE
VIDEO-8647 - Fixing Chrome Docker Image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,11 +294,11 @@ workflows:
   Build_Docker_Images_Workflow:
     triggers:
       - schedule:
-          cron: "0 3 * * *"
+          cron: "0 0 * * *"
           filters:
             branches:
               only:
-                - VIDEO-8647-Fix-Chrome-Docker-Image
+                - master
     jobs:
       - Build-Docker-Test-Image:
           context: dockerhub-push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,11 +294,11 @@ workflows:
   Build_Docker_Images_Workflow:
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: "0 18 * * *"
           filters:
             branches:
               only:
-                - master
+                - VIDEO-8647-Fix-Chrome-Docker-Image
     jobs:
       - Build-Docker-Test-Image:
           context: dockerhub-push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,11 +294,11 @@ workflows:
   Build_Docker_Images_Workflow:
     triggers:
       - schedule:
-          cron: "0 2 * * *"
+          cron: "0 0 * * *"
           filters:
             branches:
               only:
-                - VIDEO-8647-Fix-Chrome-Docker-Image
+                - master
     jobs:
       - Build-Docker-Test-Image:
           context: dockerhub-push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,11 +294,11 @@ workflows:
   Build_Docker_Images_Workflow:
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: "0 2 * * *"
           filters:
             branches:
               only:
-                - master
+                - VIDEO-8647-Fix-Chrome-Docker-Image
     jobs:
       - Build-Docker-Test-Image:
           context: dockerhub-push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,11 +294,11 @@ workflows:
   Build_Docker_Images_Workflow:
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: "0 3 * * *"
           filters:
             branches:
               only:
-                - master
+                - VIDEO-8647-Fix-Chrome-Docker-Image
     jobs:
       - Build-Docker-Test-Image:
           context: dockerhub-push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,11 +294,11 @@ workflows:
   Build_Docker_Images_Workflow:
     triggers:
       - schedule:
-          cron: "0 18 * * *"
+          cron: "0 0 * * *"
           filters:
             branches:
               only:
-                - VIDEO-8647-Fix-Chrome-Docker-Image
+                - master
     jobs:
       - Build-Docker-Test-Image:
           context: dockerhub-push

--- a/.circleci/images/chrome/beta/Dockerfile
+++ b/.circleci/images/chrome/beta/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/node:current
+FROM cimg/node:current-browsers
 
 USER root
 ENV BROWSER='chrome'
@@ -11,7 +11,9 @@ RUN echo "Installing Chrome: $BVER" \
 && apt-get update \
 && echo "Installing google-chrome-$BVER from apt-get" \
 && apt-get install -y google-chrome-$BVER \
-&& rm -rf /var/lib/apt/lists/*
+&& rm -rf /var/lib/apt/lists/* \
+&& echo "Installing xvfb from apt-get" \
+&& apt-get install -y xvfb
 
 # start xvfb automatically to avoid needing to express in circle.yml
 ENV DISPLAY :99

--- a/.circleci/images/chrome/beta/Dockerfile
+++ b/.circleci/images/chrome/beta/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/node:latest
+FROM cimg/node:current
 
 USER root
 ENV BROWSER='chrome'

--- a/.circleci/images/chrome/stable/Dockerfile
+++ b/.circleci/images/chrome/stable/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/r/browserless/chrome/dockerfile/
-FROM circleci/node:lts-browsers
+FROM cimg/node:lts
 
 # install selected browser / version
 ENV BROWSER='chrome'
@@ -10,7 +10,13 @@ USER root
 
 # Install and enable iptables
 RUN echo "Setting up iptables..." &&\
+echo "Installing Chrome: $BVER" &&\
+wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - &&\
+echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list &&\
 apt-get update &&\
+echo "Installing google-chrome-$BVER from apt-get" &&\
+apt-get install -y google-chrome-$BVER &&\
+rm -rf /var/lib/apt/lists/* &&\
 apt-get install -y iptables &&\
 adduser user1 &&\
 adduser user1 sudo &&\

--- a/.circleci/images/chrome/unstable/Dockerfile
+++ b/.circleci/images/chrome/unstable/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/node:current
+FROM cimg/node:current-browsers
 
 USER root
 ENV BROWSER='chrome'
@@ -11,7 +11,9 @@ RUN echo "Installing Chrome: $BVER" \
 && apt-get update \
 && echo "Installing google-chrome-$BVER from apt-get" \
 && apt-get install -y google-chrome-$BVER \
-&& rm -rf /var/lib/apt/lists/*
+&& rm -rf /var/lib/apt/lists/* \
+&& echo "Installing xvfb from apt-get" \
+&& apt-get install -y xvfb
 
 # start xvfb automatically to avoid needing to express in circle.yml
 ENV DISPLAY :99

--- a/.circleci/images/chrome/unstable/Dockerfile
+++ b/.circleci/images/chrome/unstable/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/node:latest
+FROM cimg/node:current
 
 USER root
 ENV BROWSER='chrome'


### PR DESCRIPTION
JIRA Ticket : [VIDEO-8647](https://issues.corp.twilio.com/browse/VIDEO-8647)

This PR addresses our Circle CI Job that builds our chrome images. Previously our job was not updating chrome to the latest stable version. We have updated to pulling from `cimg/node` instead of `circleci/node` as that is now deprecated. I've added updates to `beta` and `unstable` chrome Dockerfile as well.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review
