### PR TITLE
VIDEO-9282 - Migrate SDK from using node.js util.

### DIFF
--- a/lib/media/track/es5/localaudiotrack.js
+++ b/lib/media/track/es5/localaudiotrack.js
@@ -3,8 +3,7 @@
 // only in place so that we can support ES6 classes without requiring `new`.
 'use strict';
 
-const { inherits } = require('util');
-
+const inherits = require('../../../vendor/inherits');
 const LocalAudioTrackClass = require('../localaudiotrack');
 
 function LocalAudioTrack(mediaStreamTrack, options) {

--- a/lib/media/track/es5/localdatatrack.js
+++ b/lib/media/track/es5/localdatatrack.js
@@ -3,7 +3,7 @@
 // only in place so that we can support ES6 classes without requiring `new`.
 'use strict';
 
-const { inherits } = require('util');
+const inherits = require('../../../vendor/inherits');
 
 const LocalDataTrackClass = require('../localdatatrack');
 

--- a/lib/media/track/es5/localvideotrack.js
+++ b/lib/media/track/es5/localvideotrack.js
@@ -3,7 +3,7 @@
 // only in place so that we can support ES6 classes without requiring `new`.
 'use strict';
 
-const { inherits } = require('util');
+const inherits = require('../../../vendor/inherits');
 
 const LocalVideoTrackClass = require('../localvideotrack');
 

--- a/lib/twilioconnection.js
+++ b/lib/twilioconnection.js
@@ -61,7 +61,7 @@ const WS_CLOSE_BUSY_WAIT = 3005;
 const WS_CLOSE_SERVER_BUSY = 3006;
 const WS_CLOSE_OPEN_TIMEOUT = 3007;
 
-const toplevel = global.window || global;
+const toplevel = window || global;
 const WebSocket = toplevel.WebSocket ? toplevel.WebSocket : require('ws');
 
 const CloseReason = {

--- a/lib/util/insightspublisher/index.js
+++ b/lib/util/insightspublisher/index.js
@@ -8,7 +8,7 @@ const MAX_RECONNECT_ATTEMPTS = 5;
 const RECONNECT_INTERVAL_MS = 50;
 const WS_CLOSE_NORMAL = 1000;
 
-const toplevel = global.window || global;
+const toplevel = window || global;
 const WebSocket = toplevel.WebSocket ? toplevel.WebSocket : require('ws');
 const util = require('../../util');
 

--- a/lib/vendor/inherits.js
+++ b/lib/vendor/inherits.js
@@ -1,0 +1,24 @@
+module.exports = function inherits(ctor, superCtor) {
+  if (ctor && superCtor) {
+    ctor.super_ = superCtor;
+    if (typeof Object.create === 'function') {
+      // implementation from standard node.js 'util' module
+      ctor.prototype = Object.create(superCtor.prototype, {
+        constructor: {
+          value: ctor,
+          enumerable: false,
+          writable: true,
+          configurable: true
+        }
+      });
+    } else {
+      // old school shim for old browsers
+      class TempCtor {
+        constructor() { }
+      }
+      TempCtor.prototype = superCtor.prototype;
+      ctor.prototype = new TempCtor();
+      ctor.prototype.constructor = ctor;
+    }
+  }
+};

--- a/lib/webrtc/rtcpeerconnection/chrome.js
+++ b/lib/webrtc/rtcpeerconnection/chrome.js
@@ -3,7 +3,7 @@
 
 var ChromeRTCSessionDescription = require('../rtcsessiondescription/chrome');
 var EventTarget = require('../util/eventtarget');
-var inherits = require('util').inherits;
+var inherits = require('../../vendor/inherits');
 var Latch = require('../util/latch');
 var MediaStream = require('../mediastream');
 var RTCRtpSenderShim = require('../rtcrtpsender');

--- a/lib/webrtc/rtcpeerconnection/firefox.js
+++ b/lib/webrtc/rtcpeerconnection/firefox.js
@@ -3,7 +3,7 @@
 
 var EventTarget = require('../util/eventtarget');
 var FirefoxRTCSessionDescription = require('../rtcsessiondescription/firefox');
-var inherits = require('util').inherits;
+var inherits = require('../../vendor/inherits');
 var updateTracksToSSRCs = require('../util/sdp').updateUnifiedPlanTrackIdsToSSRCs;
 var util = require('../util');
 

--- a/lib/webrtc/rtcpeerconnection/safari.js
+++ b/lib/webrtc/rtcpeerconnection/safari.js
@@ -2,7 +2,7 @@
 'use strict';
 
 var EventTarget = require('../util/eventtarget');
-var inherits = require('util').inherits;
+var inherits = require('../../vendor/inherits');
 var Latch = require('../util/latch');
 var sdpUtils = require('../util/sdp');
 var util = require('../util');

--- a/test/lib/webrtc/fakemediastream.js
+++ b/test/lib/webrtc/fakemediastream.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var inherits = require('util').inherits;
+var inherits = require('../../../lib/vendor/inherits');
 var randomName = require('./util').randomName;
 var EventTarget = require('../../../lib/webrtc/util/eventtarget');
 


### PR DESCRIPTION
**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details
In this PR, we are redefining the way we grab the global context.
`global.window` to `window`

as well as 

migrating the `util.inherits` method into the SDK

### Description
This PR partially addresses [VIDEO-9282](https://issues.corp.twilio.com/browse/VIDEO-9282). 

We have migrated the SDK dependencies off of the node.js `util` module as well as fixing the issue mentioned on [this issue](https://github.com/twilio/twilio-video.js/issues/455).

However, there is a larger effort and a ticket in place to address our dependencies that rely on `util` still which will be addressed in the future.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review
