### PR TITLE
VIDEO-10104 -  send switchOn message after ms track changes

### DIFF
--- a/lib/signaling/v3/room.js
+++ b/lib/signaling/v3/room.js
@@ -147,9 +147,16 @@ class RoomV3 extends RoomV2 {
           trackSignaling.setTrackTransceiver(null, isSwitchedOff);
         }
         if (!isSwitchedOff) {
-          this._getTrackReceiver(mid, 'mid').then(trackReceiver => trackSignaling.setTrackTransceiver(trackReceiver, true));
+          this._getTrackReceiver(mid, 'mid').then(trackReceiver => {
+            trackSignaling.setTrackTransceiver(trackReceiver, true);
+
+            // NOTE(mpatwardhan): when track is switched on, send the switchOn message
+            // only after track receiver is set so that application can access (new) mediaStreamTrack
+            trackSignaling.setSwitchedOff(isSwitchedOff, switchOffReason);
+          });
+        } else {
+          trackSignaling.setSwitchedOff(isSwitchedOff, switchOffReason);
         }
-        trackSignaling.setSwitchedOff(isSwitchedOff, switchOffReason);
       });
 
       dataTrackSidsToTrackStates.forEach(({ label }, sid) => {

--- a/test/unit/spec/signaling/v3/room.js
+++ b/test/unit/spec/signaling/v3/room.js
@@ -1426,7 +1426,6 @@ describe('RoomV3', () => {
             type: 'track_subscriptions'
           });
           track = await trackSwitchOnPromise;
-          await test.room._getTrackReceiver('0', 'mid');
           sinon.assert.calledWith(track.setTrackTransceiver, trackReceiver3, true);
           sinon.assert.calledWith(track.setSwitchedOff, false, null);
         });


### PR DESCRIPTION
when track subscriptions changed mid line for track or attached mid for the first time we send 'switchOn message. However this was being sent synchronously, while trackReceiver was being set async, causing applications to receives the `switchOn` message with either null or stale mediaStreamTrack. This change fixes that.
 
**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

A description of what this PR does.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review
