### PR TITLE
VIDEO-8756 Fix Room.getStats()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 
 **Version 1.x reached End of Life on September 8th, 2021.** See the changelog entry [here](https://www.twilio.com/changelog/end-of-life-complete-for-unsupported-versions-of-the-programmable-video-sdk). Support for the 1.x version ended on December 4th, 2020.
 
+3.0.0-preview.2 (in progress)
+=============================
+
+Changes
+-------
+
+- `Room.getStats()`, which was broken in `3.0.0-preview.1`, has been fixed in this release. Note that the values reported
+  are best-effort approximations based off of the raw WebRTC statistics. (VIDEO-8756)
+
 3.0.0-preview.1 (July 25, 2022)
 ===============================
 

--- a/lib/room.js
+++ b/lib/room.js
@@ -151,8 +151,8 @@ class Room extends EventEmitter {
 
   /**
    * Get the {@link Room}'s media statistics. This is not supported in Safari 12.0 or below
-   * due to this bug : https://bugs.webkit.org/show_bug.cgi?id=192601
-   *
+   * due to this bug : https://bugs.webkit.org/show_bug.cgi?id=192601. Note that the values
+   * reported are best-effort approximations based off of the raw WebRTC statistics.
    * @returns {Promise.<Array<StatsReport>>}
    */
   getStats() {

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -5,7 +5,8 @@ const {
   RTCIceCandidate: DefaultRTCIceCandidate,
   RTCPeerConnection: DefaultRTCPeerConnection,
   RTCSessionDescription: DefaultRTCSessionDescription,
-  getStats: getStatistics
+  getStats: getStatistics,
+  getTrackStats: getTrackStatistics
 } = require('../../webrtc');
 
 const util = require('../../webrtc/util');
@@ -1620,6 +1621,16 @@ class PeerConnectionV2 extends StateMachine {
         throw error;
       });
     });
+  }
+
+  /**
+   * Get the statistics for a given remote MediaStreamTrack
+   * @param {MediaStreamTrack} mediaStreamTrack
+   * @returns {Promise<StandardizedTrackStatsReport>}
+   */
+  getRemoteTrackStats(mediaStreamTrack) {
+    return getTrackStatistics(this._peerConnection, mediaStreamTrack, { isRemote: true })
+      .then(([stats]) => rewriteTrackId(this, stats));
   }
 
   /**

--- a/lib/signaling/v2/peerconnectionmanager.js
+++ b/lib/signaling/v2/peerconnectionmanager.js
@@ -354,6 +354,19 @@ class PeerConnectionManager extends QueueingEventEmitter {
   }
 
   /**
+   * Get the statistics for a remote MediaStreamTrack.
+   * @param {MediaStreamTrack} mediaStreamTrack
+   * @returns {Promise<Map<PeerConnectionV2#id, StandardizedTrackStatsReport>>}
+   */
+  getRemoteTrackStats(mediaStreamTrack) {
+    const peerConnections = Array.from(this._peerConnections.values());
+    return Promise.all(peerConnections.map(peerConnection => peerConnection.getRemoteTrackStats(mediaStreamTrack).then(stats => [
+      peerConnection.id,
+      stats
+    ]))).then(reports => new Map(reports));
+  }
+
+  /**
    * Get the {@link PeerConnectionManager}'s media statistics.
    * @returns {Promise.<Map<PeerConnectionV2#id, StandardizedStatsResponse>>}
    */

--- a/lib/signaling/v2/remoteparticipant.js
+++ b/lib/signaling/v2/remoteparticipant.js
@@ -39,6 +39,9 @@ class RemoteParticipantV2 extends RemoteParticipantSignaling {
       _getPendingTrackReceiver: {
         value: options.getPendingTrackReceiver
       },
+      _getTrackStats: {
+        value: options.getTrackStats
+      },
       updateSubscriberTrackPriority: {
         value: (trackSid, priority) => setPriority(trackSid, priority)
       },

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -94,14 +94,14 @@ class RoomV2 extends RoomSignaling {
       _RemoteParticipantSignaling: {
         value: options.RemoteParticipantSignaling
       },
-      _subscribed: {
-        value: new Map()
-      },
       _subscribedRevision: {
         value: 0,
         writable: true
       },
       _subscriptionFailures: {
+        value: new Map()
+      },
+      _trackSidsToTrackIds: {
         value: new Map()
       },
       _dominantSpeakerSignaling: {
@@ -395,7 +395,7 @@ class RoomV2 extends RoomSignaling {
     });
 
     trackSidsToTrackSignalings.forEach(trackSignaling => {
-      const trackId = this._subscribed.get(trackSignaling.sid);
+      const trackId = this._trackSidsToTrackIds.get(trackSignaling.sid);
       if (!trackId || (trackSignaling.isSubscribed && trackSignaling.trackTransceiver.id !== trackId)) {
         trackSignaling.setTrackTransceiver(null);
       }
@@ -523,7 +523,7 @@ class RoomV2 extends RoomSignaling {
     subscribed.tracks.forEach(trackState => {
       if (trackState.id) {
         this._subscriptionFailures.delete(trackState.sid);
-        this._subscribed.set(trackState.sid, trackState.id);
+        this._trackSidsToTrackIds.set(trackState.sid, trackState.id);
       } else if (trackState.error && !this._subscriptionFailures.has(trackState.sid)) {
         this._subscriptionFailures.set(trackState.sid, trackState.error);
       }
@@ -533,9 +533,9 @@ class RoomV2 extends RoomSignaling {
       .filter(trackState => !!trackState.id)
       .map(trackState => trackState.sid));
 
-    this._subscribed.forEach((trackId, trackSid) => {
+    this._trackSidsToTrackIds.forEach((trackId, trackSid) => {
       if (!subscribedTrackSids.has(trackSid)) {
-        this._subscribed.delete(trackSid);
+        this._trackSidsToTrackIds.delete(trackSid);
       }
     });
   }
@@ -681,7 +681,7 @@ function filterAndAddLocalTrackSids(roomV2, localTrackStats) {
  * @returns {Array<RemoteTrackStats>}
  */
 function filterAndAddRemoteTrackSids(roomV2, remoteTrackStats) {
-  const idToSid = new Map(Array.from(roomV2._subscribed.entries()).map(([sid, id]) => [id, sid]));
+  const idToSid = new Map(Array.from(roomV2._trackSidsToTrackIds.entries()).map(([sid, id]) => [id, sid]));
   return filterAndAddTrackSids(idToSid, remoteTrackStats);
 }
 

--- a/lib/signaling/v3/remoteparticipant.js
+++ b/lib/signaling/v3/remoteparticipant.js
@@ -15,6 +15,7 @@ class RemoteParticipantV3 extends RemoteParticipantV2 {
    * @param {function(Track.SID, Track.Priority): boolean} setPriority
    * @param {function(Track.SID, ClientRenderHint): Promise<void>} setRenderHint
    * @param {function(Track.SID): void} clearTrackHint
+   * @param {function(MediaStreamTrack): Promise<Map<PeerConnectionV2#id, StandardizedTrackStatsReport>>} getTrackStats
    * @param {object} [options]
    */
   constructor(
@@ -24,11 +25,13 @@ class RemoteParticipantV3 extends RemoteParticipantV2 {
     setPriority,
     setRenderHint,
     clearTrackHint,
+    getTrackStats,
     options
   ) {
     options = Object.assign({
       RemoteTrackPublicationSignaling: RemoteTrackPublicationV3,
-      getPendingTrackReceiver
+      getPendingTrackReceiver,
+      getTrackStats
     }, options);
 
     super(
@@ -47,14 +50,15 @@ class RemoteParticipantV3 extends RemoteParticipantV2 {
   _getOrCreateTrack(trackState) {
     const {
       _RemoteTrackPublicationSignaling: RemoteTrackPublicationV3,
-      _getPendingTrackReceiver: getPendingTrackReceiver
+      _getPendingTrackReceiver: getPendingTrackReceiver,
+      _getTrackStats: getTrackStats
     } = this;
     let track = this.tracks.get(trackState.sid);
     if (!track) {
-      const { state, switchOffReason } = this.kind === 'data'
+      const { state, switchOffReason = null } = this.kind === 'data'
         ? { state: 'ON', switchOffReason: null }
         : this._getInitialTrackSwitchOffState(trackState.sid);
-      track = new RemoteTrackPublicationV3(trackState, state === 'OFF', switchOffReason);
+      track = new RemoteTrackPublicationV3(trackState, state === 'OFF', switchOffReason, getTrackStats);
       this.addTrack(track);
 
       getPendingTrackReceiver(track.sid).then(trackReceiver => {

--- a/lib/signaling/v3/remotetrackpublication.js
+++ b/lib/signaling/v3/remotetrackpublication.js
@@ -36,15 +36,19 @@ class RemoteTrackPublicationV3 extends RemoteTrackPublicationSignaling {
         value: false,
         writable: true
       },
+      _pendingGetTrackStatsPromise: {
+        value: Promise.resolve(),
+        writable: true
+      },
       _switchOffReason: {
         value: switchOffReason,
         writable: true
       },
-      _switchOnMediaStreamTrackStats: {
+      _switchOffStateChangeStats: {
         value: initialTrackStats(sid, kind),
         writable: true
       },
-      _switchOnStats: {
+      _switchOnMediaStreamTrackStats: {
         value: initialTrackStats(sid, kind),
         writable: true
       }
@@ -68,13 +72,13 @@ class RemoteTrackPublicationV3 extends RemoteTrackPublicationSignaling {
   }
 
   /**
-   * Adjust Track statistics based on new stats. Returns the most
-   * recent switched on Track statistics if no argument is provided.
+   * Adjust Track statistics based on new stats. Returns the most recent switched
+   * off state change Track statistics if no argument is provided.
    * @param {StandardizedTrackStatsReport} [newMediaStreamTrackStats]
    * @returns {StandardizedTrackStatsReport}
    */
   adjustTrackStats(newMediaStreamTrackStats = {}) {
-    const cumStatsProps = [
+    const cumulativeStatsProps = [
       'bytesReceived',
       'framesDecoded',
       'packetsLost',
@@ -97,11 +101,11 @@ class RemoteTrackPublicationV3 extends RemoteTrackPublicationSignaling {
       'timestamp',
       'trackId'
     ];
-    const trackStats = Object.assign({}, this._switchOnStats);
+    const trackStats = Object.assign({}, this._switchOffStateChangeStats, { timestamp: Date.now() });
 
-    cumStatsProps.forEach(prop => {
+    cumulativeStatsProps.forEach(prop => {
       if (prop in newMediaStreamTrackStats) {
-        trackStats[prop] = this._switchOnStats[prop] + newMediaStreamTrackStats[prop] - this._switchOnMediaStreamTrackStats[prop];
+        trackStats[prop] = this._switchOffStateChangeStats[prop] + newMediaStreamTrackStats[prop] - this._switchOnMediaStreamTrackStats[prop];
       }
     });
 
@@ -144,14 +148,18 @@ class RemoteTrackPublicationV3 extends RemoteTrackPublicationSignaling {
     const shouldEmitUpdated = trackReceiver !== this.trackTransceiver || isSubscribed !== this.isSubscribed;
 
     if (this.kind !== 'data' && trackReceiver !== this.trackTransceiver) {
-      this._getTrackStats((trackReceiver || this._trackTransceiver).track).then(report => {
-        // NOTE(mmalavalli): Because RSPv3 is associated with Large Rooms only, the statistics
-        // map will contain an entry associated with only one RTCPeerConnection.
-        const mediaStreamTrackStats = report.values().next().value;
-        if (trackReceiver) {
-          this._switchOnMediaStreamTrackStats = mediaStreamTrackStats;
-        }
-        this._switchOnStats = this.adjustTrackStats(mediaStreamTrackStats);
+      const { track } = trackReceiver || this.trackTransceiver;
+      this._pendingGetTrackStatsPromise.then(() => {
+        this._pendingGetTrackStatsPromise = this._getTrackStats(track).then(report => {
+          // NOTE(mmalavalli): Because RSPv3 is associated with Large Rooms only, the statistics
+          // map will contain an entry associated with only one RTCPeerConnection.
+          const mediaStreamTrackStats = report.values().next().value;
+          if (trackReceiver) {
+            this._switchOnMediaStreamTrackStats = mediaStreamTrackStats;
+          }
+          this._switchOffStateChangeStats = this.adjustTrackStats(mediaStreamTrackStats);
+          this._pendingGetTrackStatsPromise = Promise.resolve();
+        });
       });
     }
 

--- a/lib/signaling/v3/remotetrackpublication.js
+++ b/lib/signaling/v3/remotetrackpublication.js
@@ -91,7 +91,6 @@ class RemoteTrackPublicationV3 extends RemoteTrackPublicationSignaling {
       'estimatedPlayoutTimestamp',
       'frameHeightReceived',
       'frameRateReceived',
-      'framesDecoded',
       'frameWidthReceived',
       'jitter',
       'jitterBufferDelay',
@@ -101,7 +100,7 @@ class RemoteTrackPublicationV3 extends RemoteTrackPublicationSignaling {
       'timestamp',
       'trackId'
     ];
-    const trackStats = Object.assign({}, this._switchOffStateChangeStats, { timestamp: Date.now() });
+    const trackStats = Object.assign({}, this._switchOffStateChangeStats);
 
     cumulativeStatsProps.forEach(prop => {
       if (prop in newMediaStreamTrackStats) {
@@ -114,6 +113,12 @@ class RemoteTrackPublicationV3 extends RemoteTrackPublicationSignaling {
         trackStats[prop] = newMediaStreamTrackStats[prop];
       }
     });
+
+    if (!this.isSubscribed || this.isSwitchedOff) {
+      trackStats.ssrc = '';
+      trackStats.timestamp = Date.now();
+      trackStats.trackId = '';
+    }
 
     return trackStats;
   }
@@ -149,17 +154,15 @@ class RemoteTrackPublicationV3 extends RemoteTrackPublicationSignaling {
 
     if (this.kind !== 'data' && trackReceiver !== this.trackTransceiver) {
       const { track } = trackReceiver || this.trackTransceiver;
-      this._pendingGetTrackStatsPromise.then(() => {
-        this._pendingGetTrackStatsPromise = this._getTrackStats(track).then(report => {
-          // NOTE(mmalavalli): Because RSPv3 is associated with Large Rooms only, the statistics
-          // map will contain an entry associated with only one RTCPeerConnection.
-          const mediaStreamTrackStats = report.values().next().value;
-          if (trackReceiver) {
-            this._switchOnMediaStreamTrackStats = mediaStreamTrackStats;
-          }
-          this._switchOffStateChangeStats = this.adjustTrackStats(mediaStreamTrackStats);
-          this._pendingGetTrackStatsPromise = Promise.resolve();
-        });
+      this._pendingGetTrackStatsPromise = this._pendingGetTrackStatsPromise.then(() => this._getTrackStats(track)).then(report => {
+        // NOTE(mmalavalli): Because RSPv3 is associated with Large Rooms only, the statistics
+        // map will contain an entry associated with only one RTCPeerConnection.
+        const mediaStreamTrackStats = report.values().next().value;
+        if (trackReceiver) {
+          this._switchOnMediaStreamTrackStats = mediaStreamTrackStats;
+        }
+        this._switchOffStateChangeStats = this.adjustTrackStats(mediaStreamTrackStats);
+        this._pendingGetTrackStatsPromise = Promise.resolve();
       });
     }
 

--- a/lib/signaling/v3/remotetrackpublication.js
+++ b/lib/signaling/v3/remotetrackpublication.js
@@ -11,8 +11,9 @@ class RemoteTrackPublicationV3 extends RemoteTrackPublicationSignaling {
    * @param {RemoteTrackPublicationV3#Representation} track
    * @param {boolean} isSwitchedOff
    * @param {?string} switchOffReason
+   * @param {function(MediaStreamTrack): Promise<Map<PeerConnectionV2#id, StandardizedTrackStatsReport>>} getTrackStats
    */
-  constructor(track, isSwitchedOff, switchOffReason = null) {
+  constructor(track, isSwitchedOff, switchOffReason, getTrackStats) {
     switchOffReason = isSwitchedOff ? switchOffReason : null;
     const enabled = isEnabled(isSwitchedOff, switchOffReason);
     const { kind, name, priority, sid } = track;
@@ -28,12 +29,23 @@ class RemoteTrackPublicationV3 extends RemoteTrackPublicationSignaling {
     );
 
     Object.defineProperties(this, {
+      _getTrackStats: {
+        value: getTrackStats
+      },
       _isSubscribed: {
         value: false,
         writable: true
       },
       _switchOffReason: {
         value: switchOffReason,
+        writable: true
+      },
+      _switchOnMediaStreamTrackStats: {
+        value: initialTrackStats(kind),
+        writable: true
+      },
+      _switchOnStats: {
+        value: initialTrackStats(kind),
         writable: true
       }
     });
@@ -53,6 +65,53 @@ class RemoteTrackPublicationV3 extends RemoteTrackPublicationSignaling {
    */
   get switchOffReason() {
     return this._switchOffReason;
+  }
+
+  /**
+   * Adjust Track statistics based on new stats. Returns the most
+   * recent switched on Track statistics if no argument is provided.
+   * @param {StandardizedTrackStatsReport} [newMediaStreamTrackStats]
+   * @returns {StandardizedTrackStatsReport}
+   */
+  adjustTrackStats(newMediaStreamTrackStats = {}) {
+    const cumStatsProps = [
+      'bytesReceived',
+      'framesDecoded',
+      'packetsLost',
+      'packetsReceived',
+      'totalDecodeTime'
+    ];
+    const snapshotStatsProps = [
+      'audioOutputLevel',
+      'codecName',
+      'estimatedPlayoutTimestamp',
+      'frameHeightReceived',
+      'frameRateReceived',
+      'framesDecoded',
+      'frameWidthReceived',
+      'jitter',
+      'jitterBufferDelay',
+      'jitterBufferEmittedCount',
+      'roundTripTime',
+      'ssrc',
+      'timestamp',
+      'trackId'
+    ];
+    const trackStats = Object.assign({}, this._switchOnStats);
+
+    cumStatsProps.forEach(prop => {
+      if (prop in newMediaStreamTrackStats) {
+        trackStats[prop] = this._switchOnStats[prop] + newMediaStreamTrackStats[prop] - this._switchOnMediaStreamTrackStats[prop];
+      }
+    });
+
+    snapshotStatsProps.forEach(prop => {
+      if (prop in newMediaStreamTrackStats) {
+        trackStats[prop] = newMediaStreamTrackStats[prop];
+      }
+    });
+
+    return trackStats;
   }
 
   /**
@@ -83,6 +142,19 @@ class RemoteTrackPublicationV3 extends RemoteTrackPublicationSignaling {
   setTrackTransceiver(trackReceiver, isSubscribed) {
     isSubscribed = !!trackReceiver || isSubscribed;
     const shouldEmitUpdated = trackReceiver !== this.trackTransceiver || isSubscribed !== this.isSubscribed;
+
+    if (this.kind !== 'data' && trackReceiver !== this.trackTransceiver) {
+      this._getTrackStats((trackReceiver || this._trackTransceiver).track).then(report => {
+        // NOTE(mmalavalli): Because RSPv3 is associated with Large Rooms only, the statistics
+        // map will contain an entry associated with only one RTCPeerConnection.
+        const mediaStreamTrackStats = report.values().next().value;
+        if (trackReceiver) {
+          this._switchOnMediaStreamTrackStats = mediaStreamTrackStats;
+        }
+        this._switchOnStats = this.adjustTrackStats(mediaStreamTrackStats);
+      });
+    }
+
     this._trackTransceiver = trackReceiver;
     this._isSubscribed = isSubscribed;
     if (shouldEmitUpdated) {
@@ -113,6 +185,40 @@ class RemoteTrackPublicationV3 extends RemoteTrackPublicationSignaling {
  */
 function isEnabled(isSwitchedOff, switchOffReason) {
   return !(isSwitchedOff && switchOffReason === 'DISABLED_BY_PUBLISHER');
+}
+
+/**
+ * @private
+ * @param {Track.Kind} kind
+ * @returns {StandardizedTrackStatsReport}
+ */
+function initialTrackStats(kind) {
+  return Object.assign({
+    bytesReceived: 0,
+    codecName: '',
+    estimatedPlayoutTimestamp: 0,
+    jitter: 0,
+    jitterBufferDelay: 0,
+    jitterBufferEmittedCount: 0,
+    packetsLost: 0,
+    packetsReceived: 0,
+    roundTripTime: 0,
+    ssrc: '',
+    timestamp: 0,
+    trackId: ''
+  }, {
+    audio: {
+      audioOutputLevel: 0
+    },
+    data: {},
+    video: {
+      frameHeightReceived: 0,
+      frameRateReceived: 0,
+      framesDecoded: 0,
+      frameWidthReceived: 0,
+      totalDecodeTime: 0
+    }
+  }[kind]);
 }
 
 /**

--- a/lib/signaling/v3/remotetrackpublication.js
+++ b/lib/signaling/v3/remotetrackpublication.js
@@ -41,11 +41,11 @@ class RemoteTrackPublicationV3 extends RemoteTrackPublicationSignaling {
         writable: true
       },
       _switchOnMediaStreamTrackStats: {
-        value: initialTrackStats(kind),
+        value: initialTrackStats(sid, kind),
         writable: true
       },
       _switchOnStats: {
-        value: initialTrackStats(kind),
+        value: initialTrackStats(sid, kind),
         writable: true
       }
     });
@@ -189,10 +189,11 @@ function isEnabled(isSwitchedOff, switchOffReason) {
 
 /**
  * @private
+ * @param {Track.SID} sid
  * @param {Track.Kind} kind
  * @returns {StandardizedTrackStatsReport}
  */
-function initialTrackStats(kind) {
+function initialTrackStats(sid, kind) {
   return Object.assign({
     bytesReceived: 0,
     codecName: '',
@@ -205,7 +206,8 @@ function initialTrackStats(kind) {
     roundTripTime: 0,
     ssrc: '',
     timestamp: 0,
-    trackId: ''
+    trackId: '',
+    trackSid: sid
   }, {
     audio: {
       audioOutputLevel: 0

--- a/lib/signaling/v3/room.js
+++ b/lib/signaling/v3/room.js
@@ -53,7 +53,8 @@ class RoomV3 extends RoomV2 {
       trackSid => this._getInitialTrackSwitchOffState(trackSid),
       (trackSid, priority) => this._trackPrioritySignaling.sendTrackPriorityUpdate(trackSid, 'subscribe', priority),
       (trackSid, hint) => this._renderHintsSignaling.setTrackHint(trackSid, hint),
-      trackSid => this._renderHintsSignaling.clearTrackHint(trackSid)
+      trackSid => this._renderHintsSignaling.clearTrackHint(trackSid),
+      track => this._peerConnectionManager.getRemoteTrackStats(track)
     );
   }
 
@@ -191,6 +192,55 @@ class RoomV3 extends RoomV2 {
    */
   _updateSubscribed(roomState) {
     /* Do nothing since RSP v3 messages will not contain the "subscribed" property. */
+  }
+
+  /**
+   * Get the {@link RoomV3}'s media statistics.
+   * @returns {Promise.<Map<PeerConnectionV2#id, StandardizedStatsResponse>>}
+   */
+  getStats() {
+    return super.getStats().then(responses => {
+      const trackSidsToTrackSignalings = this._getTrackSidsToTrackSignalings();
+      const trackSignalings = Array.from(trackSidsToTrackSignalings.values());
+      const switchedOffMediaTrackSignalings = trackSignalings.filter(({ isSubscribed, isSwitchedOff, kind }) => kind !== 'data' && isSubscribed && isSwitchedOff);
+      const switchedOffMediaTrackSidsToTrackStats = new Map(switchedOffMediaTrackSignalings.map(trackSignaling => [trackSignaling.sid, trackSignaling.adjustTrackStats()]));
+
+      responses.forEach(response => {
+        const { remoteAudioTrackStats, remoteVideoTrackStats } = response;
+
+        // NOTE(mmalavalli): Adjust stats for switched on RemoteAudioTracks with respect
+        // to its associated MediaStreamTrack.
+        remoteAudioTrackStats.forEach((stats, i) => {
+          const trackSignaling = trackSidsToTrackSignalings.get(stats.trackSid);
+          if (trackSignaling) {
+            remoteAudioTrackStats[i] = trackSignaling.adjustTrackStats(stats);
+          }
+        });
+
+        // NOTE(mmalavalli): Adjust stats for switched on RemoteVideoTracks with respect
+        // to its associated MediaStreamTrack.
+        remoteVideoTrackStats.forEach((stats, i) => {
+          const trackSignaling = trackSidsToTrackSignalings.get(stats.trackSid);
+          if (trackSignaling) {
+            remoteVideoTrackStats[i] = trackSignaling.adjustTrackStats(stats);
+          }
+        });
+
+        // NOTE(mmalavalli): Add stats for switched off media RemoteTracks in
+        // remoteAudioTrackStats and remoteVideoTrackStats respectively.
+        switchedOffMediaTrackSidsToTrackStats.forEach((trackStats, trackSid) => {
+          const trackSignaling = trackSidsToTrackSignalings.get(trackSid) || {};
+          const trackStatsWithTrackSid = Object.assign({ trackSid }, trackStats);
+          if (trackSignaling.kind === 'audio') {
+            remoteAudioTrackStats.push(trackStatsWithTrackSid);
+          } else if (trackSignaling.kind === 'video') {
+            remoteVideoTrackStats.push(trackStatsWithTrackSid);
+          }
+        });
+      });
+
+      return responses;
+    });
   }
 }
 

--- a/lib/signaling/v3/room.js
+++ b/lib/signaling/v3/room.js
@@ -142,11 +142,12 @@ class RoomV3 extends RoomV2 {
           // MID. If a RemoteTrackPublicationV3's RemoteTrack is switched off, then we should still be subscribed
           // to it, even though it no longer has an MID associated with it.
           trackSignaling.setTrackTransceiver(null, isSwitchedOff);
+          this._trackSidsToTrackIds.delete(trackSignaling.sid);
         }
         if (!isSwitchedOff) {
           this._getTrackReceiver(mid, 'mid').then(trackReceiver => {
             trackSignaling.setTrackTransceiver(trackReceiver, true);
-
+            this._trackSidsToTrackIds.set(trackSignaling.sid, trackReceiver.id);
             // NOTE(mpatwardhan): when track is switched on, send the switchOn message
             // only after track receiver is set so that application can access (new) mediaStreamTrack
             trackSignaling.setSwitchedOff(isSwitchedOff, switchOffReason);
@@ -178,6 +179,7 @@ class RoomV3 extends RoomV2 {
           this._pendingSwitchOffStates.delete(sid);
           this._pendingTrackMids.delete(sid);
           trackSignaling.setTrackTransceiver(null, false);
+          this._trackSidsToTrackIds.delete(trackSignaling.sid);
         }
       });
     });

--- a/lib/signaling/v3/room.js
+++ b/lib/signaling/v3/room.js
@@ -195,7 +195,8 @@ class RoomV3 extends RoomV2 {
   }
 
   /**
-   * Get the {@link RoomV3}'s media statistics.
+   * Get the {@link RoomV3}'s media statistics. Note that the values reported
+   * are best-effort approximations based off of the raw WebRTC statistics.
    * @returns {Promise.<Map<PeerConnectionV2#id, StandardizedStatsResponse>>}
    */
   getStats() {

--- a/lib/webrtc/getstats.js
+++ b/lib/webrtc/getstats.js
@@ -62,7 +62,6 @@ function _getStats(peerConnection, options) {
         isRemote: isRemote
       }, options)).then(function(trackStatsArray) {
         trackStatsArray.forEach(function(trackStats) {
-          trackStats.trackId = track.id;
           statsResponse[statsArrayName].push(trackStats);
         });
       });
@@ -348,7 +347,7 @@ function chromeOrSafariGetTrackStats(peerConnection, track) {
       return;
     }
     peerConnection.getStats(track).then(function(response) {
-      resolve(standardizeChromeOrSafariStats(response));
+      resolve(standardizeChromeOrSafariStats(response, track));
     }, reject);
   });
 }
@@ -363,7 +362,7 @@ function chromeOrSafariGetTrackStats(peerConnection, track) {
 function firefoxGetTrackStats(peerConnection, track, isRemote) {
   return new Promise(function(resolve, reject) {
     peerConnection.getStats(track).then(function(response) {
-      resolve([standardizeFirefoxStats(response, isRemote)]);
+      resolve([standardizeFirefoxStats(response, track, isRemote)]);
     }, reject);
   });
 }
@@ -379,7 +378,7 @@ function standardizeChromeLegacyStats(response, track) {
     return report.type === 'ssrc' && report.stat('googTrackId') === track.id;
   });
 
-  var standardizedStats = {};
+  var standardizedStats = { trackId: track.id };
 
   if (ssrcReport) {
     standardizedStats.timestamp = Math.round(Number(ssrcReport.timestamp));
@@ -445,9 +444,10 @@ function standardizeChromeLegacyStats(response, track) {
 /**
  * Standardize the MediaStreamTrack's statistics in Chrome or Safari.
  * @param {RTCStatsResponse} response
+ * @param {MediaStreamTrack} track
  * @returns {Array<StandardizedTrackStatsReport>}
  */
-function standardizeChromeOrSafariStats(response) {
+function standardizeChromeOrSafariStats(response, mediaStreamTrack) {
   var inbound = null;
 
   // NOTE(mpatwardhan): We should expect more than one "outbound-rtp" stats for a
@@ -492,7 +492,7 @@ function standardizeChromeOrSafariStats(response) {
   var remoteSource = isRemote ? remoteOutbound : remoteInbound; // remote rtp stats
 
   mainSources.forEach(function(source) {
-    var standardizedStats = {};
+    var standardizedStats = { trackId: mediaStreamTrack.id };
     var statSources = [
       source, // local rtp stats
       localMedia,
@@ -642,10 +642,11 @@ function standardizeChromeOrSafariStats(response) {
 /**
  * Standardize the MediaStreamTrack's statistics in Firefox.
  * @param {RTCStatsReport} response
+ * @param {MediaStreamTrack} track
  * @param {boolean} isRemote
  * @returns {StandardizedTrackStatsReport}
  */
-function standardizeFirefoxStats(response, isRemote) {
+function standardizeFirefoxStats(response, track, isRemote) {
   // NOTE(mroberts): If getStats is called on a closed RTCPeerConnection,
   // Firefox returns undefined instead of an RTCStatsReport. We workaround this
   // here. See the following bug for more details:
@@ -695,7 +696,7 @@ function standardizeFirefoxStats(response, isRemote) {
     return null;
   }
 
-  var standardizedStats = {};
+  var standardizedStats = { trackId: track.id };
   var timestamp = getStatValue('timestamp');
   standardizedStats.timestamp = Math.round(timestamp);
 
@@ -888,4 +889,5 @@ function standardizeFirefoxStats(response, isRemote) {
  * @property {AudioLevel} [audioOutputLevel] - The {@link AudioLevel} of the remote video MediaStreamTrack
  */
 
-module.exports = getStats;
+exports.getStats = getStats;
+exports.getTrackStats = getTrackStats;

--- a/lib/webrtc/index.js
+++ b/lib/webrtc/index.js
@@ -1,11 +1,17 @@
 'use strict';
 
+var stats = require('./getstats');
+
 var WebRTC = {};
 
 Object.defineProperties(WebRTC, {
   getStats: {
     enumerable: true,
-    value: require('./getstats')
+    value: stats.getStats
+  },
+  getTrackStats: {
+    enumerable: true,
+    value: stats.getTrackStats
   },
   getUserMedia: {
     enumerable: true,

--- a/test/integration/spec/webrtc/getstats.js
+++ b/test/integration/spec/webrtc/getstats.js
@@ -6,7 +6,7 @@ const {
   remoteCandidateStatsNullProps
 } = require('../../../lib/webrtc/util');
 
-const getStats = require('../../../../es5/webrtc/getstats');
+const { getStats } = require('../../../../es5/webrtc/getstats');
 const getUserMedia = require('../../../../es5/webrtc/getusermedia');
 const RTCPeerConnection = require('../../../../es5/webrtc/rtcpeerconnection');
 const { guessBrowser } = require('../../../../es5/webrtc/util');

--- a/test/unit/spec/signaling/v3/remoteparticipant.js
+++ b/test/unit/spec/signaling/v3/remoteparticipant.js
@@ -910,6 +910,7 @@ function makeTest(options) {
   options.setRenderHints = options.setRenderHints || sinon.spy(() => { return false; });
   options.setPriority = options.setPriority || sinon.spy(() => { return false; });
   options.clearRenderHint = options.clearRenderHint || sinon.spy(() => { return false; });
+  options.getTrackStats = options.getTrackStats || sinon.spy(() => Promise.resolve(new Map()));
   options.participant = options.participant || makeRemoteParticipantV3(options);
 
   options.state = revision => {
@@ -960,6 +961,7 @@ function makeRemoteParticipantV3(options) {
     options.setPriority,
     options.setRenderHints,
     options.clearRenderHint,
+    options.getTrackStats,
     options
   );
 }

--- a/test/unit/spec/signaling/v3/remotetrackpublication.js
+++ b/test/unit/spec/signaling/v3/remotetrackpublication.js
@@ -17,7 +17,7 @@ describe('RemoteTrackPublicationV3', () => {
           sid: makeSid()
         };
         const { isSwitchedOff, switchOffReason } = makeSwitchedOff();
-        assert.equal((new RemoteTrackPublicationV3(trackState, isSwitchedOff, switchOffReason))[prop], trackState[prop]);
+        assert.equal((new RemoteTrackPublicationV3(trackState, isSwitchedOff, switchOffReason, () => Promise.resolve(Promise.resolve(new Map()))))[prop], trackState[prop]);
       });
     });
 
@@ -29,7 +29,7 @@ describe('RemoteTrackPublicationV3', () => {
             name: makeUUID(),
             priority: makeUUID(),
             sid: makeSid()
-          }, true, enabled ? 'DISABLED_BY_SUBSCRIBER' : 'DISABLED_BY_PUBLISHER')).isEnabled, enabled);
+          }, true, enabled ? 'DISABLED_BY_SUBSCRIBER' : 'DISABLED_BY_PUBLISHER', () => Promise.resolve(new Map()))).isEnabled, enabled);
         });
       });
     });
@@ -42,7 +42,7 @@ describe('RemoteTrackPublicationV3', () => {
             name: makeUUID(),
             priority: makeUUID(),
             sid: makeSid()
-          }, isSwitchedOff, 'DISABLED_BY_SUBSCRIBER');
+          }, isSwitchedOff, 'DISABLED_BY_SUBSCRIBER', () => Promise.resolve(new Map()));
           assert.equal(track.isSwitchedOff, isSwitchedOff);
           assert.equal(track.switchOffReason, isSwitchedOff ? 'DISABLED_BY_SUBSCRIBER' : null);
         });
@@ -79,7 +79,8 @@ describe('RemoteTrackPublicationV3', () => {
             sid: makeSid()
           },
           initialIsSwitchedOff,
-          initialSwitchOffReason
+          initialSwitchOffReason,
+          () => Promise.resolve(new Map())
         );
         track.once('updated', () => { updated = true; });
         track.setSwitchedOff(isSwitchedOff, switchOffReason);
@@ -126,7 +127,7 @@ describe('RemoteTrackPublicationV3', () => {
           name: makeUUID(),
           priority: makeUUID(),
           sid: makeSid()
-        }, false, null);
+        }, false, null, () => Promise.resolve(new Map()));
         assert.equal(track, track.setTrackTransceiver(mediaTrackReceiver, isSubscribed));
       });
 
@@ -137,7 +138,7 @@ describe('RemoteTrackPublicationV3', () => {
           name: makeUUID(),
           priority: makeUUID(),
           sid: makeSid()
-        }, false, null);
+        }, false, null, () => Promise.resolve(new Map()));
         assert.equal(track.setTrackTransceiver(mediaTrackReceiver, isSubscribed).isSubscribed, expectedIsSubscribed);
       });
 
@@ -148,7 +149,7 @@ describe('RemoteTrackPublicationV3', () => {
           name: makeUUID(),
           priority: makeUUID(),
           sid: makeSid()
-        }, false, null);
+        }, false, null, () => Promise.resolve(new Map()));
 
         let updated;
         track.once('updated', () => { updated = true; });
@@ -170,7 +171,7 @@ describe('RemoteTrackPublicationV3', () => {
               priority: oldPriorityValue,
               sid: makeSid()
             };
-            const track = new RemoteTrackPublicationV3(trackState, false, null);
+            const track = new RemoteTrackPublicationV3(trackState, false, null, () => Promise.resolve(new Map()));
             trackState.priority = newPriorityValue;
             assert.equal(track, track.update(trackState));
           });
@@ -182,7 +183,7 @@ describe('RemoteTrackPublicationV3', () => {
               priority: oldPriorityValue,
               sid: makeSid()
             };
-            const track = new RemoteTrackPublicationV3(trackState, false, null);
+            const track = new RemoteTrackPublicationV3(trackState, false, null, () => Promise.resolve(new Map()));
             trackState.priority = newPriorityValue;
             track.update(trackState);
             assert.equal(track.priority, newPriorityValue);
@@ -198,7 +199,7 @@ describe('RemoteTrackPublicationV3', () => {
               };
 
               let priority;
-              const track = new RemoteTrackPublicationV3(trackState, false, null);
+              const track = new RemoteTrackPublicationV3(trackState, false, null, () => Promise.resolve(new Map()));
               trackState.priority = newPriorityValue;
               track.once('updated', () => { priority = track.priority; });
               track.update(trackState);
@@ -214,7 +215,7 @@ describe('RemoteTrackPublicationV3', () => {
               };
 
               let updated = false;
-              const track = new RemoteTrackPublicationV3(trackState, false, null);
+              const track = new RemoteTrackPublicationV3(trackState, false, null, () => Promise.resolve(new Map()));
               trackState.priority = newPriorityValue;
               track.once('updated', () => { updated = true; });
               track.update(trackState);
@@ -237,7 +238,7 @@ describe('RemoteTrackPublicationV3', () => {
           name: makeUUID(),
           priority: makeUUID(),
           sid: makeSid()
-        }, false, null);
+        }, false, null, () => Promise.resolve(new Map()));
         assert.equal(track, track.disable());
       });
 
@@ -247,7 +248,7 @@ describe('RemoteTrackPublicationV3', () => {
           name: makeUUID(),
           priority: makeUUID(),
           sid: makeSid()
-        }, false, null);
+        }, false, null, () => Promise.resolve(new Map()));
         track.disable();
         assert(!track.isEnabled);
       });
@@ -258,7 +259,7 @@ describe('RemoteTrackPublicationV3', () => {
           name: makeUUID(),
           priority: makeUUID(),
           sid: makeSid()
-        }, false, null);
+        }, false, null, () => Promise.resolve(new Map()));
         let isEnabled;
         track.once('updated', () => { isEnabled = track.isEnabled; });
         track.disable();
@@ -273,7 +274,7 @@ describe('RemoteTrackPublicationV3', () => {
           name: makeUUID(),
           priority: makeUUID(),
           sid: makeSid()
-        }, true, 'DISABLED_BY_PUBLISHER');
+        }, true, 'DISABLED_BY_PUBLISHER', () => Promise.resolve(new Map()));
         assert.equal(track, track.disable());
       });
 
@@ -283,7 +284,7 @@ describe('RemoteTrackPublicationV3', () => {
           name: makeUUID(),
           priority: makeUUID(),
           sid: makeSid()
-        }, true, 'DISABLED_BY_PUBLISHER');
+        }, true, 'DISABLED_BY_PUBLISHER', () => Promise.resolve(new Map()));
         track.disable();
         assert(!track.isEnabled);
       });
@@ -294,7 +295,7 @@ describe('RemoteTrackPublicationV3', () => {
           name: makeUUID(),
           priority: makeUUID(),
           sid: makeSid()
-        }, true, 'DISABLED_BY_PUBLISHER');
+        }, true, 'DISABLED_BY_PUBLISHER', () => Promise.resolve(new Map()));
         let updated;
         track.once('updated', () => { updated = true; });
         track.disable();
@@ -312,7 +313,7 @@ describe('RemoteTrackPublicationV3', () => {
             name: makeUUID(),
             priority: makeUUID(),
             sid: makeSid()
-          }, false, null);
+          }, false, null, () => Promise.resolve(new Map()));
           assert.equal(track, track.enable(false));
         });
 
@@ -322,7 +323,7 @@ describe('RemoteTrackPublicationV3', () => {
             name: makeUUID(),
             priority: makeUUID(),
             sid: makeSid()
-          }, false, null);
+          }, false, null, () => Promise.resolve(new Map()));
           track.enable(false);
           assert(!track.isEnabled);
         });
@@ -333,7 +334,7 @@ describe('RemoteTrackPublicationV3', () => {
             name: makeUUID(),
             priority: makeUUID(),
             sid: makeSid()
-          }, false, null);
+          }, false, null, () => Promise.resolve(new Map()));
           let isEnabled;
           track.once('updated', () => { isEnabled = track.isEnabled; });
           track.enable(false);
@@ -348,7 +349,7 @@ describe('RemoteTrackPublicationV3', () => {
             name: makeUUID(),
             priority: makeUUID(),
             sid: makeSid()
-          }, true, 'DISABLED_BY_PUBLISHER');
+          }, true, 'DISABLED_BY_PUBLISHER', () => Promise.resolve(new Map()));
           assert.equal(track, track.enable(false));
         });
 
@@ -358,7 +359,7 @@ describe('RemoteTrackPublicationV3', () => {
             name: makeUUID(),
             priority: makeUUID(),
             sid: makeSid()
-          }, true, 'DISABLED_BY_PUBLISHER');
+          }, true, 'DISABLED_BY_PUBLISHER', () => Promise.resolve(new Map()));
           track.enable(false);
           assert(!track.isEnabled);
         });
@@ -369,7 +370,7 @@ describe('RemoteTrackPublicationV3', () => {
             name: makeUUID(),
             priority: makeUUID(),
             sid: makeSid()
-          }, true, 'DISABLED_BY_PUBLISHER');
+          }, true, 'DISABLED_BY_PUBLISHER', () => Promise.resolve(new Map()));
           let updated;
           track.once('updated', () => { updated = true; });
           track.enable(false);
@@ -386,7 +387,7 @@ describe('RemoteTrackPublicationV3', () => {
             name: makeUUID(),
             priority: makeUUID(),
             sid: makeSid()
-          }, false, null);
+          }, false, null, () => Promise.resolve(new Map()));
           assert.equal(track, track.enable(true));
         });
 
@@ -396,7 +397,7 @@ describe('RemoteTrackPublicationV3', () => {
             name: makeUUID(),
             priority: makeUUID(),
             sid: makeSid()
-          }, false, null);
+          }, false, null, () => Promise.resolve(new Map()));
           track.enable(true);
           assert(track.isEnabled);
         });
@@ -407,7 +408,7 @@ describe('RemoteTrackPublicationV3', () => {
             name: makeUUID(),
             priority: makeUUID(),
             sid: makeSid()
-          }, false, null);
+          }, false, null, () => Promise.resolve(new Map()));
           let updated;
           track.once('updated', () => { updated = true; });
           track.enable(true);
@@ -422,7 +423,7 @@ describe('RemoteTrackPublicationV3', () => {
             name: makeUUID(),
             priority: makeUUID(),
             sid: makeSid()
-          }, true, 'DISABLED_BY_PUBLISHER');
+          }, true, 'DISABLED_BY_PUBLISHER', () => Promise.resolve(new Map()));
           assert.equal(track, track.enable(true));
         });
 
@@ -432,7 +433,7 @@ describe('RemoteTrackPublicationV3', () => {
             name: makeUUID(),
             priority: makeUUID(),
             sid: makeSid()
-          }, true, 'DISABLED_BY_PUBLISHER');
+          }, true, 'DISABLED_BY_PUBLISHER', () => Promise.resolve(new Map()));
           track.enable(true);
           assert(track.isEnabled);
         });
@@ -443,7 +444,7 @@ describe('RemoteTrackPublicationV3', () => {
             name: makeUUID(),
             priority: makeUUID(),
             sid: makeSid()
-          }, true, 'DISABLED_BY_PUBLISHER');
+          }, true, 'DISABLED_BY_PUBLISHER', () => Promise.resolve(new Map()));
           let isEnabled;
           track.once('updated', () => { isEnabled = track.isEnabled; });
           track.enable(true);
@@ -460,7 +461,7 @@ describe('RemoteTrackPublicationV3', () => {
             name: makeUUID(),
             priority: makeUUID(),
             sid: makeSid()
-          }, false, null);
+          }, false, null, () => Promise.resolve(new Map()));
           assert.equal(track, track.enable());
         });
 
@@ -470,7 +471,7 @@ describe('RemoteTrackPublicationV3', () => {
             name: makeUUID(),
             priority: makeUUID(),
             sid: makeSid()
-          }, false, null);
+          }, false, null, () => Promise.resolve(new Map()));
           track.enable();
           assert(track.isEnabled);
         });
@@ -481,7 +482,7 @@ describe('RemoteTrackPublicationV3', () => {
             name: makeUUID(),
             priority: makeUUID(),
             sid: makeSid()
-          }, false, null);
+          }, false, null, () => Promise.resolve(new Map()));
           let updated;
           track.once('updated', () => { updated = true; });
           track.enable();
@@ -496,7 +497,7 @@ describe('RemoteTrackPublicationV3', () => {
             name: makeUUID(),
             priority: makeUUID(),
             sid: makeSid()
-          }, true, 'DISABLED_BY_PUBLISHER');
+          }, true, 'DISABLED_BY_PUBLISHER', () => Promise.resolve(new Map()));
           assert.equal(track, track.enable());
         });
 
@@ -506,7 +507,7 @@ describe('RemoteTrackPublicationV3', () => {
             name: makeUUID(),
             priority: makeUUID(),
             sid: makeSid()
-          }, true, 'DISABLED_BY_PUBLISHER');
+          }, true, 'DISABLED_BY_PUBLISHER', () => Promise.resolve(new Map()));
           track.enable();
           assert(track.isEnabled);
         });
@@ -517,7 +518,7 @@ describe('RemoteTrackPublicationV3', () => {
             name: makeUUID(),
             priority: makeUUID(),
             sid: makeSid()
-          }, true, 'DISABLED_BY_PUBLISHER');
+          }, true, 'DISABLED_BY_PUBLISHER', () => Promise.resolve(new Map()));
           let isEnabled;
           track.once('updated', () => { isEnabled = track.isEnabled; });
           track.enable();

--- a/test/unit/spec/signaling/v3/room.js
+++ b/test/unit/spec/signaling/v3/room.js
@@ -10,8 +10,6 @@ const StatsReport = require('../../../../../lib/stats/statsreport');
 const RoomV3 = require('../../../../../lib/signaling/v3/room');
 const RealTrackPrioritySignaling = require('../../../../../lib/signaling/v2/trackprioritysignaling');
 const RealTrackSubscriptionsSignaling = require('../../../../../lib/signaling/v3/tracksubscriptionssignaling');
-
-// eslint-disable-next-line no-warning-comments
 const RemoteTrackPublicationV3 = require('../../../../../lib/signaling/v3/remotetrackpublication');
 
 
@@ -2093,7 +2091,7 @@ function makeLocalParticipant(options) {
 }
 
 function makeRemoteTrack(options) {
-  return new RemoteTrackPublicationV3(options);
+  return new RemoteTrackPublicationV3(options, false, null, () => Promise.resolve(new Map()));
 }
 
 function makeTrack(options) {

--- a/test/unit/spec/signaling/v3/room.js
+++ b/test/unit/spec/signaling/v3/room.js
@@ -470,7 +470,6 @@ describe('RoomV3', () => {
           packetsReceived: 0,
           roundTripTime: 0,
           ssrc: '',
-          timestamp: 0,
           trackId: '3',
           trackSid: 'MT3'
         }
@@ -491,13 +490,19 @@ describe('RoomV3', () => {
           packetsReceived: 0,
           roundTripTime: 0,
           ssrc: '',
-          timestamp: 0,
           totalDecodeTime: 0,
           trackId: '4',
           trackSid: 'MT4'
         }
       ];
-      assert.deepEqual([...reports.values()], [
+
+      const reportsWithoutRemoteTrackTimestamps = [...reports.values()].map(report => {
+        report.remoteAudioTrackStats.forEach(stat => delete stat.timestamp);
+        report.remoteVideoTrackStats.forEach(stat => delete stat.timestamp);
+        return report;
+      });
+
+      assert.deepEqual(reportsWithoutRemoteTrackTimestamps, [
         {
           activeIceCandidatePair: {
             includesRelayProtocol: true,

--- a/test/unit/spec/webrtc/getstats.js
+++ b/test/unit/spec/webrtc/getstats.js
@@ -4,7 +4,7 @@
 var assert = require('assert');
 var { FakeMediaStream, FakeMediaStreamTrack } = require('../../../lib/webrtc/fakemediastream');
 var { FakeRTCPeerConnection } = require('../../../lib/webrtc/fakestats');
-var getStats = require('../../../../lib/webrtc/getstats');
+var { getStats } = require('../../../../lib/webrtc/getstats');
 
 describe('getStats', function() {
   it('should reject the promise if RTCPeerConnection is not specified', () => {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

This PR fixes the broken `Room.getStats()` behavior in large rooms, based on the proposal described [here](https://docs.google.com/document/d/1Utox0H6ygX7v4K0_-tOIPi9amIZgiccvW05Jg-Fuuaw/edit#heading=h.y4yxwjxm6rxd).

### Highlights

* No changes for LocalTrack stats, since they already work.
* For each RemoteTrackPublication, we cache the following stats objects:
  * `_switchOffStateChangeStats` - the RemoteTrack stats captured at the most recent switch off state change
  * `_switchOnMediaStreamTrackStats` - the MediaStreamTrack stats captured when the RemoteTrack is switched on
* Ensure that `RoomV2.getStats()` returns the stats for the switched on RemoteTracks.
* `RoomV3.getStats()` will take the RemoteTrack stats returned by `RoomV2.getStats()` and perform the following transformations:
  * Add stats for switched off RemoteTracks by accessing the cached `_switchOffStateChangeStats`
  * Adjust stats for switched on RemoteTracks using the following rules:
    * If the stats property represents a cumulative value, like `bytesReceived`, then `stats[property] = _switchOffStateChangeStats[property] + sampleStatsFromRoomV2getStats[property] - _switchOnMediaStreamTrackStats[property]`
    * If the stats property represents a snapshot value, like `jitter`, then `stats[property] = sampleStatsFromRoomV2getStats[property]`

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
