### PR TITLE
large room audio dummy element handling 

### DIFF
--- a/lib/media/track/audiotrack.js
+++ b/lib/media/track/audiotrack.js
@@ -31,18 +31,6 @@ class AudioTrack extends MediaTrack {
   }
 
   /**
-   * @private
-   */
-  _start() {
-    super._start();
-    if (this._dummyEl) {
-      // once started let go of dummy element
-      this._dummyEl.srcObject = null;
-      this._dummyEl = null;
-    }
-  }
-
-  /**
    * Create an HTMLAudioElement and attach the {@link AudioTrack} to it.
    *
    * The HTMLAudioElement's <code>srcObject</code> will be set to a new

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -125,7 +125,9 @@ class MediaTrack extends Track {
 
     const self = this;
     log.debug('Initializing');
-    this._dummyEl = this._createElement();
+    if (!this._dummyEl) {
+      this._dummyEl = this._createElement();
+    }
 
     this.mediaStreamTrack.addEventListener('ended', function onended() {
       self._end();
@@ -195,9 +197,9 @@ class MediaTrack extends Track {
       mediaStream.addTrack(mediaStreamTrack);
     }
 
-    // NOTE(mpatwardhan): resetting `srcObject` here, causes flicker (JSDK-2641), but it lets us
-    // sidestep the chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1052353
-    el.srcObject = mediaStream;
+    if (!el.srcObject) {
+      el.srcObject = mediaStream;
+    }
     el.autoplay = true;
     el.playsInline = true;
 

--- a/test/unit/spec/media/track/audiotrack.js
+++ b/test/unit/spec/media/track/audiotrack.js
@@ -87,10 +87,6 @@ describe('AudioTrack', () => {
             it('should set the element\'s oncanplay to null', () => {
               assert.equal(dummyElement.oncanplay, null);
             });
-
-            it('should set the element\'s srcObject to null', () => {
-              assert.equal(dummyElement.srcObject, null);
-            });
           });
         }
       });


### PR DESCRIPTION
In large rooms, as we switch m-lines RemoteAudioTracks are attached to new MediaStreamTrack. In this process we were creating new audio elements to listen to "started" event. Creation of new audio elements and attaching srcObject properties causes creation of new WebMediaPlayers. With frequent track switching (with large room's n-loudest algorithm) causes very frequent creation and destruction of media players. 

This change avoid creating/destroying web media players by letting dummy elements stay longer. This essentially undo's the optimization introduced in https://github.com/twilio/twilio-video.js/pull/1534. Its okay because chrome 92 [changes](https://bugs.chromium.org/p/chromium/issues/detail?id=1232649) that prompted  https://github.com/twilio/twilio-video.js/pull/1534 were reverted. 
**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

A description of what this PR does.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review
