### PR TITLE
Adding platformName into insights payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 ====================
 
 - Fixed an issue where the generated API documentation has a missing search bar.
+- Fixed platform name when using iPhone or iPad in Desktop Website mode.
 
 2.21.2 (June 1, 2022)
 =====================

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -7,13 +7,15 @@ module.exports.SDP_FORMAT = 'unified';
 module.exports.hardwareDevicePublisheriPad = {
   hwDeviceManufacturer: 'Apple',
   hwDeviceModel: 'iPad',
-  hwDeviceType: 'tablet'
+  hwDeviceType: 'tablet',
+  platformName: 'iOS'
 };
 
 module.exports.hardwareDevicePublisheriPhone = {
   hwDeviceManufacturer: 'Apple',
   hwDeviceModel: 'iPhone',
-  hwDeviceType: 'mobile'
+  hwDeviceType: 'mobile',
+  platformName: 'iOS'
 };
 
 module.exports.DEFAULT_ENVIRONMENT = 'prod';

--- a/test/unit/spec/util/insightspublisher.js
+++ b/test/unit/spec/util/insightspublisher.js
@@ -254,7 +254,8 @@ describe('InsightsPublisher', () => {
             false,
             { hwDeviceManufacturer: 'Apple',
               hwDeviceModel: 'iPad',
-              hwDeviceType: 'tablet' },
+              hwDeviceType: 'tablet',
+              platformName: 'iOS' },
           ],
           [
             'iPhone',
@@ -262,7 +263,8 @@ describe('InsightsPublisher', () => {
             true,
             { hwDeviceManufacturer: 'Apple',
               hwDeviceModel: 'iPhone',
-              hwDeviceType: 'mobile' },
+              hwDeviceType: 'mobile',
+              platformName: 'iOS' },
           ]
         ].forEach(([device, isIpadBool, isIphoneBool, hwFields]) => {
           it(`${device} device parameters`, async () => {


### PR DESCRIPTION
Adding in the `platformName` into our insights payload to properly identify the device platform.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

A description of what this PR does.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
