### PR TITLE
VIDEO-10023: handle VMS failover

### DIFF
--- a/lib/signaling/v3/tracksubscriptionssignaling.js
+++ b/lib/signaling/v3/tracksubscriptionssignaling.js
@@ -29,6 +29,13 @@ class TrackSubscriptionsSignaling extends MediaSignaling {
             break;
         }
       });
+
+      // NOTE(mpatwardhan): we receive ready message every time
+      // MSP channel is established. That means at startup and and at every VMS-failover.
+      if (this._currentRevision !== null) {
+        log.warn('resetting current version after VMS failover', this._currentRevision);
+        this._currentRevision = null;
+      }
     });
   }
 


### PR DESCRIPTION
**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details


### Description
Track subscription protocol keeps track of last version of the message received, and ignores if new messages has lower version. However when VMS failovers the message version starts over again. This change ensures that we reset our version number when SDK detects VMS failover.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review
