### PR TITLE
VIDEO-9802 DataTrack subscription state is now an object instead of a data channel label.

### DIFF
--- a/lib/signaling/v3/room.js
+++ b/lib/signaling/v3/room.js
@@ -126,7 +126,7 @@ class RoomV3 extends RoomV2 {
   _initTrackSubscriptionsSignaling() {
     this._trackSubscriptionsSignaling.on('updated', (media, data, errors) => {
       const trackSidsToTrackSignalings = this._getTrackSidsToTrackSignalings();
-      const dataTrackSidsToDataChannelLabels = new Map(Object.entries(data));
+      const dataTrackSidsToTrackStates = new Map(Object.entries(data));
       const mediaTrackSidsToTrackStates = new Map(Object.entries(media));
       const trackSidsToErrors = new Map(Object.entries(errors));
 
@@ -152,13 +152,13 @@ class RoomV3 extends RoomV2 {
         trackSignaling.setSwitchedOff(isSwitchedOff, switchOffReason);
       });
 
-      dataTrackSidsToDataChannelLabels.forEach((dataChannelLabel, sid) => {
+      dataTrackSidsToTrackStates.forEach(({ label }, sid) => {
         const trackSignaling = trackSidsToTrackSignalings.get(sid);
         if (!trackSignaling) {
-          this._pendingDataChannelLabels.set(sid, dataChannelLabel);
+          this._pendingDataChannelLabels.set(sid, label);
           return;
         }
-        this._getTrackReceiver(dataChannelLabel).then(trackReceiver => trackSignaling.setTrackTransceiver(trackReceiver, true));
+        this._getTrackReceiver(label).then(trackReceiver => trackSignaling.setTrackTransceiver(trackReceiver, true));
       });
 
       trackSidsToErrors.forEach(({ code, message }, sid) => {
@@ -170,7 +170,7 @@ class RoomV3 extends RoomV2 {
 
       trackSidsToTrackSignalings.forEach(trackSignaling => {
         const { sid } = trackSignaling;
-        if (!mediaTrackSidsToTrackStates.has(sid) && !dataTrackSidsToDataChannelLabels.has(sid)) {
+        if (!mediaTrackSidsToTrackStates.has(sid) && !dataTrackSidsToTrackStates.has(sid)) {
           this._pendingSwitchOffStates.delete(sid);
           this._pendingTrackMids.delete(sid);
           trackSignaling.setTrackTransceiver(null, false);

--- a/test/unit/spec/signaling/v3/room.js
+++ b/test/unit/spec/signaling/v3/room.js
@@ -1441,7 +1441,7 @@ describe('RoomV3', () => {
           mediaTrack.setTrackTransceiver = sinon.spy((...args) => mediaSetTrackTransceiver.apply(mediaTrack, args));
 
           dataTrackTransport.emit('message', {
-            data: { MT5: '6' },
+            data: { MT5: { label: '6' } },
             // eslint-disable-next-line camelcase
             media: { MT3: { state: 'ON', mid: '0' } },
             revision: 2,


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

This PR implements [this change](https://code.hq.twilio.com/client/room-signaling-protocol/pull/87/files) in the Track Subscriptions MSP spec change.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
