### PR TITLE
[Large Rooms] Deprecations and renamings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,66 @@ twilio-video.js now allows you to create and join a [Large Room](TODO_doc_link),
 
 - A RemoteAudioTrack of a Participant that is not active in the Large Room will now be switched off. (VIDEO-8668)
 - RemoteAudioTrack and RemoteVideoTrack will now have an additional property called [`switchOffReason`](TODO_doc_link),
-  which describes the reason for it being switched off. (VIDEO-8670, VIDEO-8748)
+  which describes the reason for it being switched off. The `switchOff` event will also have this reason string as a second
+  argument. (VIDEO-8670, VIDEO-8748)
 - A RemoteVideoTrack will now be switched off if the number of switched on RemoteVideoTracks reached the limit set
   by the media server. (VIDEO-8745)
+- Renamed BandwidthProfileOptions to BandwidthProfile. (VIDEO-8754)
+- Renamed VideoBandwidthProfileOptions to VideoBandwidthProfile. (VIDEO-8753)
+- The `isEnabled` property of the RemoteTrack is deprecated and scheduled for removal. Alternatively, you can determine if
+  a RemoteTrack is enabled by using the following expression. (VIDEO-8742, VIDEO-8750)
+  ```js
+  const isEnabled = !(remoteTrack.isSwitchedOff && remoteTrack.switchOffReason === 'disabled-by-publisher');
+  ```
+- The `disabled` and `enabled` events of the RemoteTrack are deprecated and scheduled for removal. Alternatively, you can
+  listen to `switchedOff` and `switchedOn` events as shown below. (VIDEO-8742, VIDEO-8750)
+  ```js
+  let recentSwitchOffReason = remoteTrack.switchOffReason;
+
+  remoteTrack.on('switchedOff', switchOffReason => {
+    recentSwitchOffReason = switchOffReason;
+    if (switchOffReason === 'disabled-by-publisher') {
+      /* The RemoteTrack is disabled. */
+    }
+  });
+  
+  remoteTrack.on('switchedOn', () => {
+    if (recentSwitchOffReason === 'disabled-by-publisher') {
+      /* The RemoteTrack is enabled. */
+    }
+    recentSwitchOffReason = null;
+  });
+  ```
+
+- The `isTrackEnabled` property of the RemoteTrackPublication is deprecated and scheduled for removal. Alternatively, you 
+  can determine if a RemoteTrackPublication is enabled by using the following expression. (VIDEO-8743, VIDEO-8751)
+  ```js
+  const { track } = remoteTrackPublication;
+  const isTrackEnabled = (track && track.isSwitchedOff && track.switchOffReason === 'disabled-by-publisher');
+  ```
+  `isTrackEnabled` is now only valid for RemoteTracks that are subscribed to, and defaults to `true` for unsubscribed
+  RemoteTracks.
+- The `trackDisabled` and `trackEnabled` events of the RemoteTrack are deprecated and scheduled for removal. Alternatively,
+  you can listen to `trackSwitchedOff` and `trackSwitchedOn` events as shown below. (VIDEO-8743, VIDEO-8751)
+  ```js
+  const { track } = remoteTrackPublication;
+  let recentSwitchOffReason = track ? track.switchOffReason : null;
+
+  remoteTrackPublication.on('trackSwitchedOff', (track, switchOffReason) => {
+    recentSwitchOffReason = switchOffReason;
+    if (switchOffReason === 'disabled-by-publisher') {
+      /* The RemoteTrack is disabled. */
+    }
+  });
+  
+  remoteTrackPublication.on('trackSwitchedOn', (track) => {
+    if (recentSwitchOffReason === 'disabled-by-publisher') {
+      /* The RemoteTrack is enabled. */
+    }
+    recentSwitchOffReason = null;
+  });
+  ```
+  The `trackDisabled` and `trackEnabled` events are now only fired for subscribed RemoteTracks.
 
 2.21.1 (March 22, 2022)
 =======================

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -423,7 +423,7 @@ function connect(token, options) {
  *   not subscribe to any RemoteTrack in a Group or Small Group Room. Setting it to
  *   <code>true</code>, or not setting it at all preserves the default behavior. This
  *   flag does not have any effect in a Peer-to-Peer Room.
- * @property {BandwidthProfileOptions} [bandwidthProfile] - You can optionally configure
+ * @property {BandwidthProfile} [bandwidthProfile] - You can optionally configure
  *   how your available downlink bandwidth is shared among the RemoteTracks you have subscribed
  *   to in a Group Room. By default, bandwidth is shared equally among the RemoteTracks.
  *   This has no effect in Peer-to-Peer Rooms.
@@ -510,9 +510,9 @@ function connect(token, options) {
  */
 
 /**
- * {@link BandwidthProfileOptions} allows you to configure how your available downlink
+ * {@link BandwidthProfile} allows you to configure how your available downlink
  * bandwidth is shared among the RemoteTracks you have subscribed to in a Group Room.
- * @typedef {object} BandwidthProfileOptions
+ * @typedef {object} BandwidthProfile
  * @property {VideoBandwidthProfile} [video] - Optional parameter to configure
  *   how your available downlink bandwidth is shared among the {@link RemoteVideoTrack}s you
  *   have subscribed to in a Group Room.

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -64,7 +64,7 @@ const deprecatedConnectOptionsProps = new Set([
   { didWarn: false, shouldDelete: false, name: 'logLevel', newName: 'Video.Logger' },
 ]);
 
-const deprecatedBandwidthProfileOptions = new Set([
+const deprecatedVideoBandwidthProfileOptions = new Set([
   { didWarn: false, shouldDelete: false, name: 'maxTracks', newName: 'bandwidthProfile.video.clientTrackSwitchOffControl' },
   { didWarn: false, shouldDelete: false, name: 'renderDimensions', newName: 'bandwidthProfile.video.contentPreferencesMode' },
 ]);
@@ -218,7 +218,7 @@ function connect(token, options) {
   // NOTE(csantos): Log a warning for the deprecated ConnectOptions properties.
   // The warning is displayed only for the first call to connect() per browser session.
   // Additionally, the options that are no longer needed will be removed.
-  deprecateOptions(options, log, deprecatedConnectOptionsProps);
+  deprecateOptions(options, 'ConnectOptions', log, deprecatedConnectOptionsProps);
 
   const adaptiveSimulcast = options.preferredVideoCodecs === 'auto';
   if (adaptiveSimulcast) {
@@ -339,7 +339,7 @@ function connect(token, options) {
     if (options.bandwidthProfile.video) {
 
       // log any warnings about deprecated bwp options
-      deprecateOptions(options.bandwidthProfile.video, log, deprecatedBandwidthProfileOptions);
+      deprecateOptions(options.bandwidthProfile.video, 'ConnectOptions.bandwidthProfile.video', log, deprecatedVideoBandwidthProfileOptions);
 
       if ('maxTracks' in options.bandwidthProfile.video) {
         // when deprecated maxTracks is specified. disable clientTrackSwitchOffControl
@@ -965,7 +965,7 @@ const EventListenerGroup = {
  */
 
 
-function deprecateOptions(options, log, deprecationTable) {
+function deprecateOptions(options, optionsName, log, deprecationTable) {
   deprecationTable.forEach(prop => {
     const { didWarn, name, newName, shouldDelete } = prop;
     if (name in options && typeof options[name] !== 'undefined') {
@@ -976,7 +976,7 @@ function deprecateOptions(options, log, deprecationTable) {
         delete options[name];
       }
       if (!didWarn && !['error', 'off'].includes(log.level)) {
-        log.warn(`The ConnectOptions "${name}" is ${newName
+        log.warn(`The ${optionsName} property "${name}" is ${newName
           ? `deprecated and scheduled for removal. Please use "${newName}" instead.`
           : 'no longer applicable and will be ignored.'}`);
         prop.didWarn = true;

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -513,15 +513,15 @@ function connect(token, options) {
  * {@link BandwidthProfileOptions} allows you to configure how your available downlink
  * bandwidth is shared among the RemoteTracks you have subscribed to in a Group Room.
  * @typedef {object} BandwidthProfileOptions
- * @property {VideoBandwidthProfileOptions} [video] - Optional parameter to configure
+ * @property {VideoBandwidthProfile} [video] - Optional parameter to configure
  *   how your available downlink bandwidth is shared among the {@link RemoteVideoTrack}s you
  *   have subscribed to in a Group Room.
  */
 
 /**
- * {@link VideoBandwidthProfileOptions} allows you to configure how your available downlink
+ * {@link VideoBandwidthProfile} allows you to configure how your available downlink
  * bandwidth is shared among the {@link RemoteVideoTrack}s you have subscribed to in a Group Room.
- * @typedef {object} VideoBandwidthProfileOptions
+ * @typedef {object} VideoBandwidthProfile
  * @property {Track.Priority} [dominantSpeakerPriority="standard"] - Optional parameter to
  *   specify the minimum subscribe {@link Track.Priority} of the Dominant Speaker's {@link RemoteVideoTrack}s.
  *   This means that the Dominant Speaker's {@link RemoteVideoTrack}s that are published with
@@ -750,22 +750,21 @@ const TrackSwitchOffReason = {
    * The {@link RemoteVideoTrack} was switched off because the remaining
    * downlink bandwidth is not sufficient to receive its media. The bandwidth
    * limit is configured by specifying <code>maxSubscriptionBitrate</code>
-   * in {@link VideoBandwidthProfileOptions} or a default value is selected
+   * in {@link VideoBandwidthProfile} or a default value is selected
    * by the media server.
    */
   'max-bandwidth-reached': 'max-bandwidth-reached',
 
   /**
    * The {@link RemoteTrack} was switched off because the number of switched on
-   * {@link Track}s reached the limit specified by the <code>maxSwitchedOnTracks</code>
-   * property in {@link AudioBandwidthProfile} or {@link VideoBandwidthProfileOptions}.
+   * {@link Track}s reached the limit set by the media server.
    */
   'max-tracks-switched-on': 'max-tracks-switched-on',
 
   /**
    * The {@link RemoteVideoTrack} was switched off because network congestion
    * was detected or predicted. The <code>trackSwitchOffMode</code> property
-   * on {@link VideoBandwidthProfileOptions} allows you to specify how the
+   * on {@link VideoBandwidthProfile} allows you to specify how the
    * switch off is managed.
    */
   'network-congestion': 'network-congestion'

--- a/lib/media/track/index.js
+++ b/lib/media/track/index.js
@@ -2,7 +2,7 @@
 
 const EventEmitter = require('../../eventemitter');
 const { buildLogLevels, valueToJSON } = require('../../util');
-const DEFAULT_LOG_LEVEL = require('../../util/constants').DEFAULT_LOG_LEVEL;
+const { DEFAULT_LOG_LEVEL } = require('../../util/constants');
 const Log = require('../../util/log');
 
 let nInstances = 0;

--- a/lib/media/track/remoteaudiotrack.js
+++ b/lib/media/track/remoteaudiotrack.js
@@ -9,7 +9,8 @@ const RemoteMediaAudioTrack = mixinRemoteMediaTrack(AudioTrack);
  * A {@link RemoteAudioTrack} represents an {@link AudioTrack} published to a
  * {@link Room} by a {@link RemoteParticipant}.
  * @extends AudioTrack
- * @property {boolean} isEnabled - Whether the {@link RemoteAudioTrack} is enabled
+ * @property {boolean} isEnabled - <code>Deprecated: Use (.isSwitchedOff && .switchOffReason === "disabled-by-publisher") instead</code>
+ *   Whether the {@link RemoteAudioTrack} is enabled
  * @property {boolean} isSwitchedOff - Whether the {@link RemoteAudioTrack} is switched off
  * @property {?TrackSwitchOffReason} switchOffReason - The reason for the {@link RemoteAudioTrack} being switched off;
  *   If switched on, it is set to <code>null</code>; The {@link RemoteAudioTrack} is initially switched off with this
@@ -57,6 +58,7 @@ class RemoteAudioTrack extends RemoteMediaAudioTrack {
 
 /**
  * The {@link RemoteAudioTrack} was disabled, i.e. "muted".
+ * @deprecated Use <a href="#event:switchedOff"><code>switchedOff</code></a> (<code>.switchOffReason === "disabled-by-publisher"</code>) instead
  * @param {RemoteAudioTrack} track - The {@link RemoteAudioTrack} that was
  *   disabled
  * @event RemoteAudioTrack#disabled
@@ -64,6 +66,7 @@ class RemoteAudioTrack extends RemoteMediaAudioTrack {
 
 /**
  * The {@link RemoteAudioTrack} was enabled, i.e. "unmuted".
+ * @deprecated Use <a href="#event:switchedOn"><code>switchedOn</code></a> instead
  * @param {RemoteAudioTrack} track - The {@link RemoteAudioTrack} that was
  *   enabled
  * @event RemoteAudioTrack#enabled

--- a/lib/media/track/remoteaudiotrackpublication.js
+++ b/lib/media/track/remoteaudiotrackpublication.js
@@ -44,13 +44,39 @@ class RemoteAudioTrackPublication extends RemoteTrackPublication {
  */
 
 /**
- * The {@link RemoteAudioTrack} was disabled.
+ * The {@link RemoteAudioTrack} was disabled. It is fired only if <code>.isSubscribed</code>
+ * is set to <code>true</code>.
+ * @deprecated Use <a href="event:trackSwitchedOff"><code>trackSwitchedOff</code></a> (<code>track.switchOffReason === "disabled-by-publisher"</code>) instead
  * @event RemoteAudioTrackPublication#trackDisabled
  */
 
 /**
- * The {@link RemoteAudioTrack} was enabled.
+ * The {@link RemoteAudioTrack} was enabled. It is fired only if <code>.isSubscribed</code>
+ * @deprecated Use <a href="event:trackSwitchedOn"><code>trackSwitchedOn</code></a> instead
+ * is set to <code>true</code>.
  * @event RemoteAudioTrackPublication#trackEnabled
+ */
+
+/**
+ * The {@link RemoteAudioTrack} was switched off. The media server stops sending media for
+ * the {@link RemoteAudioTrack} until it is switched back on. Just before the event is raised,
+ * <code>isSwitchedOff</code> is set to <code>true</code> and <code>switchOffReason</code>
+ * is set to a {@link TrackSwitchOffReason}. Also, the <code>mediaStreamTrack</code> property
+ * is set to <code>null</code>.
+ * @param {RemoteAudioTrack} track - the {@link RemoteAudioTrack} that was switched off
+ * @param {?TrackSwitchOffReason} switchOffReason - the reason the {@link RemoteAudioTrack}
+ *   was switched off
+ * @event RemoteAudioTrackPublication#trackSwitchedOff
+ */
+
+/**
+ * The {@link RemoteAudioTrack} was switched on. The media server starts sending media for
+ * the {@link RemoteAudioTrack} until it is switched off. Just before the event is raised,
+ * <code>isSwitchedOff</code> is set to <code>false</code> and <code>switchOffReason</code>
+ * is set to <code>null</code>. Also, the <code>mediaStreamTrack</code> property is set to a
+ * MediaStreamTrack that is the source of the {@link RemoteAudioTrack}'s media.
+ * @param {RemoteAudioTrack} track - the {@link RemoteAudioTrack} that was switched on
+ * @event RemoteAudioTrackPublication#trackSwitchedOn
  */
 
 /**

--- a/lib/media/track/remotemediatrack.js
+++ b/lib/media/track/remotemediatrack.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { deprecateEvents } = require('../../util');
 const { typeErrors: E, trackPriority, trackSwitchOffReason } = require('../../util/constants');
 const { guessBrowser, isIOSChrome } = require('../../webrtc/util');
 const documentVisibilityMonitor = require('../../util/documentvisibilitymonitor.js');
@@ -8,7 +9,8 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
   /**
    * A {@link RemoteMediaTrack} represents a {@link MediaTrack} published to a
    * {@link Room} by a {@link RemoteParticipant}.
-   * @property {boolean} isEnabled - Whether the {@link RemoteMediaTrack} is enabled
+   * @property {boolean} isEnabled - <code>Deprecated: Use (.isSwitchedOff && .switchOffReason === "disabled-by-publisher") instead</code>
+   *   Whether the {@link RemoteAudioTrack} is enabled
    * @property {boolean} isSwitchedOff - Whether the {@link RemoteMediaTrack} is switched off
    * @property {?TrackSwitchOffReason} switchOffReason - The reason for the {@link RemoteMediaTrack} being switched off;
    *   If switched on, it is set to <code>null</code>; The {@link RemoteMediaTrack} is initially switched off with this
@@ -83,6 +85,9 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
         isEnabled: {
           enumerable: true,
           get() {
+            this._log.deprecated('.isEnabled is deprecated and scheduled for removal. '
+             + 'The RemoteMediaTrack is can be considered disabled if .isSwitchedOff is '
+             + 'set to true and .switchOffReason is set to "disabled-by-publisher".');
             return this._isEnabled;
           }
         },
@@ -109,6 +114,12 @@ function mixinRemoteMediaTrack(AudioOrVideoTrack) {
           }
         }
       });
+
+      const { _log: log, constructor: { name } } = this;
+      deprecateEvents(name, this, new Map([
+        ['disabled', 'switchedOff (.switchOffReason === "disabled-by-publisher")'],
+        ['enabled', 'switchedOn']
+      ]), log);
     }
 
     /**
@@ -256,6 +267,7 @@ function playIfPausedWhileInBackground(remoteMediaTrack) {
 
 /**
  * A {@link RemoteMediaTrack} was disabled.
+ * @deprecated Use <a href="#event:switchedOff"><code>switchedOff</code></a> (<code>.switchOffReason === "disabled-by-publisher"</code>) instead
  * @param {RemoteMediaTrack} track - The {@link RemoteMediaTrack} that was
  *   disabled
  * @event RemoteMediaTrack#disabled
@@ -263,6 +275,7 @@ function playIfPausedWhileInBackground(remoteMediaTrack) {
 
 /**
  * A {@link RemoteMediaTrack} was enabled.
+ * @deprecated Use <a href="#event:switchedOn"><code>switchedOn</code></a> instead
  * @param {RemoteMediaTrack} track - The {@link RemoteMediaTrack} that was
  *   enabled
  * @event RemoteMediaTrack#enabled

--- a/lib/media/track/remotetrackpublication.js
+++ b/lib/media/track/remotetrackpublication.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { deprecateEvents } = require('../../util');
 const TrackPublication = require('./trackpublication');
 
 /**
@@ -8,8 +9,8 @@ const TrackPublication = require('./trackpublication');
  * @extends TrackPublication
  * @property {boolean} isSubscribed - whether the published {@link RemoteTrack}
  *   is subscribed to
- * @property {boolean} isTrackEnabled - whether the published
- *   {@link RemoteTrack} is enabled
+ * @property {boolean} isTrackEnabled - <code>Deprecated: this property is only valid if the corresponding RemoteTrack is subscribed to.</code>
+ *   whether the published {@link RemoteTrack} is enabled
  * @property {Track.Kind} kind - kind of the published {@link RemoteTrack}
  * @property {Track.Priority} publishPriority - the {@link Track.Priority} of the published
  *   {@link RemoteTrack} set by the {@link RemoteParticipant}
@@ -52,6 +53,9 @@ class RemoteTrackPublication extends TrackPublication {
       isTrackEnabled: {
         enumerable: true,
         get() {
+          this._log.deprecated('.isTrackEnabled is deprecated and scheduled for removal. '
+            + 'During the deprecation period, this property is only valid if the corresponding '
+            + 'RemoteTrack is subscribed to.');
           return signaling.isEnabled;
         }
       },
@@ -83,7 +87,12 @@ class RemoteTrackPublication extends TrackPublication {
       trackTransceiver
     } = signaling;
 
-    const { _log: log } = this;
+    const { _log: log, constructor: { name } } = this;
+
+    deprecateEvents(name, this, new Map([
+      ['trackDisabled', 'trackSwitchedOff (track.switchOffReason === "disabled-by-publisher")'],
+      ['trackEnabled', 'trackSwitchedOn']
+    ]), log);
 
     signaling.on('updated', () => {
       if (error !== signaling.error) {
@@ -177,12 +186,16 @@ class RemoteTrackPublication extends TrackPublication {
  */
 
 /**
- * The {@link RemoteTrack} was disabled.
+ * The {@link RemoteTrack} was disabled. It is fired only if <code>.isSubscribed</code>
+ * is set to <code>true</code>.
+ * @deprecated Use <a href="event:trackSwitchedOff"><code>trackSwitchedOff</code></a> (<code>track.switchOffReason === "disabled-by-publisher"</code>) instead
  * @event RemoteTrackPublication#trackDisabled
  */
 
 /**
- * The {@link RemoteTrack} was enabled.
+ * The {@link RemoteTrack} was enabled. It is fired only if <code>.isSubscribed</code>
+ * @deprecated Use <a href="event:trackSwitchedOn"><code>trackSwitchedOn</code></a> instead
+ * is set to <code>true</code>.
  * @event RemoteTrackPublication#trackEnabled
  */
 

--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -13,7 +13,8 @@ const TRACK_TURN_OF_DELAY_MS = 50;
  * A {@link RemoteVideoTrack} represents a {@link VideoTrack} published to a
  * {@link Room} by a {@link RemoteParticipant}.
  * @extends VideoTrack
- * @property {boolean} isEnabled - Whether the {@link RemoteVideoTrack} is enabled
+ * @property {boolean} isEnabled - <code>Deprecated: Use (.isSwitchedOff && .switchOffReason === "disabled-by-publisher") instead</code>
+ *   Whether the {@link RemoteAudioTrack} is enabled
  * @property {boolean} isSwitchedOff - Whether the {@link RemoteVideoTrack} is switched off
  * @property {?TrackSwitchOffReason} switchOffReason - The reason for the {@link RemoteVideoTrack} being switched off;
  *   If switched on, it is set to <code>null</code>; The {@link RemoteVideoTrack} is initially switched off with this
@@ -421,6 +422,7 @@ function maybeUpdateDimensionHint(remoteVideoTrack) {
 
 /**
  * The {@link RemoteVideoTrack} was disabled, i.e. "paused".
+ * @deprecated Use <a href="#event:switchedOff"><code>switchedOff</code></a> (<code>.switchOffReason === "disabled-by-publisher"</code>) instead
  * @param {RemoteVideoTrack} track - The {@link RemoteVideoTrack} that was
  *   disabled
  * @event RemoteVideoTrack#disabled
@@ -428,6 +430,7 @@ function maybeUpdateDimensionHint(remoteVideoTrack) {
 
 /**
  * The {@link RemoteVideoTrack} was enabled, i.e. "resumed".
+ * @deprecated Use <a href="#event:switchedOn"><code>switchedOn</code></a> instead
  * @param {RemoteVideoTrack} track - The {@link RemoteVideoTrack} that was
  *   enabled
  * @event RemoteVideoTrack#enabled

--- a/lib/media/track/remotevideotrackpublication.js
+++ b/lib/media/track/remotevideotrackpublication.js
@@ -44,13 +44,39 @@ class RemoteVideoTrackPublication extends RemoteTrackPublication {
  */
 
 /**
- * The {@link RemoteVideoTrack} was disabled.
+ * The {@link RemoteVideoTrack} was disabled. It is fired only if <code>.isSubscribed</code>
+ * is set to <code>true</code>.
+ * @deprecated Use <a href="event:trackSwitchedOff"><code>trackSwitchedOff</code></a> (<code>track.switchOffReason === "disabled-by-publisher"</code>) instead
  * @event RemoteVideoTrackPublication#trackDisabled
  */
 
 /**
- * The {@link RemoteVideoTrack} was enabled.
+ * The {@link RemoteVideoTrack} was enabled. It is fired only if <code>.isSubscribed</code>
+ * @deprecated Use <a href="event:trackSwitchedOn"><code>trackSwitchedOn</code></a> instead
+ * is set to <code>true</code>.
  * @event RemoteVideoTrackPublication#trackEnabled
+ */
+
+/**
+ * The {@link RemoteVideoTrack} was switched off. The media server stops sending media for
+ * the {@link RemoteVideoTrack} until it is switched back on. Just before the event is raised,
+ * <code>isSwitchedOff</code> is set to <code>true</code> and <code>switchOffReason</code>
+ * is set to a {@link TrackSwitchOffReason}. Also, the <code>mediaStreamTrack</code> property
+ * is set to <code>null</code>.
+ * @param {RemoteVideoTrack} track - the {@link RemoteVideoTrack} that was switched off
+ * @param {?TrackSwitchOffReason} switchOffReason - the reason the {@link RemoteVideoTrack}
+ *   was switched off
+ * @event RemoteVideoTrackPublication#trackSwitchedOff
+ */
+
+/**
+ * The {@link RemoteVideoTrack} was switched on. The media server starts sending media for
+ * the {@link RemoteVideoTrack} until it is switched off. Just before the event is raised,
+ * <code>isSwitchedOff</code> is set to <code>false</code> and <code>switchOffReason</code>
+ * is set to <code>null</code>. Also, the <code>mediaStreamTrack</code> property is set to a
+ * MediaStreamTrack that is the source of the {@link RemoteVideoTrack}'s media.
+ * @param {RemoteVideoTrack} track - the {@link RemoteVideoTrack} that was switched on
+ * @event RemoteVideoTrackPublication#trackSwitchedOn
  */
 
 /**

--- a/lib/signaling/v2/localparticipant.js
+++ b/lib/signaling/v2/localparticipant.js
@@ -8,7 +8,7 @@ const { buildLogLevels, isDeepEqual } = require('../../util');
 
 /**
  * @extends ParticipantSignaling
- * @property {BandwidthProfileOptions} bandwidthProfile
+ * @property {BandwidthProfile} bandwidthProfile
  * @property {NetworkQualityConfigurationImpl} networkQualityConfiguration
  * @property {number} revision
  * @emits LocalParticipantV2#updated
@@ -111,8 +111,8 @@ class LocalParticipantV2 extends LocalParticipantSignaling {
   }
 
   /**
-   * Update the {@link BandwidthProfileOptions}.
-   * @param {BandwidthProfileOptions} bandwidthProfile
+   * Update the {@link BandwidthProfile}.
+   * @param {BandwidthProfile} bandwidthProfile
    */
   setBandwidthProfile(bandwidthProfile) {
     if (!isDeepEqual(this._bandwidthProfile, bandwidthProfile)) {

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -653,7 +653,7 @@ function createRoomConnectEventPayload(connectOptions) {
 
 /**
  * Create the bandwidth profile payload included in an RSP connect message.
- * @param {BandwidthProfileOptions} bandwidthProfile
+ * @param {BandwidthProfile} bandwidthProfile
  * @returns {object}
  */
 function createBandwidthProfilePayload(bandwidthProfile) {

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -64,7 +64,7 @@ function deprecateEvents(name, emitter, events, log) {
   const warningsShown = new Set();
   emitter.on('newListener', function newListener(event) {
     if (events.has(event) && !warningsShown.has(event)) {
-      log.deprecated(`${name}#${event} has been deprecated and scheduled for removal in twilio-video.js@2.0.0.${events.get(event)
+      log.deprecated(`${name}#${event} has been deprecated and scheduled for removal.${events.get(event)
         ? ` Use ${name}#${events.get(event)} instead.`
         : ''}`);
       warningsShown.add(event);

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -664,7 +664,7 @@ function createBandwidthProfilePayload(bandwidthProfile) {
 
 /**
  * Create the bandwidth profile video payload included in an RSP connect message.
- * @param {VideoBandwidthProfileOptions} bandwidthProfileVideo
+ * @param {VideoBandwidthProfile} bandwidthProfileVideo
  * @returns {object}
  */
 function createBandwidthProfileVideoPayload(bandwidthProfileVideo) {

--- a/lib/util/validate.js
+++ b/lib/util/validate.js
@@ -4,8 +4,8 @@ const { isNonArrayObject } = require('./');
 const { typeErrors: E, clientTrackSwitchOffControl, videoContentPreferencesMode, subscriptionMode, trackPriority, trackSwitchOffMode } = require('./constants');
 
 /**
- * Validate the {@link BandwidthProfileOptions} object.
- * @param {BandwidthProfileOptions} bandwidthProfile
+ * Validate the {@link BandwidthProfile} object.
+ * @param {BandwidthProfile} bandwidthProfile
  * @returns {?Error} - null if valid, Error if not.
  */
 function validateBandwidthProfile(bandwidthProfile) {

--- a/test/integration/spec/bandwidthprofile/regressions.js
+++ b/test/integration/spec/bandwidthprofile/regressions.js
@@ -30,7 +30,7 @@ function monitorTrackSwitchOffs(remoteTrack, trackName) {
   });
 }
 
-describe('BandwidthProfileOptions: regressions', function() {
+describe('BandwidthProfile: regressions', function() {
   // eslint-disable-next-line no-invalid-this
   this.timeout(120 * 1000);
   // eslint-disable-next-line no-invalid-this

--- a/test/integration/spec/bandwidthprofile/renderhints.js
+++ b/test/integration/spec/bandwidthprofile/renderhints.js
@@ -20,7 +20,7 @@ const {
 const { trackPriority: { PRIORITY_STANDARD } } = require('../../../../es5/util/constants');
 const { waitForSometime } = require('../../../../es5/util');
 
-describe('BandwidthProfileOptions: renderHints', function() {
+describe('BandwidthProfile: renderHints', function() {
   // eslint-disable-next-line no-invalid-this
   this.timeout(120 * 1000);
   // eslint-disable-next-line no-invalid-this

--- a/test/integration/spec/bandwidthprofile/video.js
+++ b/test/integration/spec/bandwidthprofile/video.js
@@ -35,7 +35,7 @@ function monitorTrackSwitchOffs(remoteTrack, trackName) {
   });
 }
 
-describe('BandwidthProfileOptions: video', function() {
+describe('BandwidthProfile: video', function() {
   // eslint-disable-next-line no-invalid-this
   this.timeout(120 * 1000);
   // eslint-disable-next-line no-invalid-this

--- a/test/unit/spec/media/track/remotemediatrack.js
+++ b/test/unit/spec/media/track/remotemediatrack.js
@@ -2,7 +2,6 @@
 
 const assert = require('assert');
 const sinon = require('sinon');
-const log = require('../../../../lib/fakelog');
 const Document = require('../../../../lib/document');
 const { capitalize } = require('../../../../lib/util');
 const MediaTrackReceiver = require('../../../../../lib/media/track/receiver');
@@ -16,16 +15,19 @@ const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserv
   ['audio', RemoteAudioTrack],
   ['video', RemoteVideoTrack]
 ].forEach(([kind, RemoteTrack]) => {
-  let name = `Remote${capitalize(kind)}Track`;
-  describe(`${name}`, () => {
+  const className = `Remote${capitalize(kind)}Track`;
+  describe(`${className}`, () => {
     describe('constructor', () => {
       const name = 'bar';
       let error;
+      let log;
       let track;
 
       before(() => {
         try {
-          track = makeTrack({ id: 'foo', mid: 'baz', sid: 'bar', kind, isEnabled: true, isSwitchedOff: false, options: { log, name }, RemoteTrack });
+          track = makeTrack({ id: 'foo', mid: 'baz', sid: 'bar', kind, isEnabled: true, isSwitchedOff: false, options: { name }, RemoteTrack });
+          log = track._log;
+          log.warn = sinon.spy();
         } catch (e) {
           error = e;
         }
@@ -35,12 +37,21 @@ const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserv
         assert(!error);
       });
 
-      it(`should return an instance of ${name}`, () => {
+      it(`should return an instance of ${className}`, () => {
         assert(track instanceof RemoteTrack);
       });
 
-      it('should set the .isEnabled property', () => {
+      it('should set the .isEnabled property and log deprecation warning the first time it is accessed', () => {
         assert.equal(track.isEnabled, true);
+        sinon.assert.callCount(log.warn, 1);
+        sinon.assert.calledWith(log.warn, '.isEnabled is deprecated and scheduled for removal. '
+          + 'The RemoteMediaTrack is can be considered disabled if .isSwitchedOff is '
+          + 'set to true and .switchOffReason is set to "disabled-by-publisher".');
+      });
+
+      it('should not log deprecation warning when .isEnabled is accessed a second time', () => {
+        assert.equal(track.isEnabled, true);
+        sinon.assert.callCount(log.warn, 1);
       });
 
       it('should set the .isSwitchedOff property', () => {
@@ -57,6 +68,22 @@ const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserv
 
       it('should set the .sid property', () => {
         assert.equal(track.sid, 'bar');
+      });
+
+      [
+        ['disabled', `${className}#disabled has been deprecated and scheduled for removal. Use ${className}#switchedOff (.switchOffReason === "disabled-by-publisher") instead.`],
+        ['enabled', `${className}#enabled has been deprecated and scheduled for removal. Use ${className}#switchedOn instead.`]
+      ].forEach(([event, warning], i) => {
+        it(`should emit deprecation warning when "${event}" event is listened to for the first time`, () => {
+          track.on(event, () => {});
+          sinon.assert.callCount(log.warn, 2 + i);
+          sinon.assert.calledWith(log.warn, warning);
+        });
+
+        it(`should not emit deprecation warning when "${event}" event is listened to for the second time`, () => {
+          track.on(event, () => {});
+          sinon.assert.callCount(log.warn, 2 + i);
+        });
       });
     });
 
@@ -140,7 +167,7 @@ const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserv
             assert.equal(track.isEnabled, newIsEnabled);
           });
 
-          it(`should emit "${newIsEnabled ? 'enabled' : 'disabled'}" on the ${name} with the ${name} itself`, () => {
+          it(`should emit "${newIsEnabled ? 'enabled' : 'disabled'}" on the ${className} with the ${className} itself`, () => {
             assert(newIsEnabled ? trackEnabled : trackDisabled);
             assert(!(newIsEnabled ? trackDisabled : trackEnabled));
             assert.equal(arg, track);
@@ -193,7 +220,7 @@ const { NullIntersectionObserver } = require('../../../../../lib/util/nullobserv
             assert.equal(track.isSwitchedOff, newIsSwitchedOff);
           });
 
-          it(`should emit "${newIsSwitchedOff ? 'switchedOff' : 'switchedOn'}" on the ${name} with the ${name} itself`, () => {
+          it(`should emit "${newIsSwitchedOff ? 'switchedOff' : 'switchedOn'}" on the ${className} with the ${className} itself`, () => {
             assert(newIsSwitchedOff ? trackSwitchedOff : trackSwitchedOn);
             assert(!(newIsSwitchedOff ? trackSwitchedOn : trackSwitchedOff));
             assert.equal(arg, track);

--- a/test/unit/spec/media/track/remotetrackpublication.js
+++ b/test/unit/spec/media/track/remotetrackpublication.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const sinon = require('sinon');
 const { EventEmitter } = require('events');
 const { capitalize, randomBoolean, randomName } = require('../../../../lib/util');
 const RemoteAudioTrackPublication = require('../../../../../lib/media/track/remoteaudiotrackpublication');
@@ -15,24 +16,60 @@ const RemoteVideoTrackPublication = require('../../../../../lib/media/track/remo
   const className = `Remote${capitalize(kind)}TrackPublication`;
   describe(className, () => {
     describe('constructor', () => {
-      const signaling = makeSignaling(randomBoolean(), false, kind, 'MT123');
-      const publication = new RemoteTrackPublication(signaling);
+      let log;
+      let publication;
+      let signaling;
+
+      before(() => {
+        signaling = makeSignaling(randomBoolean(), false, kind, 'MT123');
+        publication = new RemoteTrackPublication(signaling);
+        log = publication._log;
+        log.warn = sinon.spy();
+      });
 
       it(`should return an instance of ${className}`, () => {
         assert(publication instanceof RemoteTrackPublication);
       });
 
       [
-        ['isSubscribed', false],
-        ['isTrackEnabled', signaling.isEnabled],
-        ['kind', kind],
-        ['publishPriority', signaling.priority],
-        ['track', null],
-        ['trackName', signaling.name],
-        ['trackSid', signaling.sid]
-      ].forEach(([prop, expectedValue]) => {
+        ['isSubscribed', () => false],
+        ['isTrackEnabled', () => signaling.isEnabled],
+        ['kind', () => kind],
+        ['publishPriority', () => signaling.priority],
+        ['track', () => null],
+        ['trackName', () => signaling.name],
+        ['trackSid', () => signaling.sid]
+      ].forEach(([prop, getExpectedValue]) => {
         it(`should set the .${prop} property`, () => {
-          assert.equal(publication[prop], expectedValue);
+          assert.equal(publication[prop], getExpectedValue());
+        });
+
+        if (prop === 'isTrackEnabled') {
+          it('should show deprecation warning when accessed the first time', () => {
+            sinon.assert.callCount(log.warn, 1);
+            sinon.assert.calledWith(log.warn, '.isTrackEnabled is deprecated and scheduled for removal. During the deprecation period, this property is only valid if the corresponding RemoteTrack is subscribed to.');
+          });
+
+          it('should not show deprecation warning when accessed the second time', () => {
+            assert(typeof publication[prop], 'boolean');
+            sinon.assert.callCount(log.warn, 1);
+          });
+        }
+      });
+
+      [
+        ['trackDisabled', `${className}#trackDisabled has been deprecated and scheduled for removal. Use ${className}#trackSwitchedOff (track.switchOffReason === "disabled-by-publisher") instead.`],
+        ['trackEnabled', `${className}#trackEnabled has been deprecated and scheduled for removal. Use ${className}#trackSwitchedOn instead.`]
+      ].forEach(([event, warning], i) => {
+        it(`should emit deprecation warning when "${event}" event is listened to for the first time`, () => {
+          publication.on(event, () => {});
+          sinon.assert.callCount(log.warn, 2 + i);
+          sinon.assert.calledWith(log.warn, warning);
+        });
+
+        it(`should not emit deprecation warning when "${event}" event is listened to for the second time`, () => {
+          publication.on(event, () => {});
+          sinon.assert.callCount(log.warn, 2 + i);
         });
       });
     });

--- a/test/unit/spec/signaling/v2/localparticipant.js
+++ b/test/unit/spec/signaling/v2/localparticipant.js
@@ -237,7 +237,7 @@ describe('LocalParticipantV2', () => {
       ['renderDimensions.standard', { width: 3 }],
       ['']
     ].forEach(([prop, value]) => {
-      context(`when called with a BandwidthProfileOptions that ${prop ? `has a different .${prop}` : 'is the same'}`, () => {
+      context(`when called with a BandwidthProfile that ${prop ? `has a different .${prop}` : 'is the same'}`, () => {
         let bandwidthProfileRevision;
         let initialBandwidthProfile;
         let newBandwidthProfile;
@@ -277,7 +277,7 @@ describe('LocalParticipantV2', () => {
         });
 
         if (prop) {
-          it('should set .bandwidthProfile to the new BandwidthProfileOptions', () => {
+          it('should set .bandwidthProfile to the new BandwidthProfile', () => {
             assert.deepEqual(localParticipant.bandwidthProfile, newBandwidthProfile);
           });
 

--- a/tsdef/RemoteAudioTrack.d.ts
+++ b/tsdef/RemoteAudioTrack.d.ts
@@ -5,14 +5,24 @@ export class RemoteAudioTrack extends AudioTrack {
   sid: Track.SID;
   priority: Track.Priority | null;
   isSwitchedOff: boolean;
+  switchOffReason: Track.SwitchOffReason | null;
+  /**
+   * @deprecated Use (.isSwitchedOff && .switchOffReason === Track.SwitchOffReason.DISABLED_BY_PUBLISHER) instead
+   */
   isEnabled: boolean;
 
   setPriority(priority: Track.Priority | null): this;
 
+  /**
+   * @deprecated Use "switchedOff" (.isSwitchedOff && .switchOffReason === Track.SwitchOffReason.DISABLED_BY_PUBLISHER) instead
+   */
   on(event: 'disabled', listener: (track: this) => void): this;
+  /**
+   * @deprecated Use "switchedOn" instead
+   */
   on(event: 'enabled', listener: (track: this) => void): this;
   on(event: 'started', listener: (track: this) => void): this;
-  on(event: 'switchedOff', listener: (track: this) => void): this;
+  on(event: 'switchedOff', listener: (track: this, switchOffReason: Track.SwitchOffReason) => void): this;
   on(event: 'switchedOn', listener: (track: this) => void): this;
   on(event: string, listener: (...args: any[]) => void): this;
 }

--- a/tsdef/RemoteParticipant.d.ts
+++ b/tsdef/RemoteParticipant.d.ts
@@ -25,7 +25,7 @@ export class RemoteParticipant extends Participant {
   on(event: 'trackStarted', listener: (track: RemoteTrack) => void): this;
   on(event: 'trackSubscribed', listener: (track: RemoteTrack, publication: RemoteTrackPublication) => void): this;
   on(event: 'trackSubscriptionFailed', listener: (error: TwilioError, publication: RemoteTrackPublication) => void): this;
-  on(event: 'trackSwitchedOff', listener: (track: RemoteTrack, publication: RemoteTrackPublication) => void): this;
+  on(event: 'trackSwitchedOff', listener: (track: RemoteTrack, publication: RemoteTrackPublication, switchOffReason: Track.SwitchOffReason) => void): this;
   on(event: 'trackSwitchedOn', listener: (track: RemoteTrack, publication: RemoteTrackPublication) => void): this;
   on(event: 'trackUnpublished', listener: (publication: RemoteTrackPublication) => void): this;
   on(event: 'trackUnsubscribed', listener: (track: RemoteTrack, publication: RemoteTrackPublication) => void): this;

--- a/tsdef/RemoteTrackPublication.d.ts
+++ b/tsdef/RemoteTrackPublication.d.ts
@@ -13,7 +13,7 @@ export class RemoteTrackPublication extends TrackPublication {
   on(event: 'publishPriorityChanged', listener: (priority: Track.Priority) => void): this;
   on(event: 'subscribed', listener: (track: RemoteTrack) => void): this;
   on(event: 'subscriptionFailed', listener: (error: TwilioError) => void): this;
-  on(event: 'trackSwitchedOff', listener: (track: RemoteTrack) => void): this;
+  on(event: 'trackSwitchedOff', listener: (track: RemoteTrack, switchOffReason: Track.SwitchOffReason) => void): this;
   on(event: 'trackSwitchedOn', listener: (track: RemoteTrack) => void): this;
   on(event: 'unsubscribed', listener: (track: RemoteTrack) => void): this;
   on(event: string, listener: (...args: any[]) => void): this;

--- a/tsdef/RemoteVideoTrack.d.ts
+++ b/tsdef/RemoteVideoTrack.d.ts
@@ -9,6 +9,10 @@ export class RemoteVideoTrack extends VideoTrack {
   sid: Track.SID;
   priority: Track.Priority | null;
   isSwitchedOff: boolean;
+  switchOffReason: Track.SwitchOffReason | null;
+  /**
+   * @deprecated Use (.isSwitchedOff && .switchOffReason === Track.SwitchOffReason.DISABLED_BY_PUBLISHER) instead
+   */
   isEnabled: boolean;
 
   setPriority(priority: Track.Priority | null): this;
@@ -17,11 +21,17 @@ export class RemoteVideoTrack extends VideoTrack {
   setContentPreferences(content: VideoContentPreferences): this;
 
   on(event: 'dimensionsChanged', listener: (track: this) => void): this;
+  /**
+   * @deprecated Use "switchedOff" (.isSwitchedOff && .switchOffReason === Track.SwitchOffReason.DISABLED_BY_PUBLISHER) instead
+   */
   on(event: 'disabled', listener: (track: this) => void): this;
+  /**
+   * @deprecated Use "switchedOn" instead
+   */
   on(event: 'enabled', listener: (track: this) => void): this;
   on(event: 'started', listener: (track: this) => void): this;
   on(event: 'stopped', listener: (track: this) => void): this;
-  on(event: 'switchedOff', listener: (track: this) => void): this;
+  on(event: 'switchedOff', listener: (track: this, switchOffReason: Track.SwitchOffReason) => void): this;
   on(event: 'switchedOn', listener: (track: this) => void): this;
   on(event: string, listener: (...args: any[]) => void): this;
 }

--- a/tsdef/Room.d.ts
+++ b/tsdef/Room.d.ts
@@ -45,7 +45,7 @@ export class Room extends EventEmitter {
   on(event: 'trackStarted', listener: (track: RemoteTrack, participant: RemoteParticipant) => void): this;
   on(event: 'trackSubscribed', listener: (track: RemoteTrack, publication: RemoteTrackPublication, participant: RemoteParticipant) => void): this;
   on(event: 'trackSubscriptionFailed', listener: (error: TwilioError, publication: RemoteTrackPublication, participant: RemoteParticipant) => void): this;
-  on(event: 'trackSwitchedOff', listener: (track: RemoteTrack, publication: RemoteTrackPublication, participant: RemoteParticipant) => void): this;
+  on(event: 'trackSwitchedOff', listener: (track: RemoteTrack, publication: RemoteTrackPublication, participant: RemoteParticipant, switchOffReason: Track.SwitchOffReason) => void): this;
   on(event: 'trackSwitchedOn', listener: (track: RemoteTrack, publication: RemoteTrackPublication, participant: RemoteParticipant) => void): this;
   on(event: 'trackUnpublished', listener: (publication: RemoteTrackPublication, participant: RemoteParticipant) => void): this;
   on(event: 'trackUnsubscribed', listener: (track: RemoteTrack, publication: RemoteTrackPublication, participant: RemoteParticipant) => void): this;

--- a/tsdef/Track.d.ts
+++ b/tsdef/Track.d.ts
@@ -5,6 +5,13 @@ export namespace Track {
   type Priority = 'low' | 'standard' | 'high';
   type ID = string;
   type SID = string;
+  enum SwitchOffReason {
+    DISABLED_BY_PUBLISHER = 'disabled-by-publisher',
+    DISABLED_BY_SUBSCRIBER = 'disabled-by-subscriber',
+    MAX_BANDWIDTH_REACHED = 'max-bandwidth-reached',
+    MAX_TRACKS_SWITCHED_ON = 'max-tracks-switched-on',
+    NETWORK_CONGESTION = 'network-congestion'
+  }
 }
 
 export class Track extends EventEmitter {

--- a/tsdef/index.d.ts
+++ b/tsdef/index.d.ts
@@ -48,7 +48,7 @@ export {
   AudioLevel,
   AudioTrackPublication,
   BandwidthProfileMode,
-  BandwidthProfileOptions,
+  BandwidthProfile,
   ConnectOptions,
   CreateLocalTrackOptions,
   CreateLocalTracksOptions,

--- a/tsdef/index.d.ts
+++ b/tsdef/index.d.ts
@@ -80,7 +80,7 @@ export {
   StatsReport,
   TrackStats,
   TrackSwitchOffMode,
-  VideoBandwidthProfileOptions,
+  VideoBandwidthProfile,
   VideoCodec,
   VideoCodecSettings,
   VideoRenderDimensions,

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -124,7 +124,7 @@ export interface VideoBandwidthProfile {
   trackSwitchOffMode?: TrackSwitchOffMode;
 }
 
-export interface BandwidthProfileOptions {
+export interface BandwidthProfile {
   video?: VideoBandwidthProfile;
 }
 
@@ -167,7 +167,7 @@ export interface CreateLocalTrackOptions extends MediaTrackConstraints {
 export interface ConnectOptions {
   audio?: boolean | CreateLocalTrackOptions;
   automaticSubscription?: boolean;
-  bandwidthProfile?: BandwidthProfileOptions;
+  bandwidthProfile?: BandwidthProfile;
   dominantSpeaker?: boolean;
 
   /**

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -99,8 +99,8 @@ export type VideoContentPreferencesMode = 'auto' | 'manual';
 export type ClientTrackSwitchOffControl = 'auto' | 'manual';
 
 /**
-* @deprecated
-*/
+ * @deprecated
+ */
 export interface VideoRenderDimensions {
   high?: VideoTrack.Dimensions;
   low?: VideoTrack.Dimensions;
@@ -112,13 +112,13 @@ export interface VideoBandwidthProfile {
   dominantSpeakerPriority?: Track.Priority;
   maxSubscriptionBitrate?: number;
   /**
-  * @deprecated use clientTrackSwitchOffControl instead
-  */
+   * @deprecated use clientTrackSwitchOffControl instead
+   */
   maxTracks?: number;
   mode?: BandwidthProfileMode;
   /**
-  * @deprecated use contentPreferencesMode instead
-  */
+   * @deprecated use contentPreferencesMode instead
+   */
   renderDimensions?: VideoRenderDimensions;
   clientTrackSwitchOffControl?: ClientTrackSwitchOffControl;
   trackSwitchOffMode?: TrackSwitchOffMode;

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -107,7 +107,7 @@ export interface VideoRenderDimensions {
   standard?: VideoTrack.Dimensions;
 }
 
-export interface VideoBandwidthProfileOptions {
+export interface VideoBandwidthProfile {
   contentPreferencesMode?: VideoContentPreferencesMode;
   dominantSpeakerPriority?: Track.Priority;
   maxSubscriptionBitrate?: number;
@@ -125,7 +125,7 @@ export interface VideoBandwidthProfileOptions {
 }
 
 export interface BandwidthProfileOptions {
-  video?: VideoBandwidthProfileOptions;
+  video?: VideoBandwidthProfile;
 }
 
 export interface AudioCodecSettings {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

- Renaming `VideoBandwitdhProfileOptions` to `VideoBandwidthProfile`.
- Renaming `BandwidthProfileOptions` to `BandwidthProfile`.
- Deprecating `VideoBandwidthProfile.maxTracks`.
- Deprecating `RemoteTrack` property `isEnabled` and events `disabled` and `enabled`.
- Deprecating `RemoteTrackPublication` property `isTrackEnabled` and events `trackDisabled` and `trackEnabled`.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
