### PR TITLE
VIDEO-8817 Integration with RSP and SFU changes for large rooms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,21 @@ twilio-video.js now allows you to create and join a [Large Room](TODO_doc_link),
   ```
   The `trackDisabled` and `trackEnabled` events are now only fired for subscribed RemoteTracks.
 
+- Any audio and video Tracks shared while joining the Room will **no longer** be guaranteed to be published by the time
+  the CancelablePromise returned by `connect()` is resolved. The application will now have to listen to the "trackPublished"
+  event on the LocalParticipant. (VIDEO-8817)
+  ```js
+  const room = await connect('token', {
+    audio: true,
+    video: true,
+    room: 'my-large-room'
+  });
+
+  room.localParticipant.on('trackPublished', publication => {
+    console.log(`Successfully published ${publication.kind} Track`);
+  });
+  ```
+
 2.21.1 (March 22, 2022)
 =======================
 

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -82,6 +82,10 @@ const deprecatedVideoBandwidthProfileOptions = new Set([
  *   {@link LocalAudioTrack} and {@link LocalVideoTrack} automatically, you can
  *   pass your own array which you can stop yourself. See {@link ConnectOptions}
  *   for more information.
+ *   <br><br>
+ *   A "trackPublished" event is fired on the {@link LocalParticipant} for each
+ *   LocalTrack that was successfully published. A "trackPublicationFailed" event
+ *   is fired for each LocalTrack that was failed to be published.
  * @alias module:twilio-video.connect
  * @param {string} token - The Access Token string
  * @param {ConnectOptions} [options] - Options to override the default behavior, invalid options are ignored.
@@ -158,7 +162,7 @@ const deprecatedVideoBandwidthProfileOptions = new Set([
  *   audio: { name: 'microphone' },
  *   video: { name: 'camera' }
  * }).then(function(room) {
- *   room.localParticipants.trackPublications.forEach(function(publication) {
+ *   room.localParticipant.on('trackPublished', function(publication) {
  *     console.log('The LocalTrack "' + publication.trackName + '" was successfully published');
  *   });
  * }).catch(error => {

--- a/lib/localparticipant.js
+++ b/lib/localparticipant.js
@@ -109,12 +109,11 @@ class LocalParticipant extends Participant {
   /**
    * @private
    * @param {LocalTrack} track
-   * @param {Track.ID} id
    * @param {Track.Priority} priority
    * @returns {?LocalTrack}
    */
-  _addTrack(track, id, priority) {
-    const addedTrack = super._addTrack(track, id);
+  _addTrack(track, priority) {
+    const addedTrack = super._addTrack(track, track.id);
     if (addedTrack && this.state !== 'disconnected') {
       this._addLocalTrack(track, priority);
     }
@@ -136,11 +135,10 @@ class LocalParticipant extends Participant {
   /**
    * @private
    * @param {LocalTrack} track
-   * @param {Track.ID} id
    * @returns {?LocalTrack}
    */
-  _removeTrack(track, id) {
-    const removedTrack = super._removeTrack(track, id);
+  _removeTrack(track) {
+    const removedTrack = super._removeTrack(track, track.id);
     if (removedTrack && this.state !== 'disconnected') {
       this._signaling.removeTrack(track._trackSender);
       this._log.info(`Removed a ${trackClass(track, true)}:`, track.id);
@@ -281,7 +279,7 @@ class LocalParticipant extends Participant {
         if (error) {
           trackSignaling.removeListener('updated', updated);
           log.warn(`Failed to publish the ${trackClass(localTrack, true)}: ${error.message}`);
-          self._removeTrack(localTrack, localTrack.id);
+          self._removeTrack(localTrack);
           setTimeout(() => {
             self.emit('trackPublicationFailed', error, localTrack);
           });
@@ -443,7 +441,7 @@ class LocalParticipant extends Participant {
       return Promise.reject(E.INVALID_VALUE('LocalTrackPublishOptions.priority', priorityValues));
     }
 
-    let addedLocalTrack = this._addTrack(localTrack, localTrack.id, options.priority)
+    let addedLocalTrack = this._addTrack(localTrack, options.priority)
       || this._tracks.get(localTrack.id);
 
     return this._getOrCreateLocalTrackPublication(addedLocalTrack);
@@ -582,7 +580,7 @@ class LocalParticipant extends Participant {
     const trackSignaling = this._signaling.getPublication(localTrack._trackSender);
     trackSignaling.publishFailed(new Error(`The ${localTrack} was unpublished`));
 
-    localTrack = this._removeTrack(localTrack, localTrack.id);
+    localTrack = this._removeTrack(localTrack);
     if (!localTrack) {
       return null;
     }

--- a/lib/media/track/remotetrackpublication.js
+++ b/lib/media/track/remotetrackpublication.js
@@ -125,7 +125,7 @@ class RemoteTrackPublication extends TrackPublication {
         log.debug(`${this.trackSid} MediaTrackReceiver changed:`, trackTransceiver, signaling.trackTransceiver);
         trackTransceiver = signaling.trackTransceiver;
         if (this.track && this.kind !== 'data') {
-          this.track._setTrackReceiver(trackTransceiver);
+          this.track._setMediaTrackReceiver(trackTransceiver);
         } else {
           log.warn('Track was not subscribed to when TrackReceiver changed.');
         }

--- a/lib/participant.js
+++ b/lib/participant.js
@@ -207,26 +207,26 @@ class Participant extends EventEmitter {
 
   /**
    * @private
-   * @param {RemoteTrack} track
-   * @param {Track.ID} id
-   * @returns {?RemoteTrack}
+   * @param {Track} track
+   * @param {key} key
+   * @returns {?Track}
    */
-  _addTrack(track, id) {
+  _addTrack(track, key) {
     const log = this._log;
-    if (this._tracks.has(id)) {
+    if (this._tracks.has(key)) {
       return null;
     }
-    this._tracks.set(id, track);
+    this._tracks.set(key, track);
 
     const tracksByKind = {
       audio: this._audioTracks,
       video: this._videoTracks,
       data: this._dataTracks
     }[track.kind];
-    tracksByKind.set(id, track);
-    reemitTrackEvents(this, track, id);
+    tracksByKind.set(key, track);
+    reemitTrackEvents(this, track, key);
 
-    log.info(`Added a new ${util.trackClass(track)}:`, id);
+    log.info(`Added a new ${util.trackClass(track)}:`, key);
     log.debug(`${util.trackClass(track)}:`, track);
 
     return track;
@@ -329,14 +329,6 @@ class Participant extends EventEmitter {
       }[kind];
 
       const publication = self.tracks.get(sid);
-
-      // NOTE(mroberts): It should never be the case that the TrackSignaling and
-      // MediaStreamTrack or DataTrackReceiver kinds disagree; however, just in
-      // case, we handle it here.
-      if (!RemoteTrack || kind !== trackTransceiver.kind) {
-        return;
-      }
-
       const options = { log, name, clientTrackSwitchOffControl, contentPreferencesMode };
       const setPriority = newPriority => participantSignaling.updateSubscriberTrackPriority(sid, newPriority);
       const setRenderHint = renderHint => {
@@ -348,14 +340,14 @@ class Participant extends EventEmitter {
         ? new RemoteTrack(sid, trackTransceiver, options)
         : new RemoteTrack(sid, trackTransceiver, isEnabled, isSwitchedOff, switchOffReason, setPriority, setRenderHint, options);
 
-      self._addTrack(track, publication, trackTransceiver.id);
+      self._addTrack(track, publication);
     }
 
     function trackSignalingUnsubscribed(signaling) {
-      const [id, track] = Array.from(self._tracks.entries()).find(([, track]) => track.sid === signaling.sid);
+      const track = self._tracks.get(signaling.sid);
       const publication = self.tracks.get(signaling.sid);
       if (track) {
-        self._removeTrack(track, publication, id);
+        self._removeTrack(track, publication);
       }
     }
 
@@ -386,30 +378,30 @@ class Participant extends EventEmitter {
 
   /**
    * @private
-   * @param {RemoteTrack} track
-   * @param {Track.ID} id
-   * @returns {?RemoteTrack}
+   * @param {Track} track
+   * @param {string} key
+   * @returns {?Track}
    */
-  _removeTrack(track, id) {
-    if (!this._tracks.has(id)) {
+  _removeTrack(track, key) {
+    if (!this._tracks.has(key)) {
       return null;
     }
-    this._tracks.delete(id);
+    this._tracks.delete(key);
 
     const tracksByKind = {
       audio: this._audioTracks,
       video: this._videoTracks,
       data: this._dataTracks
     }[track.kind];
-    tracksByKind.delete(id);
+    tracksByKind.delete(key);
 
-    const reemitters = this._trackEventReemitters.get(id) || new Map();
+    const reemitters = this._trackEventReemitters.get(key) || new Map();
     reemitters.forEach((reemitter, event) => {
       track.removeListener(event, reemitter);
     });
 
     const log = this._log;
-    log.info(`Removed a ${util.trackClass(track)}:`, id);
+    log.info(`Removed a ${util.trackClass(track)}:`, key);
     log.debug(`${util.trackClass(track)}:`, track);
     return track;
   }
@@ -554,7 +546,9 @@ function reemitSignalingStateChangedEvents(participant, signaling) {
       signaling.removeListener('stateChanged', stateChanged);
 
       participant._tracks.forEach(track => {
-        const reemitters = participant._trackEventReemitters.get(track.id);
+        // NOTE(mmalavalli): Event re-emitters for LocalTracks use the Track.ID as the key,
+        // whereas event re-emitters for RemoteTracks use the Track.SID as the key.
+        const reemitters = participant._trackEventReemitters.get(track.id || track.sid);
         if (track && reemitters) {
           reemitters.forEach((reemitter, event) => {
             track.removeListener(event, reemitter);
@@ -566,8 +560,8 @@ function reemitSignalingStateChangedEvents(participant, signaling) {
       // TODO(joma): Removing this introduced unit test failures in the RemoteParticipant.
       // Investigate further before removing.
       signaling.tracks.forEach(trackSignaling => {
-        const track = participant._tracks.get(trackSignaling.id);
-        const reemitters = participant._trackEventReemitters.get(trackSignaling.id);
+        const track = participant._tracks.get(trackSignaling.sid);
+        const reemitters = participant._trackEventReemitters.get(trackSignaling.sid);
         if (track && reemitters) {
           reemitters.forEach((reemitter, event) => {
             track.removeListener(event, reemitter);
@@ -592,10 +586,10 @@ function reemitSignalingStateChangedEvents(participant, signaling) {
  * Re-emit {@link Track} events.
  * @param {Participant} participant
  * @param {Track} track
- * @param {Track.ID} id
+ * @param {string} key
  * @private
  */
-function reemitTrackEvents(participant, track, id) {
+function reemitTrackEvents(participant, track, key) {
   const trackEventReemitters = new Map();
 
   if (participant.state === 'disconnected') {
@@ -614,7 +608,7 @@ function reemitTrackEvents(participant, track, id) {
     track.on(trackEvent, trackEventReemitters.get(trackEvent));
   });
 
-  participant._trackEventReemitters.set(id, trackEventReemitters);
+  participant._trackEventReemitters.set(key, trackEventReemitters);
 }
 
 /**

--- a/lib/remoteparticipant.js
+++ b/lib/remoteparticipant.js
@@ -50,11 +50,10 @@ class RemoteParticipant extends Participant {
    * @private
    * @param {RemoteTrack} remoteTrack
    * @param {RemoteTrackPublication} publication
-   * @param {Track.ID} id
    * @returns {?RemoteTrack}
    */
-  _addTrack(remoteTrack, publication, id) {
-    if (!super._addTrack(remoteTrack, id)) {
+  _addTrack(remoteTrack, publication) {
+    if (!super._addTrack(remoteTrack, remoteTrack.sid)) {
       return null;
     }
     publication._subscribed(remoteTrack);
@@ -107,16 +106,15 @@ class RemoteParticipant extends Participant {
    * @private
    * @param {RemoteTrack} remoteTrack
    * @param {RemoteTrackPublication} publication
-   * @param {Track.ID} id
    * @returns {?RemoteTrack}
    */
-  _removeTrack(remoteTrack, publication, id) {
-    const unsubscribedTrack = this._tracks.get(id);
+  _removeTrack(remoteTrack, publication) {
+    const unsubscribedTrack = this._tracks.get(remoteTrack.sid);
     if (!unsubscribedTrack) {
       return null;
     }
 
-    super._removeTrack(unsubscribedTrack, id);
+    super._removeTrack(unsubscribedTrack, unsubscribedTrack.sid);
     publication._unsubscribe();
     this.emit('trackUnsubscribed', unsubscribedTrack, publication);
     return unsubscribedTrack;

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -119,11 +119,6 @@ class RoomV2 extends RoomSignaling {
       _trackPrioritySignaling: {
         value: new options.TrackPrioritySignaling(getTrackReceiver, { log }),
       },
-      _trackSubscriptionsSignaling: {
-        value: options.TrackSubscriptionsSignaling
-          ? new options.TrackSubscriptionsSignaling(getTrackReceiver, { log })
-          : null
-      },
       _trackSwitchOffSignaling: {
         value: new options.TrackSwitchOffSignaling(getTrackReceiver, { log }),
       },
@@ -142,25 +137,7 @@ class RoomV2 extends RoomSignaling {
       }
     });
 
-    this._initTrackSwitchOffSignaling();
-    this._initDominantSpeakerSignaling();
-    this._initNetworkQualityMonitorSignaling();
-    this._initPublisherHintSignaling();
-
-    if (this._trackSubscriptionsSignaling) {
-      this._initTrackSubscriptionsSignaling();
-    }
-
-    handleLocalParticipantEvents(this, localParticipant);
-    handlePeerConnectionEvents(this, peerConnectionManager);
-    handleTransportEvents(this, transport);
-    periodicallyPublishStats(this, transport, options.statsPublishIntervalMs);
-
-    this._update(initialState);
-
-    // NOTE(mpatwardhan) after initial state we know if publisher_hints are enabled or not
-    // if they are not enabled. we need to undo simulcast that if it was enabled with initial offer.
-    this._peerConnectionManager.setEffectiveAdaptiveSimulcast(this._publisherHintsSignaling.isSetup);
+    this._init(localParticipant, peerConnectionManager, transport, options, initialState);
   }
 
   /**
@@ -318,6 +295,27 @@ class RoomV2 extends RoomSignaling {
     return {
       participant: this.localParticipant.getState()
     };
+  }
+
+  /**
+   * @private
+   */
+  _init(localParticipant, peerConnectionManager, transport, options, initialState) {
+    this._initTrackSwitchOffSignaling();
+    this._initDominantSpeakerSignaling();
+    this._initNetworkQualityMonitorSignaling();
+    this._initPublisherHintSignaling();
+
+    handleLocalParticipantEvents(this, localParticipant);
+    handlePeerConnectionEvents(this, peerConnectionManager);
+    handleTransportEvents(this, transport);
+    periodicallyPublishStats(this, transport, options.statsPublishIntervalMs);
+
+    this._update(initialState);
+
+    // NOTE(mpatwardhan) after initial state we know if publisher_hints are enabled or not
+    // if they are not enabled. we need to undo simulcast that if it was enabled with initial offer.
+    this._peerConnectionManager.setEffectiveAdaptiveSimulcast(this._publisherHintsSignaling.isSetup);
   }
 
   /**

--- a/lib/signaling/v3/remoteparticipant.js
+++ b/lib/signaling/v3/remoteparticipant.js
@@ -56,7 +56,14 @@ class RemoteParticipantV3 extends RemoteParticipantV2 {
         : this._getInitialTrackSwitchOffState(trackState.sid);
       track = new RemoteTrackPublicationV3(trackState, state === 'OFF', switchOffReason);
       this.addTrack(track);
-      getPendingTrackReceiver(track.sid).then(trackReceiver => track.setTrackTransceiver(trackReceiver, true));
+
+      getPendingTrackReceiver(track.sid).then(trackReceiver => {
+        // NOTE(mmalavalli): DataTracks are subscribed to only if corresponding DataTrackReceivers
+        // are available, whereas MediaTracks can be subscribed to irrespective of whether corresponding
+        // MediaTrackReceivers are available. MediaTracks without MediaTrackReceivers are considered
+        // switched off.
+        track.setTrackTransceiver(trackReceiver, track.kind !== 'data' || !!trackReceiver);
+      });
     }
     return track;
   }

--- a/lib/signaling/v3/room.js
+++ b/lib/signaling/v3/room.js
@@ -149,7 +149,7 @@ class RoomV3 extends RoomV2 {
         if (!isSwitchedOff) {
           this._getTrackReceiver(mid, 'mid').then(trackReceiver => trackSignaling.setTrackTransceiver(trackReceiver, true));
         }
-        trackSignaling.setSwitchedOff(isSwitchedOff);
+        trackSignaling.setSwitchedOff(isSwitchedOff, switchOffReason);
       });
 
       dataTrackSidsToDataChannelLabels.forEach((dataChannelLabel, sid) => {

--- a/lib/signaling/v3/room.js
+++ b/lib/signaling/v3/room.js
@@ -28,15 +28,6 @@ class RoomV3 extends RoomV2 {
       peerConnectionManager,
       options
     );
-
-    Object.defineProperties(this, {
-      _pendingDataChannelLabels: {
-        value: new Map()
-      },
-      _pendingTrackMids: {
-        value: new Map()
-      }
-    });
   }
 
   /**
@@ -103,6 +94,30 @@ class RoomV3 extends RoomV2 {
    */
   _handleSubscriptions() {
     /* Do nothing since RSP v3 messages will not contain the "subscribed" property. */
+  }
+
+  /**
+   * @private
+   * @override
+   */
+  _init(localParticipant, peerConnectionManager, transport, options, initialState) {
+    const getTrackReceiver = id => this._getTrackReceiver(id);
+    const { _log: log } = this;
+
+    Object.defineProperties(this, {
+      _pendingDataChannelLabels: {
+        value: new Map()
+      },
+      _pendingTrackMids: {
+        value: new Map()
+      },
+      _trackSubscriptionsSignaling: {
+        value: new options.TrackSubscriptionsSignaling(getTrackReceiver, { log })
+      }
+    });
+
+    this._initTrackSubscriptionsSignaling();
+    super._init(localParticipant, peerConnectionManager, transport, options, initialState);
   }
 
   /**

--- a/lib/signaling/v3/tracksubscriptionssignaling.js
+++ b/lib/signaling/v3/tracksubscriptionssignaling.js
@@ -38,13 +38,15 @@ class TrackSubscriptionsSignaling extends MediaSignaling {
   _handleIncomingMessage(message) {
     const { _log: log, _currentRevision: currentRevision } = this;
     const { data = {}, errors = {}, media = {}, revision } = message;
-    if (currentRevision !== null && currentRevision >= revision) {
+    // TODO(mmalavalli): Remove this once SFU sends revision as integer instead of string.
+    const revisionNumber = Number(revision);
+    if (currentRevision !== null && currentRevision >= revisionNumber) {
       log.warn(`Ignoring incoming ${this.channel} message as ${currentRevision} (current revision) >= ${revision} (incoming revision)`);
       log.debug(`Ignored incoming ${this.channel} message:`, message);
       return;
     }
     log.debug(`Incoming ${this.channel} MSP message:`, message);
-    this._currentRevision = revision;
+    this._currentRevision = revisionNumber;
     this.emit('updated', media, data, errors);
   }
 }

--- a/test/unit/spec/remoteparticipant.js
+++ b/test/unit/spec/remoteparticipant.js
@@ -137,11 +137,11 @@ describe('RemoteParticipant', () => {
         context(`when ${a(kind)} Remote${kind}Track with the same RemoteTrackPublicationSignaling .id exists in .tracks`, () => {
           before(() => {
             trackSignaling = makeTrackSignaling({ kind: kind.toLowerCase() });
-            newTrackSignaling = makeTrackSignaling({ id: trackSignaling.id, kind: kind.toLowerCase() });
-            track = new test[`Remote${kind}Track`]('foo', trackSignaling.trackTransceiver);
-            newTrack = new test[`Remote${kind}Track`]('foo', newTrackSignaling.trackTransceiver);
-            test.participant._tracks.set(trackSignaling.id, track);
-            test.participant[`_${kind.toLowerCase()}Tracks`].set(trackSignaling.id, track);
+            newTrackSignaling = makeTrackSignaling({ sid: trackSignaling.sid, kind: kind.toLowerCase() });
+            track = new test[`Remote${kind}Track`](trackSignaling.sid, trackSignaling.trackTransceiver);
+            newTrack = new test[`Remote${kind}Track`](trackSignaling.sid, newTrackSignaling.trackTransceiver);
+            test.participant._tracks.set(trackSignaling.sid, track);
+            test.participant[`_${kind.toLowerCase()}Tracks`].set(trackSignaling.sid, track);
             participantEvents = {};
             publication = new EventEmitter();
             publication._subscribed = track => { publication.emit('subscribed', track); };
@@ -161,19 +161,19 @@ describe('RemoteParticipant', () => {
               trackUnsubscribed = track;
               tracksOnceUnsubscribed = Array.from(test.participant._tracks.values());
             });
-            ret = test.participant[method](newTrack, publication, newTrackSignaling.id);
+            ret = test.participant[method](newTrack, publication);
           });
 
           it(`${method === '_addTrack' ? 'should not' : 'should'} ${action} the Remote${kind}Track ${toOrFrom} ._tracks`, () => {
             assert(method === '_addTrack'
-              ? test.participant._tracks.get(newTrackSignaling.id) === track
-              : !test.participant._tracks.has(newTrackSignaling.id));
+              ? test.participant._tracks.get(newTrackSignaling.sid) === track
+              : !test.participant._tracks.has(newTrackSignaling.sid));
           });
 
           it(`${method === '_addTrack' ? 'should not' : 'should'} ${action} the Remote${kind}Track ${toOrFrom} ._${kind.toLowerCase()}Tracks`, () => {
             assert(method === '_addTrack'
-              ? test.participant[`_${kind.toLowerCase()}Tracks`].get(newTrackSignaling.id) === track
-              : !test.participant[`_${kind.toLowerCase()}Tracks`].has(newTrackSignaling.id));
+              ? test.participant[`_${kind.toLowerCase()}Tracks`].get(newTrackSignaling.sid) === track
+              : !test.participant[`_${kind.toLowerCase()}Tracks`].has(newTrackSignaling.sid));
           });
 
           it(`should return ${method === '_addTrack' ? 'null' : `the Remote${kind}Track`}`, () => {
@@ -208,24 +208,24 @@ describe('RemoteParticipant', () => {
 
           before(() => {
             newTrackSignaling = makeTrackSignaling({ kind: kind.toLowerCase() });
-            newTrack = new test[`Remote${kind}Track`]('foo', newTrackSignaling.trackTransceiver);
+            newTrack = new test[`Remote${kind}Track`](newTrackSignaling.sid, newTrackSignaling.trackTransceiver);
             participantEvents = {};
             ['trackSubscribed', 'trackUnsubscribed'].forEach(event => {
               test.participant.once(event, track => { participantEvents[event] = track; sids[event] = track.sid; });
             });
-            ret = test.participant[method](newTrack, makeRemoteTrackPublication(newTrackSignaling), newTrackSignaling.id);
+            ret = test.participant[method](newTrack, makeRemoteTrackPublication(newTrackSignaling));
           });
 
           it(`${method === '_addTrack' ? 'should' : 'should not'} ${action} the Remote${kind}Track ${toOrFrom} ._tracks`, () => {
             assert(method === '_addTrack'
-              ? test.participant._tracks.get(newTrackSignaling.id) === newTrack
-              : !test.participant._tracks.has(newTrackSignaling.id));
+              ? test.participant._tracks.get(newTrackSignaling.sid) === newTrack
+              : !test.participant._tracks.has(newTrackSignaling.sid));
           });
 
           it(`${method === '_addTrack' ? 'should' : 'should not'} ${action} the Remote${kind}Track ${toOrFrom} ._${kind.toLowerCase()}Tracks`, () => {
             assert(method === '_addTrack'
-              ? test.participant[`_${kind.toLowerCase()}Tracks`].get(newTrackSignaling.id) === newTrack
-              : !test.participant[`_${kind.toLowerCase()}Tracks`].has(newTrackSignaling.id));
+              ? test.participant[`_${kind.toLowerCase()}Tracks`].get(newTrackSignaling.sid) === newTrack
+              : !test.participant[`_${kind.toLowerCase()}Tracks`].has(newTrackSignaling.sid));
           });
 
           it(`should return ${method === '_addTrack' ? `the Remote${kind}Track` : 'null'}`, () => {
@@ -719,9 +719,9 @@ describe('RemoteParticipant', () => {
               updated(dataTrack)
             ];
 
-            audioTrack.setTrackTransceiver({ id: audioTrack.id, kind: audioTrack.kind, track: {} });
-            videoTrack.setTrackTransceiver({ id: videoTrack.id, kind: videoTrack.kind, track: {} });
-            dataTrack.setTrackTransceiver({ id: dataTrack.id, kind: dataTrack.kind, track: {} });
+            audioTrack.setTrackTransceiver({ id: audioTrack.sid, kind: audioTrack.kind, track: {} });
+            videoTrack.setTrackTransceiver({ id: videoTrack.sid, kind: videoTrack.kind, track: {} });
+            dataTrack.setTrackTransceiver({ id: dataTrack.sid, kind: dataTrack.kind, track: {} });
 
             return Promise.all(updateds).then(() => {
               assert.equal(audioTrack.trackTransceiver, test.RemoteAudioTrack.args[0][1]);
@@ -754,20 +754,19 @@ describe('RemoteParticipant', () => {
               updated(dataTrack)
             ];
 
-            audioTrack.setTrackTransceiver({ id: audioTrack.id, kind: audioTrack.kind, track: {} });
-            videoTrack.setTrackTransceiver({ id: videoTrack.id, kind: videoTrack.kind, track: {} });
-            dataTrack.setTrackTransceiver({ id: dataTrack.id, kind: dataTrack.kind, track: {} });
+            audioTrack.setTrackTransceiver({ id: audioTrack.sid, kind: audioTrack.kind, track: {} });
+            videoTrack.setTrackTransceiver({ id: videoTrack.sid, kind: videoTrack.kind, track: {} });
+            dataTrack.setTrackTransceiver({ id: dataTrack.sid, kind: dataTrack.kind, track: {} });
 
             return Promise.all(updateds).then(() => {
-              assert.equal(test.tracks[0], test.participant._tracks.get(audioTrack.id));
-              assert.equal(test.tracks[1], test.participant._tracks.get(videoTrack.id));
-              assert.equal(test.tracks[2], test.participant._tracks.get(dataTrack.id));
-              assert.equal(test.tracks[0], test.participant._audioTracks.get(audioTrack.id));
-              assert.equal(test.tracks[1], test.participant._videoTracks.get(videoTrack.id));
-              assert.equal(test.tracks[2], test.participant._dataTracks.get(dataTrack.id));
+              assert.equal(test.tracks[0], test.participant._tracks.get(audioTrack.sid));
+              assert.equal(test.tracks[1], test.participant._tracks.get(videoTrack.sid));
+              assert.equal(test.tracks[2], test.participant._tracks.get(dataTrack.sid));
+              assert.equal(test.tracks[0], test.participant._audioTracks.get(audioTrack.sid));
+              assert.equal(test.tracks[1], test.participant._videoTracks.get(videoTrack.sid));
+              assert.equal(test.tracks[2], test.participant._dataTracks.get(dataTrack.sid));
             });
           });
-
 
           it('fires the "trackSubscribed" event on the RemoteParticipant', () => {
             const test = makeTest();


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

@makarandp0 @PikaJoyce 

 - [x] Changes based on integration with Room Service (RSP v3)
   - Tracks specified in ConnectOptions are now published after the connect Promise is resolved
 - [x] Changes based on integration with SFU changes
   - RemoteTracks are keyed off of Track SIDs in internal maps instead of Track IDs, since they can be associated with more than one MediaStreamTrack in large Rooms
   - Keep existing subscription behavior foe DataTracks

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
