### PR TITLE
Noise cancellation api update

### DIFF
--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -169,6 +169,7 @@ export type NoiseCancellationVendor = 'krisp' | 'rnnoise';
 
 export interface NoiseCancellation {
   vendor: NoiseCancellationVendor;
+  sourceTrack: MediaStreamTrack;
   enable: () => Promise<void>;
   disable: () => Promise<void>;
 }


### PR DESCRIPTION
While working on integrating  noise cancellation API with react app, I found two issues

1) We have some stricter type check against the tracks passed to connect being of type es5/LocalAudioTrack
a small refactor (which also makes the code cleaner) fixed this.

2) Ahoy app call getSettings() on published LocalTrack.mediaStream Tracks , This won't work with track cleaned with noise cancellation. To fix this added access to srcTrack in `NoiseCancellation` interface. 
This part needs an update to API documentation and more discussion - but for now I would like to merge this to get the pilot out along with Ahoy app implementation.
 
**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

A description of what this PR does.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review
