### PR TITLE
TSDef Fix - LocalDataTrackOptions (#1826)

### DIFF
--- a/tsdef/LocalTrackOptions.d.ts
+++ b/tsdef/LocalTrackOptions.d.ts
@@ -1,10 +1,10 @@
-import { LogLevel, LogLevels } from './types';
+import { LogLevel, LogLevels } from "./types";
 
 export interface LocalTrackOptions {
   /**
    * @deprecated
    */
-    logLevel: LogLevel | LogLevels;
-    name?: string;
-    workaroundWebKitBug1208516?: boolean
-  }
+  logLevel?: LogLevel | LogLevels;
+  name?: string;
+  workaroundWebKitBug1208516?: boolean;
+}


### PR DESCRIPTION
* LocalDataTrackOptions Type Definitions Fix - logLevel is deprecated therefore should be optional.

This PR resolves issue [1826](https://github.com/twilio/twilio-video.js/issues/1826)

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

Make LocalDataTrackOptions.logLevel optional. 

### Description

This PR resolves issue [1826](https://github.com/twilio/twilio-video.js/issues/1826) by marking the deprecated `LocalDataTrackOptions.logLevel `as optional.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review
