### PR TITLE
VIDEO-10307 isSupported now returns false when on plan-b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 
 **Version 1.x reached End of Life on September 8th, 2021.** See the changelog entry [here](https://www.twilio.com/changelog/end-of-life-complete-for-unsupported-versions-of-the-programmable-video-sdk). Support for the 1.x version ended on December 4th, 2020.
 
+2.22.2 (In Progress)
+====================
+
+Changes
+-------
+
+- `isSupported` flag now returns `false` if the browser does not support the Unified Plan SDP format. (VIDEO-10307)
+
 2.22.1 (July 11, 2022)
 ======================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changes
 -------
 
 - `isSupported` flag now returns `false` if the browser does not support the Unified Plan SDP format. (VIDEO-10307)
+  
   The following is a list of browsers with Unified Plan as the default SDP format.
   - Chrome 72+
   - Safari 12.1+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Changes
 -------
 
 - `isSupported` flag now returns `false` if the browser does not support the Unified Plan SDP format. (VIDEO-10307)
+  The following is a list of browsers with Unified Plan as the default SDP format.
+  - Chrome 72+
+  - Safari 12.1+
+  - Firefox 38+
 
 2.22.1 (July 11, 2022)
 ======================

--- a/lib/util/support.js
+++ b/lib/util/support.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { guessBrowser, support: isWebRTCSupported } = require('../webrtc/util');
+const { getSdpFormat } = require('../webrtc/util/sdp');
 const { isAndroid, isMobile, isNonChromiumEdge, rebrandedChromeBrowser, mobileWebKitBrowser } = require('./browserdetection');
 
 const SUPPORTED_CHROME_BASED_BROWSERS = [
@@ -41,6 +42,7 @@ function isSupported() {
 
   return !!browser
     && isWebRTCSupported()
+    && getSdpFormat() === 'unified'
     && (!rebrandedChrome || SUPPORTED_CHROME_BASED_BROWSERS.includes(rebrandedChrome))
     && !isNonChromiumEdge(browser)
     && (!mobileWebKit || SUPPORTED_MOBILE_WEBKIT_BASED_BROWSERS.includes(mobileWebKit))

--- a/lib/webrtc/util/sdp.js
+++ b/lib/webrtc/util/sdp.js
@@ -36,6 +36,13 @@ function checkIfSdpSemanticsIsSupported() {
 var chromeSdpFormat = null;
 
 /**
+ * Clear cached Chrome's SDP format
+ */
+function clearChromeCachedSdpFormat() {
+  chromeSdpFormat = null;
+}
+
+/**
  * Get Chrome's default SDP format.
  * @returns {'planb'|'unified'}
  */
@@ -299,6 +306,7 @@ function updateUnifiedPlanTrackIdsToSSRCs(trackIdsToSSRCs, sdp) {
   return updateTrackIdsToSSRCs(getUnifiedPlanTrackIdsToSSRCs, trackIdsToSSRCs, sdp);
 }
 
+exports.clearChromeCachedSdpFormat = clearChromeCachedSdpFormat;
 exports.getSdpFormat = getSdpFormat;
 exports.getMediaSections = getMediaSections;
 exports.getPlanBTrackIds = getPlanBTrackIds;

--- a/lib/webrtc/util/sdp.js
+++ b/lib/webrtc/util/sdp.js
@@ -50,12 +50,14 @@ function getChromeDefaultSdpFormat() {
   if (!chromeSdpFormat) {
     if (typeof RTCPeerConnection !== 'undefined'
       && 'addTransceiver' in RTCPeerConnection.prototype) {
+      const pc = new RTCPeerConnection();
       try {
-        new RTCPeerConnection().addTransceiver('audio');
+        pc.addTransceiver('audio');
         chromeSdpFormat = 'unified';
       } catch (e) {
         chromeSdpFormat = 'planb';
       }
+      pc.close();
     } else {
       chromeSdpFormat = 'planb';
     }

--- a/test/lib/mockwebrtc.js
+++ b/test/lib/mockwebrtc.js
@@ -105,6 +105,15 @@ class RTCSessionDescription {
   }
 }
 
+class RTCRtpTransceiver {
+  constructor() {
+
+  }
+  get currentDirection() {
+    return 'foo';
+  }
+}
+
 class RTCPeerConnection extends EventEmitter {
   constructor() {
     super();
@@ -114,6 +123,10 @@ class RTCPeerConnection extends EventEmitter {
     this.peerIdentity = null;
     this.remoteDescription = null;
     this.signalingState = 'stable';
+  }
+
+  addTransceiver() {
+
   }
 
   createOffer() {
@@ -232,6 +245,7 @@ function mockWebRTC(_global) {
   _global.webkitMediaStream = MediaStream;
   _global.MediaStream = MediaStream;
   _global.RTCDataChannel = RTCDataChannel;
+  _global.RTCRtpTransceiver = RTCRtpTransceiver;
   _global.RTCPeerConnection = RTCPeerConnection;
   _global.RTCSessionDescription = RTCSessionDescription;
   _global.attachMediaStream = attachMediaStream;
@@ -250,6 +264,7 @@ module.exports.webkitMediaStream = MediaStream;
 module.exports.getUserMedia = getUserMedia;
 module.exports.navigator = navigator;
 module.exports.RTCDataChannel = RTCDataChannel;
+module.exports.RTCRtpTransceiver = RTCRtpTransceiver;
 module.exports.DUMMY_SDP = DUMMY_SDP;
 module.exports.RTCPeerConnection = RTCPeerConnection;
 module.exports.RTCSessionDescription = RTCSessionDescription;

--- a/test/unit/spec/util/support.js
+++ b/test/unit/spec/util/support.js
@@ -239,6 +239,7 @@ describe('isSupported', () => {
           this.addTransceiver = function() {
             throw new Error();
           };
+          this.close = function() {};
         };
         global.RTCPeerConnection.prototype.addTransceiver = function() {};
         assert.equal(isSupported(), false);

--- a/test/unit/spec/util/support.js
+++ b/test/unit/spec/util/support.js
@@ -238,9 +238,9 @@ describe('isSupported', () => {
         global.RTCPeerConnection = function() {
           this.addTransceiver = function() {
             throw new Error();
-          }
+          };
         };
-        global.RTCPeerConnection.prototype.addTransceiver = function(){};
+        global.RTCPeerConnection.prototype.addTransceiver = function() {};
         assert.equal(isSupported(), false);
       });
     });
@@ -266,7 +266,7 @@ describe('isSupported', () => {
       });
 
       it('and RTCRtpTransceiver is supported but currentDirection is missing', () => {
-        delete RTCRtpTransceiver.prototype.currentDirection;
+        delete global.RTCRtpTransceiver.prototype.currentDirection;
         assert.equal(isSupported(), false);
       });
     });

--- a/test/unit/spec/util/support.js
+++ b/test/unit/spec/util/support.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert');
 const isSupported = require('../../../../lib/util/support');
+const { clearChromeCachedSdpFormat } = require('../../../../lib/webrtc/util/sdp');
 
 describe('isSupported', () => {
   let oldAgent;
@@ -10,6 +11,7 @@ describe('isSupported', () => {
   });
 
   afterEach(() => {
+    clearChromeCachedSdpFormat();
     navigator.userAgent = oldAgent;
     if (global.chrome) {
       delete global.chrome;
@@ -208,6 +210,65 @@ describe('isSupported', () => {
         navigator.brave = brave;
       }
       assert.equal(isSupported(), false);
+    });
+  });
+
+  describe('return false when sdp format is plan-b', () => {
+    describe('and browser is chrome', () => {
+      let oldRTCPeerConnection;
+      let oldUserAgent;
+
+      beforeEach(() => {
+        oldUserAgent = navigator.userAgent;
+        navigator.userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36';
+        oldRTCPeerConnection = global.RTCPeerConnection;
+      });
+
+      afterEach(() => {
+        navigator.userAgent = oldUserAgent;
+        global.RTCPeerConnection = oldRTCPeerConnection;
+      });
+
+      it('and RTCPeerConnection.prototype.addTransceiver is not supported', () => {
+        global.RTCPeerConnection.prototype = {};
+        assert.equal(isSupported(), false);
+      });
+
+      it('and RTCPeerConnection.prototype.addTransceiver throws an exception', () => {
+        global.RTCPeerConnection = function() {
+          this.addTransceiver = function() {
+            throw new Error();
+          }
+        };
+        global.RTCPeerConnection.prototype.addTransceiver = function(){};
+        assert.equal(isSupported(), false);
+      });
+    });
+
+    describe('and browser is safari', () => {
+      let oldUserAgent;
+      let oldRTCRtpTransceiver;
+
+      beforeEach(() => {
+        oldUserAgent = navigator.userAgent;
+        navigator.userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13 Safari/605.1.15';
+        oldRTCRtpTransceiver = global.RTCRtpTransceiver;
+      });
+
+      afterEach(() => {
+        navigator.userAgent = oldUserAgent;
+        global.RTCRtpTransceiver = oldRTCRtpTransceiver;
+      });
+
+      it('and RTCRtpTransceiver is not supported', () => {
+        delete global.RTCRtpTransceiver;
+        assert.equal(isSupported(), false);
+      });
+
+      it('and RTCRtpTransceiver is supported but currentDirection is missing', () => {
+        delete RTCRtpTransceiver.prototype.currentDirection;
+        assert.equal(isSupported(), false);
+      });
     });
   });
 });


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

isSupported now returns false when on plan-b

sources for browser version unified plan support
https://hacks.mozilla.org/2015/06/firefox-multistream-and-renegotiation-for-jitsi-videobridge/
https://webkit.org/blog/8672/on-the-road-to-webrtc-1-0-including-vp8/
https://webrtc.org/getting-started/unified-plan-transition-guide

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
