### PR TITLE
Fix warning is not bubbling up

### DIFF
--- a/lib/signaling/v2/twilioconnectiontransport.js
+++ b/lib/signaling/v2/twilioconnectiontransport.js
@@ -535,6 +535,7 @@ function setupTransport(transport) {
           case 'connected':
           case 'synced':
           case 'update':
+          case 'warning':
             transport.emit('message', message);
             return;
           case 'disconnected':

--- a/test/unit/spec/signaling/v2/twilioconnectiontransport.js
+++ b/test/unit/spec/signaling/v2/twilioconnectiontransport.js
@@ -1173,7 +1173,8 @@ describe('TwilioConnectionTransport', () => {
         [
           { session: 'foo', type: 'connected' },
           { type: 'synced' },
-          { type: 'update' }
+          { type: 'update' },
+          { type: 'warning' }
         ].forEach(expectedMessage => {
           context(`"${expectedMessage.type}"`, () => {
             let connected;


### PR DESCRIPTION
Found a bug where warning RSP messages are not bubbling up.