### PR TITLE
fix dimensionsChanged/videoWidth bug

### DIFF
--- a/lib/media/track/videotrack.js
+++ b/lib/media/track/videotrack.js
@@ -457,6 +457,10 @@ class VideoTrack extends MediaTrack {
 VideoTrack.DIMENSIONS_CHANGED = 'dimensionsChanged';
 
 function dimensionsChanged(track, elem) {
+  if (!elem) {
+    return false;
+  }
+
   return track.dimensions.width !== elem.videoWidth
     || track.dimensions.height !== elem.videoHeight;
 }


### PR DESCRIPTION
Avoid 'Cannot read property of undefined/null' by checking if elem is still set within the func called by the resize callback (where previously it was only guarded before setting up the callback).

I didn't dive deeper to understand _why_ `this._dummyEl` is null when this onresize callback is called - I guess because `_end()` was called and null'd it out.  Seems unlikely to cause any real issues though, since the net effect is just to guard _setting values on the now-null _dummyEl_ anyway.

We've had over a dozen uesrs run into this bug in production.  All on iOS/Safari.
![image](https://user-images.githubusercontent.com/2048/170847219-9925de80-aa02-45a7-8a36-02cf274aca4a.png)
