### PR TITLE
VIDEO-9966 - use no media_region as a signal to revert to unicast

### DIFF
--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -410,6 +410,8 @@ class PeerConnectionV2 extends StateMachine {
       return false;
     }
 
+    console.trace('makarand: _shouldApplySimulcast');
+
     // adaptiveSimulcast is set to false after connected message is received if other party does not support it.
     const simulcast = this._preferredVideoCodecs.some(cs => {
       return cs.codec.toLowerCase() === 'vp8' && cs.simulcast && cs.adaptiveSimulcast !== false;

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -410,8 +410,6 @@ class PeerConnectionV2 extends StateMachine {
       return false;
     }
 
-    console.trace('makarand: _shouldApplySimulcast');
-
     // adaptiveSimulcast is set to false after connected message is received if other party does not support it.
     const simulcast = this._preferredVideoCodecs.some(cs => {
       return cs.codec.toLowerCase() === 'vp8' && cs.simulcast && cs.adaptiveSimulcast !== false;

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -313,9 +313,11 @@ class RoomV2 extends RoomSignaling {
 
     this._update(initialState);
 
-    // NOTE(mpatwardhan) after initial state we know if publisher_hints are enabled or not
-    // if they are not enabled. we need to undo simulcast that if it was enabled with initial offer.
-    this._peerConnectionManager.setEffectiveAdaptiveSimulcast(this._publisherHintsSignaling.isSetup);
+    // NOTE(mpatwardhan) after initial state we know if we are connected to group room or not.
+    // if we are not connected to group room turn off adaptive simulcast.
+    if (!this.mediaRegion) {
+      this._peerConnectionManager.setEffectiveAdaptiveSimulcast(false);
+    }
   }
 
   /**

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -315,9 +315,7 @@ class RoomV2 extends RoomSignaling {
 
     // NOTE(mpatwardhan) after initial state we know if we are connected to group room or not.
     // if we are not connected to group room turn off adaptive simulcast.
-    if (!this.mediaRegion) {
-      this._peerConnectionManager.setEffectiveAdaptiveSimulcast(false);
-    }
+    this._peerConnectionManager.setEffectiveAdaptiveSimulcast(!!this.mediaRegion);
   }
 
   /**

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -313,8 +313,8 @@ class RoomV2 extends RoomSignaling {
 
     this._update(initialState);
 
-    // NOTE(mpatwardhan) after initial state we know if we are connected to group room or not.
-    // if we are not connected to group room turn off adaptive simulcast.
+    // NOTE(mpatwardhan) after initial state we can find out if we are connected to a P2P or group room by checking if there is a mediaRegion.
+    // if we are not connected to group room, turn off adaptive simulcast.
     this._peerConnectionManager.setEffectiveAdaptiveSimulcast(!!this.mediaRegion);
   }
 


### PR DESCRIPTION
when connected with `preferredVideoCodecs="auto"` we enable adaptive simulcast. That mean we default to  simulcast and if joined a p2p room revert back to unicast. Previously we used the media_signaling payload in  `connected` response from room service, as a signal to determine if we need to revert to unicast or not. We reverted to unicast if publisher_hint MSP channel was not part of the connected response.

With large rooms, connected response  does not contain information about media_signaling. This caused us to always revert to unicast for large rooms. To fix this issue this code change now looks at `media_region` in connected response as a clue to decide on reverting to unicast. `media_region` is available only when connecting to group rooms - so If media_region is not part of connected response we will revert to unicast.



**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

A description of what this PR does.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Included screenshot as PR comment (if needed)
* [x] Ready for review
