### PR TITLE
VIDEO-9511 - do not configure encodings for stopped tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 
 **Version 1.x reached End of Life on September 8th, 2021.** See the changelog entry [here](https://www.twilio.com/changelog/end-of-life-complete-for-unsupported-versions-of-the-programmable-video-sdk). Support for the 1.x version ended on December 4th, 2020.
 
+2.21.2 (In Progress)
+====================
+
+Bug Fixes
+---------
+
+- Fixed the issue where some extraneous errors were logged to console when a video track was stopped. (VIDEO-9511)
+
 2.21.1 (March 22, 2022)
 =======================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 Bug Fixes
 ---------
 
-- Fixed the issue where some extraneous errors were logged to console when a video track was stopped. (VIDEO-9511)
+- Fixed an issue where some extraneous errors were logged to console when a video track was stopped. (VIDEO-9511)
 
 2.21.1 (March 22, 2022)
 =======================

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -469,12 +469,7 @@ class PeerConnectionV2 extends StateMachine {
    * @returns {boolean} true if encodings were updated.
    */
   _maybeUpdateEncodings(track, encodings, trackReplaced = false) {
-    if (track.kind !== 'video') {
-      return false;
-    }
-
-    if (track.readyState === 'ended') {
-      // do not attempt to configure stopped tracks.
+    if (track.kind !== 'video' || track.readyState === 'ended') {
       return false;
     }
 

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -472,6 +472,12 @@ class PeerConnectionV2 extends StateMachine {
     if (track.kind !== 'video') {
       return false;
     }
+
+    if (track.readyState === 'ended') {
+      // do not attempt to configure stopped tracks.
+      return false;
+    }
+
     const browser = util.guessBrowser();
 
     // Note(mpatwardhan): always configure encodings for safari.
@@ -522,7 +528,9 @@ class PeerConnectionV2 extends StateMachine {
       ];
 
       const trackPixels =  width * height;
+      console.warn('makarand trackPixels: ', trackPixels);
       const activeLayersInfo = pixelsToMaxActiveLayers.find(layer => trackPixels >= layer.pixels);
+      console.warn('makarand activeLayersInfo: ', activeLayersInfo);
       const activeLayers = Math.min(encodings.length, activeLayersInfo.maxActiveLayers);
       encodings.forEach((encoding, i) => {
         const enabled  = i < activeLayers;

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -528,9 +528,7 @@ class PeerConnectionV2 extends StateMachine {
       ];
 
       const trackPixels =  width * height;
-      console.warn('makarand trackPixels: ', trackPixels);
       const activeLayersInfo = pixelsToMaxActiveLayers.find(layer => trackPixels >= layer.pixels);
-      console.warn('makarand activeLayersInfo: ', activeLayersInfo);
       const activeLayers = Math.min(encodings.length, activeLayersInfo.maxActiveLayers);
       encodings.forEach((encoding, i) => {
         const enabled  = i < activeLayers;

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -186,6 +186,14 @@ describe('PeerConnectionV2', () => {
         preferredCodecs: { audio: [], video: [{ codec: 'vp8', simulcast: true }] }
       },
       {
+        browser: 'chrome',
+        testName: 'does not update encodings when track is stopped',
+        readyState: 'ended',
+        width: 960,
+        height: 540,
+        encodings: [{}, {}, {}],
+      },
+      {
         browser: 'safari',
         testName: 'updates encoding for safari (irrespective of adaptiveSimulcast) ',
         width: 480,
@@ -229,7 +237,7 @@ describe('PeerConnectionV2', () => {
         height: 270,
         encodings: [{}, {}, {}],
       }
-    ].forEach(({ width, height, encodings, testName, browser, preferredCodecs, trackReplaced = false, expectedEncodings = null, isScreenShare = false, kind = 'video' }) => {
+    ].forEach(({ width, height, encodings, testName, browser, preferredCodecs, trackReplaced = false, expectedEncodings = null, isScreenShare = false, kind = 'video', readyState = 'live' }) => {
       it(`${browser}:${testName}`, () => {
         stub = stub.returns(browser);
         const trackSettings = { width, height };
@@ -238,6 +246,7 @@ describe('PeerConnectionV2', () => {
         }
         const mediaStreamTrack = {
           kind,
+          readyState,
           getSettings: () => trackSettings
         };
 

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -182,6 +182,7 @@ describe('PeerConnectionV2', () => {
         testName: 'does not update encodings when not using adaptive simulcast',
         width: 960,
         height: 540,
+        readyState: 'live',
         encodings: [{}, {}, {}],
         preferredCodecs: { audio: [], video: [{ codec: 'vp8', simulcast: true }] }
       },


### PR DESCRIPTION
For adaptive simulcast we configure simulcast layers depending on the track dimensions. This code encounters an exception and emits a console error for tracks that are stopped.  Thats because stopped track return `NaN` values for width and height [here](https://github.com/twilio/twilio-video.js/blob/82995cd8515ed384fe82acce23aa9340c2eb2f98/lib/signaling/v2/peerconnection.js#L521)

This change fixes this by not attempting to change encodings for stopped tracks. 


**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

A description of what this PR does.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Included screenshot as PR comment (if needed)
* [x] Ready for review
