### PR TITLE
VIDEO-10752 Detach empty MediaStream from media element.

### DIFF
--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -197,9 +197,13 @@ class MediaTrack extends Track {
       mediaStream.addTrack(mediaStreamTrack);
     }
 
+    const isEmptyMediaStream = mediaStream.getTracks().length <= 0;
     if (!el.srcObject) {
-      el.srcObject = mediaStream;
+      el.srcObject = isEmptyMediaStream ? null : mediaStream;
+    } else if (isEmptyMediaStream) {
+      el.srcObject = null;
     }
+
     el.autoplay = true;
     el.playsInline = true;
 

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -197,10 +197,15 @@ class MediaTrack extends Track {
       mediaStream.addTrack(mediaStreamTrack);
     }
 
-    const isEmptyMediaStream = mediaStream.getTracks().length <= 0;
+    const isEmptyVideoMediaStream = this.kind === 'video' && mediaStream.getTracks().length <= 0;
     if (!el.srcObject) {
-      el.srcObject = isEmptyMediaStream ? null : mediaStream;
-    } else if (isEmptyMediaStream) {
+      el.srcObject = isEmptyVideoMediaStream ? null : mediaStream;
+    } else if (isEmptyVideoMediaStream) {
+      // NOTE(mmalavalli): VIDEO-10752 - When a track is switched off, and the attached video element's .srcObject property
+      // is assigned a MediaStream that does not contain any MediaStreamTrack, the browser for some reason caches a snapshot
+      // from the most recently removed MediaStreamTrack and displays it in the video element. The workaround for this is
+      // to set the .srcObject property to null which causes the browser to clear any cached snapshots from the removed
+      // MediaStreamTrack and show a black frame.
       el.srcObject = null;
     }
 

--- a/test/unit/spec/media/track/mediatrack.js
+++ b/test/unit/spec/media/track/mediatrack.js
@@ -510,6 +510,7 @@ describe('MediaTrack', () => {
           });
           MediaStream.prototype.addTrack = sinon.spy();
           MediaStream.prototype.getAudioTracks = sinon.spy(() => [track.mediaStreamTrack]);
+          MediaStream.prototype.getTracks = sinon.spy(() => [track.mediaStreamTrack]);
           MediaStream.prototype.removeTrack = sinon.spy();
           el = document.createElement('audio');
           track = createMediaTrack(1, 'foo', kind, { MediaStream: MediaStream });


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

The description of the issue and the potential fix is specified [here](https://issues.corp.twilio.com/browse/VIDEO-10752?focusedCommentId=4301660&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-4301660).

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
