### PR TITLE
Audiocontext resume test + mark unstable

### DIFF
--- a/test/integration/spec/webrtc/rtcpeerconnection.js
+++ b/test/integration/spec/webrtc/rtcpeerconnection.js
@@ -436,9 +436,27 @@ describe(`RTCPeerConnection(${sdpFormat})`, function() {
     });
   });
 
+  // eslint-disable-next-line no-warning-comments
+  // TODO: firefox when running inside our docker containers,
+  // does not resume audioContext. The resume promise never settles.
+  // This is causing few other tests to fail as well.
+  // We need to find workaround for this.
+  describe('audiocontext should resume' + isFirefox ? ' @unstable: VIDEO-10685 ' : '', () => {
+    it('audiocontext should resume', async () => {
+      const audioContext = new AudioContext();
+      if (audioContext.state === 'suspended') {
+        const timeoutPromise = new Promise(resolve => setTimeout(resolve, 5000));
+        console.log('audioContext.state = suspended');
+        await Promise.race([audioContext.resume(), timeoutPromise]);
+        console.log('audioContext.state = ',  audioContext.state);
+        assert(audioContext.state === 'running');
+      }
+    });
+  });
+
   // NOTE(mroberts): This integration test is ported from the JSFiddle in Bug
   // 1480277.
-  (isFirefox ? describe : describe.skip)('Bug 1480277', () => {
+  (isFirefox ? describe : describe.skip)('@unstable: VIDEO-10685 Bug 1480277', () => {
     it('is worked around', async () => {
       const configuration = {
         bundlePolicy: 'max-bundle',


### PR DESCRIPTION
While investigating a failing test, I found the root cause (`audioContext.resume` does not settle on firefox when running in docker image) but did not find a solution to it. 
This change adds a simple test to demonstrate the issue, and marks it as `@unstable`
**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

A description of what this PR does.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review
