### PR TITLE
add NoiseCancellation.isEnabled property

### DIFF
--- a/assets/noisecancellation/rnnoise/1.0.0/rnnoise_sdk.mjs
+++ b/assets/noisecancellation/rnnoise/1.0.0/rnnoise_sdk.mjs
@@ -1,4 +1,6 @@
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+// Author: Makarand Patwardhan
+// Implements interface to interact with twilio-video SDK
+
 /* eslint-disable no-console */
 async function fetchAndCompileWebAssemblyModule(moduleUrl) {
   const response = await fetch(moduleUrl);

--- a/assets/noisecancellation/rnnoise/1.0.0/rnnoise_sdk.mjs
+++ b/assets/noisecancellation/rnnoise/1.0.0/rnnoise_sdk.mjs
@@ -50,9 +50,11 @@ class RNNoiseNode extends AudioWorkletNode {
   }
   enable() {
     this.port.postMessage('enable');
+    this._isEnabled = true;
   }
   disable() {
     this.port.postMessage('disable');
+    this._isEnabled = false;
   }
   destroy() {
     this.port.postMessage('destroy');

--- a/lib/media/track/noisecancellationimpl.ts
+++ b/lib/media/track/noisecancellationimpl.ts
@@ -28,6 +28,13 @@ export class NoiseCancellationImpl implements NoiseCancellation {
   }
 
   /**
+   * @returns {boolean} true if noise cancellation is enabled
+   */
+  get isEnabled(): boolean {
+    return this._processor.isEnabled();
+  }
+
+  /**
    * enables noise cancellation
    */
   enable() : Promise<void> {

--- a/test/integration/spec/noisecancellation.js
+++ b/test/integration/spec/noisecancellation.js
@@ -37,9 +37,15 @@ describe('createLocalAudioTrack', () => {
           assert(audioTrack.noiseCancellation, `unexpected audioTrack.noiseCancellation: ${audioTrack.noiseCancellation}`);
           assert.equal(audioTrack.noiseCancellation.vendor, expectedVendor, 'unexpected vendor');
 
+          // ensure that source track is accessible.
+          assert(audioTrack.noiseCancellation.sourceTrack.getSettings());
+
           // verify that noise cancellation can be enable/disable'd.
-          audioTrack.noiseCancellation.disable();
-          audioTrack.noiseCancellation.enable();
+          await audioTrack.noiseCancellation.disable();
+          assert.equal(audioTrack.noiseCancellation.isEnabled, false, `unexpected audioTrack.noiseCancellation.isEnabled:${audioTrack.noiseCancellation.isEnabled}`);
+
+          await audioTrack.noiseCancellation.enable();
+          assert.equal(audioTrack.noiseCancellation.isEnabled, true, `unexpected audioTrack.noiseCancellation.isEnabled:${audioTrack.noiseCancellation.isEnabled}`);
 
         } else {
           assert.equal(audioTrack.noiseCancellation, null, `unexpected audioTrack.noiseCancellation: ${audioTrack.noiseCancellation}`);

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -168,8 +168,10 @@ export interface CreateLocalTrackOptions extends MediaTrackConstraints {
 export type NoiseCancellationVendor = 'krisp' | 'rnnoise';
 
 export interface NoiseCancellation {
-  vendor: NoiseCancellationVendor;
-  sourceTrack: MediaStreamTrack;
+  readonly vendor: NoiseCancellationVendor;
+  readonly sourceTrack: MediaStreamTrack;
+  readonly isEnabled: boolean;
+
   enable: () => Promise<void>;
   disable: () => Promise<void>;
 }


### PR DESCRIPTION
While working on integrating noise cancellation with ahoy app, I found need for this property. Adding it to the public interface. 
 
**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

A description of what this PR does.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review
