### PR TITLE
VIDEO-8668,VIDEO-8670,VIDEO-8671 [Large Rooms] RemoteAudioTrack subscription and switch on/off.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 
 **Version 1.x reached End of Life on September 8th, 2021.** See the changelog entry [here](https://www.twilio.com/changelog/end-of-life-complete-for-unsupported-versions-of-the-programmable-video-sdk). Support for the 1.x version ended on December 4th, 2020.
 
+3.0.0-preview.1
+===============
+
+New Features
+------------
+
+**Large Rooms Pilot**
+
+twilio-video.js now allows you to create and join a [Large Room](TODO_doc_link), which supports a large number of Participants (> 50).
+
+- A RemoteAudioTrack of a Participant that is not active in the Room will now be switched off. (VIDEO-8668)
+- A RemoteAudioTrack will now have an additional property called [`switchOffReason`](TODO_doc_link), which describes
+  the reason for it being switched off. (VIDEO-8670)
+
 2.21.0 (In Progress)
 ==========================
 

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -727,6 +727,37 @@ const TrackSwitchOffMode = {
 };
 
 /**
+ * TrackSwitchOffReason describes why a {@link RemoteTrack} is switched off.
+ * @enum {string}
+ */
+const TrackSwitchOffReason = {
+  /**
+   * The publisher disabled the {@link RemoteTrack}.
+   */
+  'disabled-by-publisher': 'disabled-by-publisher',
+
+  /**
+   * The subscriber requested to stop receiving media for the {@link RemoteTrack}.
+   */
+  'disabled-by-subscriber': 'disabled-by-subscriber',
+
+  /**
+   * The remaining downlink bandwidth is not sufficient to receive media for the {@link RemoteTrack}.
+   */
+  'max-bandwidth-reached': 'max-bandwidth-reached',
+
+  /**
+   * The maximum number of {@link RemoteTrack}s of a {@link Track.Kind} that can be switch on has been reached.
+   */
+  'max-tracks-switched-on': 'max-tracks-switched-on',
+
+  /**
+   * Media for the {@link RemoteTrack} could not be received due to network congestion.
+   */
+  'network-congestion': 'network-congestion'
+};
+
+/**
  * {@link BandwidthProfileMode} specifies how {@link RemoteVideoTrack}s' {@link Track.Priority} values
  * are mapped to bandwidth allocation in Group Rooms.
  * @enum {string}

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -727,32 +727,46 @@ const TrackSwitchOffMode = {
 };
 
 /**
- * TrackSwitchOffReason describes why a {@link RemoteTrack} is switched off.
+ * {@link TrackSwitchOffReason} describes why a {@link RemoteTrack} is switched off. This reason
+ * accompanies the {@link RemoteTrack} event <code>switchedOff</code> and is used for
+ * the {@link RemoteTrack} property <code>switchOffReason</code>.
  * @enum {string}
  */
 const TrackSwitchOffReason = {
   /**
-   * The publisher disabled the {@link RemoteTrack}.
+   * The {@link RemoteTrack} was disabled by the publishing {@link Participant}.
+   * The media server does not send media to the subscribing {@link Participant}s
+   * for a disabled {@link Track}.
    */
   'disabled-by-publisher': 'disabled-by-publisher',
 
   /**
-   * The subscriber requested to stop receiving media for the {@link RemoteTrack}.
+   * The {@link RemoteVideoTrack} was disabled by the subscribing {@link Participant}
+   * and the media server stopped sending its media.
    */
   'disabled-by-subscriber': 'disabled-by-subscriber',
 
   /**
-   * The remaining downlink bandwidth is not sufficient to receive media for the {@link RemoteTrack}.
+   * The {@link RemoteVideoTrack} was switched off because the remaining
+   * downlink bandwidth is not sufficient to receive its media. The bandwidth
+   * limit is configured by specifying <code>maxSubscriptionBitrate</code>
+   * in {@link VideoBandwidthProfileOptions} or a default value is selected
+   * by the media server.
    */
   'max-bandwidth-reached': 'max-bandwidth-reached',
 
   /**
-   * The maximum number of {@link RemoteTrack}s of a {@link Track.Kind} that can be switch on has been reached.
+   * The {@link RemoteTrack} was switched off because the number of switched on
+   * {@link Track}s reached the limit specified by the <code>maxSwitchedOnTracks</code>
+   * property in {@link AudioBandwidthProfile} or {@link VideoBandwidthProfileOptions}.
    */
   'max-tracks-switched-on': 'max-tracks-switched-on',
 
   /**
-   * Media for the {@link RemoteTrack} could not be received due to network congestion.
+   * The {@link RemoteVideoTrack} was switched off because network congestion
+   * was detected or predicted. The <code>trackSwitchOffMode</code> property
+   * on {@link VideoBandwidthProfileOptions} allows you to specify how the
+   * switch off is managed.
    */
   'network-congestion': 'network-congestion'
 };

--- a/lib/media/track/audiotrack.js
+++ b/lib/media/track/audiotrack.js
@@ -11,7 +11,7 @@ const MediaTrack = require('./mediatrack');
  * @property {boolean} isEnabled - Whether or not the {@link AudioTrack} is
  *   enabled; if the {@link AudioTrack} is not enabled, it is "muted"
  * @property {Track.Kind} kind - "audio"
- * @property {MediaStreamTrack} mediaStreamTrack - An audio MediaStreamTrack
+ * @property {?MediaStreamTrack} mediaStreamTrack - An audio MediaStreamTrack
  * @property {?MediaStreamTrack} processedTrack - The source of processed audio samples.
  * It is always null as audio processing is not currently supported.
  * @emits AudioTrack#disabled
@@ -21,11 +21,12 @@ const MediaTrack = require('./mediatrack');
 class AudioTrack extends MediaTrack {
   /**
    * Construct an {@link AudioTrack}.
-   * @param {MediaTrackTransceiver} mediaTrackTransceiver
-   * @param {{log: Log}} options
+   * @param {Track.Kind} kind
+   * @param {?MediaTrackTransceiver} mediaTrackTransceiver
+   * @param {{log: Log, name: string}} options
    */
-  constructor(mediaTrackTransceiver, options) {
-    super(mediaTrackTransceiver, options);
+  constructor(kind, mediaTrackTransceiver, options) {
+    super(kind, mediaTrackTransceiver, options);
   }
 
   /**

--- a/lib/media/track/audiotrack.js
+++ b/lib/media/track/audiotrack.js
@@ -21,12 +21,11 @@ const MediaTrack = require('./mediatrack');
 class AudioTrack extends MediaTrack {
   /**
    * Construct an {@link AudioTrack}.
-   * @param {Track.Kind} kind
    * @param {?MediaTrackTransceiver} mediaTrackTransceiver
    * @param {{log: Log, name: string}} options
    */
-  constructor(kind, mediaTrackTransceiver, options) {
-    super(kind, mediaTrackTransceiver, options);
+  constructor(mediaTrackTransceiver, options) {
+    super('audio', mediaTrackTransceiver, options);
   }
 
   /**

--- a/lib/media/track/audiotrack.js
+++ b/lib/media/track/audiotrack.js
@@ -11,7 +11,9 @@ const MediaTrack = require('./mediatrack');
  * @property {boolean} isEnabled - Whether or not the {@link AudioTrack} is
  *   enabled; if the {@link AudioTrack} is not enabled, it is "muted"
  * @property {Track.Kind} kind - "audio"
- * @property {?MediaStreamTrack} mediaStreamTrack - An audio MediaStreamTrack
+ * @property {?MediaStreamTrack} mediaStreamTrack - Provides access to the underlying
+ *   MediaStreamTrack; It is set to <code>null</code> if it is a {@link RemoteAudioTrack}
+ *   that is switched off
  * @property {?MediaStreamTrack} processedTrack - The source of processed audio samples.
  * It is always null as audio processing is not currently supported.
  * @emits AudioTrack#disabled

--- a/lib/media/track/index.js
+++ b/lib/media/track/index.js
@@ -16,13 +16,11 @@ let nInstances = 0;
 class Track extends EventEmitter {
   /**
    * Construct a {@link Track}.
-   * @param {Track.ID} id - The {@link Track}'s ID
    * @param {Track.Kind} kind - The {@link Track}'s kind
-   * @param {{ log: Log, name: ?string }} options
+   * @param {{ log: Log, name: string }} options
    */
-  constructor(id, kind, options) {
+  constructor(kind, options) {
     options = Object.assign({
-      name: id,
       log: null,
       logLevel: DEFAULT_LOG_LEVEL
     }, options);
@@ -30,8 +28,8 @@ class Track extends EventEmitter {
     super();
 
     const name = String(options.name);
-
     const logLevels = buildLogLevels(options.logLevel);
+
     const log = options.log
       ? options.log.createLog('media', this)
       : new Log('media', this, logLevels, options.loggerName);

--- a/lib/media/track/localmediatrack.js
+++ b/lib/media/track/localmediatrack.js
@@ -49,7 +49,7 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
       const mediaTrackSender = new MediaTrackSender(mediaStreamTrack);
       const { kind } = mediaTrackSender;
 
-      super(kind, mediaTrackSender, options);
+      super(mediaTrackSender, options);
 
       Object.defineProperties(this, {
         _constraints: {

--- a/lib/media/track/localmediatrack.js
+++ b/lib/media/track/localmediatrack.js
@@ -41,6 +41,7 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
       options = Object.assign({
         getUserMedia,
         isCreatedByCreateLocalTracks: false,
+        name: mediaStreamTrack.id,
         workaroundWebKitBug1208516,
         gUMSilentTrackWorkaround
       }, options);
@@ -48,7 +49,7 @@ function mixinLocalMediaTrack(AudioOrVideoTrack) {
       const mediaTrackSender = new MediaTrackSender(mediaStreamTrack);
       const { kind } = mediaTrackSender;
 
-      super(mediaTrackSender, options);
+      super(kind, mediaTrackSender, options);
 
       Object.defineProperties(this, {
         _constraints: {

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -14,23 +14,20 @@ const Track = require('./');
  * @property {Track.ID} id - This {@link Track}'s ID
  * @property {boolean} isStarted - Whether or not the {@link MediaTrack} has
  *   started
- * @property {boolean} isEnabled - Whether or not the {@link MediaTrack} is
- *   enabled (i.e., whether it is paused or muted)
  * @property {Track.Kind} kind - The kind of the underlying
  *   MediaStreamTrack, "audio" or "video"
- * @property {MediaStreamTrack} mediaStreamTrack - The underlying
+ * @property {?MediaStreamTrack} mediaStreamTrack - The underlying
  *   MediaStreamTrack
- * @emits MediaTrack#disabled
- * @emits MediaTrack#enabled
  * @emits MediaTrack#started
  */
 class MediaTrack extends Track {
   /**
    * Construct a {@link MediaTrack}.
-   * @param {MediaTrackTransceiver} mediaTrackTransceiver
-   * @param {{log: Log}} options
+   * @param {Track.Kind} kind
+   * @param {?MediaTrackTransceiver} mediaTrackTransceiver
+   * @param {{ log: Log, name: string }} options
    */
-  constructor(mediaTrackTransceiver, options) {
+  constructor(kind, mediaTrackTransceiver, options) {
     options = Object.assign({
       playPausedElementsIfNotBackgrounded: (guessBrowser() === 'safari' || isIOSChrome())
         && typeof document === 'object'
@@ -38,8 +35,7 @@ class MediaTrack extends Track {
         && typeof document.visibilityState === 'string'
     }, options);
 
-    super(mediaTrackTransceiver.id, mediaTrackTransceiver.kind, options);
-    let isStarted = false;
+    super(kind, options);
 
     options = Object.assign({
       MediaStream
@@ -58,12 +54,12 @@ class MediaTrack extends Track {
         value: new WeakMap()
       },
       _isStarted: {
-        get() {
-          return isStarted;
-        },
-        set(_isStarted) {
-          isStarted = _isStarted;
-        }
+        value: false,
+        writable: true
+      },
+      _mediaTrackTransceiver: {
+        value: mediaTrackTransceiver,
+        writable: true
       },
       _playPausedElementsIfNotBackgrounded: {
         value: options.playPausedElementsIfNotBackgrounded
@@ -82,13 +78,15 @@ class MediaTrack extends Track {
       isStarted: {
         enumerable: true,
         get() {
-          return isStarted;
+          return this._isStarted;
         }
       },
       mediaStreamTrack: {
         enumerable: true,
         get() {
-          return this._unprocessedTrack || mediaTrackTransceiver.track;
+          return this._unprocessedTrack || (this._mediaTrackTransceiver
+            ? this._mediaTrackTransceiver.track
+            : null);
         }
       },
       processedTrack: {
@@ -118,9 +116,14 @@ class MediaTrack extends Track {
    * @private
    */
   _initialize() {
-    const self = this;
+    const { _log: log } = this;
+    if (!this.mediaStreamTrack) {
+      log.debug('Skipping initialization as .mediaStreamTrack is null');
+      return;
+    }
 
-    this._log.debug('Initializing');
+    const self = this;
+    log.debug('Initializing');
     this._dummyEl = this._createElement();
 
     this.mediaStreamTrack.addEventListener('ended', function onended() {
@@ -131,10 +134,8 @@ class MediaTrack extends Track {
     if (this._dummyEl) {
       this._dummyEl.muted = true;
       this._dummyEl.oncanplay = this._start.bind(this, this._dummyEl);
-
       // NOTE(csantos): We always want to attach the original mediaStreamTrack for dummyEl
       this._attach(this._dummyEl, this.mediaStreamTrack);
-
       this._attachments.delete(this._dummyEl);
     }
   }
@@ -143,8 +144,13 @@ class MediaTrack extends Track {
    * @private
    */
   _end() {
-    this._log.debug('Ended');
+    const { _log: log } = this;
+    if (!this.mediaStreamTrack) {
+      log.debug('Skipping ended as .mediaStreamTrack is null');
+      return;
+    }
     if (this._dummyEl) {
+      this._log.debug('Ended');
       this._dummyEl.remove();
       this._dummyEl.srcObject = null;
       this._dummyEl.oncanplay = null;
@@ -174,36 +180,26 @@ class MediaTrack extends Track {
    * Attach the provided MediaStreamTrack to the media element.
    * @param el - The media element to attach to
    * @param mediaStreamTrack - The MediaStreamTrack to attach. If this is
-   * not provided, it uses the processedTrack if it exists
-   * or it defaults to the current mediaStreamTrack
+   * not provided, it uses the .processedTrack if it exists,
+   * or it defaults to the current .mediaStreamTrack
    * @private
    */
   _attach(el, mediaStreamTrack = this.processedTrack || this.mediaStreamTrack) {
-    let mediaStream = el.srcObject;
-    if (!(mediaStream instanceof this._MediaStream)) {
-      mediaStream = new this._MediaStream();
+    const mediaStream = el.srcObject || new this._MediaStream();
+    const getTracks = this.kind === 'audio' ? 'getAudioTracks' : 'getVideoTracks';
+
+    mediaStream[getTracks]().forEach(track => mediaStream.removeTrack(track));
+    if (mediaStreamTrack) {
+      mediaStream.addTrack(mediaStreamTrack);
     }
 
-    const getTracks = mediaStreamTrack.kind === 'audio'
-      ? 'getAudioTracks'
-      : 'getVideoTracks';
-
-    mediaStream[getTracks]().forEach(track => {
-      mediaStream.removeTrack(track);
-    });
-    mediaStream.addTrack(mediaStreamTrack);
-
     // NOTE(mpatwardhan): resetting `srcObject` here, causes flicker (JSDK-2641), but it lets us
-    // to sidestep the a chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1052353
-    //
+    // sidestep the chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1052353
     el.srcObject = mediaStream;
     el.autoplay = true;
     el.playsInline = true;
 
-    if (!this._attachments.has(el)) {
-      this._attachments.add(el);
-    }
-
+    this._attachments.add(el);
     return el;
   }
 
@@ -212,11 +208,9 @@ class MediaTrack extends Track {
    */
   _selectElement(selector) {
     const el = document.querySelector(selector);
-
     if (!el) {
       throw new Error(`Selector matched no element: ${selector}`);
     }
-
     return el;
   }
 
@@ -224,7 +218,7 @@ class MediaTrack extends Track {
    * @private
    */
   _updateElementsMediaStreamTrack() {
-    this._log.debug('Reattaching all elements to update mediaStreamTrack');
+    this._log.debug('Reattaching all elements to update .mediaStreamTrack');
     this._getAllAttachedElements().forEach(el => this._attach(el));
   }
 
@@ -268,17 +262,16 @@ class MediaTrack extends Track {
       return el;
     }
     const mediaStream = el.srcObject;
-    if (mediaStream instanceof this._MediaStream) {
-      mediaStream.removeTrack(this.processedTrack || this.mediaStreamTrack);
+    const mediaStreamTrack = this.processedTrack || this.mediaStreamTrack;
+    if (mediaStream && mediaStreamTrack) {
+      mediaStream.removeTrack(mediaStreamTrack);
     }
     this._attachments.delete(el);
-
     if (this._shouldShimAttachedElements && this._elShims.has(el)) {
       const shim = this._elShims.get(el);
       shim.unShim();
       this._elShims.delete(el);
     }
-
     return el;
   }
 
@@ -286,13 +279,7 @@ class MediaTrack extends Track {
    * @private
    */
   _getAllAttachedElements() {
-    const els = [];
-
-    this._attachments.forEach(el => {
-      els.push(el);
-    });
-
-    return els;
+    return Array.from(this._attachments);
   }
 }
 

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -16,8 +16,9 @@ const Track = require('./');
  *   started
  * @property {Track.Kind} kind - The kind of the underlying
  *   MediaStreamTrack, "audio" or "video"
- * @property {?MediaStreamTrack} mediaStreamTrack - The underlying
- *   MediaStreamTrack
+ * @property {?MediaStreamTrack} mediaStreamTrack - Provides access to the underlying
+ *   MediaStreamTrack; It is set to <code>null</code> if it is a {@link RemoteTrack}
+ *   that is switched off
  * @emits MediaTrack#started
  */
 class MediaTrack extends Track {

--- a/lib/media/track/receiver.js
+++ b/lib/media/track/receiver.js
@@ -10,10 +10,11 @@ class MediaTrackReceiver extends MediaTrackTransceiver {
   /**
    * Construct a {@link MediaTrackReceiver}.
    * @param {Track.ID} id - The MediaStreamTrack ID signaled through RSP/SDP
+   * @param {?string} mid - The MID associated with the MediaStreamTrack
    * @param {MediaStreamTrack} mediaStreamTrack - The remote MediaStreamTrack
    */
-  constructor(id, mediaStreamTrack) {
-    super(id, mediaStreamTrack);
+  constructor(id, mid, mediaStreamTrack) {
+    super(id, mid, mediaStreamTrack);
   }
 }
 

--- a/lib/media/track/remoteaudiotrack.js
+++ b/lib/media/track/remoteaudiotrack.js
@@ -11,6 +11,7 @@ const RemoteMediaAudioTrack = mixinRemoteMediaTrack(AudioTrack);
  * @extends AudioTrack
  * @property {boolean} isEnabled - Whether the {@link RemoteAudioTrack} is enabled
  * @property {boolean} isSwitchedOff - Whether the {@link RemoteAudioTrack} is switched off
+ * @property {?TrackSwitchOffReason} switchOffReason - The reason for the {@link RemoteMediaTrack} being switched off
  * @property {Track.SID} sid - The {@link RemoteAudioTrack}'s SID
  * @property {?Track.Priority} priority - The subscribe priority of the {@link RemoteAudioTrack}
  * @emits RemoteAudioTrack#disabled
@@ -23,16 +24,17 @@ class RemoteAudioTrack extends RemoteMediaAudioTrack {
   /**
    * Construct a {@link RemoteAudioTrack}.
    * @param {Track.SID} sid - The {@link RemoteAudioTrack}'s SID
-   * @param {MediaTrackReceiver} mediaTrackReceiver - An audio MediaStreamTrack container
+   * @param {?MediaTrackReceiver} mediaTrackReceiver - An audio MediaStreamTrack container
    * @param {boolean} isEnabled - Whether the {@link RemoteAudioTrack} is enabled
    * @param {boolean} isSwitchedOff - Whether the {@link RemoteAudioTrack} is switched off
+   * @param {?string} switchOffReason - The reason the {@link RemoteAudioTrack} is switched off
    * @param {function(?Track.Priority): void} setPriority - Set or clear the subscribe
    *  {@link Track.Priority} of the {@link RemoteAudioTrack}
    * @param {function(ClientRenderHint): void} setRenderHint - Set render hints.
-   * @param {{log: Log}} options - The {@link RemoteTrack} options
+   * @param {{log: Log, name: string}} options - The {@link RemoteTrack} options
    */
-  constructor(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, setPriority, setRenderHint, options) {
-    super(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, setPriority, setRenderHint, options);
+  constructor(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, switchOffReason, setPriority, setRenderHint, options) {
+    super('audio', sid, mediaTrackReceiver, isEnabled, isSwitchedOff, switchOffReason, setPriority, setRenderHint, options);
   }
 
   toString() {
@@ -76,6 +78,8 @@ class RemoteAudioTrack extends RemoteMediaAudioTrack {
  * A {@link RemoteAudioTrack} was switched off.
  * @param {RemoteAudioTrack} track - The {@link RemoteAudioTrack} that was
  *   switched off
+ * @param {?TrackSwitchOffReason} switchOffReason - The reason the {@link RemoteAudioTrack}
+ *   was switched off
  * @event RemoteAudioTrack#switchedOff
  */
 

--- a/lib/media/track/remoteaudiotrack.js
+++ b/lib/media/track/remoteaudiotrack.js
@@ -11,7 +11,9 @@ const RemoteMediaAudioTrack = mixinRemoteMediaTrack(AudioTrack);
  * @extends AudioTrack
  * @property {boolean} isEnabled - Whether the {@link RemoteAudioTrack} is enabled
  * @property {boolean} isSwitchedOff - Whether the {@link RemoteAudioTrack} is switched off
- * @property {?TrackSwitchOffReason} switchOffReason - The reason for the {@link RemoteMediaTrack} being switched off
+ * @property {?TrackSwitchOffReason} switchOffReason - The reason for the {@link RemoteMediaTrack} being switched off;
+ *   If switched on, it is set to <code>null</code>; The {@link RemoteMediaTrack} is initially switched off with this
+ *   property set to <code>disabled-by-subscriber</code>
  * @property {Track.SID} sid - The {@link RemoteAudioTrack}'s SID
  * @property {?Track.Priority} priority - The subscribe priority of the {@link RemoteAudioTrack}
  * @emits RemoteAudioTrack#disabled
@@ -75,7 +77,11 @@ class RemoteAudioTrack extends RemoteMediaAudioTrack {
  */
 
 /**
- * A {@link RemoteAudioTrack} was switched off.
+ * A {@link RemoteAudioTrack} was switched off. The media server stops sending media for the
+ * {@link RemoteAudioTrack} until it is switched back on. Just before the event is raised,
+ * <code>isSwitchedOff</code> is set to <code>true</code> and <code>switchOffReason</code> is
+ * set to a {@link TrackSwitchOffReason}. Also, the <code>mediaStreamTrack</code> property is
+ * set to <code>null</code>.
  * @param {RemoteAudioTrack} track - The {@link RemoteAudioTrack} that was
  *   switched off
  * @param {?TrackSwitchOffReason} switchOffReason - The reason the {@link RemoteAudioTrack}
@@ -84,7 +90,11 @@ class RemoteAudioTrack extends RemoteMediaAudioTrack {
  */
 
 /**
- * A {@link RemoteAudioTrack} was switched on.
+ * A {@link RemoteAudioTrack} was switched on. The media server starts sending media for the
+ * {@link RemoteAudioTrack} until it is switched off. Just before the event is raised,
+ * <code>isSwitchedOff</code> is set to <code>false</code> and <code>switchOffReason</code>
+ * is set to <code>null</code>. Also, the <code>mediaStreamTrack</code> property is set to a
+ * MediaStreamTrack that is the source of the {@link RemoteAudioTrack}'s media.
  * @param {RemoteAudioTrack} track - The {@link RemoteAudioTrack} that was
  *   switched on
  * @event RemoteAudioTrack#switchedOn

--- a/lib/media/track/remotemediatrack.js
+++ b/lib/media/track/remotemediatrack.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { typeErrors: E, trackPriority } = require('../../util/constants');
+const { typeErrors: E, trackPriority, trackSwitchOffReason } = require('../../util/constants');
 const { guessBrowser, isIOSChrome } = require('@twilio/webrtc/lib/util');
 const documentVisibilityMonitor = require('../../util/documentvisibilitymonitor.js');
 
@@ -10,6 +10,7 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
    * {@link Room} by a {@link RemoteParticipant}.
    * @property {boolean} isEnabled - Whether the {@link RemoteMediaTrack} is enabled
    * @property {boolean} isSwitchedOff - Whether the {@link RemoteMediaTrack} is switched off
+   * @property {?TrackSwitchOffReason} switchOffReason - The reason for the {@link RemoteMediaTrack} being switched off
    * @property {Track.SID} sid - The SID assigned to the {@link RemoteMediaTrack}
    * @property {?Track.Priority} priority - The subscribe priority of the {@link RemoteMediaTrack}
    * @emits RemoteMediaTrack#disabled
@@ -20,16 +21,18 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
   return class RemoteMediaTrack extends AudioOrVideoTrack {
     /**
      * Construct a {@link RemoteMediaTrack}.
+     * @param {Track.Kind} kind
      * @param {Track.SID} sid
-     * @param {MediaTrackReceiver} mediaTrackReceiver
+     * @param {?MediaTrackReceiver} mediaTrackReceiver
      * @param {boolean} isEnabled
-      @param {boolean} isSwitchedOff
+     * @param {boolean} isSwitchedOff
+     * @param {?string} switchOffReason
      * @param {function(?Track.Priority): void} setPriority - Set or clear the subscribe
      *  {@link Track.Priority} of the {@link RemoteMediaTrack}
      * @param {function(ClientRenderHint): void} setRenderHint - Set render hints.
-     * @param {{log: Log, name: ?string}} options
+     * @param {{log: Log, name: string}} options
      */
-    constructor(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, setPriority, setRenderHint, options) {
+    constructor(kind, sid, mediaTrackReceiver, isEnabled, isSwitchedOff, switchOffReason, setPriority, setRenderHint, options) {
       options = Object.assign({
         // NOTE(mpatwardhan): WebKit bug: 212780 sometimes causes the audio/video elements to stay paused when safari
         // regains foreground. To workaround it, when safari gains foreground - we will play any elements that were
@@ -40,7 +43,7 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
           && typeof document.visibilityState === 'string'
       }, options);
 
-      super(mediaTrackReceiver, options);
+      super(kind, mediaTrackReceiver, options);
 
       Object.defineProperties(this, {
         _isEnabled: {
@@ -64,6 +67,17 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
             setRenderHint(renderHint);
           }
         },
+        _switchOffReason: {
+          value: switchOffReason,
+          writable: true
+        },
+        _workaroundWebKitBug212780: {
+          value: options.workaroundWebKitBug212780
+        },
+        _workaroundWebKitBug212780Cleanup: {
+          value: null,
+          writable: true
+        },
         isEnabled: {
           enumerable: true,
           get() {
@@ -86,12 +100,11 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
           enumerable: true,
           value: sid
         },
-        _workaroundWebKitBug212780: {
-          value: options.workaroundWebKitBug212780
-        },
-        _workaroundWebKitBug212780Cleanup: {
-          value: null,
-          writable: true
+        switchOffReason: {
+          enumerable: true,
+          get() {
+            return trackSwitchOffReason[this._switchOffReason] || null;
+          }
         }
       });
     }
@@ -130,18 +143,32 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
 
     /**
      * @private
-     * @param {boolean} isSwitchedOff
+     * @param {?MediaTrackReceiver} mediaTrackReceiver
      */
-    _setSwitchedOff(isSwitchedOff) {
-      if (this._isSwitchedOff !== isSwitchedOff) {
+    _setMediaTrackReceiver(mediaTrackReceiver) {
+      if (this._mediaTrackTransceiver !== mediaTrackReceiver) {
+        this._mediaTrackTransceiver = mediaTrackReceiver;
+        this._initialize();
+        this._updateElementsMediaStreamTrack();
+      }
+    }
+
+    /**
+     * @private
+     * @param {boolean} isSwitchedOff
+     * @param {?string} [switchOffReason=null]
+     */
+    _setSwitchedOff(isSwitchedOff, switchOffReason = null) {
+      if (this._isSwitchedOff !== isSwitchedOff || this._switchOffReason !== switchOffReason) {
         this._isSwitchedOff = isSwitchedOff;
-        this.emit(isSwitchedOff ? 'switchedOff' : 'switchedOn', this);
+        this._switchOffReason = switchOffReason;
+        this.emit(isSwitchedOff ? 'switchedOff' : 'switchedOn', this, ...(isSwitchedOff ? [this.switchOffReason] : []));
       }
     }
 
     attach(el) {
       const result = super.attach(el);
-      if (this.mediaStreamTrack.enabled !== true) {
+      if (this.mediaStreamTrack && this.mediaStreamTrack.enabled !== true) {
         // NOTE(mpatwardhan): we disable mediaStreamTrack when there
         // are no attachments to it (see notes below). Now that there
         // are attachments re-enable the track.
@@ -173,11 +200,12 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
         // https://bugs.chromium.org/p/chromium/issues/detail?id=749928
         // to workaround: here disable the track when
         // there are no elements attached to it.
-        this.mediaStreamTrack.enabled = false;
+        if (this.mediaStreamTrack) {
+          this.mediaStreamTrack.enabled = false;
+        }
         if (this.processedTrack) {
           this.processedTrack.enabled = false;
         }
-
         if (this._workaroundWebKitBug212780Cleanup) {
           // unhook visibility change
           this._workaroundWebKitBug212780Cleanup();
@@ -242,6 +270,8 @@ function playIfPausedWhileInBackground(remoteMediaTrack) {
  * A {@link RemoteMediaTrack} was switched off.
  * @param {RemoteMediaTrack} track - The {@link RemoteMediaTrack} that was
  *   switched off
+ * @param {?TrackSwitchOffReason} switchOffReason - The reason the {@link RemoteMediaTrack}
+ *   was switched off
  * @event RemoteMediaTrack#switchedOff
  */
 

--- a/lib/media/track/remotemediatrack.js
+++ b/lib/media/track/remotemediatrack.js
@@ -10,7 +10,9 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
    * {@link Room} by a {@link RemoteParticipant}.
    * @property {boolean} isEnabled - Whether the {@link RemoteMediaTrack} is enabled
    * @property {boolean} isSwitchedOff - Whether the {@link RemoteMediaTrack} is switched off
-   * @property {?TrackSwitchOffReason} switchOffReason - The reason for the {@link RemoteMediaTrack} being switched off
+   * @property {?TrackSwitchOffReason} switchOffReason - The reason for the {@link RemoteMediaTrack} being switched off;
+   *   If switched on, it is set to <code>null</code>; The {@link RemoteMediaTrack} is initially switched off with this
+   *   property set to <code>disabled-by-subscriber</code>
    * @property {Track.SID} sid - The SID assigned to the {@link RemoteMediaTrack}
    * @property {?Track.Priority} priority - The subscribe priority of the {@link RemoteMediaTrack}
    * @emits RemoteMediaTrack#disabled
@@ -267,7 +269,11 @@ function playIfPausedWhileInBackground(remoteMediaTrack) {
  */
 
 /**
- * A {@link RemoteMediaTrack} was switched off.
+ * A {@link RemoteMediaTrack} was switched off. The media server stops sending media for the
+ * {@link RemoteMediaTrack} until it is switched back on. Just before the event is raised,
+ * <code>isSwitchedOff</code> is set to <code>true</code> and <code>switchOffReason</code> is
+ * set to a {@link TrackSwitchOffReason}. Also, the <code>mediaStreamTrack</code> property is
+ * set to <code>null</code>.
  * @param {RemoteMediaTrack} track - The {@link RemoteMediaTrack} that was
  *   switched off
  * @param {?TrackSwitchOffReason} switchOffReason - The reason the {@link RemoteMediaTrack}
@@ -276,7 +282,11 @@ function playIfPausedWhileInBackground(remoteMediaTrack) {
  */
 
 /**
- * A {@link RemoteMediaTrack} was switched on.
+ * A {@link RemoteMediaTrack} was switched on. The media server starts sending media for the
+ * {@link RemoteMediaTrack} until it is switched off. Just before the event is raised,
+ * <code>isSwitchedOff</code> is set to <code>false</code> and <code>switchOffReason</code>
+ * is set to <code>null</code>. Also, the <code>mediaStreamTrack</code> property is set to a
+ * MediaStreamTrack that is the source of the {@link RemoteMediaTrack}'s media.
  * @param {RemoteMediaTrack} track - The {@link RemoteMediaTrack} that was
  *   switched on
  * @event RemoteMediaTrack#switchedOn

--- a/lib/media/track/remotemediatrack.js
+++ b/lib/media/track/remotemediatrack.js
@@ -43,7 +43,7 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
           && typeof document.visibilityState === 'string'
       }, options);
 
-      super(kind, mediaTrackReceiver, options);
+      super(mediaTrackReceiver, options);
 
       Object.defineProperties(this, {
         _isEnabled: {

--- a/lib/media/track/remotetrackpublication.js
+++ b/lib/media/track/remotetrackpublication.js
@@ -106,7 +106,7 @@ class RemoteTrackPublication extends TrackPublication {
         switchOffReason = newSwitchOffReason;
         if (this.track) {
           this.track._setSwitchedOff(signaling.isSwitchedOff, switchOffReason);
-          this.emit(`trackSwitched${isSwitchedOff ? 'Off' : 'On'}`,  this.track, ...(isSwitchedOff ? [switchOffReason] : []));
+          this.emit(`trackSwitched${isSwitchedOff ? 'Off' : 'On'}`,  this.track, ...(isSwitchedOff ? [this.track.switchOffReason] : []));
         } else {
           log.warn(`Track was not subscribed to when switched ${isSwitchedOff ? 'off' : 'on'}.`);
         }
@@ -189,6 +189,8 @@ class RemoteTrackPublication extends TrackPublication {
 /**
  * The {@link RemoteTrack} was switched off.
  * @param {RemoteTrack} track - the {@link RemoteTrack} that was switched off
+ * @param {?TrackSwitchOffReason} switchOffReason - the reason the {@link RemoteTrack}
+ *   was switched off
  * @event RemoteTrackPublication#trackSwitchedOff
  */
 

--- a/lib/media/track/remotetrackpublication.js
+++ b/lib/media/track/remotetrackpublication.js
@@ -28,7 +28,7 @@ const TrackPublication = require('./trackpublication');
 class RemoteTrackPublication extends TrackPublication {
   /**
    * Construct a {@link RemoteTrackPublication}.
-   * @param {RemoteTrackPublicationSignaling} signaling - {@link RemoteTrackPublication} signaling
+   * @param {RemoteTrackPublicationV2|RemoteTrackPublicationV3} signaling - {@link RemoteTrackPublication} signaling
    * @param {RemoteTrackPublicationOptions} options - {@link RemoteTrackPublication}
    *   options
    */
@@ -78,8 +78,12 @@ class RemoteTrackPublication extends TrackPublication {
       error,
       isEnabled,
       isSwitchedOff,
-      priority
+      priority,
+      switchOffReason = null,
+      trackTransceiver
     } = signaling;
+
+    const { _log: log } = this;
 
     signaling.on('updated', () => {
       if (error !== signaling.error) {
@@ -94,14 +98,26 @@ class RemoteTrackPublication extends TrackPublication {
         }
         this.emit(signaling.isEnabled ? 'trackEnabled' : 'trackDisabled');
       }
-      if (isSwitchedOff !== signaling.isSwitchedOff) {
-        this._log.debug(`${this.trackSid}: ${isSwitchedOff ? 'OFF' : 'ON'} => ${signaling.isSwitchedOff ? 'OFF' : 'ON'}`);
+      const newSwitchOffReason = signaling.switchOffReason || null;
+      if (isSwitchedOff !== signaling.isSwitchedOff || switchOffReason !== newSwitchOffReason) {
+        log.debug(`${this.trackSid}: ${isSwitchedOff ? 'OFF' : 'ON'} => ${signaling.isSwitchedOff ? 'OFF' : 'ON'}`);
+        log.debug(`${this.trackSid} off_reason: ${switchOffReason} => ${newSwitchOffReason}`);
         isSwitchedOff = signaling.isSwitchedOff;
+        switchOffReason = newSwitchOffReason;
         if (this.track) {
-          this.track._setSwitchedOff(signaling.isSwitchedOff);
-          this.emit(isSwitchedOff ? 'trackSwitchedOff' : 'trackSwitchedOn',  this.track);
-        } else if (isSwitchedOff) {
-          this._log.warn('Track was not subscribed when switched Off.');
+          this.track._setSwitchedOff(signaling.isSwitchedOff, switchOffReason);
+          this.emit(`trackSwitched${isSwitchedOff ? 'Off' : 'On'}`,  this.track, ...(isSwitchedOff ? [switchOffReason] : []));
+        } else {
+          log.warn(`Track was not subscribed to when switched ${isSwitchedOff ? 'off' : 'on'}.`);
+        }
+      }
+      if (trackTransceiver !== signaling.trackTransceiver) {
+        log.debug(`${this.trackSid} MediaTrackReceiver changed:`, trackTransceiver, signaling.trackTransceiver);
+        trackTransceiver = signaling.trackTransceiver;
+        if (this.track) {
+          this.track._setTrackReceiver(trackTransceiver);
+        } else {
+          log.warn('Track was not subscribed to when TrackReceiver changed.');
         }
       }
       if (priority !== signaling.priority) {

--- a/lib/media/track/remotetrackpublication.js
+++ b/lib/media/track/remotetrackpublication.js
@@ -106,7 +106,7 @@ class RemoteTrackPublication extends TrackPublication {
         switchOffReason = newSwitchOffReason;
         if (this.track) {
           this.track._setSwitchedOff(signaling.isSwitchedOff, switchOffReason);
-          this.emit(`trackSwitched${isSwitchedOff ? 'Off' : 'On'}`,  this.track, ...(isSwitchedOff ? [this.track.switchOffReason] : []));
+          this.emit(isSwitchedOff ? 'trackSwitchedOff' : 'trackSwitchedOn',  this.track, ...(isSwitchedOff ? [this.track.switchOffReason] : []));
         } else {
           log.warn(`Track was not subscribed to when switched ${isSwitchedOff ? 'off' : 'on'}.`);
         }

--- a/lib/media/track/remotetrackpublication.js
+++ b/lib/media/track/remotetrackpublication.js
@@ -187,7 +187,11 @@ class RemoteTrackPublication extends TrackPublication {
  */
 
 /**
- * The {@link RemoteTrack} was switched off.
+ * The {@link RemoteTrack} was switched off. The media server stops sending media or data
+ * for the {@link RemoteTrack} until it is switched back on. Just before the event is raised,
+ * <code>isSwitchedOff</code> is set to <code>true</code> and <code>switchOffReason</code>
+ * is set to a {@link TrackSwitchOffReason}. Also, if the {@link RemoteTrack} receives either
+ * audio or video media, the <code>mediaStreamTrack</code> property is set to <code>null</code>.
  * @param {RemoteTrack} track - the {@link RemoteTrack} that was switched off
  * @param {?TrackSwitchOffReason} switchOffReason - the reason the {@link RemoteTrack}
  *   was switched off
@@ -195,7 +199,12 @@ class RemoteTrackPublication extends TrackPublication {
  */
 
 /**
- * The {@link RemoteTrack} was switched on.
+ * The {@link RemoteTrack} was switched on. The media server starts sending media or data
+ * for the {@link RemoteMediaTrack} until it is switched off. Just before the event is raised,
+ * <code>isSwitchedOff</code> is set to <code>false</code> and <code>switchOffReason</code>
+ * is set to <code>null</code>. Also, if the {@link RemoteTrack} receives either audio or video
+ * media,the <code>mediaStreamTrack</code> property is set to a MediaStreamTrack that is the
+ * source of the {@link RemoteTrack}'s media.
  * @param {RemoteTrack} track - the {@link RemoteTrack} that was switched on
  * @event RemoteTrackPublication#trackSwitchedOn
  */

--- a/lib/media/track/sender.js
+++ b/lib/media/track/sender.js
@@ -13,7 +13,7 @@ class MediaTrackSender extends MediaTrackTransceiver {
    * @param {MediaStreamTrack} mediaStreamTrack
    */
   constructor(mediaStreamTrack) {
-    super(mediaStreamTrack.id, mediaStreamTrack);
+    super(mediaStreamTrack.id, null, mediaStreamTrack);
     Object.defineProperties(this, {
       _clones: {
         value: new Set()

--- a/lib/media/track/transceiver.js
+++ b/lib/media/track/transceiver.js
@@ -12,9 +12,10 @@ class MediaTrackTransceiver extends TrackTransceiver {
   /**
    * Construct a {@link MediaTrackTransceiver}.
    * @param {Track.ID} id - The MediaStreamTrack ID signaled through RSP/SDP
+   * @param {?string} mid - The MID associated with the MediaStreamTrack
    * @param {MediaStreamTrack} mediaStreamTrack
    */
-  constructor(id, mediaStreamTrack) {
+  constructor(id, mid, mediaStreamTrack) {
     super(id, mediaStreamTrack.kind);
     Object.defineProperties(this, {
       _track: {
@@ -26,6 +27,10 @@ class MediaTrackTransceiver extends TrackTransceiver {
         get() {
           return this._track.enabled;
         }
+      },
+      mid: {
+        enumerable: true,
+        value: mid
       },
       readyState: {
         enumerable: true,

--- a/lib/participant.js
+++ b/lib/participant.js
@@ -632,7 +632,12 @@ function reemitTrackPublicationEvents(participant, publication) {
 
   participant._getTrackPublicationEvents().forEach(([publicationEvent, participantEvent]) => {
     publicationEventReemitters.set(publicationEvent, (...args) => {
-      participant.emit(participantEvent, ...args, publication);
+      if (publicationEvent === 'trackSwitchedOff') {
+        const [track, switchOffReason] = args;
+        participant.emit(participantEvent, track, publication, switchOffReason);
+      } else {
+        participant.emit(participantEvent, ...args, publication);
+      }
     });
     publication.on(publicationEvent, publicationEventReemitters.get(publicationEvent));
   });

--- a/lib/participant.js
+++ b/lib/participant.js
@@ -307,7 +307,7 @@ class Participant extends EventEmitter {
 
     function trackSignalingRemoved(signaling) {
       if (signaling.isSubscribed) {
-        signaling.setTrackTransceiver(null);
+        signaling.setTrackTransceiver(null, false);
       }
       const updated = self._trackSignalingUpdatedEventCallbacks.get(signaling.sid);
       if (updated) {
@@ -321,7 +321,7 @@ class Participant extends EventEmitter {
     }
 
     function trackSignalingSubscribed(signaling) {
-      const { isEnabled, name, kind, sid, trackTransceiver, isSwitchedOff } = signaling;
+      const { isEnabled, name, kind, sid, trackTransceiver, isSwitchedOff, switchOffReason = null } = signaling;
       const RemoteTrack = {
         audio: RemoteAudioTrack,
         video: RemoteVideoTrack,
@@ -346,7 +346,7 @@ class Participant extends EventEmitter {
       };
       const track = kind === 'data'
         ? new RemoteTrack(sid, trackTransceiver, options)
-        : new RemoteTrack(sid, trackTransceiver, isEnabled, isSwitchedOff, setPriority, setRenderHint, options);
+        : new RemoteTrack(sid, trackTransceiver, isEnabled, isSwitchedOff, switchOffReason, setPriority, setRenderHint, options);
 
       self._addTrack(track, publication, trackTransceiver.id);
     }

--- a/lib/remoteparticipant.js
+++ b/lib/remoteparticipant.js
@@ -232,15 +232,26 @@ class RemoteParticipant extends Participant {
  */
 
 /**
- * A {@link RemoteParticipant}'s {@link RemoteTrack} was subscribed to.
+ * A {@link RemoteParticipant}'s {@link RemoteTrack} was switched off. The media server stops
+ * sending media or data for the {@link RemoteTrack} until it is switched back on. Just before
+ * the event is raised, <code>isSwitchedOff</code> is set to <code>true</code> and <code>switchOffReason</code>
+ * is set to a {@link TrackSwitchOffReason}. Also, if the {@link RemoteTrack} receives either audio or video
+ * media, the <code>mediaStreamTrack</code> property is set to <code>null</code>.
  * @param {RemoteTrack} track - The {@link RemoteTrack} that was switched off
  * @param {RemoteTrackPublication} publication - The {@link RemoteTrackPublication}
  *   for the {@link RemoteTrack} that was switched off
+ * @param {?TrackSwitchOffReason} switchOffReason - The reason the {@link RemoteMediaTrack}
+ *   was switched off
  * @event RemoteParticipant#trackSwitchedOff
  */
 
 /**
- * A {@link RemoteParticipant}'s {@link RemoteTrack} was switched on.
+ * A {@link RemoteParticipant}'s {@link RemoteTrack} was switched on. The media server starts
+ * sending media for the {@link RemoteTrack} until it is switched off. Just before the event is raised,
+ * <code>isSwitchedOff</code> is set to <code>false</code> and <code>switchOffReason</code>
+ * is set to <code>null</code>. Also, if the {@link RemoteTrack} receives either audio or video media,
+ * the <code>mediaStreamTrack</code> property is set to a MediaStreamTrack that is the source of the
+ * {@link RemoteTrack}'s media.
  * @param {RemoteTrack} track - The {@link RemoteTrack} that was switched on.
  * @param {RemoteTrackPublication} publication - The {@link RemoteTrackPublication}
  *   for the {@link RemoteTrack} that was switched on

--- a/lib/room.js
+++ b/lib/room.js
@@ -387,17 +387,28 @@ function rewriteLocalTrackIds(room, trackStats) {
  */
 
 /**
- * A {@link RemoteParticipant}'s {@link RemoteTrack} was switched off.
+ * A {@link RemoteParticipant}'s {@link RemoteTrack} was switched off. The media server stops
+ * sending media or data for the {@link RemoteTrack} until it is switched back on. Just before
+ * the event is raised, <code>isSwitchedOff</code> is set to <code>true</code> and <code>switchOffReason</code>
+ * is set to a {@link TrackSwitchOffReason}. Also, if the {@link RemoteTrack} receives either audio or video
+ * media, the <code>mediaStreamTrack</code> property is set to <code>null</code>.
  * @param {RemoteTrack} track - The {@link RemoteTrack} that was switched off
  * @param {RemoteTrackPublication} publication - The {@link RemoteTrackPublication}
  *   for the {@link RemoteTrack} that was subscribed to
  * @param {RemoteParticipant} participant - The {@link RemoteParticipant} whose
  *   {@link RemoteTrack} was switched off
+ * @param {TrackSwitchOffReason} switchOffReason - The reason the {@link RemoteTrack}
+ *   was switched off
  * @event Room#trackSwitchedOff
  */
 
 /**
- * A {@link RemoteParticipant}'s {@link RemoteTrack} was switched on.
+ * A {@link RemoteParticipant}'s {@link RemoteTrack} was switched on. The media server starts
+ * sending media for the {@link RemoteTrack} until it is switched off. Just before the event is raised,
+ * <code>isSwitchedOff</code> is set to <code>false</code> and <code>switchOffReason</code>
+ * is set to <code>null</code>. Also, if the {@link RemoteTrack} receives either audio or video media,
+ * the <code>mediaStreamTrack</code> property is set to a MediaStreamTrack that is the source of the
+ * {@link RemoteTrack}'s media.
  * @param {RemoteTrack} track - The {@link RemoteTrack} that was switched on
  * @param {RemoteTrackPublication} publication - The {@link RemoteTrackPublication}
  *   for the {@link RemoteTrack} that was subscribed to
@@ -488,7 +499,12 @@ function connectParticipant(room, participantSignaling) {
     function reemit() {
       const args = [].slice.call(arguments);
       args.unshift(participantEvent);
-      args.push(participant);
+      if (participantEvent === 'trackSwitchedOff') {
+        const switchOffReason = args.pop();
+        args.push(participant, switchOffReason);
+      } else {
+        args.push(participant);
+      }
       room.emit(...args);
     }
     participant.on(event, reemit);

--- a/lib/signaling/remotetrackpublication.js
+++ b/lib/signaling/remotetrackpublication.js
@@ -28,14 +28,6 @@ class RemoteTrackPublicationSignaling extends TrackSignaling {
   }
 
   /**
-   * Whether the {@link RemoteTrackPublicationSignaling} is subscribed to.
-   * @property {boolean}
-   */
-  get isSubscribed() {
-    return !!this.trackTransceiver;
-  }
-
-  /**
    * Whether the {@link RemoteTrackPublicationSignaling} is switched off.
    * @property {boolean}
    */

--- a/lib/signaling/track.js
+++ b/lib/signaling/track.js
@@ -125,7 +125,6 @@ class TrackSignaling extends EventEmitter {
    * @param {TrackTransceiver} trackTransceiver
    * @returns {this}
    */
-
   setTrackTransceiver(trackTransceiver) {
     trackTransceiver = trackTransceiver || null;
     if (this.trackTransceiver !== trackTransceiver) {

--- a/lib/signaling/v2/cancelableroomsignalingpromise.js
+++ b/lib/signaling/v2/cancelableroomsignalingpromise.js
@@ -3,6 +3,7 @@
 const CancelablePromise = require('../../util/cancelablepromise');
 const DefaultPeerConnectionManager = require('./peerconnectionmanager');
 const DefaultRoomV2 = require('./room');
+const DefaultRoomV3 = require('../v3/room');
 const DefaultTransport = require('./twilioconnectiontransport');
 
 const {
@@ -16,11 +17,12 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
   options = Object.assign({
     PeerConnectionManager: DefaultPeerConnectionManager,
     RoomV2: DefaultRoomV2,
+    RoomV3: DefaultRoomV3,
     Transport: DefaultTransport
   }, options);
 
   const adaptiveSimulcast = preferredCodecs.video[0] &&  preferredCodecs.video[0].adaptiveSimulcast === true;
-  const { PeerConnectionManager, RoomV2, Transport, iceServers, log } = options;
+  const { PeerConnectionManager, RoomV2, RoomV3, Transport, iceServers, log } = options;
   const peerConnectionManager = new PeerConnectionManager(encodingParameters, preferredCodecs, options);
   const trackSenders = flatMap(localParticipant.tracks, trackV2 => [trackV2.trackTransceiver]);
   peerConnectionManager.setTrackSenders(trackSenders);
@@ -123,9 +125,10 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
         return;
       }
 
-      const { options: { signaling_region: signalingRegion } } = initialState;
+      const { options: { signaling_region: signalingRegion }, version } = initialState;
       localParticipant.setSignalingRegion(signalingRegion);
-      resolve(new RoomV2(localParticipant, initialState, transport, peerConnectionManager, options));
+      const RoomSignaling = version === 3 ? RoomV3 : RoomV2;
+      resolve(new RoomSignaling(localParticipant, initialState, transport, peerConnectionManager, options));
     });
 
     transport.once('stateChanged', (state, error) => {

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -903,9 +903,9 @@ class PeerConnectionV2 extends StateMachine {
     this._trackMatcher = this._trackMatcher || new TrackMatcher();
     this._trackMatcher.update(sdp);
 
-    const mediaStreamTrack = event.track;
+    const { track: mediaStreamTrack, transceiver: { mid } } = event;
     const signaledTrackId = this._trackMatcher.match(event) || mediaStreamTrack.id;
-    const mediaTrackReceiver = new MediaTrackReceiver(signaledTrackId, mediaStreamTrack);
+    const mediaTrackReceiver = new MediaTrackReceiver(signaledTrackId, mid, mediaStreamTrack);
 
     // NOTE(mmalavalli): "ended" is not fired on the remote MediaStreamTrack when
     // the remote peer removes a track. So, when this MediaStreamTrack is re-used

--- a/lib/signaling/v2/remoteparticipant.js
+++ b/lib/signaling/v2/remoteparticipant.js
@@ -21,7 +21,8 @@ class RemoteParticipantV2 extends RemoteParticipantSignaling {
     super(participantState.sid, participantState.identity);
 
     options = Object.assign({
-      RemoteTrackPublicationV2
+      RemoteTrackPublicationSignaling: RemoteTrackPublicationV2,
+      otherProperties: {}
     }, options);
 
     Object.defineProperties(this, {
@@ -29,8 +30,8 @@ class RemoteParticipantV2 extends RemoteParticipantSignaling {
         writable: true,
         value: null
       },
-      _RemoteTrackPublicationV2: {
-        value: options.RemoteTrackPublicationV2
+      _RemoteTrackPublicationSignaling: {
+        value: options.RemoteTrackPublicationSignaling
       },
       _getInitialTrackSwitchOffState: {
         value: getInitialTrackSwitchOffState
@@ -52,6 +53,10 @@ class RemoteParticipantV2 extends RemoteParticipantSignaling {
       }
     });
 
+    Object.entries(options.otherProperties).forEach((value, key) => {
+      Object.defineProperty(this, key, { value });
+    });
+
     return this.update(participantState);
   }
 
@@ -59,7 +64,7 @@ class RemoteParticipantV2 extends RemoteParticipantSignaling {
    * @private
    */
   _getOrCreateTrack(trackState) {
-    const RemoteTrackPublicationV2 = this._RemoteTrackPublicationV2;
+    const RemoteTrackPublicationV2 = this._RemoteTrackPublicationSignaling;
     let track = this.tracks.get(trackState.sid);
     if (!track) {
       const isSwitchedOff = this._getInitialTrackSwitchOffState(trackState.sid);

--- a/lib/signaling/v2/remoteparticipant.js
+++ b/lib/signaling/v2/remoteparticipant.js
@@ -22,7 +22,7 @@ class RemoteParticipantV2 extends RemoteParticipantSignaling {
 
     options = Object.assign({
       RemoteTrackPublicationSignaling: RemoteTrackPublicationV2,
-      otherProperties: {}
+      getPendingTrackReceiver: () => null
     }, options);
 
     Object.defineProperties(this, {
@@ -35,6 +35,9 @@ class RemoteParticipantV2 extends RemoteParticipantSignaling {
       },
       _getInitialTrackSwitchOffState: {
         value: getInitialTrackSwitchOffState
+      },
+      _getPendingTrackReceiver: {
+        value: options.getPendingTrackReceiver
       },
       updateSubscriberTrackPriority: {
         value: (trackSid, priority) => setPriority(trackSid, priority)
@@ -53,11 +56,7 @@ class RemoteParticipantV2 extends RemoteParticipantSignaling {
       }
     });
 
-    Object.entries(options.otherProperties).forEach(([key, value]) => {
-      Object.defineProperty(this, key, { value });
-    });
-
-    return this.update(participantState);
+    this.update(participantState);
   }
 
   /**

--- a/lib/signaling/v2/remoteparticipant.js
+++ b/lib/signaling/v2/remoteparticipant.js
@@ -53,7 +53,7 @@ class RemoteParticipantV2 extends RemoteParticipantSignaling {
       }
     });
 
-    Object.entries(options.otherProperties).forEach((value, key) => {
+    Object.entries(options.otherProperties).forEach(([key, value]) => {
       Object.defineProperty(this, key, { value });
     });
 

--- a/lib/signaling/v2/remotetrackpublication.js
+++ b/lib/signaling/v2/remotetrackpublication.js
@@ -17,6 +17,14 @@ class RemoteTrackPublicationV2 extends RemoteTrackPublicationSignaling {
   }
 
   /**
+   * Whether the {@link RemoteTrackPublicationV2} is subscribed to.
+   * @property {boolean}
+   */
+  get isSubscribed() {
+    return !!this.trackTransceiver;
+  }
+
+  /**
    * Compare the {@link RemoteTrackPublicationV2} to a
    * {@link RemoteTrackPublicationV2#Representation} of itself and perform any
    * updates necessary.

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 'use strict';
 
 const DominantSpeakerSignaling = require('./dominantspeakersignaling');
@@ -43,7 +42,7 @@ class RoomV2 extends RoomSignaling {
       NetworkQualityMonitor,
       NetworkQualitySignaling,
       RecordingSignaling: RecordingV2,
-      RemoteParticipantV2,
+      RemoteParticipantSignaling: RemoteParticipantV2,
       TrackPrioritySignaling,
       TrackSwitchOffSignaling,
       bandwidthProfile: null,
@@ -87,8 +86,8 @@ class RoomV2 extends RoomSignaling {
         value: 0,
         writable: true
       },
-      _RemoteParticipantV2: {
-        value: options.RemoteParticipantV2
+      _RemoteParticipantSignaling: {
+        value: options.RemoteParticipantSignaling
       },
       _subscribed: {
         value: new Map()
@@ -190,14 +189,14 @@ class RoomV2 extends RoomSignaling {
   /**
    * @private
    */
-  _getOrCreateTrackReceiverDeferred(id) {
+  _getOrCreateTrackReceiverDeferred(id, idOrMid = 'id') {
     const deferred = this._trackReceiverDeferreds.get(id) || defer();
     const trackReceivers = this._peerConnectionManager.getTrackReceivers();
 
     // NOTE(mmalavalli): In Firefox, there can be instances where a MediaStreamTrack
     // for the given Track ID already exists, for example, when a Track is removed
     // and added back. If that is the case, then we should resolve 'deferred'.
-    const trackReceiver = trackReceivers.find(trackReceiver => trackReceiver.id === id && trackReceiver.readyState !== 'ended');
+    const trackReceiver = trackReceivers.find(trackReceiver => trackReceiver[idOrMid] === id && trackReceiver.readyState !== 'ended');
 
     if (trackReceiver) {
       deferred.resolve(trackReceiver);
@@ -223,6 +222,20 @@ class RoomV2 extends RoomSignaling {
   /**
    * @private
    */
+  _createRemoteParticipant(participantState) {
+    const { _RemoteParticipantSignaling: RemoteParticipantV2 } = this;
+    return new RemoteParticipantV2(
+      participantState,
+      trackSid => this._getInitialTrackSwitchOffState(trackSid),
+      (trackSid, priority) => this._trackPrioritySignaling.sendTrackPriorityUpdate(trackSid, 'subscribe', priority),
+      (trackSid, hint) => this._renderHintsSignaling.setTrackHint(trackSid, hint),
+      trackSid => this._renderHintsSignaling.clearTrackHint(trackSid)
+    );
+  }
+
+  /**
+   * @private
+   */
   _disconnect(error) {
     const didDisconnect = super._disconnect.call(this, error);
     if (didDisconnect) {
@@ -241,8 +254,8 @@ class RoomV2 extends RoomSignaling {
   /**
    * @private
    */
-  _getTrackReceiver(id) {
-    return this._getOrCreateTrackReceiverDeferred(id).promise.then(trackReceiver => {
+  _getTrackReceiver(id, idOrMid = 'id') {
+    return this._getOrCreateTrackReceiverDeferred(id, idOrMid).promise.then(trackReceiver => {
       this._deleteTrackReceiverDeferred(id);
       return trackReceiver;
     });
@@ -273,17 +286,10 @@ class RoomV2 extends RoomSignaling {
    * @private
    */
   _getOrCreateRemoteParticipant(participantState) {
-    const RemoteParticipantV2 = this._RemoteParticipantV2;
     let participant = this.participants.get(participantState.sid);
     const self = this;
     if (!participant) {
-      participant = new RemoteParticipantV2(
-        participantState,
-        trackSid => this._getInitialTrackSwitchOffState(trackSid),
-        (trackSid, priority) => this._trackPrioritySignaling.sendTrackPriorityUpdate(trackSid, 'subscribe', priority),
-        (trackSid, hint) => this._renderHintsSignaling.setTrackHint(trackSid, hint),
-        trackSid => this._renderHintsSignaling.clearTrackHint(trackSid)
-      );
+      participant = this._createRemoteParticipant(participantState);
       participant.on('stateChanged', function stateChanged(state) {
         if (state === 'disconnected') {
           participant.removeListener('stateChanged', stateChanged);
@@ -339,33 +345,83 @@ class RoomV2 extends RoomSignaling {
    * @private
    */
   _update(roomState) {
-    if (roomState.subscribed && roomState.subscribed.revision > this._subscribedRevision) {
-      this._subscribedRevision = roomState.subscribed.revision;
-      roomState.subscribed.tracks.forEach(trackState => {
-        if (trackState.id) {
-          this._subscriptionFailures.delete(trackState.sid);
-          this._subscribed.set(trackState.sid, trackState.id);
-        } else if (trackState.error && !this._subscriptionFailures.has(trackState.sid)) {
-          this._subscriptionFailures.set(trackState.sid, trackState.error);
-        }
-      });
+    const { type } = roomState;
+    this._updateSubscribed(roomState);
+    this._updateParticipants(roomState, type);
+    this._handleSubscriptions();
+    this._updatePeerConnections(roomState, type);
+    this._updateRecording(roomState);
+    this._updatePublished(roomState);
+    this._connectLocalParticipant(roomState);
+    this._setupMediaSignalings(roomState);
+    return this;
+  }
 
-      const subscribedTrackSids = new Set(roomState.subscribed.tracks
-        .filter(trackState => !!trackState.id)
-        .map(trackState => trackState.sid));
-
-      this._subscribed.forEach((trackId, trackSid) => {
-        if (!subscribedTrackSids.has(trackSid)) {
-          this._subscribed.delete(trackSid);
-        }
-      });
+  /**
+   * @private
+   */
+  _connectLocalParticipant({ participant }) {
+    if (!participant) {
+      return;
     }
+    const { sid, identity } = participant;
+    this.localParticipant.connect(sid, identity);
+  }
 
+  /**
+   * @private
+   */
+  _handleSubscriptions() {
+    const trackSidsToTrackSignalings = this._getTrackSidsToTrackSignalings();
+
+    this._subscriptionFailures.forEach((error, trackSid) => {
+      const trackSignaling = trackSidsToTrackSignalings.get(trackSid);
+      if (trackSignaling) {
+        this._subscriptionFailures.delete(trackSid);
+        trackSignaling.subscribeFailed(createTwilioError(error.code, error.message));
+      }
+    });
+
+    trackSidsToTrackSignalings.forEach(trackSignaling => {
+      const trackId = this._subscribed.get(trackSignaling.sid);
+      if (!trackId || (trackSignaling.isSubscribed && trackSignaling.trackTransceiver.id !== trackId)) {
+        trackSignaling.setTrackTransceiver(null);
+      }
+      if (trackId) {
+        this._getTrackReceiver(trackId).then(trackReceiver => trackSignaling.setTrackTransceiver(trackReceiver));
+      }
+    });
+  }
+
+  /**
+   * @private
+   */
+  _setupMediaSignalings({ media_signaling: mediaSignalings }) {
+    [
+      this._dominantSpeakerSignaling,
+      this._networkQualitySignaling,
+      this._trackPrioritySignaling,
+      this._trackSwitchOffSignaling,
+      this._renderHintsSignaling,
+      this._publisherHintsSignaling
+    ].forEach(mediaSignaling => {
+      const channel = mediaSignaling.channel;
+      if (!mediaSignaling.isSetup
+        && mediaSignalings
+        && mediaSignalings[channel]
+        && mediaSignalings[channel].transport
+        && mediaSignalings[channel].transport.type === 'data-channel') {
+        mediaSignaling.setup(mediaSignalings[channel].transport.label);
+      }
+    });
+  }
+
+  /**
+   * @private
+   */
+  _updateParticipants({ participants = [] }, roomStateType) {
     const participantsToKeep = new Set();
-
-    // eslint-disable-next-line no-warning-comments
-    // TODO(mroberts): Remove me once the Server is fixed.
-    (roomState.participants || []).forEach(participantState => {
+    participants.forEach(participantState => {
       if (participantState.sid === this.localParticipant.sid) {
         return;
       }
@@ -387,62 +443,75 @@ class RoomV2 extends RoomSignaling {
       participantsToKeep.add(participant);
     });
 
-    if (roomState.type === 'synced') {
+    if (roomStateType === 'synced') {
       this.participants.forEach(participant => {
         if (!participantsToKeep.has(participant)) {
           participant.disconnect();
         }
       });
     }
+  }
 
-    handleSubscriptions(this);
-
-    // eslint-disable-next-line no-warning-comments
-    // TODO(mroberts): Remove me once the Server is fixed.
-    /* eslint camelcase:0 */
-    if (roomState.peer_connections) {
-      this._peerConnectionManager.update(roomState.peer_connections, roomState.type === 'synced');
+  /**
+   * @private
+   */
+  _updatePeerConnections({ peer_connections: peerConnections }, roomStateType) {
+    if (peerConnections) {
+      this._peerConnectionManager.update(peerConnections, roomStateType === 'synced');
     }
+  }
 
-    if (roomState.recording) {
-      this.recording.update(roomState.recording);
+  /**
+   * @private
+   */
+  _updateRecording({ recording }) {
+    if (recording) {
+      this.recording.update(recording);
     }
+  }
 
-    if (roomState.published && roomState.published.revision > this._publishedRevision) {
-      this._publishedRevision = roomState.published.revision;
-      roomState.published.tracks.forEach(track => {
-        if (track.sid) {
-          this._published.set(track.id, track.sid);
-        }
-      });
-      this.localParticipant.update(roomState.published);
+  /**
+   * @private
+   */
+  _updatePublished({ published }) {
+    if (!published || published.revision <= this._publishedRevision) {
+      return;
     }
+    this._publishedRevision = published.revision;
+    published.tracks.forEach(track => {
+      if (track.sid) {
+        this._published.set(track.id, track.sid);
+      }
+    });
+    this.localParticipant.update(published);
+  }
 
-    if (roomState.participant) {
-      this.localParticipant.connect(
-        roomState.participant.sid,
-        roomState.participant.identity);
+  /**
+   * @private
+   */
+  _updateSubscribed({ subscribed }) {
+    if (!subscribed || subscribed.revision <= this._subscribedRevision) {
+      return;
     }
-
-    [
-      this._dominantSpeakerSignaling,
-      this._networkQualitySignaling,
-      this._trackPrioritySignaling,
-      this._trackSwitchOffSignaling,
-      this._renderHintsSignaling,
-      this._publisherHintsSignaling
-    ].forEach(mediaSignaling => {
-      const channel = mediaSignaling.channel;
-      if (!mediaSignaling.isSetup
-        && roomState.media_signaling
-        && roomState.media_signaling[channel]
-        && roomState.media_signaling[channel].transport
-        && roomState.media_signaling[channel].transport.type === 'data-channel') {
-        mediaSignaling.setup(roomState.media_signaling[channel].transport.label);
+    this._subscribedRevision = subscribed.revision;
+    subscribed.tracks.forEach(trackState => {
+      if (trackState.id) {
+        this._subscriptionFailures.delete(trackState.sid);
+        this._subscribed.set(trackState.sid, trackState.id);
+      } else if (trackState.error && !this._subscriptionFailures.has(trackState.sid)) {
+        this._subscriptionFailures.set(trackState.sid, trackState.error);
       }
     });
 
-    return this;
+    const subscribedTrackSids = new Set(subscribed.tracks
+      .filter(trackState => !!trackState.id)
+      .map(trackState => trackState.sid));
+
+    this._subscribed.forEach((trackId, trackSid) => {
+      if (!subscribedTrackSids.has(trackSid)) {
+        this._subscribed.delete(trackSid);
+      }
+    });
   }
 
   _initPublisherHintSignaling() {
@@ -752,28 +821,6 @@ function periodicallyPublishStats(roomV2, transport, intervalMs) {
     if (state === 'disconnected') {
       clearInterval(interval);
       roomV2.removeListener('stateChanged', onStateChanged);
-    }
-  });
-}
-
-function handleSubscriptions(room) {
-  const trackSidsToTrackSignalings = room._getTrackSidsToTrackSignalings();
-
-  room._subscriptionFailures.forEach((error, trackSid) => {
-    const trackSignaling = trackSidsToTrackSignalings.get(trackSid);
-    if (trackSignaling) {
-      room._subscriptionFailures.delete(trackSid);
-      trackSignaling.subscribeFailed(createTwilioError(error.code, error.message));
-    }
-  });
-
-  trackSidsToTrackSignalings.forEach(trackSignaling => {
-    const trackId = room._subscribed.get(trackSignaling.sid);
-    if (!trackId || (trackSignaling.isSubscribed && trackSignaling.trackTransceiver.id !== trackId)) {
-      trackSignaling.setTrackTransceiver(null);
-    }
-    if (trackId) {
-      room._getTrackReceiver(trackId).then(trackReceiver => trackSignaling.setTrackTransceiver(trackReceiver));
     }
   });
 }

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -119,11 +119,13 @@ class RoomV2 extends RoomSignaling {
       _trackPrioritySignaling: {
         value: new options.TrackPrioritySignaling(getTrackReceiver, { log }),
       },
+      _trackSubscriptionsSignaling: {
+        value: options.TrackSubscriptionsSignaling
+          ? new options.TrackSubscriptionsSignaling(getTrackReceiver, { log })
+          : null
+      },
       _trackSwitchOffSignaling: {
         value: new options.TrackSwitchOffSignaling(getTrackReceiver, { log }),
-      },
-      _otherMediaSignalings: {
-        value: options.otherMediaSignalings
       },
       _pendingSwitchOffStates: {
         value: new Map()
@@ -145,12 +147,9 @@ class RoomV2 extends RoomSignaling {
     this._initNetworkQualityMonitorSignaling();
     this._initPublisherHintSignaling();
 
-    this._otherMediaSignalings.forEach(({ MediaSignaling, name, initMethod }) => {
-      Object.defineProperty(this, name, {
-        value: new MediaSignaling(getTrackReceiver, { log })
-      });
-      this[initMethod]();
-    });
+    if (this._trackSubscriptionsSignaling) {
+      this._initTrackSubscriptionsSignaling();
+    }
 
     handleLocalParticipantEvents(this, localParticipant);
     handlePeerConnectionEvents(this, peerConnectionManager);
@@ -407,7 +406,9 @@ class RoomV2 extends RoomSignaling {
    * @private
    */
   _setupMediaSignalings({ media_signaling: mediaSignalings }) {
-    const otherMediaSignalings = this._otherMediaSignalings.map(({ name }) => this[name]);
+    const otherMediaSignalings = this._trackSubscriptionsSignaling
+      ? [this._trackSubscriptionsSignaling]
+      : [];
     [
       this._dominantSpeakerSignaling,
       this._networkQualitySignaling,

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -46,6 +46,7 @@ class RoomV2 extends RoomSignaling {
       TrackPrioritySignaling,
       TrackSwitchOffSignaling,
       bandwidthProfile: null,
+      otherMediaSignalings: [],
       sessionTimeout: initialState.options.session_timeout * 1000,
       statsPublishIntervalMs: STATS_PUBLISH_INTERVAL_MS
     }, options);
@@ -121,6 +122,9 @@ class RoomV2 extends RoomSignaling {
       _trackSwitchOffSignaling: {
         value: new options.TrackSwitchOffSignaling(getTrackReceiver, { log }),
       },
+      _otherMediaSignalings: {
+        value: options.otherMediaSignalings
+      },
       _pendingSwitchOffStates: {
         value: new Map()
       },
@@ -140,6 +144,13 @@ class RoomV2 extends RoomSignaling {
     this._initDominantSpeakerSignaling();
     this._initNetworkQualityMonitorSignaling();
     this._initPublisherHintSignaling();
+
+    this._otherMediaSignalings.forEach(({ MediaSignaling, name, initMethod }) => {
+      Object.defineProperty(this, name, {
+        value: new MediaSignaling(getTrackReceiver, { log })
+      });
+      this[initMethod]();
+    });
 
     handleLocalParticipantEvents(this, localParticipant);
     handlePeerConnectionEvents(this, peerConnectionManager);
@@ -397,14 +408,15 @@ class RoomV2 extends RoomSignaling {
    * @private
    */
   _setupMediaSignalings({ media_signaling: mediaSignalings }) {
+    const otherMediaSignalings = this._otherMediaSignalings.map(({ name }) => this[name]);
     [
       this._dominantSpeakerSignaling,
       this._networkQualitySignaling,
       this._trackPrioritySignaling,
       this._trackSwitchOffSignaling,
       this._renderHintsSignaling,
-      this._publisherHintsSignaling
-    ].forEach(mediaSignaling => {
+      this._publisherHintsSignaling,
+    ].concat(otherMediaSignalings).forEach(mediaSignaling => {
       const channel = mediaSignaling.channel;
       if (!mediaSignaling.isSetup
         && mediaSignalings

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -284,7 +284,6 @@ class RoomV2 extends RoomSignaling {
     return initiallySwitchedOff;
   }
 
-
   /**
    * @private
    */

--- a/lib/signaling/v3/remoteparticipant.js
+++ b/lib/signaling/v3/remoteparticipant.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const RemoteParticipantV2 = require('../v2/remoteparticipant');
+const RemoteTrackPublicationV3 = require('./remotetrackpublication');
 
 /**
  * @extends RemoteParticipantV2
@@ -26,6 +27,7 @@ class RemoteParticipantV3 extends RemoteParticipantV2 {
     options
   ) {
     options = Object.assign({
+      RemoteTrackPublicationSignaling: RemoteTrackPublicationV3,
       otherProperties: {
         _getPendingTrackReceiver: getPendingTrackReceiver
       }
@@ -45,10 +47,17 @@ class RemoteParticipantV3 extends RemoteParticipantV2 {
    * @private
    */
   _getOrCreateTrack(trackState) {
-    const { _getPendingTrackReceiver: getPendingTrackReceiver } = this;
-    const track = super._getOrCreateTrack(trackState);
-    if (track) {
-      getPendingTrackReceiver(track.sid).then(trackReceiver => track.setTrackTransceiver(trackReceiver));
+    const {
+      _RemoteTrackPublicationSignaling: RemoteTrackPublicationV3,
+      _getPendingTrackReceiver: getPendingTrackReceiver
+    } = this;
+
+    let track = this.tracks.get(trackState.sid);
+    if (!track) {
+      const { state, switchOffReason } = this._getInitialTrackSwitchOffState(trackState.sid);
+      track = new RemoteTrackPublicationV3(trackState, state === 'OFF', switchOffReason);
+      this.addTrack(track);
+      getPendingTrackReceiver(track.sid).then(trackReceiver => track.setTrackTransceiver(trackReceiver, true));
     }
     return track;
   }

--- a/lib/signaling/v3/remoteparticipant.js
+++ b/lib/signaling/v3/remoteparticipant.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const RemoteParticipantV2 = require('../v2/remoteparticipant');
+
+/**
+ * @extends RemoteParticipantV2
+ */
+class RemoteParticipantV3 extends RemoteParticipantV2 {
+  /**
+   * Construct a {@link RemoteParticipantV2}.
+   * @param {object} participantState
+   * @param {function(Track.SID): Promise<MediaTrackReceiver>} getPendingTrackReceiver
+   * @param {function(Track.SID): boolean} getInitialTrackSwitchOffState
+   * @param {function(Track.SID, Track.Priority): boolean} setPriority
+   * @param {function(Track.SID, ClientRenderHint): Promise<void>} setRenderHint
+   * @param {function(Track.SID): void} clearTrackHint
+   * @param {object} [options]
+   */
+  constructor(
+    participantState,
+    getPendingTrackReceiver,
+    getInitialTrackSwitchOffState,
+    setPriority,
+    setRenderHint,
+    clearTrackHint,
+    options
+  ) {
+    options = Object.assign({
+      otherProperties: {
+        _getPendingTrackReceiver: getPendingTrackReceiver
+      }
+    }, options);
+
+    super(
+      participantState,
+      getInitialTrackSwitchOffState,
+      setPriority,
+      setRenderHint,
+      clearTrackHint,
+      options
+    );
+  }
+
+  /**
+   * @private
+   */
+  _getOrCreateTrack(trackState) {
+    const { _getPendingTrackReceiver: getPendingTrackReceiver } = this;
+    const track = super._getOrCreateTrack(trackState);
+    if (track) {
+      getPendingTrackReceiver(track.sid).then(trackReceiver => track.setTrackTransceiver(trackReceiver));
+    }
+    return track;
+  }
+}
+
+module.exports = RemoteParticipantV3;

--- a/lib/signaling/v3/remoteparticipant.js
+++ b/lib/signaling/v3/remoteparticipant.js
@@ -28,9 +28,7 @@ class RemoteParticipantV3 extends RemoteParticipantV2 {
   ) {
     options = Object.assign({
       RemoteTrackPublicationSignaling: RemoteTrackPublicationV3,
-      otherProperties: {
-        _getPendingTrackReceiver: getPendingTrackReceiver
-      }
+      getPendingTrackReceiver
     }, options);
 
     super(

--- a/lib/signaling/v3/remotetrackpublication.js
+++ b/lib/signaling/v3/remotetrackpublication.js
@@ -92,7 +92,7 @@ class RemoteTrackPublicationV3 extends RemoteTrackPublicationSignaling {
 
   /**
    * Compare the {@link RemoteTrackPublicationV3} to a
-   * {@link RemoteTrackPublicationV2#Representation} of itself and perform any
+   * {@link RemoteTrackPublicationV3#Representation} of itself and perform any
    * updates necessary.
    * @param {RemoteTrackPublicationV3#Representation} track
    * @returns {this}

--- a/lib/signaling/v3/remotetrackpublication.js
+++ b/lib/signaling/v3/remotetrackpublication.js
@@ -1,0 +1,115 @@
+'use strict';
+
+const RemoteTrackPublicationSignaling = require('../remotetrackpublication');
+
+/**
+ * @extends RemoteTrackPublicationSignaling
+ */
+class RemoteTrackPublicationV3 extends RemoteTrackPublicationSignaling {
+  /**
+   * Construct a {@link RemoteTrackPublicationV3}.
+   * @param {RemoteTrackPublicationV3#Representation} track
+   * @param {boolean} isSwitchedOff
+   * @param {?string} switchOffReason
+   */
+  constructor(track, isSwitchedOff, switchOffReason = null) {
+    const enabled = switchOffReason !== 'DISABLED_BY_PUBLISHER';
+    const { kind, name, priority, sid } = track;
+
+    super(
+      sid,
+      name,
+      kind,
+      enabled,
+      priority,
+      isSwitchedOff
+    );
+
+    Object.defineProperties(this, {
+      _isSubscribed: {
+        value: false,
+        writable: true
+      },
+      _switchOffReason: {
+        value: switchOffReason,
+        writable: true
+      }
+    });
+  }
+
+  /**
+   * Whether the {@link RemoteTrackPublicationV3} is subscribed to.
+   * @property {boolean}
+   */
+  get isSubscribed() {
+    return this._isSubscribed;
+  }
+
+  /**
+   * The reason for the {@link RemoteTrackPublicationV3} being switched off.
+   * @returns {?string}
+   */
+  get switchOffReason() {
+    return this._switchOffReason;
+  }
+
+  /**
+   * Updates track switch on/off state.
+   * @param {boolean} isSwitchedOff
+   * @param {?string} switchOffReason
+   * @returns {this}
+   */
+  setSwitchedOff(isSwitchedOff, switchOffReason) {
+    const shouldEmitUpdated = isSwitchedOff !== this.isSwitchedOff
+      || switchOffReason !== this.switchOffReason;
+    this._isSwitchedOff = isSwitchedOff;
+    this._switchOffReason = switchOffReason;
+    if (shouldEmitUpdated) {
+      this.emit('updated');
+    }
+    return this.enable(this.switchOffReason !== 'DISABLED_BY_PUBLISHER');
+  }
+
+  /**
+   * Set the {@link MediaTrackReceiver} on the {@link RemoteTrackPublicationV3}.
+   * @override
+   * @param {MediaTrackReceiver} trackReceiver
+   * @param {boolean} isSubscribed
+   * @returns {this}
+   */
+  setTrackTransceiver(trackReceiver, isSubscribed) {
+    const shouldEmitUpdated = trackReceiver !== this.trackTransceiver
+      || isSubscribed !== this.isSubscribed;
+    this._trackTransceiver = trackReceiver;
+    this._isSubscribed = isSubscribed;
+    if (shouldEmitUpdated) {
+      this.emit('updated');
+    }
+    return this;
+  }
+
+  /**
+   * Compare the {@link RemoteTrackPublicationV3} to a
+   * {@link RemoteTrackPublicationV2#Representation} of itself and perform any
+   * updates necessary.
+   * @param {RemoteTrackPublicationV3#Representation} track
+   * @returns {this}
+   * @fires TrackSignaling#updated
+   */
+  update(track) {
+    this.setPriority(track.priority);
+    return this;
+  }
+}
+
+/**
+ * The Room Signaling Protocol (RSP) representation of a {@link RemoteTrackPublicationV3}.
+ * @typedef {object} RemoteTrackPublicationV3#Representation
+ * @property {Track.ID} id
+ * @property {Track.Kind} kind
+ * @property {string} name
+ * @priority {Track.Priority} priority
+ * @property {Track.SID} sid
+ */
+
+module.exports = RemoteTrackPublicationV3;

--- a/lib/signaling/v3/remotetrackpublication.js
+++ b/lib/signaling/v3/remotetrackpublication.js
@@ -82,8 +82,6 @@ class RemoteTrackPublicationV3 extends RemoteTrackPublicationSignaling {
   setTrackTransceiver(trackReceiver, isSubscribed) {
     isSubscribed = !!trackReceiver || isSubscribed;
     const shouldEmitUpdated = trackReceiver !== this.trackTransceiver || isSubscribed !== this.isSubscribed;
-    // eslint-disable-next-line no-console
-    console.log(isSubscribed, this.isSubscribed, shouldEmitUpdated);
     this._trackTransceiver = trackReceiver;
     this._isSubscribed = isSubscribed;
     if (shouldEmitUpdated) {

--- a/lib/signaling/v3/remotetrackpublication.js
+++ b/lib/signaling/v3/remotetrackpublication.js
@@ -13,7 +13,8 @@ class RemoteTrackPublicationV3 extends RemoteTrackPublicationSignaling {
    * @param {?string} switchOffReason
    */
   constructor(track, isSwitchedOff, switchOffReason = null) {
-    const enabled = switchOffReason !== 'DISABLED_BY_PUBLISHER';
+    switchOffReason = isSwitchedOff ? switchOffReason : null;
+    const enabled = isEnabled(isSwitchedOff, switchOffReason);
     const { kind, name, priority, sid } = track;
 
     super(
@@ -60,6 +61,7 @@ class RemoteTrackPublicationV3 extends RemoteTrackPublicationSignaling {
    * @returns {this}
    */
   setSwitchedOff(isSwitchedOff, switchOffReason) {
+    switchOffReason = isSwitchedOff ? switchOffReason : null;
     const shouldEmitUpdated = isSwitchedOff !== this.isSwitchedOff
       || switchOffReason !== this.switchOffReason;
     this._isSwitchedOff = isSwitchedOff;
@@ -67,7 +69,7 @@ class RemoteTrackPublicationV3 extends RemoteTrackPublicationSignaling {
     if (shouldEmitUpdated) {
       this.emit('updated');
     }
-    return this.enable(this.switchOffReason !== 'DISABLED_BY_PUBLISHER');
+    return this.enable(isEnabled(isSwitchedOff, switchOffReason));
   }
 
   /**
@@ -78,8 +80,10 @@ class RemoteTrackPublicationV3 extends RemoteTrackPublicationSignaling {
    * @returns {this}
    */
   setTrackTransceiver(trackReceiver, isSubscribed) {
-    const shouldEmitUpdated = trackReceiver !== this.trackTransceiver
-      || isSubscribed !== this.isSubscribed;
+    isSubscribed = !!trackReceiver || isSubscribed;
+    const shouldEmitUpdated = trackReceiver !== this.trackTransceiver || isSubscribed !== this.isSubscribed;
+    // eslint-disable-next-line no-console
+    console.log(isSubscribed, this.isSubscribed, shouldEmitUpdated);
     this._trackTransceiver = trackReceiver;
     this._isSubscribed = isSubscribed;
     if (shouldEmitUpdated) {
@@ -103,9 +107,18 @@ class RemoteTrackPublicationV3 extends RemoteTrackPublicationSignaling {
 }
 
 /**
+ * @private
+ * @param {boolean} isSwitchedOff
+ * @param {?string} switchOffReason
+ * @returns {boolean}
+ */
+function isEnabled(isSwitchedOff, switchOffReason) {
+  return !(isSwitchedOff && switchOffReason === 'DISABLED_BY_PUBLISHER');
+}
+
+/**
  * The Room Signaling Protocol (RSP) representation of a {@link RemoteTrackPublicationV3}.
  * @typedef {object} RemoteTrackPublicationV3#Representation
- * @property {Track.ID} id
  * @property {Track.Kind} kind
  * @property {string} name
  * @priority {Track.Priority} priority

--- a/lib/signaling/v3/room.js
+++ b/lib/signaling/v3/room.js
@@ -21,12 +21,6 @@ class RoomV3 extends RoomV2 {
       TrackSubscriptionsSignaling
     }, options);
 
-    options.otherMediaSignalings = [{
-      MediaSignaling: options.TrackSubscriptionsSignaling,
-      initMethod: '_initTrackSubscriptionsSignaling',
-      name: '_trackSubscriptionsSignaling'
-    }];
-
     super(
       localParticipant,
       initialState,
@@ -75,7 +69,7 @@ class RoomV3 extends RoomV2 {
    */
   _getInitialTrackSwitchOffState(trackSid) {
     const switchOffState = this._pendingSwitchOffStates.get(trackSid)
-      || { state: 'ON', switchOffReason: null };
+      || { state: 'OFF', switchOffReason: 'DISABLED_BY_SUBSCRIBER' };
     this._pendingSwitchOffStates.delete(trackSid);
     if (switchOffState.state === 'OFF') {
       this._log.warn(`[${trackSid}] was initially switched off! `);

--- a/lib/signaling/v3/room.js
+++ b/lib/signaling/v3/room.js
@@ -2,8 +2,7 @@
 
 const { createTwilioError } = require('../../util/twilio-video-errors');
 const RoomV2 = require('../v2/room');
-// TODO(mmalavalli): Change to RemoteParticipantV3 once implemented.
-const RemoteParticipantV2 = require('../v2/remoteparticipant');
+const RemoteParticipantV3 = require('../v3/remoteparticipant');
 const TrackSubscriptionsSignaling = require('./tracksubscriptionssignaling');
 
 /**
@@ -18,8 +17,7 @@ class RoomV3 extends RoomV2 {
     options
   ) {
     options = Object.assign({
-      // TODO(mmalavalli): Change to RemoteParticipantV3 once implemented.
-      RemoteParticipantSignaling: RemoteParticipantV2,
+      RemoteParticipantSignaling: RemoteParticipantV3,
       TrackSubscriptionsSignaling
     }, options);
 
@@ -60,14 +58,10 @@ class RoomV3 extends RoomV2 {
    * @override
    */
   _createRemoteParticipant(participantState) {
-    // eslint-disable-next-line no-warning-comments
-    // TODO(mmalavalli): Change to RemoteParticipantV3 once implemented.
-    const { _RemoteParticipantSignaling: RemoteParticipantV2 } = this;
-    return new RemoteParticipantV2(
+    const { _RemoteParticipantSignaling: RemoteParticipantV3 } = this;
+    return new RemoteParticipantV3(
       participantState,
-      // eslint-disable-next-line no-warning-comments
-      // TODO(mmalavalli): Uncomment once RemoteParticipantV3 is implemented.
-      /* trackSid => this._getPendingTrackReceiver(trackSid), */
+      trackSid => this._getPendingTrackReceiver(trackSid),
       trackSid => this._getInitialTrackSwitchOffState(trackSid),
       (trackSid, priority) => this._trackPrioritySignaling.sendTrackPriorityUpdate(trackSid, 'subscribe', priority),
       (trackSid, hint) => this._renderHintsSignaling.setTrackHint(trackSid, hint),

--- a/lib/signaling/v3/room.js
+++ b/lib/signaling/v3/room.js
@@ -1,7 +1,9 @@
 'use strict';
 
-const RemoteParticipantV3 = require('./remoteparticipant');
+const { createTwilioError } = require('../../util/twilio-video-errors');
 const RoomV2 = require('../v2/room');
+// TODO(mmalavalli): Change to RemoteParticipantV3 once implemented.
+const RemoteParticipantV2 = require('../v2/remoteparticipant');
 const TrackSubscriptionsSignaling = require('./tracksubscriptionssignaling');
 
 /**
@@ -16,9 +18,16 @@ class RoomV3 extends RoomV2 {
     options
   ) {
     options = Object.assign({
-      RemoteParticipantSignaling: RemoteParticipantV3,
+      // TODO(mmalavalli): Change to RemoteParticipantV3 once implemented.
+      RemoteParticipantSignaling: RemoteParticipantV2,
       TrackSubscriptionsSignaling
     }, options);
+
+    options.otherMediaSignalings = [{
+      MediaSignaling: options.TrackSubscriptionsSignaling,
+      initMethod: '_initTrackSubscriptionsSignaling',
+      name: '_trackSubscriptionsSignaling'
+    }];
 
     super(
       localParticipant,
@@ -28,19 +37,11 @@ class RoomV3 extends RoomV2 {
       options
     );
 
-    const getTrackReceiver = id => this._getTrackReceiver(id);
-    const { _log: log } = this;
-
     Object.defineProperties(this, {
       _pendingTrackMids: {
         value: new Map()
-      },
-      _trackSubscriptionsSignaling: {
-        value: new options.TrackSubscriptionsSignaling(getTrackReceiver, { log })
       }
     });
-
-    this._initTrackSubscriptionsSignaling();
   }
 
   /**
@@ -48,7 +49,8 @@ class RoomV3 extends RoomV2 {
    * @override
    */
   _addTrackReceiver(trackReceiver) {
-    const deferred = this._getOrCreateTrackReceiverDeferred(trackReceiver.mid, 'mid');
+    const idType = trackReceiver.kind === 'data' ? 'id' : 'mid';
+    const deferred = this._getOrCreateTrackReceiverDeferred(trackReceiver[idType], idType);
     deferred.resolve(trackReceiver);
     return this;
   }
@@ -58,10 +60,14 @@ class RoomV3 extends RoomV2 {
    * @override
    */
   _createRemoteParticipant(participantState) {
-    const { _RemoteParticipantSignaling: RemoteParticipantV3 } = this;
-    return new RemoteParticipantV3(
+    // eslint-disable-next-line no-warning-comments
+    // TODO(mmalavalli): Change to RemoteParticipantV3 once implemented.
+    const { _RemoteParticipantSignaling: RemoteParticipantV2 } = this;
+    return new RemoteParticipantV2(
       participantState,
-      trackSid => this._getPendingTrackReceiver(trackSid),
+      // eslint-disable-next-line no-warning-comments
+      // TODO(mmalavalli): Uncomment once RemoteParticipantV3 is implemented.
+      /* trackSid => this._getPendingTrackReceiver(trackSid), */
       trackSid => this._getInitialTrackSwitchOffState(trackSid),
       (trackSid, priority) => this._trackPrioritySignaling.sendTrackPriorityUpdate(trackSid, 'subscribe', priority),
       (trackSid, hint) => this._renderHintsSignaling.setTrackHint(trackSid, hint),
@@ -93,9 +99,10 @@ class RoomV3 extends RoomV2 {
    * @private
    */
   _initTrackSubscriptionsSignaling() {
-    this._trackSubscriptionsSignaling.on('updated', trackStates => {
+    this._trackSubscriptionsSignaling.on('updated', (subscribed, errors) => {
       const trackSidsToTrackSignalings = this._getTrackSidsToTrackSignalings();
-      const trackSidsToTrackStates = new Map(Object.entries(trackStates));
+      const trackSidsToTrackStates = new Map(Object.entries(subscribed));
+      const trackSidsToErrors = new Map(Object.entries(errors));
 
       trackSidsToTrackStates.forEach(({ mid, state }, sid) => {
         const trackSignaling = trackSidsToTrackSignalings.get(sid);
@@ -105,7 +112,7 @@ class RoomV3 extends RoomV2 {
           this._pendingTrackMids.set(sid, mid);
           return;
         }
-        if (isSwitchedOff || trackSignaling.trackTransceiver.mid !== mid) {
+        if (isSwitchedOff || (trackSignaling.trackTransceiver && trackSignaling.trackTransceiver.mid !== mid)) {
           trackSignaling.setTrackTransceiver(null);
         }
         if (!isSwitchedOff) {
@@ -114,30 +121,19 @@ class RoomV3 extends RoomV2 {
         trackSignaling.setSwitchedOff(isSwitchedOff);
       });
 
+      trackSidsToErrors.forEach(({ code, message }, sid) => {
+        const trackSignaling = trackSidsToTrackSignalings.get(sid);
+        if (trackSignaling) {
+          trackSignaling.subscribeFailed(createTwilioError(code, message));
+        }
+      });
+
       trackSidsToTrackSignalings.forEach(trackSignaling => {
         if (!trackSidsToTrackStates.has(trackSignaling.sid)) {
           trackSignaling.setTrackTransceiver(null);
         }
       });
     });
-  }
-
-  /**
-   * @private
-   * @override
-   */
-  _setupMediaSignalings(roomState) {
-    const { media_signaling: mediaSignalings } = roomState;
-    const { _trackSubscriptionsSignaling: trackSubscriptionsSignaling } = this;
-    const { channel, isSetup } = trackSubscriptionsSignaling;
-    super._setupMediaSignalings(roomState);
-    if (!isSetup
-      && mediaSignalings
-      && mediaSignalings[channel]
-      && mediaSignalings[channel].transport
-      && mediaSignalings[channel].transport.type === 'data-channel') {
-      trackSubscriptionsSignaling.setup(roomState.media_signaling[channel].transport.label);
-    }
   }
 
   /**

--- a/lib/signaling/v3/room.js
+++ b/lib/signaling/v3/room.js
@@ -71,6 +71,20 @@ class RoomV3 extends RoomV2 {
 
   /**
    * @private
+   * @override
+   */
+  _getInitialTrackSwitchOffState(trackSid) {
+    const switchOffState = this._pendingSwitchOffStates.get(trackSid)
+      || { state: 'ON', switchOffReason: null };
+    this._pendingSwitchOffStates.delete(trackSid);
+    if (switchOffState.state === 'OFF') {
+      this._log.warn(`[${trackSid}] was initially switched off! `);
+    }
+    return switchOffState;
+  }
+
+  /**
+   * @private
    */
   _getPendingTrackReceiver(trackSid) {
     const mid = this._pendingTrackMids.get(trackSid);
@@ -98,19 +112,24 @@ class RoomV3 extends RoomV2 {
       const trackSidsToTrackStates = new Map(Object.entries(subscribed));
       const trackSidsToErrors = new Map(Object.entries(errors));
 
-      trackSidsToTrackStates.forEach(({ mid, state }, sid) => {
+      trackSidsToTrackStates.forEach(({ mid, off_reason: switchOffReason = null, state }, sid) => {
         const trackSignaling = trackSidsToTrackSignalings.get(sid);
-        const isSwitchedOff = state === 'OFF';
+        const trackState = { state, switchOffReason };
         if (!trackSignaling) {
-          this._pendingSwitchOffStates.set(sid, isSwitchedOff);
+          this._pendingSwitchOffStates.set(sid, trackState);
           this._pendingTrackMids.set(sid, mid);
           return;
         }
+        const isSwitchedOff = state === 'OFF';
         if (isSwitchedOff || (trackSignaling.trackTransceiver && trackSignaling.trackTransceiver.mid !== mid)) {
-          trackSignaling.setTrackTransceiver(null);
+          // NOTE(mmalavalli): If a RemoteTrackPublicationV3's MID changes, then we need to unsubscribe
+          // from the RemoteTrack before subscribing to it again with the MediaTrackReceiver associated with the new
+          // MID. If a RemoteTrackPublicationV3's RemoteTrack is switched off, then we should still be subscribed
+          // to it, even though it no longer has an MID associated with it.
+          trackSignaling.setTrackTransceiver(null, isSwitchedOff);
         }
         if (!isSwitchedOff) {
-          this._getTrackReceiver(mid, 'mid').then(trackReceiver => trackSignaling.setTrackTransceiver(trackReceiver));
+          this._getTrackReceiver(mid, 'mid').then(trackReceiver => trackSignaling.setTrackTransceiver(trackReceiver, true));
         }
         trackSignaling.setSwitchedOff(isSwitchedOff);
       });
@@ -123,8 +142,11 @@ class RoomV3 extends RoomV2 {
       });
 
       trackSidsToTrackSignalings.forEach(trackSignaling => {
-        if (!trackSidsToTrackStates.has(trackSignaling.sid)) {
-          trackSignaling.setTrackTransceiver(null);
+        const { sid } = trackSignaling;
+        if (!trackSidsToTrackStates.has(sid)) {
+          this._pendingSwitchOffStates.delete(sid);
+          this._pendingTrackMids.delete(sid);
+          trackSignaling.setTrackTransceiver(null, false);
         }
       });
     });

--- a/lib/signaling/v3/room.js
+++ b/lib/signaling/v3/room.js
@@ -1,0 +1,152 @@
+'use strict';
+
+const RemoteParticipantV3 = require('./remoteparticipant');
+const RoomV2 = require('../v2/room');
+const TrackSubscriptionsSignaling = require('./tracksubscriptionssignaling');
+
+/**
+ * @extends RoomV2
+ */
+class RoomV3 extends RoomV2 {
+  constructor(
+    localParticipant,
+    initialState,
+    transport,
+    peerConnectionManager,
+    options
+  ) {
+    options = Object.assign({
+      RemoteParticipantSignaling: RemoteParticipantV3,
+      TrackSubscriptionsSignaling
+    }, options);
+
+    super(
+      localParticipant,
+      initialState,
+      transport,
+      peerConnectionManager,
+      options
+    );
+
+    const getTrackReceiver = id => this._getTrackReceiver(id);
+    const { _log: log } = this;
+
+    Object.defineProperties(this, {
+      _pendingTrackMids: {
+        value: new Map()
+      },
+      _trackSubscriptionsSignaling: {
+        value: new options.TrackSubscriptionsSignaling(getTrackReceiver, { log })
+      }
+    });
+
+    this._initTrackSubscriptionsSignaling();
+  }
+
+  /**
+   * @private
+   * @override
+   */
+  _addTrackReceiver(trackReceiver) {
+    const deferred = this._getOrCreateTrackReceiverDeferred(trackReceiver.mid, 'mid');
+    deferred.resolve(trackReceiver);
+    return this;
+  }
+
+  /**
+   * @private
+   * @override
+   */
+  _createRemoteParticipant(participantState) {
+    const { _RemoteParticipantSignaling: RemoteParticipantV3 } = this;
+    return new RemoteParticipantV3(
+      participantState,
+      trackSid => this._getPendingTrackReceiver(trackSid),
+      trackSid => this._getInitialTrackSwitchOffState(trackSid),
+      (trackSid, priority) => this._trackPrioritySignaling.sendTrackPriorityUpdate(trackSid, 'subscribe', priority),
+      (trackSid, hint) => this._renderHintsSignaling.setTrackHint(trackSid, hint),
+      trackSid => this._renderHintsSignaling.clearTrackHint(trackSid)
+    );
+  }
+
+  /**
+   * @private
+   */
+  _getPendingTrackReceiver(trackSid) {
+    const mid = this._pendingTrackMids.get(trackSid);
+    if (!mid) {
+      return Promise.resolve(null);
+    }
+    this._pendingTrackMids.delete(trackSid);
+    return this._getTrackReceiver(mid, 'mid');
+  }
+
+  /**
+   * @private
+   * @override
+   */
+  _handleSubscriptions() {
+    /* Do nothing since RSP v3 messages will not contain the "subscribed" property. */
+  }
+
+  /**
+   * @private
+   */
+  _initTrackSubscriptionsSignaling() {
+    this._trackSubscriptionsSignaling.on('updated', trackStates => {
+      const trackSidsToTrackSignalings = this._getTrackSidsToTrackSignalings();
+      const trackSidsToTrackStates = new Map(Object.entries(trackStates));
+
+      trackSidsToTrackStates.forEach(({ mid, state }, sid) => {
+        const trackSignaling = trackSidsToTrackSignalings.get(sid);
+        const isSwitchedOff = state === 'OFF';
+        if (!trackSignaling) {
+          this._pendingSwitchOffStates.set(sid, isSwitchedOff);
+          this._pendingTrackMids.set(sid, mid);
+          return;
+        }
+        if (isSwitchedOff || trackSignaling.trackTransceiver.mid !== mid) {
+          trackSignaling.setTrackTransceiver(null);
+        }
+        if (!isSwitchedOff) {
+          this._getTrackReceiver(mid, 'mid').then(trackReceiver => trackSignaling.setTrackTransceiver(trackReceiver));
+        }
+        trackSignaling.setSwitchedOff(isSwitchedOff);
+      });
+
+      trackSidsToTrackSignalings.forEach(trackSignaling => {
+        if (!trackSidsToTrackStates.has(trackSignaling.sid)) {
+          trackSignaling.setTrackTransceiver(null);
+        }
+      });
+    });
+  }
+
+  /**
+   * @private
+   * @override
+   */
+  _setupMediaSignalings(roomState) {
+    const { media_signaling: mediaSignalings } = roomState;
+    const { _trackSubscriptionsSignaling: trackSubscriptionsSignaling } = this;
+    const { channel, isSetup } = trackSubscriptionsSignaling;
+    super._setupMediaSignalings(roomState);
+    if (!isSetup
+      && mediaSignalings
+      && mediaSignalings[channel]
+      && mediaSignalings[channel].transport
+      && mediaSignalings[channel].transport.type === 'data-channel') {
+      trackSubscriptionsSignaling.setup(roomState.media_signaling[channel].transport.label);
+    }
+  }
+
+  /**
+   * @private
+   * @override
+   */
+  _updateSubscribed(roomState) {
+    /* Do nothing since RSP v3 messages will not contain the "subscribed" property. */
+  }
+}
+
+module.exports = RoomV3;

--- a/lib/signaling/v3/tracksubscriptionssignaling.js
+++ b/lib/signaling/v3/tracksubscriptionssignaling.js
@@ -11,7 +11,7 @@ class TrackSubscriptionsSignaling extends MediaSignaling {
 
     Object.defineProperties(this, {
       _currentRevision: {
-        value: 0,
+        value: null,
         writable: true
       }
     });
@@ -39,7 +39,7 @@ class TrackSubscriptionsSignaling extends MediaSignaling {
     const { _log: log, _currentRevision: currentRevision } = this;
     const { errors = {}, revision, subscribed = {} } = message;
 
-    if (currentRevision >= revision) {
+    if (currentRevision !== null && currentRevision >= revision) {
       log.warn(`Ignoring incoming ${this.channel} message as ${currentRevision} (current revision) >= ${revision} (incoming revision)`);
       log.debug(`Ignored incoming ${this.channel} message:`, message);
       return;

--- a/lib/signaling/v3/tracksubscriptionssignaling.js
+++ b/lib/signaling/v3/tracksubscriptionssignaling.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const MediaSignaling = require('../v2/mediasignaling');
+
+class TrackSubscriptionsSignaling extends MediaSignaling {
+  /**
+   * Construct a {@link TrackSubscriptionsSignaling}.
+   */
+  constructor(getReceiver, options) {
+    super(getReceiver, 'track_subscriptions', options);
+
+    Object.defineProperties(this, {
+      _currentRevision: {
+        value: 0,
+        writable: true
+      }
+    });
+    const { _log: log } = this;
+
+    this.on('ready', transport => {
+      log.debug(`${this.channel} transport ready`);
+      transport.on('message', message => {
+        switch (message.type) {
+          case this.channel:
+            this._handleIncomingMessage(message);
+            break;
+          default:
+            log.warn(`Unknown ${this.channel} MSP message type:`, message.type);
+            break;
+        }
+      });
+    });
+  }
+
+  /**
+   * @private
+   */
+  _handleIncomingMessage(message) {
+    const { _log: log, _currentRevision: currentRevision } = this;
+    const { revision, subscribed } = message;
+
+    if (currentRevision >= revision) {
+      log.warn(`Ignoring incoming ${this.channel} message as ${currentRevision} (current revision) >= ${revision} (incoming revision)`);
+      log.debug(`Ignored incoming ${this.channel} message:`, message);
+      return;
+    }
+    log.debug(`Incoming ${this.channel} MSP message:`, message);
+    this._currentRevision = revision;
+    this.emit('updated', subscribed);
+  }
+}
+
+module.exports = TrackSubscriptionsSignaling;

--- a/lib/signaling/v3/tracksubscriptionssignaling.js
+++ b/lib/signaling/v3/tracksubscriptionssignaling.js
@@ -37,7 +37,7 @@ class TrackSubscriptionsSignaling extends MediaSignaling {
    */
   _handleIncomingMessage(message) {
     const { _log: log, _currentRevision: currentRevision } = this;
-    const { revision, subscribed } = message;
+    const { errors = {}, revision, subscribed = {} } = message;
 
     if (currentRevision >= revision) {
       log.warn(`Ignoring incoming ${this.channel} message as ${currentRevision} (current revision) >= ${revision} (incoming revision)`);
@@ -46,7 +46,7 @@ class TrackSubscriptionsSignaling extends MediaSignaling {
     }
     log.debug(`Incoming ${this.channel} MSP message:`, message);
     this._currentRevision = revision;
-    this.emit('updated', subscribed);
+    this.emit('updated', subscribed, errors);
   }
 }
 

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -84,6 +84,14 @@ module.exports.trackSwitchOffMode = {
   MODE_PREDICTED: 'predicted'
 };
 
+module.exports.trackSwitchOffReason = {
+  DISABLED_BY_PUBLISHER: 'disabled-by-publisher',
+  DISABLED_BY_SUBSCRIBER: 'disabled-by-subscriber',
+  MAX_BANDWIDTH_REACHED: 'max-bandwidth-reached',
+  MAX_TRACKS_SWITCHED_ON: 'max-tracks-switched-on',
+  NETWORK_CONGESTION: 'network-congestion'
+};
+
 module.exports.trackPriority = {
   PRIORITY_HIGH: 'high',
   PRIORITY_LOW: 'low',

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -63,6 +63,9 @@ require('./spec/signaling/v2/remotetrackpublication');
 require('./spec/signaling/v2/trackprioritysignaling');
 require('./spec/signaling/v2/twilioconnectiontransport');
 
+require('./spec/signaling/v3/room');
+require('./spec/signaling/v3/tracksubscriptionssignaling');
+
 require('./spec/util');
 require('./spec/util/asyncvar');
 require('./spec/util/browserdetection');

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -64,6 +64,7 @@ require('./spec/signaling/v2/trackprioritysignaling');
 require('./spec/signaling/v2/twilioconnectiontransport');
 
 require('./spec/signaling/v3/remoteparticipant');
+require('./spec/signaling/v3/remotetrackpublication');
 require('./spec/signaling/v3/room');
 require('./spec/signaling/v3/tracksubscriptionssignaling');
 

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -63,6 +63,7 @@ require('./spec/signaling/v2/remotetrackpublication');
 require('./spec/signaling/v2/trackprioritysignaling');
 require('./spec/signaling/v2/twilioconnectiontransport');
 
+require('./spec/signaling/v3/remoteparticipant');
 require('./spec/signaling/v3/room');
 require('./spec/signaling/v3/tracksubscriptionssignaling');
 

--- a/test/unit/spec/media/track/audiotrack.js
+++ b/test/unit/spec/media/track/audiotrack.js
@@ -32,7 +32,7 @@ describe('AudioTrack', () => {
     let dummyElement;
 
     before(() => {
-      track = createAudioTrack('1', 'audio');
+      track = createAudioTrack('1', 'foo', 'audio');
       track._attach = sinon.spy();
       track._detachElement = sinon.spy();
       track._attachments.delete = sinon.spy();
@@ -93,9 +93,9 @@ describe('AudioTrack', () => {
 
 });
 
-function createAudioTrack(id, kind, options) {
+function createAudioTrack(id, mid, kind, options) {
   const mediaStreamTrack = new MediaStreamTrack(id, kind);
-  const mediaTrackTransceiver = new MediaTrackTransceiver(id, mediaStreamTrack);
+  const mediaTrackTransceiver = new MediaTrackTransceiver(id, mid, mediaStreamTrack);
   const mediaTrack = new AudioTrack(mediaTrackTransceiver, Object.assign({ log: log }, options));
   mediaTrack.tranceiver = mediaTrackTransceiver;
   return mediaTrack;

--- a/test/unit/spec/media/track/audiotrack.js
+++ b/test/unit/spec/media/track/audiotrack.js
@@ -101,7 +101,7 @@ describe('AudioTrack', () => {
 function createAudioTrack(id, mid, options) {
   const mediaStreamTrack = new MediaStreamTrack(id, 'audio');
   const mediaTrackTransceiver = id ? new MediaTrackTransceiver(id, mid, mediaStreamTrack) : null;
-  const mediaTrack = new AudioTrack('audio', mediaTrackTransceiver, Object.assign({ log: log, name: 'bar' }, options));
+  const mediaTrack = new AudioTrack(mediaTrackTransceiver, Object.assign({ log: log, name: 'bar' }, options));
   mediaTrack.tranceiver = mediaTrackTransceiver;
   return mediaTrack;
 }

--- a/test/unit/spec/media/track/audiotrack.js
+++ b/test/unit/spec/media/track/audiotrack.js
@@ -31,72 +31,77 @@ describe('AudioTrack', () => {
   describe('_initialize', () => {
     let dummyElement;
 
-    before(() => {
-      track = createAudioTrack('1', 'foo', 'audio');
-      track._attach = sinon.spy();
-      track._detachElement = sinon.spy();
-      track._attachments.delete = sinon.spy();
+    [null, '1'].forEach(id => {
+      context(`when called with ${id ? 'non-' : ''}null .mediaTrackTransceiver`, () => {
+        before(() => {
+          track = createAudioTrack(id, 'foo', 'audio');
+          track._attach = sinon.spy();
+          track._detachElement = sinon.spy();
+          track._attachments.delete = sinon.spy();
 
-      dummyElement = { oncanplay: 'bar', remove: sinon.spy(), srcObject: 'something' };
-      track._createElement = sinon.spy(() => {
-        return dummyElement;
-      });
+          dummyElement = { oncanplay: 'bar', remove: sinon.spy(), srcObject: 'something' };
+          track._createElement = sinon.spy(() => {
+            return dummyElement;
+          });
 
-      _initialize.call(track);
-    });
+          _initialize.call(track);
+        });
 
-    it('should call ._createElement', () => {
-      assert.equal(track._createElement.callCount, 1);
-    });
+        it(`should ${id ? '' : 'not '}call ._createElement`, () => {
+          assert.equal(track._createElement.callCount, id ? 1 : 0);
+        });
 
-    it('should call ._attach with the created element', () => {
-      assert(track._attach.calledWith(dummyElement));
-    });
+        it(`should ${id ? '' : 'not '}call ._attach with the created element`, () => {
+          assert.equal(track._attach.calledWith(dummyElement), !!id);
+        });
 
-    it('should call .delete with the created element on the ._attachments Set', () => {
-      assert(track._attachments.delete.calledWith(dummyElement));
-    });
+        it(`should ${id ? '' : 'not '}call .delete with the created element on the ._attachments Set`, () => {
+          assert.equal(track._attachments.delete.calledWith(dummyElement), !!id);
+        });
 
-    it('should set el.oncanplay to a function', () => {
-      assert.equal(typeof dummyElement.oncanplay, 'function');
-    });
+        it(`should ${id ? '' : 'not '}set el.oncanplay to a function`, () => {
+          assert.equal(typeof dummyElement.oncanplay, id ? 'function' : 'string');
+        });
 
-    it('should set el.muted to true', () => {
-      assert.equal(dummyElement.muted, true);
-    });
+        it(`should ${id ? '' : 'not '}set el.muted to true`, () => {
+          assert.equal(dummyElement.muted, id ? true : undefined);
+        });
 
-    context('when the dummy element emits oncanplay event', () => {
-      it('should emit MediaTrack#started, passing the instance of MediaTrack', async () => {
-        _initialize.call(track);
+        if (id) {
+          context('when the dummy element emits oncanplay event', () => {
+            it('should emit MediaTrack#started, passing the instance of MediaTrack', async () => {
+              _initialize.call(track);
 
-        const trackPromise = new Promise(resolve => track.on('started', resolve));
+              const trackPromise = new Promise(resolve => track.on('started', resolve));
 
-        dummyElement.oncanplay();
+              dummyElement.oncanplay();
 
-        const _track = await trackPromise;
-        assert.equal(track, _track);
-      });
+              const _track = await trackPromise;
+              assert.equal(track, _track);
+            });
 
-      it('should set .isStarted to true', () => {
-        assert(track.isStarted);
-      });
+            it('should set .isStarted to true', () => {
+              assert(track.isStarted);
+            });
 
-      it('should set the element\'s oncanplay to null', () => {
-        assert.equal(dummyElement.oncanplay, null);
-      });
+            it('should set the element\'s oncanplay to null', () => {
+              assert.equal(dummyElement.oncanplay, null);
+            });
 
-      it('should set the element\'s srcObject to null', () => {
-        assert.equal(dummyElement.srcObject, null);
+            it('should set the element\'s srcObject to null', () => {
+              assert.equal(dummyElement.srcObject, null);
+            });
+          });
+        }
       });
     });
   });
-
 });
 
-function createAudioTrack(id, mid, kind, options) {
-  const mediaStreamTrack = new MediaStreamTrack(id, kind);
-  const mediaTrackTransceiver = new MediaTrackTransceiver(id, mid, mediaStreamTrack);
-  const mediaTrack = new AudioTrack(mediaTrackTransceiver, Object.assign({ log: log }, options));
+function createAudioTrack(id, mid, options) {
+  const mediaStreamTrack = new MediaStreamTrack(id, 'audio');
+  const mediaTrackTransceiver = id ? new MediaTrackTransceiver(id, mid, mediaStreamTrack) : null;
+  const mediaTrack = new AudioTrack('audio', mediaTrackTransceiver, Object.assign({ log: log, name: 'bar' }, options));
   mediaTrack.tranceiver = mediaTrackTransceiver;
   return mediaTrack;
 }

--- a/test/unit/spec/media/track/localdatatrack.js
+++ b/test/unit/spec/media/track/localdatatrack.js
@@ -59,11 +59,11 @@ describe('LocalDataTrack', () => {
     });
 
     context('when .name is present in LocalTrackOptions but not a string', () => {
-      const notAString = { foo: 'bar' };
-      const track = new LocalDataTrack({
-        name: notAString
+      it('sets .name to the string converted version of LocalTrackOptions.name', () => {
+        const notAString = { foo: 'bar' };
+        const track = new LocalDataTrack({ name: notAString });
+        assert.equal(track.name, String(notAString));
       });
-      assert.equal(track.name, String(notAString));
     });
 
     combinationContext([

--- a/test/unit/spec/media/track/mediatrack.js
+++ b/test/unit/spec/media/track/mediatrack.js
@@ -30,7 +30,7 @@ describe('MediaTrack', () => {
 
   describe('constructor', () => {
     beforeEach(() => {
-      track = createMediaTrack('1', 'audio');
+      track = createMediaTrack('1', 'foo', 'audio');
     });
 
     it('should call ._initialize', () => {
@@ -51,7 +51,7 @@ describe('MediaTrack', () => {
     let dummyElement;
 
     before(() => {
-      track = createMediaTrack('1', 'audio');
+      track = createMediaTrack('1', 'foo', 'audio');
       track._attach = sinon.spy();
       track._detachElement = sinon.spy();
       track._attachments.delete = sinon.spy();
@@ -112,7 +112,7 @@ describe('MediaTrack', () => {
 
     context('when undefined is passed', () => {
       before(() => {
-        track = createMediaTrack('1', 'audio');
+        track = createMediaTrack('1', 'foo', 'audio');
         element = document.createElement('audio');
 
         track._createElement = sinon.spy(() => {
@@ -145,7 +145,7 @@ describe('MediaTrack', () => {
 
     context('when null is passed', () => {
       before(() => {
-        track = createMediaTrack('1', 'audio');
+        track = createMediaTrack('1', 'foo', 'audio');
         element = document.createElement('audio');
 
         track._createElement = sinon.spy(() => {
@@ -178,7 +178,7 @@ describe('MediaTrack', () => {
 
     context('when a string is passed', () => {
       before(() => {
-        track = createMediaTrack('1', 'audio');
+        track = createMediaTrack('1', 'foo', 'audio');
         element = document.createElement('audio');
 
         track._createElement = sinon.spy();
@@ -212,7 +212,7 @@ describe('MediaTrack', () => {
 
     context('when an element is passed', () => {
       before(() => {
-        track = createMediaTrack('1', 'audio');
+        track = createMediaTrack('1', 'foo', 'audio');
         element = document.createElement('audio');
 
         track._createElement = sinon.spy();
@@ -244,7 +244,7 @@ describe('MediaTrack', () => {
   describe('_selectElement', () => {
     let element;
     before(() => {
-      track = createMediaTrack('1', 'audio');
+      track = createMediaTrack('1', 'foo', 'audio');
 
       element = document.createElement('audio');
       element.className = 'foo';
@@ -266,7 +266,7 @@ describe('MediaTrack', () => {
 
   describe('_createElement', () => {
     before(() => {
-      track = createMediaTrack('1', 'video');
+      track = createMediaTrack('1', 'bar', 'video');
     });
 
     it('should return an element with the tagName of .kind', () => {
@@ -279,7 +279,7 @@ describe('MediaTrack', () => {
       let attachedElements;
 
       before(() => {
-        track = createMediaTrack('1', 'audio');
+        track = createMediaTrack('1', 'foo', 'audio');
         attachedElements = [
           document.createElement('audio'),
           document.createElement('video')
@@ -310,7 +310,7 @@ describe('MediaTrack', () => {
       let attachedElements;
 
       before(() => {
-        track = createMediaTrack('1', 'audio');
+        track = createMediaTrack('1', 'foo', 'audio');
         attachedElements = [
           document.createElement('audio'),
           document.createElement('video')
@@ -341,7 +341,7 @@ describe('MediaTrack', () => {
       let element;
 
       before(() => {
-        track = createMediaTrack('1', 'audio');
+        track = createMediaTrack('1', 'foo', 'audio');
         element = document.createElement('audio');
 
         track._getAllAttachedElements = sinon.spy();
@@ -369,7 +369,7 @@ describe('MediaTrack', () => {
       let element;
 
       before(() => {
-        track = createMediaTrack('1', 'audio');
+        track = createMediaTrack('1', 'foo', 'audio');
         element = document.createElement('audio');
 
         track._getAllAttachedElements = sinon.spy();
@@ -394,7 +394,7 @@ describe('MediaTrack', () => {
 
   describe('_updateElementsMediaStreamTrack', () => {
     it('should reattach each existing elements', () => {
-      track = createMediaTrack('1', 'video');
+      track = createMediaTrack('1', 'foo', 'video');
       track._attach = sinon.spy();
       track._attachments.add('foo');
       track._attachments.add('bar');
@@ -408,7 +408,7 @@ describe('MediaTrack', () => {
 
   describe('_getAllAttachedElements', () => {
     it('should return an array with all elements in ._attachments', () => {
-      track = createMediaTrack('1', 'audio');
+      track = createMediaTrack('1', 'foo', 'audio');
       track._attachments.add('foo');
       track._attachments.add('bar');
 
@@ -418,7 +418,7 @@ describe('MediaTrack', () => {
 
   describe('_detachElements', () => {
     it('should run _detachElement for each element passed', () => {
-      track = createMediaTrack('1', 'audio');
+      track = createMediaTrack('1', 'foo', 'audio');
       track._detachElement = sinon.spy();
       track._detachElements(['foo', 'bar']);
       assert.equal(track._detachElement.callCount, 2);
@@ -431,7 +431,7 @@ describe('MediaTrack', () => {
     let el2;
 
     before(() => {
-      track = createMediaTrack('1', 'audio');
+      track = createMediaTrack('1', 'foo', 'audio');
       el1 = document.createElement('audio');
       el1.srcObject = new MediaStream();
       el1.srcObject.addTrack(track.mediaStreamTrack);
@@ -454,7 +454,7 @@ describe('MediaTrack', () => {
       });
 
       it('should remove the MediaTrack\'s MediaStreamTrack from the element\'s .srcObject MediaStream if there is a processedTrack', () => {
-        track = createMediaTrack('1', 'video');
+        track = createMediaTrack('1', 'foo', 'video');
         track.processedTrack = { foo: 'ff' };
         el1 = document.createElement('video');
         el1.srcObject = new MediaStream();
@@ -500,7 +500,7 @@ describe('MediaTrack', () => {
       MediaStream.prototype.getAudioTracks = sinon.spy(() => [track.mediaStreamTrack]);
       MediaStream.prototype.removeTrack = sinon.spy();
       el = document.createElement('audio');
-      track = createMediaTrack(1, 'audio', { MediaStream: MediaStream });
+      track = createMediaTrack(1, 'foo', 'audio', { MediaStream: MediaStream });
       track.processedTrack = null;
     });
 
@@ -621,9 +621,9 @@ describe('MediaTrack', () => {
   });
 });
 
-function createMediaTrack(id, kind, options) {
+function createMediaTrack(id, mid, kind, options) {
   const mediaStreamTrack = new MediaStreamTrack(id, kind);
-  const mediaTrackTransceiver = new MediaTrackTransceiver(id, mediaStreamTrack);
+  const mediaTrackTransceiver = new MediaTrackTransceiver(id, mid, mediaStreamTrack);
   const mediaTrack = new MediaTrack(mediaTrackTransceiver, Object.assign({ log: log }, options));
   mediaTrack.tranceiver = mediaTrackTransceiver;
   return mediaTrack;

--- a/test/unit/spec/media/track/receiver.js
+++ b/test/unit/spec/media/track/receiver.js
@@ -6,11 +6,12 @@ const MediaTrackReceiver = require('../../../../../lib/media/track/receiver');
 describe('MediaTrackReceiver', () => {
   describe('constructor', () => {
     const id = 'foo';
+    const mid = 'zoo';
     const mediaStreamTrack = { id: 'bar', kind: 'baz', readyState: 'zee' };
     let receiver;
 
     before(() => {
-      receiver = new MediaTrackReceiver(id, mediaStreamTrack);
+      receiver = new MediaTrackReceiver(id, mid, mediaStreamTrack);
     });
 
     it('should return a MediaTrackReceiver', () => {
@@ -23,6 +24,10 @@ describe('MediaTrackReceiver', () => {
 
     it('should set the .kind property to the MediaStreamTrack\'s .kind', () => {
       assert.equal(receiver.kind, mediaStreamTrack.kind);
+    });
+
+    it('should set the .mid property', () => {
+      assert.equal(receiver.mid, mid);
     });
 
     it('should set the .readyState property to the MediaStreamTrack\'s .readyState', () => {

--- a/test/unit/spec/media/track/remotemediatrack.js
+++ b/test/unit/spec/media/track/remotemediatrack.js
@@ -26,7 +26,7 @@ const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserv
 
           before(() => {
             try {
-              track = makeTrack({ id: 'foo', sid: 'bar', kind, isEnabled: true, isSwitchedOff: false, options: getOptions(), RemoteTrack });
+              track = makeTrack({ id: 'foo', mid: 'baz', sid: 'bar', kind, isEnabled: true, isSwitchedOff: false, options: getOptions(), RemoteTrack });
             } catch (e) {
               error = e;
             }
@@ -71,7 +71,7 @@ const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserv
       let onPriorityChange;
       beforeEach(() => {
         onPriorityChange = sinon.spy();
-        track = makeTrack({ id: 'foo', sid: 'bar', kind, isEnabled: true, options, RemoteTrack, setPriority: onPriorityChange });
+        track = makeTrack({ id: 'foo', mid: 'baz', sid: 'bar', kind, isEnabled: true, options, RemoteTrack, setPriority: onPriorityChange });
       });
 
       [null, ...Object.values(trackPriority)].forEach(priorityValue => {
@@ -114,7 +114,7 @@ const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserv
 
           before(() => {
             arg = null;
-            track = makeTrack({ id: 'foo', sid: 'bar', kind, isEnabled, options: null, RemoteTrack });
+            track = makeTrack({ id: 'foo', mid: 'baz', sid: 'bar', kind, isEnabled, options: null, RemoteTrack });
             track.once('disabled', _arg => {
               trackDisabled = true;
               arg = _arg;
@@ -167,7 +167,7 @@ const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserv
 
           before(() => {
             arg = null;
-            track = makeTrack({ id: 'foo', sid: 'bar', kind, isSwitchedOff, isEnabled: true, options: null, RemoteTrack });
+            track = makeTrack({ id: 'foo', mid: 'baz', sid: 'bar', kind, isSwitchedOff, isEnabled: true, options: null, RemoteTrack });
             track.once('switchedOff', _arg => {
               trackSwitchedOff = true;
               arg = _arg;
@@ -209,7 +209,7 @@ const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserv
       let track;
 
       before(() => {
-        track = makeTrack({ id: 'foo', sid: 'MT1', kind, isEnabled: true, options: null, RemoteTrack });
+        track = makeTrack({ id: 'foo', mid: 'bar', sid: 'MT1', kind, isEnabled: true, options: null, RemoteTrack });
       });
 
       it('only returns public properties', () => {
@@ -247,7 +247,7 @@ const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserv
       let track;
 
       beforeEach(() => {
-        track = makeTrack({ id: 'foo', sid: 'MT1', kind, isEnabled: true, options: null, RemoteTrack });
+        track = makeTrack({ id: 'foo', mid: 'bar', sid: 'MT1', kind, isEnabled: true, options: null, RemoteTrack });
         track.mediaStreamTrack.enabled = false;
         track._captureFrames = sinon.stub();
         track._createElement = sinon.spy(() => {
@@ -297,7 +297,7 @@ const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserv
       let el2;
       let track;
       beforeEach(() => {
-        track = makeTrack({ id: 'foo', sid: 'MT1', kind, isEnabled: true, options: null, RemoteTrack });
+        track = makeTrack({ id: 'foo', mid: 'bar', sid: 'MT1', kind, isEnabled: true, options: null, RemoteTrack });
         track._createElement = sinon.spy(() => {
           // return a unique element.
           return {
@@ -350,7 +350,7 @@ const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserv
       let track;
 
       before(() => {
-        track = makeTrack({ id: 'foo', sid: 'MT1', kind, isEnabled: true, options: null, RemoteTrack });
+        track = makeTrack({ id: 'foo', mid: 'bar', sid: 'MT1', kind, isEnabled: true, options: null, RemoteTrack });
       });
 
       it('only returns public properties', () => {
@@ -408,7 +408,7 @@ const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserv
           let track;
           before(() => {
             document.visibilityState = 'visible';
-            track = makeTrack({ id: 'foo', sid: 'bar', kind, isSwitchedOff: false, isEnabled: true, options: { workaroundWebKitBug212780: false }, RemoteTrack });
+            track = makeTrack({ id: 'foo', mid: 'baz', sid: 'bar', kind, isSwitchedOff: false, isEnabled: true, options: { workaroundWebKitBug212780: false }, RemoteTrack });
           });
 
           it('does not register for document visibility change', () => {
@@ -421,7 +421,7 @@ const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserv
           let track;
           before(() => {
             document.visibilityState = 'visible';
-            track = makeTrack({ id: 'foo', sid: 'bar', kind, isSwitchedOff: false, isEnabled: true, options: { workaroundWebKitBug212780: true }, RemoteTrack });
+            track = makeTrack({ id: 'foo', mid: 'baz', sid: 'bar', kind, isSwitchedOff: false, isEnabled: true, options: { workaroundWebKitBug212780: true }, RemoteTrack });
           });
 
           it('sets _workaroundWebKitBug212780 to true', () => {
@@ -454,13 +454,13 @@ const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserv
   });
 });
 
-function makeTrack({ id, sid, kind, isEnabled, options, RemoteTrack, setPriority, setRenderHint, isSwitchedOff }) {
+function makeTrack({ id, mid, sid, kind, isEnabled, options, RemoteTrack, setPriority, setRenderHint, isSwitchedOff }) {
   const emptyFn = () => undefined;
   setPriority = setPriority || emptyFn;
   setRenderHint = setRenderHint || emptyFn;
   isSwitchedOff = !!isSwitchedOff;
   const mediaStreamTrack = new FakeMediaStreamTrack(kind);
-  const mediaTrackReceiver = new MediaTrackReceiver(id, mediaStreamTrack);
+  const mediaTrackReceiver = new MediaTrackReceiver(id, mid, mediaStreamTrack);
   options = options || {};
   options.IntersectionObserver = NullIntersectionObserver;
   return new RemoteTrack(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, setPriority, setRenderHint, options);

--- a/test/unit/spec/media/track/remotemediatrack.js
+++ b/test/unit/spec/media/track/remotemediatrack.js
@@ -19,47 +19,44 @@ const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserv
   let name = `Remote${capitalize(kind)}Track`;
   describe(`${name}`, () => {
     describe('constructor', () => {
-      [() => null, () => ({ log, name: 'bar' })].forEach(getOptions => {
-        context(`when called with${getOptions() ? '' : 'out'} the options object`, () => {
-          let error;
-          let track;
+      const name = 'bar';
+      let error;
+      let track;
 
-          before(() => {
-            try {
-              track = makeTrack({ id: 'foo', mid: 'baz', sid: 'bar', kind, isEnabled: true, isSwitchedOff: false, options: getOptions(), RemoteTrack });
-            } catch (e) {
-              error = e;
-            }
-          });
+      before(() => {
+        try {
+          track = makeTrack({ id: 'foo', mid: 'baz', sid: 'bar', kind, isEnabled: true, isSwitchedOff: false, options: { log, name }, RemoteTrack });
+        } catch (e) {
+          error = e;
+        }
+      });
 
-          it('shouldn\'t throw', () => {
-            assert(!error);
-          });
+      it('shouldn\'t throw', () => {
+        assert(!error);
+      });
 
-          it(`should return an instance of ${name}`, () => {
-            assert(track instanceof RemoteTrack);
-          });
+      it(`should return an instance of ${name}`, () => {
+        assert(track instanceof RemoteTrack);
+      });
 
-          it('should set the .isEnabled property', () => {
-            assert.equal(track.isEnabled, true);
-          });
+      it('should set the .isEnabled property', () => {
+        assert.equal(track.isEnabled, true);
+      });
 
-          it('should set the .isSwitchedOff property', () => {
-            assert.equal(track.isSwitchedOff, false);
-          });
+      it('should set the .isSwitchedOff property', () => {
+        assert.equal(track.isSwitchedOff, false);
+      });
 
-          it('should set the .kind property', () => {
-            assert.equal(track.kind, kind);
-          });
+      it('should set the .kind property', () => {
+        assert.equal(track.kind, kind);
+      });
 
-          it('should set the .name property', () => {
-            assert.equal(track.name, getOptions() ? 'bar' : 'foo');
-          });
+      it('should set the .name property', () => {
+        assert.equal(track.name, name);
+      });
 
-          it('should set the .sid property', () => {
-            assert.equal(track.sid, 'bar');
-          });
-        });
+      it('should set the .sid property', () => {
+        assert.equal(track.sid, 'bar');
       });
     });
 
@@ -223,7 +220,8 @@ const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserv
             'isEnabled',
             'isSwitchedOff',
             'priority',
-            'sid'
+            'sid',
+            'switchOffReason'
           ]);
         } else {
           assert.deepEqual(Object.keys(track), [
@@ -237,7 +235,8 @@ const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserv
             'isEnabled',
             'isSwitchedOff',
             'priority',
-            'sid'
+            'sid',
+            'switchOffReason'
           ]);
         }
       });
@@ -364,7 +363,8 @@ const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserv
             name: track.name,
             priority: null,
             processedTrack: null,
-            sid: track.sid
+            sid: track.sid,
+            switchOffReason: null
           });
         } else {
           assert.deepEqual(track.toJSON(), {
@@ -378,7 +378,8 @@ const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserv
             priority: null,
             processedTrack: null,
             processor: null,
-            sid: track.sid
+            sid: track.sid,
+            switchOffReason: null
           });
         }
       });
@@ -463,5 +464,5 @@ function makeTrack({ id, mid, sid, kind, isEnabled, options, RemoteTrack, setPri
   const mediaTrackReceiver = new MediaTrackReceiver(id, mid, mediaStreamTrack);
   options = options || {};
   options.IntersectionObserver = NullIntersectionObserver;
-  return new RemoteTrack(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, setPriority, setRenderHint, options);
+  return new RemoteTrack(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, null, setPriority, setRenderHint, options);
 }

--- a/test/unit/spec/media/track/remotevideotrack.js
+++ b/test/unit/spec/media/track/remotevideotrack.js
@@ -66,7 +66,7 @@ describe('RemoteVideoTrack', () => {
       el = document.createElement('video');
       setRenderHintsSpy = sinon.spy();
 
-      track = makeTrack({ id: 'foo', sid: 'bar', setRenderHint: setRenderHintsSpy, options });
+      track = makeTrack({ id: 'foo', mid: 'baz', sid: 'bar', setRenderHint: setRenderHintsSpy, options });
       intersectionObserveSpy = sinon.spy(track._intersectionObserver, 'observe');
       intersectionUnobserveSpy = sinon.spy(track._intersectionObserver, 'unobserve');
       resizeObserveSpy = sinon.spy(track._resizeObserver, 'observe');
@@ -299,7 +299,7 @@ describe('RemoteVideoTrack', () => {
       global.document = global.document || new Document();
       el = document.createElement('video');
       setRenderHintsSpy = sinon.spy();
-      track = makeTrack({ id: 'foo', sid: 'bar', setRenderHint: setRenderHintsSpy, options: { IntersectionObserver } });
+      track = makeTrack({ id: 'foo', mid: 'baz', sid: 'bar', setRenderHint: setRenderHintsSpy, options: { IntersectionObserver } });
       observeSpy = sinon.spy(IntersectionObserver.prototype, 'observe');
       unobserveSpy = sinon.spy(IntersectionObserver.prototype, 'unobserve');
     });
@@ -347,7 +347,7 @@ describe('RemoteVideoTrack', () => {
       global.document = global.document || new Document();
       el = document.createElement('video');
       setRenderHintsSpy = sinon.spy();
-      track = makeTrack({ id: 'foo', sid: 'bar', setRenderHint: setRenderHintsSpy, options: { ResizeObserver } });
+      track = makeTrack({ id: 'foo', mid: 'baz', sid: 'bar', setRenderHint: setRenderHintsSpy, options: { ResizeObserver } });
       observeSpy = sinon.spy(track._resizeObserver, 'observe');
       unobserveSpy = sinon.spy(track._resizeObserver, 'unobserve');
     });
@@ -417,13 +417,13 @@ describe('RemoteVideoTrack', () => {
 });
 
 
-function makeTrack({ id, sid, isEnabled, options, setPriority, setRenderHint, isSwitchedOff }) {
+function makeTrack({ id, mid, sid, isEnabled, options, setPriority, setRenderHint, isSwitchedOff }) {
   const emptyFn = () => undefined;
   setPriority = setPriority || emptyFn;
   setRenderHint = setRenderHint || emptyFn;
   isSwitchedOff = !!isSwitchedOff;
   isEnabled = typeof isEnabled === 'boolean' ? true : isEnabled;
   const mediaStreamTrack = new FakeMediaStreamTrack('video');
-  const mediaTrackReceiver = new MediaTrackReceiver(id, mediaStreamTrack);
+  const mediaTrackReceiver = new MediaTrackReceiver(id, mid, mediaStreamTrack);
   return new RemoteVideoTrack(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, setPriority, setRenderHint, options);
 }

--- a/test/unit/spec/media/track/sender.js
+++ b/test/unit/spec/media/track/sender.js
@@ -42,6 +42,10 @@ describe('MediaTrackSender', () => {
       assert(sender instanceof MediaTrackSender);
     });
 
+    it('should set .mid to null', () => {
+      assert.equal(sender.mid, null);
+    });
+
     ['id', 'kind', 'readyState'].forEach(prop => {
       it(`should set the .${prop} to the MediaStreamTrack's .${prop}`, () => {
         assert.equal(sender[prop], mediaStreamTrack[prop]);

--- a/test/unit/spec/media/track/transceiver.js
+++ b/test/unit/spec/media/track/transceiver.js
@@ -6,11 +6,12 @@ const MediaTrackTransceiver = require('../../../../../lib/media/track/transceive
 describe('MediaTrackTransceiver', () => {
   describe('constructor', () => {
     const id = 'foo';
+    const mid = 'zoo';
     const mediaStreamTrack = { id: 'bar', kind: 'baz', readyState: 'zee' };
     let transceiver;
 
     before(() => {
-      transceiver = new MediaTrackTransceiver(id, mediaStreamTrack);
+      transceiver = new MediaTrackTransceiver(id, mid, mediaStreamTrack);
     });
 
     it('should set the .id property', () => {
@@ -19,6 +20,10 @@ describe('MediaTrackTransceiver', () => {
 
     it('should set the .kind property to the MediaStreamTrack\'s .kind', () => {
       assert.equal(transceiver.kind, mediaStreamTrack.kind);
+    });
+
+    it('should set the .mid property', () => {
+      assert.equal(transceiver.mid, mid);
     });
 
     it('should set the .readyState property to the MediaStreamTrack\'s .readyState', () => {

--- a/test/unit/spec/media/track/videotrack.js
+++ b/test/unit/spec/media/track/videotrack.js
@@ -41,7 +41,7 @@ describe('VideoTrack', () => {
     global.document = document;
 
     mediaStreamTrack = new MediaStreamTrack('1', 'video');
-    const mediaTrackTransceiver = new MediaTrackTransceiver('1', mediaStreamTrack);
+    const mediaTrackTransceiver = new MediaTrackTransceiver('1', 'foo', mediaStreamTrack);
     videoTrack = new VideoTrack(mediaTrackTransceiver, { log: log });
 
     videoTrack._attach = sinon.stub();

--- a/test/unit/spec/remoteparticipant.js
+++ b/test/unit/spec/remoteparticipant.js
@@ -401,6 +401,18 @@ describe('RemoteParticipant', () => {
         track.emit('started', track);
         assert.equal(track, trackStarted);
       });
+
+      it('re-emits "switchedOff" events', () => {
+        let trackSwitchedOff;
+        const trackSignaling = makeTrackSignaling({ kind: 'audio' });
+        const test = makeTest({ trackSignalings: [trackSignaling] });
+        const publication = [...test.participant.tracks.values()][0];
+        test.participant.once('trackSwitchedOff', (...args) => { trackSwitchedOff = args; });
+        trackSignaling.setSwitchedOff(true, 'DISABLED_BY_SUBSCRIBER');
+        assert.equal(trackSwitchedOff[0], publication.track);
+        assert.equal(trackSwitchedOff[1], publication);
+        assert.equal(trackSwitchedOff[2], 'DISABLED_BY_SUBSCRIBER');
+      });
     });
 
     context('when the RemoteParticipant .state transitions to "disconnected"', () => {
@@ -433,6 +445,17 @@ describe('RemoteParticipant', () => {
         test.participant.once('trackStarted', track => { trackStarted = track; });
         track.emit('started', track);
         assert(!trackStarted);
+      });
+
+      it('does not re-emit "switchedOff" events', () => {
+        let trackSwitchedOff;
+        const trackSignaling = makeTrackSignaling({ kind: 'audio' });
+        const test = makeTest({ trackSignalings: [trackSignaling] });
+        const publication = [...test.participant.tracks.values()][0];
+        test.signaling.emit('stateChanged', 'disconnected');
+        test.participant.once('trackSwitchedOff', (...args) => { trackSwitchedOff = args; });
+        trackSignaling.setSwitchedOff(true, 'DISABLED_BY_SUBSCRIBER');
+        assert(!trackSwitchedOff);
       });
 
       it('should emit "trackUnsubscribed" events for all the Participant\'s RemoteTrackPublications', () => {
@@ -476,6 +499,17 @@ describe('RemoteParticipant', () => {
         test.participant.once('trackStarted', track => { trackStarted = track; });
         track.emit('started', track);
         assert(!trackStarted);
+      });
+
+      it('does not re-emit "switchedOff" events', () => {
+        let trackSwitchedOff;
+        const trackSignaling = makeTrackSignaling({ kind: 'audio' });
+        const test = makeTest({ trackSignalings: [trackSignaling] });
+        const publication = [...test.participant.tracks.values()][0];
+        test.signaling.emit('stateChanged', 'disconnected');
+        test.participant.once('trackSwitchedOff', (...args) => { trackSwitchedOff = args; });
+        trackSignaling.setSwitchedOff(true, 'DISABLED_BY_SUBSCRIBER');
+        assert(!trackSwitchedOff);
       });
     });
   });
@@ -1622,19 +1656,24 @@ function makeTrackSignaling(options) {
   const track = new EventEmitter();
   track.id = options.id || makeId();
   track.isSubscribed = false;
+  track.isSwitchedOff = false;
   track.kind = options.kind || makeKind();
   track.name = options.name || track.id;
   track.sid = options.sid || makeId();
+  track.switchOffReason = null;
   track.setTrackTransceiver = trackTransceiver => {
     track.trackTransceiver = trackTransceiver;
     track.isSubscribed = !!track.trackTransceiver;
     track.emit('updated');
   };
+  track.setSwitchedOff = (isSwitchedOff, switchOffReason) => {
+    track.isSwitchedOff = isSwitchedOff;
+    track.switchOffReason = switchOffReason;
+    track.emit('updated');
+  };
   track.subscribeFailed = error => {
     track.error = error;
     track.emit('updated');
-  };
-  track._setSwitchedOff = () => {
   };
   track.trackTransceiver = null;
   if (!options.shouldSubscriptionFail && !options.testTrackSubscriptionRestApi) {

--- a/test/unit/spec/remoteparticipant.js
+++ b/test/unit/spec/remoteparticipant.js
@@ -1513,7 +1513,7 @@ function makeTest(options) {
   }
   options.trackSignalings = options.trackSignalings || [];
 
-  options.RemoteAudioTrack = sinon.spy(function RemoteAudioTrack(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, setPriorityCallback, setRenderHitsCallback, opts) {
+  options.RemoteAudioTrack = sinon.spy(function RemoteAudioTrack(sid, mediaTrackReceiver, isEnabled, isSwitchedOff, switchOffReason, setPriorityCallback, setRenderHitsCallback, opts) {
     EventEmitter.call(this);
     this.enabled = true;
     this.kind = mediaTrackReceiver.kind;
@@ -1521,9 +1521,16 @@ function makeTest(options) {
     this.name = opts && opts.name ? opts.name : mediaTrackReceiver.id;
     this.sid = sid;
     this.setPriority = setPriorityCallback;
+    this.switchOffReason = switchOffReason;
     this._setRenderHint = setRenderHitsCallback;
     this._setEnabled = enabled => { this.enabled = enabled; };
-    this._setSwitchedOff = switchedOff => { this.switchedOff = switchedOff; };
+    this._setSwitchedOff = (switchedOff, switchOffReason) => {
+      this.switchedOff = switchedOff;
+      this.switchOffReason = switchOffReason;
+    };
+    this._setTrackReceiver = mediaTrackReceiver => {
+      this.mediaStreamTrack = mediaTrackReceiver ? mediaTrackReceiver.track : null;
+    };
     options.tracks.push(this);
   });
   inherits(options.RemoteAudioTrack, EventEmitter);

--- a/test/unit/spec/room.js
+++ b/test/unit/spec/room.js
@@ -66,9 +66,11 @@ describe('Room', () => {
 
   describe('RemoteParticipant events', () => {
     let participants;
+    let publication;
     let track;
 
     beforeEach(() => {
+      publication = {};
       track = {};
       [
         new RemoteParticipantSignaling('PA000', 'foo'),
@@ -174,6 +176,15 @@ describe('Room', () => {
       assert(spy.calledWith(error, publication, participants.bar));
     });
 
+    it('should re-emit RemoteParticipants trackSwitchedOff event for matching RemoteParticipant only', () => {
+      const spy = sinon.spy();
+      room.on('trackSwitchedOff', spy);
+
+      participants.foo.emit('trackSwitchedOff', track, publication, 'bar');
+      assert.equal(spy.callCount, 1);
+      assert.deepStrictEqual(spy.args[0], [track, publication, participants.foo, 'bar']);
+    });
+
     it('should re-emit RemoteParticipant trackUnpublished for matching RemoteParticipant only', () => {
       const spy = sinon.spy();
       room.on('trackUnpublished', spy);
@@ -205,6 +216,8 @@ describe('Room', () => {
       room.on('trackStarted', spy);
       room.on('trackSubscribed', spy);
       room.on('trackSubscriptionFailed', spy);
+      room.on('trackSwitchedOff', spy);
+      room.on('trackSwitchedOn', spy);
       room.on('trackUnpublished', spy);
       room.on('trackUnsubscribed', spy);
 

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -770,8 +770,8 @@ describe('PeerConnectionV2', () => {
       test.pc.dispatchEvent({ type: 'datachannel', channel: dataChannel1 });
       test.pc.dispatchEvent({ type: 'datachannel', channel: dataChannel2 });
       test.pc.dispatchEvent({ type: 'datachannel', channel: dataChannel3 });
-      test.pc.dispatchEvent({ type: 'track', track: mediaTrack1 });
-      test.pc.dispatchEvent({ type: 'track', track: mediaTrack2 });
+      test.pc.dispatchEvent({ type: 'track', transceiver: { mid: '0' }, track: mediaTrack1 });
+      test.pc.dispatchEvent({ type: 'track', transceiver: { mid: '1' }, track: mediaTrack2 });
 
       assert.deepEqual(test.pcv2.getTrackReceivers().map(receiver => receiver.id),
         [dataChannel1, dataChannel2, dataChannel3, mediaTrack1, mediaTrack2].map(getTrackIdOrChannelLabel));
@@ -782,8 +782,8 @@ describe('PeerConnectionV2', () => {
       assert.deepEqual(test.pcv2.getTrackReceivers().map(receiver => receiver.id),
         [dataChannel2, dataChannel3, mediaTrack2].map(getTrackIdOrChannelLabel));
 
-      sinon.assert.calledWith(trackMatcher.match, { type: 'track', track: mediaTrack1 });
-      sinon.assert.calledWith(trackMatcher.match, { type: 'track', track: mediaTrack2 });
+      sinon.assert.calledWith(trackMatcher.match, { type: 'track', transceiver: { mid: '0' }, track: mediaTrack1 });
+      sinon.assert.calledWith(trackMatcher.match, { type: 'track', transceiver: { mid: '1' }, track: mediaTrack2 });
       sinon.assert.calledWith(trackMatcher.update, null);
     });
   });
@@ -2114,6 +2114,7 @@ describe('PeerConnectionV2', () => {
         pc.emit('track', {
           type: 'track',
           track: mediaStreamTrack,
+          transceiver: { mid: 'foo' },
           streams: [mediaStream]
         });
 
@@ -2121,6 +2122,7 @@ describe('PeerConnectionV2', () => {
       });
 
       it('emits the "trackAdded" event with a MediaTrackReceiver', () => {
+        assert.equal(trackReceiver.mid, 'foo');
         assert.equal(trackReceiver.track, mediaStreamTrack);
       });
     });

--- a/test/unit/spec/signaling/v2/room.js
+++ b/test/unit/spec/signaling/v2/room.js
@@ -1796,7 +1796,7 @@ function makeTest(options) {
   options.participants = options.participants || [];
   options.participantV2s = options.participantV2s || [];
 
-  options.RemoteParticipantV2 = options.RemoteParticipantV2 || makeRemoteParticipantV2Constructor(options);
+  options.RemoteParticipantSignaling = options.RemoteParticipantSignaling || makeRemoteParticipantV2Constructor(options);
   options.localTracks = (options.localTracks || []).map(track => {
     track.trackTransceiver = new EventEmitter();
     const eventEmitter = new EventEmitter();

--- a/test/unit/spec/signaling/v3/remoteparticipant.js
+++ b/test/unit/spec/signaling/v3/remoteparticipant.js
@@ -3,12 +3,12 @@
 const assert = require('assert');
 const sinon = require('sinon');
 
-const RemoteParticipantV2 = require('../../../../../lib/signaling/v2/remoteparticipant');
+const RemoteParticipantV3 = require('../../../../../lib/signaling/v3/remoteparticipant');
 const { defer } = require('../../../../../lib/util');
 const { combinationContext } = require('../../../../lib/util');
 
-describe('RemoteParticipantV2', () => {
-  // RemoteParticipantV2
+describe('RemoteParticipantV3', () => {
+  // RemoteParticipantV3
   // -------------------
 
   describe('constructor', () => {
@@ -48,9 +48,11 @@ describe('RemoteParticipantV2', () => {
         });
         assert.equal(sid1, test.remoteTrackPublicationV2s[0].sid);
         assert.equal(sid2, test.remoteTrackPublicationV2s[1].sid);
+        sinon.assert.calledWith(test.getPendingTrackReceiver, test.remoteTrackPublicationV2s[0].sid);
+        sinon.assert.calledWith(test.getPendingTrackReceiver, test.remoteTrackPublicationV2s[1].sid);
       });
 
-      it('adds the newly-constructed RemoteTrackPublicationV2s to the RemoteParticipantV2\'s .tracks Map', () => {
+      it('adds the newly-constructed RemoteTrackPublicationV2s to the RemoteParticipantV3\'s .tracks Map', () => {
         const sid1 = makeSid();
         const sid2 = makeSid();
         const test = makeTest({
@@ -71,7 +73,7 @@ describe('RemoteParticipantV2', () => {
 
   describe('#update, when called with a participantState at', () => {
     context('a newer revision', () => {
-      it('returns the RemoteParticipantV2', () => {
+      it('returns the RemoteParticipantV3', () => {
         const test = makeTest();
         const participantState = test.state(test.revision + 1);
         assert.equal(
@@ -95,9 +97,10 @@ describe('RemoteParticipantV2', () => {
           const participantState = test.state(test.revision + 1).setTrack({ sid });
           test.participant.update(participantState);
           assert.equal(sid, test.remoteTrackPublicationV2s[0].sid);
+          sinon.assert.calledWith(test.getPendingTrackReceiver, test.remoteTrackPublicationV2s[0].sid);
         });
 
-        it('adds the newly-constructed RemoteTrackPublicationV2 to the RemoteParticipantV2\'s .tracks Map', () => {
+        it('adds the newly-constructed RemoteTrackPublicationV2 to the RemoteParticipantV3\'s .tracks Map', () => {
           const test = makeTest();
           const sid = makeSid();
           const participantState = test.state(test.revision + 1).setTrack({ sid });
@@ -142,7 +145,7 @@ describe('RemoteParticipantV2', () => {
       });
 
       context('which no longer includes a trackState matching an existing RemoteTrackPublicationV2', () => {
-        it('deletes the RemoteTrackPublicationV2 from the RemoteParticipantV2\'s .tracks Map', () => {
+        it('deletes the RemoteTrackPublicationV2 from the RemoteParticipantV3\'s .tracks Map', () => {
           const sid = makeSid();
           const test = makeTest({ tracks: [{ sid }] });
           const participantState = test.state(test.revision + 1);
@@ -163,7 +166,7 @@ describe('RemoteParticipantV2', () => {
         });
       });
 
-      context('with .state set to "connected" when the RemoteParticipantV2\'s .state is', () => {
+      context('with .state set to "connected" when the RemoteParticipantV3\'s .state is', () => {
         context('"reconnecting"', () => {
           it('should transition the .state to "connected"', () => {
             const test = makeTest({ state: 'reconnecting' });
@@ -172,7 +175,7 @@ describe('RemoteParticipantV2', () => {
             assert.equal(test.participant.state, 'connected');
           });
 
-          it('should emit "stateChanged" on the RemoteParticipantV2', () => {
+          it('should emit "stateChanged" on the RemoteParticipantV3', () => {
             const test = makeTest({ state: 'reconnecting' });
             const participantState = test.state(test.revision + 1).setState('connected');
             let stateChanged;
@@ -191,7 +194,7 @@ describe('RemoteParticipantV2', () => {
               assert.equal(test.participant.state, state);
             });
 
-            it('should not emit "stateChanged" on the RemoteParticipantV2', () => {
+            it('should not emit "stateChanged" on the RemoteParticipantV3', () => {
               const test = makeTest({ state });
               const participantState = test.state(test.revision + 1).setState('connected');
               let stateChanged;
@@ -203,7 +206,7 @@ describe('RemoteParticipantV2', () => {
         });
       });
 
-      context('with .state set to "disconnected" when the RemoteParticipantV2\'s .state is', () => {
+      context('with .state set to "disconnected" when the RemoteParticipantV3\'s .state is', () => {
         ['connected', 'reconnecting'].forEach(state => {
           context(`"${state}"`, () => {
             it('should transition the .state to "disconnected"', () => {
@@ -213,7 +216,7 @@ describe('RemoteParticipantV2', () => {
               assert.equal(test.participant.state, 'disconnected');
             });
 
-            it('should emit "stateChanged" event on the RemoteParticipantV2"', () => {
+            it('should emit "stateChanged" event on the RemoteParticipantV3"', () => {
               const test = makeTest({ state });
               const participantState = test.state(test.revision + 1).setState('disconnected');
               let stateChanged;
@@ -247,7 +250,7 @@ describe('RemoteParticipantV2', () => {
         });
       });
 
-      context('with .state set to "reconnecting" when the RemoteParticipantV2\'s .state is', () => {
+      context('with .state set to "reconnecting" when the RemoteParticipantV3\'s .state is', () => {
         ['disconnected', 'reconnecting'].forEach(state => {
           context(`"${state}"`, () => {
             it(`the .state should remain "${state}"`, () => {
@@ -257,7 +260,7 @@ describe('RemoteParticipantV2', () => {
               assert.equal(test.participant.state, state);
             });
 
-            it('should not emit "stateChanged" event on the RemoteParticipantV2"', () => {
+            it('should not emit "stateChanged" event on the RemoteParticipantV3"', () => {
               const test = makeTest({ state });
               const participantState = test.state(test.revision + 1).setState('reconnecting');
               let stateChanged;
@@ -276,7 +279,7 @@ describe('RemoteParticipantV2', () => {
             assert.equal(test.participant.state, 'reconnecting');
           });
 
-          it('should emit "stateChanged" on the RemoteParticipantV2', () => {
+          it('should emit "stateChanged" on the RemoteParticipantV3', () => {
             const test = makeTest();
             const participantState = test.state(test.revision + 1).setState('reconnecting');
             let stateChanged;
@@ -311,7 +314,7 @@ describe('RemoteParticipantV2', () => {
     });
 
     context('the same revision', () => {
-      it('returns the RemoteParticipantV2', () => {
+      it('returns the RemoteParticipantV3', () => {
         const test = makeTest();
         const participantState = test.state(test.revision);
         assert.equal(
@@ -355,7 +358,7 @@ describe('RemoteParticipantV2', () => {
       });
 
       context('which no longer includes a trackState matching an existing RemoteTrackPublicationV2', () => {
-        it('does not delete the RemoteTrackPublicationV2 from the RemoteParticipantV2\'s .tracks Map', () => {
+        it('does not delete the RemoteTrackPublicationV2 from the RemoteParticipantV3\'s .tracks Map', () => {
           const sid = makeSid();
           const test = makeTest({ tracks: [{ sid }] });
           const participantState = test.state(test.revision);
@@ -379,7 +382,7 @@ describe('RemoteParticipantV2', () => {
       combinationContext([
         [
           ['connected', 'reconnecting', 'disconnected'],
-          x => `with .state set to "${x}" when the RemoteParticipantV2's .state is`
+          x => `with .state set to "${x}" when the RemoteParticipantV3's .state is`
         ],
         [
           ['connected', 'reconnecting', 'disconnected'],
@@ -393,7 +396,7 @@ describe('RemoteParticipantV2', () => {
           assert.equal(test.participant.state, state);
         });
 
-        it('should not emit "stateChanged" on the RemoteParticipantV2', () => {
+        it('should not emit "stateChanged" on the RemoteParticipantV3', () => {
           const test = makeTest({ state });
           const participantState = test.state(test.revision).setState(nextState);
           let stateChanged;
@@ -427,7 +430,7 @@ describe('RemoteParticipantV2', () => {
     });
 
     context('an older revision', () => {
-      it('returns the RemoteParticipantV2', () => {
+      it('returns the RemoteParticipantV3', () => {
         const test = makeTest();
         const participantState = test.state(test.revision - 1);
         test.participant.update(participantState);
@@ -472,7 +475,7 @@ describe('RemoteParticipantV2', () => {
       });
 
       context('which no longer includes a trackState matching an existing RemoteTrackPublicationV2', () => {
-        it('does not delete the RemoteTrackPublicationV2 from the RemoteParticipantV2\'s .tracks Map', () => {
+        it('does not delete the RemoteTrackPublicationV2 from the RemoteParticipantV3\'s .tracks Map', () => {
           const sid = makeSid();
           const test = makeTest({ tracks: [{ sid }] });
           const participantState = test.state(test.revision - 1);
@@ -496,7 +499,7 @@ describe('RemoteParticipantV2', () => {
       combinationContext([
         [
           ['connected', 'reconnecting', 'disconnected'],
-          x => `with .state set to "${x}" when the RemoteParticipantV2's .state is`
+          x => `with .state set to "${x}" when the RemoteParticipantV3's .state is`
         ],
         [
           ['connected', 'reconnecting', 'disconnected'],
@@ -510,7 +513,7 @@ describe('RemoteParticipantV2', () => {
           assert.equal(test.participant.state, state);
         });
 
-        it('should not emit "stateChanged" on the RemoteParticipantV2', () => {
+        it('should not emit "stateChanged" on the RemoteParticipantV3', () => {
           const test = makeTest({ state });
           const participantState = test.state(test.revision).setState(nextState);
           let stateChanged;
@@ -548,7 +551,7 @@ describe('RemoteParticipantV2', () => {
   // --------------------
 
   describe('#addTrack', () => {
-    it('returns the RemoteParticipantV2', () => {
+    it('returns the RemoteParticipantV3', () => {
       const RemoteTrackPublicationV2 = makeRemoteTrackPublicationV2Constructor();
       const test = makeTest();
       const track = new RemoteTrackPublicationV2({ sid: makeSid() });
@@ -557,7 +560,7 @@ describe('RemoteParticipantV2', () => {
         test.participant.addTrack(track));
     });
 
-    it('adds the RemoteTrackPublicationV2 to the RemoteParticipantV2\'s .tracks Map', () => {
+    it('adds the RemoteTrackPublicationV2 to the RemoteParticipantV3\'s .tracks Map', () => {
       const RemoteTrackPublicationV2 = makeRemoteTrackPublicationV2Constructor();
       const test = makeTest();
       const sid = makeSid();
@@ -582,7 +585,7 @@ describe('RemoteParticipantV2', () => {
   });
 
   describe('#connect', () => {
-    context('when the RemoteParticipantV2\'s .state is "reconnecting"', () => {
+    context('when the RemoteParticipantV3\'s .state is "reconnecting"', () => {
       it('returns true', () => {
         const test = makeTest();
         test.participant.reconnecting();
@@ -628,7 +631,7 @@ describe('RemoteParticipantV2', () => {
       });
     });
 
-    context('when the RemoteParticipantV2\'s .state is "connected"', () => {
+    context('when the RemoteParticipantV3\'s .state is "connected"', () => {
       it('returns false', () => {
         const test = makeTest();
         assert.equal(
@@ -669,7 +672,7 @@ describe('RemoteParticipantV2', () => {
       });
     });
 
-    context('when the RemoteParticipantV2\'s .state is "disconnected"', () => {
+    context('when the RemoteParticipantV3\'s .state is "disconnected"', () => {
       it('returns false', () => {
         const test = makeTest();
         test.participant.disconnect();
@@ -718,7 +721,7 @@ describe('RemoteParticipantV2', () => {
 
   describe('#disconnect', () => {
     ['connected', 'reconnecting'].forEach(state => {
-      context(`when the RemoteParticipantV2's .state is "${state}"`, () => {
+      context(`when the RemoteParticipantV3's .state is "${state}"`, () => {
         it('returns true', () => {
           const test = makeTest({ state });
           assert.equal(
@@ -746,7 +749,7 @@ describe('RemoteParticipantV2', () => {
       });
     });
 
-    context('when the RemoteParticipantV2\'s .state is "disconnected"', () => {
+    context('when the RemoteParticipantV3\'s .state is "disconnected"', () => {
       it('returns false', () => {
         const test = makeTest();
         test.participant.disconnect();
@@ -776,7 +779,7 @@ describe('RemoteParticipantV2', () => {
   });
 
   describe('#reconnecting', () => {
-    context('when the RemoteParticipantV2\'s .state is "connected"', () => {
+    context('when the RemoteParticipantV3\'s .state is "connected"', () => {
       it('should return true', () => {
         const test = makeTest();
         assert.equal(test.participant.reconnecting(), true);
@@ -788,7 +791,7 @@ describe('RemoteParticipantV2', () => {
         assert.equal(test.participant.state, 'reconnecting');
       });
 
-      it('should emit "stateChanged" on the RemoteParticipantV2', () => {
+      it('should emit "stateChanged" on the RemoteParticipantV3', () => {
         const test = makeTest();
         let stateChanged;
         test.participant.once('stateChanged', () => { stateChanged = true; });
@@ -798,7 +801,7 @@ describe('RemoteParticipantV2', () => {
     });
 
     ['reconnecting', 'disconnected'].forEach(state => {
-      context(`when the RemoteParticipantV2's .state is "${state}"`, () => {
+      context(`when the RemoteParticipantV3's .state is "${state}"`, () => {
         it('should return false', () => {
           const test = makeTest({ state });
           assert.equal(test.participant.reconnecting(), false);
@@ -810,7 +813,7 @@ describe('RemoteParticipantV2', () => {
           assert.equal(test.participant.state, state);
         });
 
-        it('should emit "stateChanged" on the RemoteParticipantV2', () => {
+        it('should emit "stateChanged" on the RemoteParticipantV3', () => {
           const test = makeTest({ state });
           let stateChanged;
           test.participant.once('stateChanged', () => { stateChanged = true; });
@@ -830,7 +833,7 @@ describe('RemoteParticipantV2', () => {
           test.participant.removeTrack(test.remoteTrackPublicationV2s[0]));
       });
 
-      it('deletes the RemoteTrackPublicationV2 from the RemoteParticipantV2\'s .tracks Map', () => {
+      it('deletes the RemoteTrackPublicationV2 from the RemoteParticipantV3\'s .tracks Map', () => {
         const test = makeTest({ tracks: [{ sid: makeSid() }] });
         test.participant.removeTrack(test.remoteTrackPublicationV2s[0]);
         assert(!test.participant.tracks.has(test.remoteTrackPublicationV2s[0].sid));
@@ -902,11 +905,12 @@ function makeTest(options) {
     || sinon.spy(() => options.getTrackTransceiverDeferred.promise);
   options.RemoteTrackPublicationSignaling = options.RemoteTrackPublicationSignaling || makeRemoteTrackPublicationV2Constructor(options);
 
-  options.getInitialTrackSwitchOffState = options.getInitialTrackSwitchOffState || sinon.spy(() => { return false; });
+  options.getInitialTrackSwitchOffState = options.getInitialTrackSwitchOffState || sinon.spy(() => false);
+  options.getPendingTrackReceiver = options.getPendingTrackReceiver || sinon.spy(() => Promise.resolve(null));
   options.setRenderHints = options.setRenderHints || sinon.spy(() => { return false; });
   options.setPriority = options.setPriority || sinon.spy(() => { return false; });
   options.clearRenderHint = options.clearRenderHint || sinon.spy(() => { return false; });
-  options.participant = options.participant || makeRemoteParticipantV2(options);
+  options.participant = options.participant || makeRemoteParticipantV3(options);
 
   options.state = revision => {
     return new RemoteParticipantStateBuilder(options.participant, revision);
@@ -948,8 +952,16 @@ RemoteParticipantStateBuilder.prototype.setTracks = function setTracks(tracks) {
   return this;
 };
 
-function makeRemoteParticipantV2(options) {
-  return new RemoteParticipantV2(options, options.getInitialTrackSwitchOffState, options.setPriority, options.setRenderHints, options.clearRenderHint, options);
+function makeRemoteParticipantV3(options) {
+  return new RemoteParticipantV3(
+    options,
+    options.getPendingTrackReceiver,
+    options.getInitialTrackSwitchOffState,
+    options.setPriority,
+    options.setRenderHints,
+    options.clearRenderHint,
+    options
+  );
 }
 
 function makeRemoteTrackPublicationV2Constructor(testOptions) {

--- a/test/unit/spec/signaling/v3/remoteparticipant.js
+++ b/test/unit/spec/signaling/v3/remoteparticipant.js
@@ -291,7 +291,7 @@ describe('RemoteParticipantV3', () => {
       });
 
       context('which changes the .identity', () => {
-        it('the .identity remains unchanged', () => {
+        it('does not change the .identity', () => {
           const test = makeTest();
           const participantState = test.state(test.revision + 1).setIdentity(makeIdentity());
           test.participant.update(participantState);
@@ -302,7 +302,7 @@ describe('RemoteParticipantV3', () => {
       });
 
       context('which changes the .sid', () => {
-        it('the .identity remains unchanged', () => {
+        it('does not change the .identity', () => {
           const test = makeTest();
           const participantState = test.state(test.revision + 1).setSid(makeSid());
           test.participant.update(participantState);
@@ -407,7 +407,7 @@ describe('RemoteParticipantV3', () => {
       });
 
       context('which changes the .identity', () => {
-        it('the .identity remains unchanged', () => {
+        it('does not change the .identity', () => {
           const test = makeTest();
           const participantState = test.state(test.revision).setIdentity(makeIdentity());
           test.participant.update(participantState);
@@ -418,7 +418,7 @@ describe('RemoteParticipantV3', () => {
       });
 
       context('which changes the .sid', () => {
-        it('the .identity remains unchanged', () => {
+        it('does not change the .identity', () => {
           const test = makeTest();
           const participantState = test.state(test.revision).setSid(makeSid());
           test.participant.update(participantState);
@@ -524,7 +524,7 @@ describe('RemoteParticipantV3', () => {
       });
 
       context('which changes the .identity', () => {
-        it('the .identity remains unchanged', () => {
+        it('does not change the .identity', () => {
           const test = makeTest();
           const participantState = test.state(test.revision - 1).setIdentity(makeIdentity());
           test.participant.update(participantState);
@@ -535,7 +535,7 @@ describe('RemoteParticipantV3', () => {
       });
 
       context('which changes the .sid', () => {
-        it('the .identity remains unchanged', () => {
+        it('does not change the .identity', () => {
           const test = makeTest();
           const participantState = test.state(test.revision - 1).setSid(makeSid());
           test.participant.update(participantState);
@@ -813,7 +813,7 @@ describe('RemoteParticipantV3', () => {
           assert.equal(test.participant.state, state);
         });
 
-        it('should emit "stateChanged" on the RemoteParticipantV3', () => {
+        it('should not emit "stateChanged" on the RemoteParticipantV3', () => {
           const test = makeTest({ state });
           let stateChanged;
           test.participant.once('stateChanged', () => { stateChanged = true; });

--- a/test/unit/spec/signaling/v3/remotetrackpublication.js
+++ b/test/unit/spec/signaling/v3/remotetrackpublication.js
@@ -1,0 +1,544 @@
+'use strict';
+
+const assert = require('assert');
+
+const { combinationContext } = require('../../../../lib/util');
+const RemoteTrackPublicationV3 = require('../../../../../lib/signaling/v3/remotetrackpublication');
+const { makeUUID } = require('../../../../../lib/util');
+
+describe('RemoteTrackPublicationV3', () => {
+  describe('constructor', () => {
+    ['kind', 'name', 'priority', 'sid'].forEach(prop => {
+      it(`sets .${prop}`, () => {
+        const trackState = {
+          kind: makeKind(),
+          name: makeUUID(),
+          priority: makeUUID(),
+          sid: makeSid()
+        };
+        const { isSwitchedOff, switchOffReason } = makeSwitchedOff();
+        assert.equal((new RemoteTrackPublicationV3(trackState, isSwitchedOff, switchOffReason))[prop], trackState[prop]);
+      });
+    });
+
+    [true, false].forEach(enabled => {
+      context(`when trackState.enabled is ${enabled}`, () => {
+        it(`sets .isEnabled to ${enabled}`, () => {
+          assert.equal((new RemoteTrackPublicationV3({
+            kind: makeKind(),
+            name: makeUUID(),
+            priority: makeUUID(),
+            sid: makeSid()
+          }, true, enabled ? 'DISABLED_BY_SUBSCRIBER' : 'DISABLED_BY_PUBLISHER')).isEnabled, enabled);
+        });
+      });
+    });
+
+    [true, false].forEach(isSwitchedOff => {
+      context(`when isSwitchedOff is ${isSwitchedOff}`, () => {
+        it(`sets .isSwitchedOff to ${isSwitchedOff} and .switchOffReason${isSwitchedOff ? '' : ' to null'}`, () => {
+          const track = new RemoteTrackPublicationV3({
+            kind: makeKind(),
+            name: makeUUID(),
+            priority: makeUUID(),
+            sid: makeSid()
+          }, isSwitchedOff, 'DISABLED_BY_SUBSCRIBER');
+          assert.equal(track.isSwitchedOff, isSwitchedOff);
+          assert.equal(track.switchOffReason, isSwitchedOff ? 'DISABLED_BY_SUBSCRIBER' : null);
+        });
+      });
+    });
+  });
+
+  describe('#setSwitchedOff, when called', () => {
+    combinationContext([
+      [
+        [true, false],
+        x => `on a RemoteTrackPublicationV3 that is ${x ? 'enabled' : 'disabled'}`
+      ],
+      [
+        [true, false],
+        x => `with isSwitchedOff = ${x}, and`
+      ],
+      [
+        [null, 'DISABLED_BY_PUBLISHER', 'DISABLED_BY_SUBSCRIBER'],
+        x => `switchOffReason = ${x}`
+      ]
+    ], ([enabled, isSwitchedOff, switchOffReason]) => {
+      const initialIsSwitchedOff = !enabled;
+      const initialSwitchOffReason = enabled ? null : 'DISABLED_BY_PUBLISHER';
+      let track;
+      let updated;
+
+      beforeEach(() => {
+        track = new RemoteTrackPublicationV3(
+          {
+            kind: makeKind(),
+            name: makeUUID(),
+            priority: makeUUID(),
+            sid: makeSid()
+          },
+          initialIsSwitchedOff,
+          initialSwitchOffReason
+        );
+        track.once('updated', () => { updated = true; });
+        track.setSwitchedOff(isSwitchedOff, switchOffReason);
+      });
+
+      it(`should set .isSwitchedOff to ${isSwitchedOff}`, () => {
+        assert.equal(track.isSwitchedOff, isSwitchedOff);
+      });
+
+      const expectedSwitchOffReason = isSwitchedOff ? switchOffReason : null;
+      it(`should set .switchOffReason to ${expectedSwitchOffReason}`, () => {
+        assert.equal(track.switchOffReason, expectedSwitchOffReason);
+      });
+
+      const expectedEnabled = !(isSwitchedOff && switchOffReason === 'DISABLED_BY_PUBLISHER');
+      it(`should set .isEnabled to ${expectedEnabled}`, () => {
+        assert.equal(track.isEnabled, expectedEnabled);
+      });
+
+      const shouldEmitUpdated = enabled !== expectedEnabled
+        || initialIsSwitchedOff !== isSwitchedOff
+        || initialSwitchOffReason !== expectedSwitchOffReason;
+
+      it(`should ${shouldEmitUpdated ? '' : 'not '}emit "updated"`, () => {
+        assert.equal(!!updated, shouldEmitUpdated);
+      });
+    });
+  });
+
+  describe('#setTrackTransceiver, when called with', () => {
+    combinationContext([
+      [
+        [null, {}],
+        x => `a ${x ? 'non-' : ''}null trackReceiver, and`
+      ],
+      [
+        [true, false],
+        x => `isSubscribed = ${x}`
+      ]
+    ], ([mediaTrackReceiver, isSubscribed]) => {
+      it('returns the RemoteTrackPublicationV3', () => {
+        const track = new RemoteTrackPublicationV3({
+          kind: makeKind(),
+          name: makeUUID(),
+          priority: makeUUID(),
+          sid: makeSid()
+        }, false, null);
+        assert.equal(track, track.setTrackTransceiver(mediaTrackReceiver, isSubscribed));
+      });
+
+      const expectedIsSubscribed = !!mediaTrackReceiver || isSubscribed;
+      it(`sets .isSubscribed to ${expectedIsSubscribed}`, () => {
+        const track = new RemoteTrackPublicationV3({
+          kind: makeKind(),
+          name: makeUUID(),
+          priority: makeUUID(),
+          sid: makeSid()
+        }, false, null);
+        assert.equal(track.setTrackTransceiver(mediaTrackReceiver, isSubscribed).isSubscribed, expectedIsSubscribed);
+      });
+
+      const shouldEmitUpdated = !!mediaTrackReceiver || isSubscribed;
+      it(`${shouldEmitUpdated ? 'emits' : 'does not emit'} "updated"`, () => {
+        const track = new RemoteTrackPublicationV3({
+          kind: makeKind(),
+          name: makeUUID(),
+          priority: makeUUID(),
+          sid: makeSid()
+        }, false, null);
+
+        let updated;
+        track.once('updated', () => { updated = true; });
+        track.setTrackTransceiver(mediaTrackReceiver, isSubscribed);
+        assert(shouldEmitUpdated ? updated : !updated);
+        assert.equal(track.trackTransceiver, mediaTrackReceiver);
+      });
+    });
+  });
+
+  describe('#update', () => {
+    ['low', 'standard', 'high'].forEach(oldPriorityValue => {
+      ['low', 'standard', 'high'].forEach(newPriorityValue => {
+        context(`called with priority change: ${oldPriorityValue} => ${newPriorityValue}`, () => {
+          it('returns the RemoteTrackPublicationV3', () => {
+            const trackState = {
+              kind: makeKind(),
+              name: makeUUID(),
+              priority: oldPriorityValue,
+              sid: makeSid()
+            };
+            const track = new RemoteTrackPublicationV3(trackState, false, null);
+            trackState.priority = newPriorityValue;
+            assert.equal(track, track.update(trackState));
+          });
+
+          it('sets .priority to new value', () => {
+            const trackState = {
+              kind: makeKind(),
+              name: makeUUID(),
+              priority: oldPriorityValue,
+              sid: makeSid()
+            };
+            const track = new RemoteTrackPublicationV3(trackState, false, null);
+            trackState.priority = newPriorityValue;
+            track.update(trackState);
+            assert.equal(track.priority, newPriorityValue);
+          });
+
+          if (newPriorityValue !== oldPriorityValue) {
+            it('emits an "updated" event with .priority set to newValue', () => {
+              const trackState = {
+                kind: makeKind(),
+                name: makeUUID(),
+                priority: oldPriorityValue,
+                sid: makeSid()
+              };
+
+              let priority;
+              const track = new RemoteTrackPublicationV3(trackState, false, null);
+              trackState.priority = newPriorityValue;
+              track.once('updated', () => { priority = track.priority; });
+              track.update(trackState);
+              assert.equal(priority, newPriorityValue);
+            });
+          } else {
+            it('does not emit an "updated" event', () => {
+              const trackState = {
+                kind: makeKind(),
+                name: makeUUID(),
+                priority: oldPriorityValue,
+                sid: makeSid()
+              };
+
+              let updated = false;
+              const track = new RemoteTrackPublicationV3(trackState, false, null);
+              trackState.priority = newPriorityValue;
+              track.once('updated', () => { updated = true; });
+              track.update(trackState);
+              assert(!updated);
+            });
+          }
+        });
+      });
+    });
+  });
+
+  // TrackSignaling
+  // --------------
+
+  describe('#disable', () => {
+    context('called when the RemoteTrackPublicationV3 is enabled', () => {
+      it('returns the RemoteTrackPublicationV3', () => {
+        const track = new RemoteTrackPublicationV3({
+          kind: makeKind(),
+          name: makeUUID(),
+          priority: makeUUID(),
+          sid: makeSid()
+        }, false, null);
+        assert.equal(track, track.disable());
+      });
+
+      it('sets .isEnabled to false', () => {
+        const track = new RemoteTrackPublicationV3({
+          kind: makeKind(),
+          name: makeUUID(),
+          priority: makeUUID(),
+          sid: makeSid()
+        }, false, null);
+        track.disable();
+        assert(!track.isEnabled);
+      });
+
+      it('emits an "updated" event with .isEnabled set to false', () => {
+        const track = new RemoteTrackPublicationV3({
+          kind: makeKind(),
+          name: makeUUID(),
+          priority: makeUUID(),
+          sid: makeSid()
+        }, false, null);
+        let isEnabled;
+        track.once('updated', () => { isEnabled = track.isEnabled; });
+        track.disable();
+        assert.equal(false, isEnabled);
+      });
+    });
+
+    context('called when the RemoteTrackPublicationV3 is disabled', () => {
+      it('returns the RemoteTrackPublicationV3', () => {
+        const track = new RemoteTrackPublicationV3({
+          kind: makeKind(),
+          name: makeUUID(),
+          priority: makeUUID(),
+          sid: makeSid()
+        }, true, 'DISABLED_BY_PUBLISHER');
+        assert.equal(track, track.disable());
+      });
+
+      it('.isEnabled remains false', () => {
+        const track = new RemoteTrackPublicationV3({
+          kind: makeKind(),
+          name: makeUUID(),
+          priority: makeUUID(),
+          sid: makeSid()
+        }, true, 'DISABLED_BY_PUBLISHER');
+        track.disable();
+        assert(!track.isEnabled);
+      });
+
+      it('"updated" does not emit', () => {
+        const track = new RemoteTrackPublicationV3({
+          kind: makeKind(),
+          name: makeUUID(),
+          priority: makeUUID(),
+          sid: makeSid()
+        }, true, 'DISABLED_BY_PUBLISHER');
+        let updated;
+        track.once('updated', () => { updated = true; });
+        track.disable();
+        assert(!updated);
+      });
+    });
+  });
+
+  describe('#enable', () => {
+    context('called with false when the RemoteTrackPublicationV3 is', () => {
+      context('enabled', () => {
+        it('returns the RemoteTrackPublicationV3', () => {
+          const track = new RemoteTrackPublicationV3({
+            kind: makeKind(),
+            name: makeUUID(),
+            priority: makeUUID(),
+            sid: makeSid()
+          }, false, null);
+          assert.equal(track, track.enable(false));
+        });
+
+        it('sets .isEnabled to false', () => {
+          const track = new RemoteTrackPublicationV3({
+            kind: makeKind(),
+            name: makeUUID(),
+            priority: makeUUID(),
+            sid: makeSid()
+          }, false, null);
+          track.enable(false);
+          assert(!track.isEnabled);
+        });
+
+        it('emits an "updated" event with .isEnabled set to false', () => {
+          const track = new RemoteTrackPublicationV3({
+            kind: makeKind(),
+            name: makeUUID(),
+            priority: makeUUID(),
+            sid: makeSid()
+          }, false, null);
+          let isEnabled;
+          track.once('updated', () => { isEnabled = track.isEnabled; });
+          track.enable(false);
+          assert.equal(false, isEnabled);
+        });
+      });
+
+      context('disabled', () => {
+        it('returns the RemoteTrackPublicationV3', () => {
+          const track = new RemoteTrackPublicationV3({
+            kind: makeKind(),
+            name: makeUUID(),
+            priority: makeUUID(),
+            sid: makeSid()
+          }, true, 'DISABLED_BY_PUBLISHER');
+          assert.equal(track, track.enable(false));
+        });
+
+        it('.isEnabled remains false', () => {
+          const track = new RemoteTrackPublicationV3({
+            kind: makeKind(),
+            name: makeUUID(),
+            priority: makeUUID(),
+            sid: makeSid()
+          }, true, 'DISABLED_BY_PUBLISHER');
+          track.enable(false);
+          assert(!track.isEnabled);
+        });
+
+        it('"updated" does not emit', () => {
+          const track = new RemoteTrackPublicationV3({
+            kind: makeKind(),
+            name: makeUUID(),
+            priority: makeUUID(),
+            sid: makeSid()
+          }, true, 'DISABLED_BY_PUBLISHER');
+          let updated;
+          track.once('updated', () => { updated = true; });
+          track.enable(false);
+          assert(!updated);
+        });
+      });
+    });
+
+    context('called with true when the RemoteTrackPublicationV3 is', () => {
+      context('enabled', () => {
+        it('returns the RemoteTrackPublicationV3', () => {
+          const track = new RemoteTrackPublicationV3({
+            kind: makeKind(),
+            name: makeUUID(),
+            priority: makeUUID(),
+            sid: makeSid()
+          }, false, null);
+          assert.equal(track, track.enable(true));
+        });
+
+        it('.isEnabled remains true', () => {
+          const track = new RemoteTrackPublicationV3({
+            kind: makeKind(),
+            name: makeUUID(),
+            priority: makeUUID(),
+            sid: makeSid()
+          }, false, null);
+          track.enable(true);
+          assert(track.isEnabled);
+        });
+
+        it('"updated" does not emit', () => {
+          const track = new RemoteTrackPublicationV3({
+            kind: makeKind(),
+            name: makeUUID(),
+            priority: makeUUID(),
+            sid: makeSid()
+          }, false, null);
+          let updated;
+          track.once('updated', () => { updated = true; });
+          track.enable(true);
+          assert(!updated);
+        });
+      });
+
+      context('disabled', () => {
+        it('returns the RemoteTrackPublicationV3', () => {
+          const track = new RemoteTrackPublicationV3({
+            kind: makeKind(),
+            name: makeUUID(),
+            priority: makeUUID(),
+            sid: makeSid()
+          }, true, 'DISABLED_BY_PUBLISHER');
+          assert.equal(track, track.enable(true));
+        });
+
+        it('sets .isEnabled to true', () => {
+          const track = new RemoteTrackPublicationV3({
+            kind: makeKind(),
+            name: makeUUID(),
+            priority: makeUUID(),
+            sid: makeSid()
+          }, true, 'DISABLED_BY_PUBLISHER');
+          track.enable(true);
+          assert(track.isEnabled);
+        });
+
+        it('emits an "updated" event with .isEnabled set to true', () => {
+          const track = new RemoteTrackPublicationV3({
+            kind: makeKind(),
+            name: makeUUID(),
+            priority: makeUUID(),
+            sid: makeSid()
+          }, true, 'DISABLED_BY_PUBLISHER');
+          let isEnabled;
+          track.once('updated', () => { isEnabled = track.isEnabled; });
+          track.enable(true);
+          assert(isEnabled);
+        });
+      });
+    });
+
+    context('called without an argument when the RemoteTrackPublicationV3 is', () => {
+      context('enabled', () => {
+        it('returns the RemoteTrackPublicationV3', () => {
+          const track = new RemoteTrackPublicationV3({
+            kind: makeKind(),
+            name: makeUUID(),
+            priority: makeUUID(),
+            sid: makeSid()
+          }, false, null);
+          assert.equal(track, track.enable());
+        });
+
+        it('.isEnabled remains true', () => {
+          const track = new RemoteTrackPublicationV3({
+            kind: makeKind(),
+            name: makeUUID(),
+            priority: makeUUID(),
+            sid: makeSid()
+          }, false, null);
+          track.enable();
+          assert(track.isEnabled);
+        });
+
+        it('"updated" does not emit', () => {
+          const track = new RemoteTrackPublicationV3({
+            kind: makeKind(),
+            name: makeUUID(),
+            priority: makeUUID(),
+            sid: makeSid()
+          }, false, null);
+          let updated;
+          track.once('updated', () => { updated = true; });
+          track.enable();
+          assert(!updated);
+        });
+      });
+
+      context('disabled', () => {
+        it('returns the RemoteTrackPublicationV3', () => {
+          const track = new RemoteTrackPublicationV3({
+            kind: makeKind(),
+            name: makeUUID(),
+            priority: makeUUID(),
+            sid: makeSid()
+          }, true, 'DISABLED_BY_PUBLISHER');
+          assert.equal(track, track.enable());
+        });
+
+        it('sets .isEnabled to true', () => {
+          const track = new RemoteTrackPublicationV3({
+            kind: makeKind(),
+            name: makeUUID(),
+            priority: makeUUID(),
+            sid: makeSid()
+          }, true, 'DISABLED_BY_PUBLISHER');
+          track.enable();
+          assert(track.isEnabled);
+        });
+
+        it('emits an "updated" event with .isEnabled set to true', () => {
+          const track = new RemoteTrackPublicationV3({
+            kind: makeKind(),
+            name: makeUUID(),
+            priority: makeUUID(),
+            sid: makeSid()
+          }, true, 'DISABLED_BY_PUBLISHER');
+          let isEnabled;
+          track.once('updated', () => { isEnabled = track.isEnabled; });
+          track.enable();
+          assert(isEnabled);
+        });
+      });
+    });
+  });
+});
+
+function makeSwitchedOff() {
+  const isSwitchedOff = (Math.random() < 0.5);
+  const switchOffReasons = ['DISABLED_BY_PUBLISHER', 'DISABLED_BY_SUBSCRIBER'];
+  const switchOffReason = isSwitchedOff ? switchOffReasons[Number(Math.random() < 0.5)] : null;
+  return { isSwitchedOff, switchOffReason };
+}
+
+function makeKind() {
+  return ['audio', 'video'][Number(Math.random() > 0.5)];
+}
+
+function makeSid() {
+  return makeUUID();
+}

--- a/test/unit/spec/signaling/v3/room.js
+++ b/test/unit/spec/signaling/v3/room.js
@@ -345,7 +345,7 @@ describe('RoomV3', () => {
           test.room.connectParticipant(test.participantV3s[0]));
       });
 
-      it('the ParticipantV3 remains in the RoomV2\'s .participants Map', () => {
+      it('the ParticipantV3 remains in the RoomV3\'s .participants Map', () => {
         const test = makeTest({
           participants: [
             { sid: makeSid(), tracks: [] }
@@ -380,7 +380,7 @@ describe('RoomV3', () => {
           test.room.connectParticipant(participant));
       });
 
-      it('adds the ParticipantV3 to the RoomV2\'s .participants Map', () => {
+      it('adds the ParticipantV3 to the RoomV3\'s .participants Map', () => {
         const RemoteParticipantV3 = makeRemoteParticipantV3Constructor();
         const participant = new RemoteParticipantV3({ sid: makeSid() });
         const test = makeTest();
@@ -405,7 +405,7 @@ describe('RoomV3', () => {
   });
 
   // eslint-disable-next-line no-warning-comments
-  // TODO(mmalavalli): Enable once RoomV2.getstats() is implemented.
+  // TODO(mmalavalli): Enable once RoomV3.getstats() is implemented.
   describe.skip('#getStats', () => {
     it('only returns results for published Local- or Remote-Tracks', async () => {
       const test = makeTest({
@@ -656,7 +656,7 @@ describe('RoomV3', () => {
 
   describe('"participantDisconnected" event', () => {
     context('when a connected ParticipantV3 emits a "stateChanged" event with a new state "disconnected"', () => {
-      it('removes the ParticipantV3 from the RoomV2\'s .participants Map', () => {
+      it('removes the ParticipantV3 from the RoomV3\'s .participants Map', () => {
         const test = makeTest({
           participants: [
             { sid: makeSid(), tracks: [] }
@@ -990,7 +990,7 @@ describe('RoomV3', () => {
               test.participantV3s[0].sid);
           });
 
-          it('does not add the newly-constructed ParticipantV3 to the RoomV2\'s .participants Map', () => {
+          it('does not add the newly-constructed ParticipantV3 to the RoomV3\'s .participants Map', () => {
             const test = makeTest();
             const sid = makeParticipantSid();
             test.transport.emit('message', {
@@ -1115,7 +1115,7 @@ describe('RoomV3', () => {
                 test.participantV3s[0].disconnect.calledOnce);
             });
 
-            it(`should ${type === 'synced' ? '' : 'not '}retain the ParticipantV3 remains in the RoomV2's .participants Map`, () => {
+            it(`should ${type === 'synced' ? '' : 'not '}retain the ParticipantV3 remains in the RoomV3's .participants Map`, () => {
               const sid = makeParticipantSid();
               const test = makeTest({
                 participants: [
@@ -1759,7 +1759,7 @@ describe('RoomV3', () => {
           });
         });
 
-        describe('then, when the RoomV2 finally disconnects,', () => {
+        describe('then, when the RoomV3 finally disconnects,', () => {
           it('calls .stop() on the NetworkQualityMonitor', () => {
             test.room.disconnect();
             assert(networkQualityMonitor.stop.calledOnce);

--- a/test/unit/spec/signaling/v3/room.js
+++ b/test/unit/spec/signaling/v3/room.js
@@ -251,7 +251,7 @@ describe('RoomV3', () => {
     });
 
     context('.participants', () => {
-      it('constructs a new ParticipantV2 for each Participant state', () => {
+      it('constructs a new ParticipantV3 for each Participant state', () => {
         const sid1 = makeParticipantSid();
         const sid2 = makeParticipantSid();
         const test = makeTest({
@@ -260,11 +260,11 @@ describe('RoomV3', () => {
             { sid: sid2, tracks: [] }
           ]
         });
-        assert.equal(sid1, test.participantV2s[0].sid);
-        assert.equal(sid2, test.participantV2s[1].sid);
+        assert.equal(sid1, test.participantV3s[0].sid);
+        assert.equal(sid2, test.participantV3s[1].sid);
       });
 
-      it('adds the newly-constructed ParticipantV2s to the RoomV3\'s .participants Map', () => {
+      it('adds the newly-constructed ParticipantV3s to the RoomV3\'s .participants Map', () => {
         const sid1 = makeParticipantSid();
         const sid2 = makeParticipantSid();
         const test = makeTest({
@@ -274,14 +274,14 @@ describe('RoomV3', () => {
           ]
         });
         assert.equal(
-          test.participantV2s[0],
+          test.participantV3s[0],
           test.room.participants.get(sid1));
         assert.equal(
-          test.participantV2s[1],
+          test.participantV3s[1],
           test.room.participants.get(sid2));
       });
 
-      it('calls .update with the Participants states on the newly-constructed ParticipantV2s', () => {
+      it('calls .update with the Participants states on the newly-constructed ParticipantV3s', () => {
         const sid1 = makeParticipantSid();
         const sid2 = makeParticipantSid();
         const test = makeTest({
@@ -292,10 +292,10 @@ describe('RoomV3', () => {
         });
         assert.deepEqual(
           { sid: sid1, foo: 'bar', tracks: [] },
-          test.participantV2s[0].update.args[0][0]);
+          test.participantV3s[0].update.args[0][0]);
         assert.deepEqual(
           { sid: sid2, baz: 'qux', tracks: [] },
-          test.participantV2s[1].update.args[0][0]);
+          test.participantV3s[1].update.args[0][0]);
       });
     });
 
@@ -332,7 +332,7 @@ describe('RoomV3', () => {
   // RoomSignaling
   // -------------
 
-  describe('#connectParticipant, called when the ParticipantV2 was', () => {
+  describe('#connectParticipant, called when the ParticipantV3 was', () => {
     context('previously connected', () => {
       it('returns false', () => {
         const test = makeTest({
@@ -342,19 +342,19 @@ describe('RoomV3', () => {
         });
         assert.equal(
           false,
-          test.room.connectParticipant(test.participantV2s[0]));
+          test.room.connectParticipant(test.participantV3s[0]));
       });
 
-      it('the ParticipantV2 remains in the RoomV2\'s .participants Map', () => {
+      it('the ParticipantV3 remains in the RoomV2\'s .participants Map', () => {
         const test = makeTest({
           participants: [
             { sid: makeSid(), tracks: [] }
           ]
         });
-        test.room.connectParticipant(test.participantV2s[0]);
+        test.room.connectParticipant(test.participantV3s[0]);
         assert.equal(
-          test.participantV2s[0],
-          test.room.participants.get(test.participantV2s[0].sid));
+          test.participantV3s[0],
+          test.room.participants.get(test.participantV3s[0].sid));
       });
 
       it('does not emit the "participantConnected" event', () => {
@@ -365,24 +365,24 @@ describe('RoomV3', () => {
         });
         let participantConnected = false;
         test.room.once('participantConnected', () => { participantConnected = true; });
-        test.room.connectParticipant(test.participantV2s[0]);
+        test.room.connectParticipant(test.participantV3s[0]);
         assert(!participantConnected);
       });
     });
 
     context('not previously connected', () => {
       it('returns true', () => {
-        const RemoteParticipantV2 = makeRemoteParticipantV2Constructor();
-        const participant = new RemoteParticipantV2({ sid: makeSid() });
+        const RemoteParticipantV3 = makeRemoteParticipantV3Constructor();
+        const participant = new RemoteParticipantV3({ sid: makeSid() });
         const test = makeTest();
         assert.equal(
           true,
           test.room.connectParticipant(participant));
       });
 
-      it('adds the ParticipantV2 to the RoomV2\'s .participants Map', () => {
-        const RemoteParticipantV2 = makeRemoteParticipantV2Constructor();
-        const participant = new RemoteParticipantV2({ sid: makeSid() });
+      it('adds the ParticipantV3 to the RoomV2\'s .participants Map', () => {
+        const RemoteParticipantV3 = makeRemoteParticipantV3Constructor();
+        const participant = new RemoteParticipantV3({ sid: makeSid() });
         const test = makeTest();
         test.room.connectParticipant(participant);
         assert.equal(
@@ -390,9 +390,9 @@ describe('RoomV3', () => {
           test.room.participants.get(participant.sid));
       });
 
-      it('emits the "participantConnected" event with the ParticipantV2', () => {
-        const RemoteParticipantV2 = makeRemoteParticipantV2Constructor();
-        const participant = new RemoteParticipantV2({ sid: makeSid() });
+      it('emits the "participantConnected" event with the ParticipantV3', () => {
+        const RemoteParticipantV3 = makeRemoteParticipantV3Constructor();
+        const participant = new RemoteParticipantV3({ sid: makeSid() });
         const test = makeTest();
         let participantConnected;
         test.room.once('participantConnected', participant => { participantConnected = participant; });
@@ -517,7 +517,7 @@ describe('RoomV3', () => {
         assert(test.transport.disconnect.calledOnce);
       });
 
-      it('does not call .disconnect on any connected ParticipantV2\'s', () => {
+      it('does not call .disconnect on any connected ParticipantV3\'s', () => {
         const test = makeTest({
           participants: [
             { sid: makeSid(), tracks: [] },
@@ -525,12 +525,12 @@ describe('RoomV3', () => {
           ]
         });
         test.room.disconnect();
-        test.participantV2s.forEach(participant => {
+        test.participantV3s.forEach(participant => {
           assert(!participant.disconnect.calledOnce);
         });
       });
 
-      it('does not remove any ParticipantV2\'s from the RoomV3\'s .participants Map', () => {
+      it('does not remove any ParticipantV3\'s from the RoomV3\'s .participants Map', () => {
         const test = makeTest({
           participants: [
             { sid: makeSid(), tracks: [] },
@@ -538,7 +538,7 @@ describe('RoomV3', () => {
           ]
         });
         test.room.disconnect();
-        test.participantV2s.forEach(participant => {
+        test.participantV3s.forEach(participant => {
           assert.equal(
             participant,
             test.room.participants.get(participant.sid));
@@ -608,7 +608,7 @@ describe('RoomV3', () => {
         assert(!test.transport.disconnect.calledTwice);
       });
 
-      it('does not call .disconnect on any connected ParticipantV2\'s', () => {
+      it('does not call .disconnect on any connected ParticipantV3\'s', () => {
         const test = makeTest({
           participants: [
             { sid: makeSid(), tracks: [] },
@@ -617,12 +617,12 @@ describe('RoomV3', () => {
         });
         test.room.disconnect();
         test.room.disconnect();
-        test.participantV2s.forEach(participant => {
+        test.participantV3s.forEach(participant => {
           assert(!participant.disconnect.calledOnce);
         });
       });
 
-      it('does not remove any ParticipantV2\'s from the RoomV3\'s .participants Map', () => {
+      it('does not remove any ParticipantV3\'s from the RoomV3\'s .participants Map', () => {
         const test = makeTest({
           participants: [
             { sid: makeSid(), tracks: [] },
@@ -631,7 +631,7 @@ describe('RoomV3', () => {
         });
         test.room.disconnect();
         test.room.disconnect();
-        test.participantV2s.forEach(participant => {
+        test.participantV3s.forEach(participant => {
           assert.equal(
             participant,
             test.room.participants.get(participant.sid));
@@ -655,18 +655,18 @@ describe('RoomV3', () => {
   });
 
   describe('"participantDisconnected" event', () => {
-    context('when a connected ParticipantV2 emits a "stateChanged" event with a new state "disconnected"', () => {
-      it('removes the ParticipantV2 from the RoomV2\'s .participants Map', () => {
+    context('when a connected ParticipantV3 emits a "stateChanged" event with a new state "disconnected"', () => {
+      it('removes the ParticipantV3 from the RoomV2\'s .participants Map', () => {
         const test = makeTest({
           participants: [
             { sid: makeSid(), tracks: [] }
           ]
         });
-        test.participantV2s[0].emit('stateChanged', 'disconnected');
-        assert(!test.room.participants.has(test.participantV2s[0].sid));
+        test.participantV3s[0].emit('stateChanged', 'disconnected');
+        assert(!test.room.participants.has(test.participantV3s[0].sid));
       });
 
-      it('emits the "participantDisconnected" event with the ParticipantV2', () => {
+      it('emits the "participantDisconnected" event with the ParticipantV3', () => {
         const test = makeTest({
           participants: [
             { sid: makeSid(), tracks: [] }
@@ -674,9 +674,9 @@ describe('RoomV3', () => {
         });
         let participantDisconnected;
         test.room.once('participantDisconnected', participant => { participantDisconnected = participant; });
-        test.participantV2s[0].emit('stateChanged', 'disconnected');
+        test.participantV3s[0].emit('stateChanged', 'disconnected');
         assert.equal(
-          test.participantV2s[0],
+          test.participantV3s[0],
           participantDisconnected);
       });
     });
@@ -911,7 +911,7 @@ describe('RoomV3', () => {
     context('.participants', () => {
       context('when .participants includes a new Participant state', () => {
         context('and the Participant state\'s .state is "connected"', () => {
-          it('constructs a new ParticipantV2 with the Participant state', () => {
+          it('constructs a new ParticipantV3 with the Participant state', () => {
             const test = makeTest();
             const sid = makeParticipantSid();
             test.transport.emit('message', {
@@ -923,10 +923,10 @@ describe('RoomV3', () => {
             });
             assert.equal(
               sid,
-              test.participantV2s[0].sid);
+              test.participantV3s[0].sid);
           });
 
-          it('adds the newly-constructed ParticipantV2 to the RoomV3\'s .participants Map', () => {
+          it('adds the newly-constructed ParticipantV3 to the RoomV3\'s .participants Map', () => {
             const test = makeTest();
             const sid = makeParticipantSid();
             test.transport.emit('message', {
@@ -937,11 +937,11 @@ describe('RoomV3', () => {
               peer_connections: []
             });
             assert.equal(
-              test.participantV2s[0],
+              test.participantV3s[0],
               test.room.participants.get(sid));
           });
 
-          it('emits the "participantConnected" event with the newly-constructed ParticipantV2', () => {
+          it('emits the "participantConnected" event with the newly-constructed ParticipantV3', () => {
             const test = makeTest();
             const sid = makeParticipantSid();
             let participantConnected;
@@ -954,11 +954,11 @@ describe('RoomV3', () => {
               peer_connections: []
             });
             assert.equal(
-              test.participantV2s[0],
+              test.participantV3s[0],
               participantConnected);
           });
 
-          it('calls .update with the Participant state on the newly-constructed ParticipantV2', () => {
+          it('calls .update with the Participant state on the newly-constructed ParticipantV3', () => {
             const test = makeTest();
             const sid = makeParticipantSid();
             test.transport.emit('message', {
@@ -970,12 +970,12 @@ describe('RoomV3', () => {
             });
             assert.deepEqual(
               { sid: sid, fizz: 'buzz', tracks: [] },
-              test.participantV2s[0].update.args[0][0]);
+              test.participantV3s[0].update.args[0][0]);
           });
         });
 
         context('and the Participant state\'s .state is "disconnected"', () => {
-          it('constructs a new ParticipantV2 with the Participant state', () => {
+          it('constructs a new ParticipantV3 with the Participant state', () => {
             const test = makeTest();
             const sid = makeParticipantSid();
             test.transport.emit('message', {
@@ -987,10 +987,10 @@ describe('RoomV3', () => {
             });
             assert.equal(
               sid,
-              test.participantV2s[0].sid);
+              test.participantV3s[0].sid);
           });
 
-          it('does not add the newly-constructed ParticipantV2 to the RoomV2\'s .participants Map', () => {
+          it('does not add the newly-constructed ParticipantV3 to the RoomV2\'s .participants Map', () => {
             const test = makeTest();
             const sid = makeParticipantSid();
             test.transport.emit('message', {
@@ -1020,8 +1020,8 @@ describe('RoomV3', () => {
         });
       });
 
-      context('when .participants includes a Participant state for a connected ParticipantV2', () => {
-        it('calls .update with the Participant state on the ParticipantV2', () => {
+      context('when .participants includes a Participant state for a connected ParticipantV3', () => {
+        it('calls .update with the Participant state on the ParticipantV3', () => {
           const sid = makeParticipantSid();
           const test = makeTest({
             participants: [
@@ -1037,11 +1037,11 @@ describe('RoomV3', () => {
           });
           assert.deepEqual(
             { sid: sid, fizz: 'buzz', tracks: [] },
-            test.participantV2s[0].update.args[1][0]);
+            test.participantV3s[0].update.args[1][0]);
         });
       });
 
-      context('when .participants includes a Participant state for a disconnected ParticipantV2', () => {
+      context('when .participants includes a Participant state for a disconnected ParticipantV3', () => {
         [
           [2, 1],
           [2, 2],
@@ -1053,14 +1053,14 @@ describe('RoomV3', () => {
               ? 'the same revision'
               : 'with a newer revision'}`, () => {
             const shouldCreate = nextRevision > revision;
-            it(`${shouldCreate ? 'constructs' : 'does not construct'} a new ParticipantV2 with the Participant state`, () => {
+            it(`${shouldCreate ? 'constructs' : 'does not construct'} a new ParticipantV3 with the Participant state`, () => {
               const sid = makeParticipantSid();
               const test = makeTest({
                 participants: [
                   { sid: sid, revision, tracks: [] }
                 ]
               });
-              test.participantV2s[0].emit('stateChanged', 'disconnected');
+              test.participantV3s[0].emit('stateChanged', 'disconnected');
               test.transport.emit('message', {
                 participants: [
                   { sid: sid, fizz: 'buzz', revision: nextRevision, tracks: [] }
@@ -1070,19 +1070,19 @@ describe('RoomV3', () => {
               });
               assert.equal(
                 shouldCreate ? 2 : 1,
-                test.participantV2s.length);
+                test.participantV3s.length);
             });
           });
         });
 
-        it('does not call .update with the Participant state on the disconnected ParticipantV2', () => {
+        it('does not call .update with the Participant state on the disconnected ParticipantV3', () => {
           const sid = makeParticipantSid();
           const test = makeTest({
             participants: [
               { sid: sid, tracks: [] }
             ]
           });
-          test.participantV2s[0].emit('stateChanged', 'disconnected');
+          test.participantV3s[0].emit('stateChanged', 'disconnected');
           test.transport.emit('message', {
             participants: [
               { sid: sid, fizz: 'buzz', tracks: [] }
@@ -1090,14 +1090,14 @@ describe('RoomV3', () => {
             // eslint-disable-next-line camelcase
             peer_connections: []
           });
-          assert(!test.participantV2s[0].update.calledTwice);
+          assert(!test.participantV3s[0].update.calledTwice);
         });
       });
 
-      context('when .participants omits a Participant state for a connected ParticipantV2', () => {
+      context('when .participants omits a Participant state for a connected ParticipantV3', () => {
         ['connected', 'synced', 'update'].forEach(type => {
           context(`when processing a "${type}" RSP message`, () => {
-            it(`should ${type === 'synced' ? '' : 'not '}call .disconnect on the ParticipantV2`, () => {
+            it(`should ${type === 'synced' ? '' : 'not '}call .disconnect on the ParticipantV3`, () => {
               const sid = makeParticipantSid();
               const test = makeTest({
                 participants: [
@@ -1112,10 +1112,10 @@ describe('RoomV3', () => {
               });
               assert.equal(
                 type === 'synced',
-                test.participantV2s[0].disconnect.calledOnce);
+                test.participantV3s[0].disconnect.calledOnce);
             });
 
-            it(`should ${type === 'synced' ? '' : 'not '}retain the ParticipantV2 remains in the RoomV2's .participants Map`, () => {
+            it(`should ${type === 'synced' ? '' : 'not '}retain the ParticipantV3 remains in the RoomV2's .participants Map`, () => {
               const sid = makeParticipantSid();
               const test = makeTest({
                 participants: [
@@ -1132,7 +1132,7 @@ describe('RoomV3', () => {
                 assert(!test.room.participants.has(sid));
               } else {
                 assert.equal(
-                  test.participantV2s[0],
+                  test.participantV3s[0],
                   test.room.participants.get(sid));
               }
             });
@@ -1294,6 +1294,9 @@ describe('RoomV3', () => {
   describe('Track Subscriptions Signaling', () => {
     describe('when update is called with an RSP message that determines Track Subscriptions over RTCDataChannel', () => {
       let TrackSubscriptionsSignaling;
+      let trackReceiver3;
+      let trackReceiver4;
+      let trackReceiver5;
       let trackSubscriptionsSignaling;
       let test;
       beforeEach(() => {
@@ -1304,11 +1307,13 @@ describe('RoomV3', () => {
 
         const mediaStreamTrack3 = { id: '3', kind: 'audio' };
         const mediaStreamTrack4 = { id: '4', kind: 'video' };
-        const trackReceiver3 = makeTrackReceiver(mediaStreamTrack3, '0');
-        const trackReceiver4 = makeTrackReceiver(mediaStreamTrack4, '1');
+        const mediaStreamTrack5 = { id: '5', kind: 'video' };
+        trackReceiver3 = makeTrackReceiver(mediaStreamTrack3, '0');
+        trackReceiver4 = makeTrackReceiver(mediaStreamTrack4, '1');
+        trackReceiver5 = makeTrackReceiver(mediaStreamTrack5, '2');
 
         const peerConnectionManager = makePeerConnectionManager([], []);
-        peerConnectionManager.getTrackReceivers = () => [trackReceiver3, trackReceiver4];
+        peerConnectionManager.getTrackReceivers = () => [trackReceiver3, trackReceiver4, trackReceiver5];
 
         test = makeTest({
           peerConnectionManager,
@@ -1381,16 +1386,17 @@ describe('RoomV3', () => {
         function getTrackSwitchOffPromise(room, trackSid, off) {
           const remoteTracks = flatMap([...room.participants.values()], participant => [...participant.tracks.values()]);
           const track = remoteTracks.find(track => track.sid === trackSid);
-          return new Promise(resolve => {
-            track.on('updated', () => {
-              if (track.isSwitchedOff === off) {
-                resolve();
-              }
-            });
-          });
+          const setTrackTransceiver = track.setTrackTransceiver;
+          track.setTrackTransceiver = sinon.spy((...args) => setTrackTransceiver.apply(track, args));
+          return new Promise(resolve => track.on('updated', function onUpdated() {
+            if (track.isSwitchedOff === off) {
+              track.removeListener('updated', onUpdated);
+              resolve(track);
+            }
+          }));
         }
 
-        it('fires trackSwitchOff / On events when such message is received on data channel', async () => {
+        it('fires trackSwitchOff / On events and calls .setTrackTransceiver on the TrackSignalings when such message is received on data channel', async () => {
           const trackSid = 'MT3';
           const trackSwitchOffPromise = getTrackSwitchOffPromise(test.room, trackSid, true /* off */);
           dataTrackTransport.emit('message', {
@@ -1399,7 +1405,8 @@ describe('RoomV3', () => {
             subscribed: { [trackSid]: { state: 'OFF', off_reason: 'bar' } },
             type: 'track_subscriptions'
           });
-          await trackSwitchOffPromise;
+          let track = await trackSwitchOffPromise;
+          sinon.assert.calledWith(track.setTrackTransceiver, null);
 
           const trackSwitchOnPromise = getTrackSwitchOffPromise(test.room, trackSid, false /* on */);
           dataTrackTransport.emit('message', {
@@ -1408,7 +1415,59 @@ describe('RoomV3', () => {
             subscribed: { [trackSid]: { state: 'ON', mid: '0' } },
             type: 'track_subscriptions'
           });
-          await trackSwitchOnPromise;
+          track = await trackSwitchOnPromise;
+          await test.room._getTrackReceiver('0', 'mid');
+          sinon.assert.calledWith(track.setTrackTransceiver, trackReceiver3);
+        });
+
+        it('calls .setTrackTransceiver and sets .isSubscribed on the TrackSignalings for subscribed and unsubscribed Tracks', async () => {
+          const track = flatMap(test.room.participants, participant => [...participant.tracks.values()]).find(track => track.sid === 'MT4');
+          const setTrackTransceiver = track.setTrackTransceiver;
+          track.setTrackTransceiver = sinon.spy((...args) => setTrackTransceiver.apply(track, args));
+
+          dataTrackTransport.emit('message', {
+            revision: 2,
+            // eslint-disable-next-line camelcase
+            subscribed: { MT3: { state: 'ON', mid: '0' } },
+            type: 'track_subscriptions'
+          });
+          sinon.assert.calledWith(track.setTrackTransceiver, null);
+          assert.equal(track.isSubscribed, false);
+
+          dataTrackTransport.emit('message', {
+            revision: 3,
+            // eslint-disable-next-line camelcase
+            subscribed: {
+              MT3: { state: 'ON', mid: '0' },
+              MT4: { state: 'ON', mid: '1' }
+            },
+            type: 'track_subscriptions'
+          });
+          await test.room._getTrackReceiver('1', 'mid');
+          sinon.assert.calledWith(track.setTrackTransceiver, trackReceiver4);
+          assert.equal(track.isSubscribed, true);
+        });
+
+        it('calls .setTrackTransceiver and set .isSubscribed twice (unsubscribed and then subscribed) when a TrackSignaling\'s mid changes', async () => {
+          const track = flatMap(test.room.participants, participant => [...participant.tracks.values()]).find(track => track.sid === 'MT4');
+          const setTrackTransceiver = track.setTrackTransceiver;
+          track.setTrackTransceiver = sinon.spy((...args) => setTrackTransceiver.apply(track, args));
+
+          dataTrackTransport.emit('message', {
+            revision: 2,
+            // eslint-disable-next-line camelcase
+            subscribed: {
+              MT3: { state: 'ON', mid: '0' },
+              MT4: { state: 'ON', mid: '2' }
+            },
+            type: 'track_subscriptions'
+          });
+          sinon.assert.calledWith(track.setTrackTransceiver, null);
+          assert.equal(track.isSubscribed, false);
+
+          await test.room._getTrackReceiver('2', 'mid');
+          sinon.assert.calledWith(track.setTrackTransceiver, trackReceiver5);
+          assert.equal(track.isSubscribed, true);
         });
       });
     });
@@ -1604,8 +1663,8 @@ describe('RoomV3', () => {
         });
 
         it('starts updating RemoteParticipant NetworkQualityLevel when NetworkQualityMonitor emits "updated"', () => {
-          const RemoteParticipantV2 = makeRemoteParticipantV2Constructor();
-          const participant = new RemoteParticipantV2({ sid: makeSid() });
+          const RemoteParticipantV3 = makeRemoteParticipantV3Constructor();
+          const participant = new RemoteParticipantV3({ sid: makeSid() });
           test.room.connectParticipant(participant);
 
           // Case 1: ICE Connection State transitions to "failed", Network
@@ -1748,7 +1807,7 @@ describe('RoomV3', () => {
 
 describe('"signalingConnectionStateChanged" event', () => {
   context('when the RoomV3\'s .signalingConnectionState is "reconnecting"', () => {
-    it('should transition the LocalParticipantV2\'s .state to "reconnecting"', () => {
+    it('should transition the LocalParticipantV3\'s .state to "reconnecting"', () => {
       const test = makeTest();
       let newState;
       test.localParticipant.once('stateChanged', state => { newState = state; });
@@ -1758,7 +1817,7 @@ describe('"signalingConnectionStateChanged" event', () => {
   });
 
   context('when the RoomV3\'s .signalingConnectionState is "connected"', () => {
-    it('should transition the LocalParticipantV2\'s .state to "connected"', () => {
+    it('should transition the LocalParticipantV3\'s .state to "connected"', () => {
       const test = makeTest();
       let newState;
       test.transport.sync();
@@ -1803,9 +1862,9 @@ function makeTest(options) {
   options.name = options.name || makeName();
   options.sid = options.sid || makeSid();
   options.participants = options.participants || [];
-  options.participantV2s = options.participantV2s || [];
+  options.participantV3s = options.participantV3s || [];
 
-  options.RemoteParticipantSignaling = options.RemoteParticipantSignaling || makeRemoteParticipantV2Constructor(options);
+  options.RemoteParticipantSignaling = options.RemoteParticipantSignaling || makeRemoteParticipantV3Constructor(options);
   options.localTracks = (options.localTracks || []).map(track => {
     track.trackTransceiver = new EventEmitter();
     const eventEmitter = new EventEmitter();
@@ -1829,11 +1888,11 @@ function makeTest(options) {
   return options;
 }
 
-function makeRemoteParticipantV2Constructor(testOptions) {
+function makeRemoteParticipantV3Constructor(testOptions) {
   testOptions = testOptions || {};
-  testOptions.participantV2s = [];
+  testOptions.participantV3s = [];
 
-  function RemoteParticipantV2(initialState, getInitialTrackSwitchOffState, setPriority) {
+  function RemoteParticipantV3(initialState, getPendingTrackReceiver, getInitialTrackSwitchOffState, setPriority) {
     EventEmitter.call(this);
     this.revision = initialState.revision || 0;
     this.tracks = (initialState.tracks || []).reduce((tracks, track) => tracks.set(track.sid, track), new Map());
@@ -1846,12 +1905,12 @@ function makeRemoteParticipantV2Constructor(testOptions) {
     });
     this.update = sinon.spy(() => {});
     this.setNetworkQualityLevel = sinon.spy();
-    testOptions.participantV2s.push(this);
+    testOptions.participantV3s.push(this);
   }
 
-  inherits(RemoteParticipantV2, EventEmitter);
+  inherits(RemoteParticipantV3, EventEmitter);
 
-  return RemoteParticipantV2;
+  return RemoteParticipantV3;
 }
 
 function makeRoomV3(options) {

--- a/test/unit/spec/signaling/v3/tracksubscriptionssignaling.js
+++ b/test/unit/spec/signaling/v3/tracksubscriptionssignaling.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const assert = require('assert');
+const { EventEmitter } = require('events');
+
+const TrackSubscriptionsSignaling = require('../../../../../lib/signaling/v3/tracksubscriptionssignaling');
+const { waitForSometime } = require('../../../../../lib/util');
+const log = require('../../../../lib/fakelog');
+
+function makeTransport() {
+  const transport = new EventEmitter();
+  transport.publish = () => {};
+  return transport;
+}
+
+function makeTest(mst) {
+  const getReceiver = () => {
+    return Promise.resolve({
+      kind: 'data',
+      toDataTransport: () => mst,
+      once: () => {}
+    });
+  };
+  const subject = new TrackSubscriptionsSignaling(getReceiver, { log });
+  subject.setup('foo');
+  return subject;
+}
+
+describe('TrackSubscriptionsSignaling', () => {
+  describe('constructor', () => {
+    it('sets .channel to "track_subscriptions"', () => {
+      const subject = makeTest(makeTransport());
+      assert.strictEqual(subject.channel, 'track_subscriptions');
+    });
+
+    it('initializes ._currentRevision to 0', () => {
+      const subject = makeTest(makeTransport());
+      assert.strictEqual(subject._currentRevision, 0);
+    });
+  });
+
+  describe('when mediaSignalingTransport emits a "message" event', () => {
+    [-1, 0, 1].forEach(revision => {
+      describe(`and the message's .revision is ${revision === -1 ? 'less than' : revision === 0 ? 'equal to' : 'greater than'} ._currentRevision`, () => {
+        const message = {
+          errors: {
+            MTaaa: { code: 100, message: 'bar' },
+            MTbbb: { code: 200, message: 'baz' }
+          },
+          revision,
+          subscribed: {
+            MTxxx: { mid: '0', state: 'ON' },
+            // eslint-disable-next-line camelcase
+            MTyyy: { off_reason: 'zee', state: 'OFF' }
+          },
+          type: 'track_subscriptions'
+        };
+        let mediaSignalingTransport;
+        let subject;
+        let updatedArgs;
+
+        beforeEach(async () => {
+          mediaSignalingTransport = makeTransport();
+          subject = makeTest(mediaSignalingTransport);
+          await waitForSometime(10);
+          subject.once('updated',  (...args) => { updatedArgs = args; });
+          mediaSignalingTransport.emit('message', message);
+        });
+
+        if (revision === 1) {
+          it('should emit "updated"', () => {
+            const [subscribed, errors] = updatedArgs;
+            assert.deepStrictEqual(subscribed, {
+              MTxxx: { mid: '0', state: 'ON' },
+              // eslint-disable-next-line camelcase
+              MTyyy: { off_reason: 'zee', state: 'OFF' }
+            });
+            assert.deepStrictEqual(errors, {
+              MTaaa: { code: 100, message: 'bar' },
+              MTbbb: { code: 200, message: 'baz' }
+            });
+          });
+        } else {
+          it('should not emit "updated"', () => {
+            assert(!updatedArgs);
+          });
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

#### Summary

This pull request contains changes for the following tickets:
- [VIDEO-8668](https://issues.corp.twilio.com/browse/VIDEO-8668) - Switch on/off RemoteAudioTracks using `track_subscriptions` MSP to keep only the N-loudest Tracks on.
- [VIDEO-8670](https://issues.corp.twilio.com/browse/VIDEO-8670) - Add `.switchOffReason` property to RemoteAudioTrack.
- [VIDEO-8671](https://issues.corp.twilio.com/browse/VIDEO-8671) - Manage RemoteAudioTrack subscriptions using `track_subscriptions` MSP instead of the RSP `subscribed` payload.

#### Details

##### RoomV3

- RemoteTracks' subscription and switch off states are received on the `track_subscriptions` MSP channel, as opposed to the `subscribed` RSP payload and `track_switch_off` MSP channels respectively in RoomV2.
- RemoteTracks are mapped to their respective MediaStreamTracks using the corresponding RTCRtpTransceivers' MIDs, as opposed to the MediaStreamTrack IDs in RoomV2.
- Cached switch off states for not-yet-known RemoteTracks contain both `isSwitchedOff` and `switchOffReason`, as opposed to only `isSwitchedOff` in RoomV2.
- MIDs for not-yet-known RemoteTracks are cached, unlike in RoomV2 where RemoteTracks were always known before their corresponding MediaStreamTrack IDs.
- RoomV3 constructs RemoteParticipantV3 instances, as opposed to RoomV2, which constructs RemoteParticipantV2 instances.

##### RemoteParticipantV3

- RemoteParticipantV3 constructs RemoteTrackPublicationV3 instances, as opposed to RemoteParticipantV2, which constructs RemoteTrackPublicationV2 instances.
- RemoteParticipantV3 makes sure that when it constructs a RemoteTrackPublicationV3 instance, it sets the corresponding MediaStreamTrack if its MID has been cached (MID was received before the RemoteTrack was known).

##### RemoteTrackPublicationV3

- Lack of association with a MediaStreamTrack does not mean that the RemoteTrack is unsubscribed from (it can be switched off). So, a separate boolean property tracks the subscription status.
- Switch off reason is also updated along with switch off state.
- The enabled state is updated based on switch off state and reason, as opposed to updating based on the `enabled` field in `participant.tracks` payload of an RSP `UPDATE` message.

##### RemoteTrackPublication

- Updates the corresponding RemoteTrack's switchOffReason.
- Updates the corresponding RemoteTrack's MediaStreamTrack.

##### RemoteAudioTrack

- Adds a new `.switchOffReason` property.
- When `.isSwitchedOff` remains `true` and the `.switchOffReason` changes, then `switchedOff` is emitted.

##### Room

- Room now accepts either a RoomV3 or a RoomV2 instance in its constructor.

##### createCancelableRoomSignalingPromise

- Depending on the `version` property in the RSP CONNECTED message, it resolves the returned Promise with either a RoomV3 or a RoomV2 instance.

#### Resources

 - [IDL changes](https://code.hq.twilio.com/client/video-sdk-api/pull/96)
 - [Track subscriptions MSP specification](https://code.hq.twilio.com/client/room-signaling-protocol/pull/82)

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
