### PR TITLE
Video 10221 update common issues

### DIFF
--- a/COMMON_ISSUES.md
+++ b/COMMON_ISSUES.md
@@ -121,7 +121,7 @@ before opening a new issue. We recommend regularly upgrading to the latest versi
 <summary>Video elements may not be visible when applying a 3d transform</summary>
 <p>
 
-   In some cases, a video element may not be visible when using a 3d CSS transform to mirror a local video track. It is recommended that a 2d transform be used instead.
+   In some cases, a video element may not be visible when using a 3d CSS transform (such as `rotateY(180deg)`) to mirror a local video track. It is recommended that a 2d transform be used instead.
 
    Recommended 2d transform to mirror a video track:
 ```css
@@ -389,10 +389,10 @@ trouble with twilio-video.js, ensure these are not running.
 </p>
 </details>
 <details>
-<summary>seSinkId method is not implemented in all browsers</summary>
+<summary>setSinkId method is not implemented in all browsers</summary>
 <p>
 
-   The `audioElement.setSinkId()` method, which is used to change the audio output device for a given HTML audio element, is only implemented in Desktop Chrome and Desktop Edge. Therefore, it will not be possible for users to change their audio output device in other browsers. Users will have to use their operating system settings to change their audio output device instead. 
+   The `audioElement.setSinkId()` method, which is used to change the audio output device for a given HTML audio element, is only implemented in Desktop Chrome and Desktop Edge. Therefore, it is not possible for users to change their audio output device in other browsers. Users will have to use their operating system settings to change their audio output device instead. 
 
    More information about this method (including browser compatibility) is available [here](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/setSinkId).
 </p>

--- a/COMMON_ISSUES.md
+++ b/COMMON_ISSUES.md
@@ -117,6 +117,22 @@ before opening a new issue. We recommend regularly upgrading to the latest versi
    once a Participant unpublishes a MediaTrack of any kind (audio or video), it will not be able to publish another MediaTrack of the same kind.        DataTracks are not affected. We have escalated this bug to the Safari Team and are keeping track of related developments.
 </p>
 </details>
+<details>
+<summary>Video elements may not be visible when applying a 3d transform</summary>
+<p>
+
+   In some cases, a video element may not be visible when using a 3d CSS transform to mirror a local video track. It is recommended that a 2d transform be used instead.
+
+   Recommended 2d transform to mirror a video track:
+```css
+transform: scaleX(-1)
+```
+
+   This issue is also present in Safari mobile.
+
+   For more information, please see the discussion in [this issue](https://github.com/twilio/twilio-video.js/issues/1724).
+</p>
+</details>
 
 ### Safari mobile
 <details>
@@ -370,5 +386,14 @@ twilio-video.js to fail. Examples of such plugins include
 
 These are unsupported and likely to break twilio-video.js. If you are having
 trouble with twilio-video.js, ensure these are not running.
+</p>
+</details>
+<details>
+<summary>seSinkId method is not implemented in all browsers</summary>
+<p>
+
+   The `audioElement.setSinkId()` method, which is used to change the audio output device for a given HTML audio element, is only implemented in Desktop Chrome and Desktop Edge. Therefore, it will not be possible for users to change their audio output device in other browsers. Users will have to use their operating system settings to change their audio output device instead. 
+
+   More information about this method (including browser compatibility) is available [here](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/setSinkId).
 </p>
 </details>


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

This pull request adds two new entries to the Common Issues document to resolve the following tickets:

[VIDEO-10211](https://issues.corp.twilio.com/browse/VIDEO-10221): This ticket relates to an issue where local video tracks occasionally cannot be seen in Safari after being mirrored with a 3d CSS transform. The solution is to use a 2d transform instead.

[VIDEO-8757](https://issues.corp.twilio.com/browse/VIDEO-8757): This ticket relates to an issue where it is not possible for a user to change their audio output device in some browsers. This is because the related method `setSindId()` is not implemented in all browsers. The workaround is for users to use their operating system settings to change their audio output devices.

You can view the new Common Issues doc [here](https://github.com/twilio/twilio-video.js/blob/VIDEO-10221-update-common-issues/COMMON_ISSUES.md).

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
