### PR TITLE
Video 3576 - emit dimensionsChanged event on track init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Bug Fixes
 ---------
 
 - Fixed an issue where some extraneous errors were logged to console when a video track was stopped. (VIDEO-9511)
+- Fixed an issue where the `dimensionsChanged` event was not firing when the track dimensions first became available. (VIDEO-3576)
 
 2.21.1 (March 22, 2022)
 =======================

--- a/lib/media/track/videotrack.js
+++ b/lib/media/track/videotrack.js
@@ -229,6 +229,7 @@ class VideoTrack extends MediaTrack {
     this.dimensions.height = dummyEl.videoHeight;
 
     this._log.debug('Dimensions:', this.dimensions);
+    this.emit(VideoTrack.DIMENSIONS_CHANGED, this);
     return super._start.call(this, dummyEl);
   }
 

--- a/test/unit/spec/media/track/videotrack.js
+++ b/test/unit/spec/media/track/videotrack.js
@@ -399,6 +399,22 @@ describe('VideoTrack', () => {
     });
   });
 
+  describe('#_start', () => {
+    it('should emit the dimensionsChanged event when new dimensions are available', () => {
+      const listener = sinon.stub();
+      const dummyEl = { videoWidth: 1920, videoHeight: 1080 };
+      videoTrack.on('dimensionsChanged', listener);
+      videoTrack._start(dummyEl);
+      sinon.assert.calledOnce(listener);
+      sinon.assert.calledWithMatch(listener, {
+        dimensions: {
+          width: 1920,
+          height: 1080,
+        },
+      });
+    });
+  });
+
   describe('#_captureFrames', () => {
     // As of node12, the Promise.then and Promise.finally requires separate
     // promises to resolve internally.


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

JIRA Ticket: [VIDEO-3576](https://issues.corp.twilio.com/browse/VIDEO-3576)

### Description

This pull requests adds a change that causes a `VideoTrack` to emit the `dimensionsChanged` event when the track dimensions first become available (during the `_start` method).

This solves an issue that a couple customers have faced where an application cannot detect the dimensions of portrait-oriented videos, and therefore cannot style them correctly in the UI. See #1470 and [VIDEO-9546](https://issues.corp.twilio.com/browse/VIDEO-9546).

Applications cannot detect the initial dimensions of a track because the `dimensionsChanged` event does not fire when the track's dimensions change from `null` to their known value. 

To demonstrate the issue, you can look at this simple reproduction of the bug: https://video-dimensions-bug.glitch.me (source code [here](https://glitch.com/edit/#!/video-dimensions-bug?path=script.js%3A21%3A0)). Notice that the app cannot report the actual dimensions of the track, despite the fact that it is listening to the `dimensionsChanged` event.

To demonstrate the fix, you can look at the same repro with the version of the twilio-video SDK from this pull request: https://video-dimensions-fix.glitch.me (source code [here](https://glitch.com/edit/#!/video-dimensions-fix?path=script.js%3A1%3A16)). Notice that the track dimensions are correctly reported, since the `dimensionsChanged` event is now emitted when the dimensions change. 

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
