### PR TITLE
Video 11047 src track was not stopped when stopping krisp enabled LocalAudioTrack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 
 **Version 1.x reached End of Life on September 8th, 2021.** See the changelog entry [here](https://www.twilio.com/changelog/end-of-life-complete-for-unsupported-versions-of-the-programmable-video-sdk). Support for the 1.x version ended on December 4th, 2020.
 
+2.23.1 (July 28, 2022)
+======================
+
+Bug Fixes
+---------
+- Fixed an issue where input media track was not stopped, after `localAudioTrack.stop()` when using noiseCancellation (VIDEO-11047)
+
 2.23.0 (July 28, 2022)
 ======================
 

--- a/lib/media/track/localaudiotrack.js
+++ b/lib/media/track/localaudiotrack.js
@@ -144,6 +144,9 @@ class LocalAudioTrack extends LocalMediaAudioTrack {
    * @fires LocalAudioTrack#stopped
    */
   stop() {
+    if (this.noiseCancellation) {
+      this.noiseCancellation.stop();
+    }
     return super.stop.apply(this, arguments);
   }
 }

--- a/lib/media/track/noisecancellationimpl.ts
+++ b/lib/media/track/noisecancellationimpl.ts
@@ -122,6 +122,15 @@ export class NoiseCancellationImpl implements NoiseCancellation {
     this._disabledPermanent = true;
     return this.disable();
   }
+
+
+  /**
+   * @private
+   */
+  stop(): void {
+    this._processor.disconnect();
+    this._sourceTrack.stop();
+  }
 }
 
 


### PR DESCRIPTION
Fixed an issue where LocalAudioTrack.stop() was not stopping underlying `noiseCancellation.srcTrack`.  
**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

A description of what this PR does.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review
