### PR TITLE
Added details in changelog entry and updated insights payload constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Bug Fixes
 
 - Fixed an issue where some extraneous errors were logged to console when a video track was stopped. (VIDEO-9511)
 - Fixed an issue where the `dimensionsChanged` event was not firing when the track dimensions first became available. (VIDEO-3576)
-- Removed references to node dependencies that causes build errors on some platforms. (VIDEO-9282)
+- Removed references to node dependencies that causes build errors on Angular and Vue. (VIDEO-9282)
 - Fixed an issue where incorrect device was detected when using iPad in Desktop Website mode. (VIDEO-8282)
 
 2.21.1 (March 22, 2022)

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -7,13 +7,13 @@ module.exports.SDP_FORMAT = 'unified';
 module.exports.hardwareDevicePublisheriPad = {
   hwDeviceManufacturer: 'Apple',
   hwDeviceModel: 'iPad',
-  hwDeviceType: 'Tablet'
+  hwDeviceType: 'tablet'
 };
 
 module.exports.hardwareDevicePublisheriPhone = {
   hwDeviceManufacturer: 'Apple',
   hwDeviceModel: 'iPhone',
-  hwDeviceType: 'Mobile'
+  hwDeviceType: 'mobile'
 };
 
 module.exports.DEFAULT_ENVIRONMENT = 'prod';

--- a/test/unit/spec/util/insightspublisher.js
+++ b/test/unit/spec/util/insightspublisher.js
@@ -254,7 +254,7 @@ describe('InsightsPublisher', () => {
             false,
             { hwDeviceManufacturer: 'Apple',
               hwDeviceModel: 'iPad',
-              hwDeviceType: 'Tablet' },
+              hwDeviceType: 'tablet' },
           ],
           [
             'iPhone',
@@ -262,7 +262,7 @@ describe('InsightsPublisher', () => {
             true,
             { hwDeviceManufacturer: 'Apple',
               hwDeviceModel: 'iPhone',
-              hwDeviceType: 'Mobile' },
+              hwDeviceType: 'mobile' },
           ]
         ].forEach(([device, isIpadBool, isIphoneBool, hwFields]) => {
           it(`${device} device parameters`, async () => {


### PR DESCRIPTION
Addressing comments from QE in these two tickets:
[VIDEO-3612](https://issues.corp.twilio.com/browse/VIDEO-3612)
[VIDEO-8282](https://issues.corp.twilio.com/browse/VIDEO-8282)

- Editing the CHANGELOG to be more specific about which frameworks we fixed.
- Fixed our insights payload to use `mobile` and `tablet` instead of `Mobile` and `Tablet` for consistency.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
