### PR TITLE
VIDEO-11223 RemoteVideoTracks not switching on when maxSwitchedOnTracks is specified.

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -300,15 +300,17 @@ function connect(token, options) {
   // 1) "auto" = sdk will decide and send the hints.
   // 2) "manual" - app can use api to send the hints.
   // 3) "disabled" = do not enable this feature. (this is internal only value)
-  // 'disabled' is needed because clientTrackSwitchOffControl is incompatible with internal property maxSwitchedOnTracks.
+  // 'disabled' is needed because clientTrackSwitchOffControl is incompatible with internal property maxTracks.
   options.clientTrackSwitchOffControl = 'disabled'; // should sdk turn off idle tracks automatically?
   if (options.bandwidthProfile) {
     options.clientTrackSwitchOffControl = 'auto';
     options.contentPreferencesMode = 'auto';
     if (options.bandwidthProfile.video) {
-      if ('maxSwitchedOnTracks' in options.bandwidthProfile.video) {
-        // when maxSwitchedOnTracks is specified. disable clientTrackSwitchOffControl
+      if ('maxTracks' in options.bandwidthProfile.video) {
+        // when maxTracks is specified. disable clientTrackSwitchOffControl
         options.clientTrackSwitchOffControl = 'disabled';
+        options.bandwidthProfile.video.maxSwitchedOnTracks = options.bandwidthProfile.video.maxTracks;
+        delete options.bandwidthProfile.video.maxTracks;
       } else if (options.bandwidthProfile.video.clientTrackSwitchOffControl === 'manual') {
         options.clientTrackSwitchOffControl = 'manual';
       }

--- a/test/integration/spec/bandwidthprofile/regressions.js
+++ b/test/integration/spec/bandwidthprofile/regressions.js
@@ -52,7 +52,7 @@ describe('BandwidthProfile: regressions', function() {
           bandwidthProfile: {
             video: {
               dominantSpeakerPriority: PRIORITY_STANDARD,
-              maxSwitchedOnTracks: 1
+              maxTracks: 1
             }
           },
           dominantSpeaker: true,

--- a/test/integration/spec/bandwidthprofile/video.js
+++ b/test/integration/spec/bandwidthprofile/video.js
@@ -49,10 +49,10 @@ describe('BandwidthProfile: video', function() {
   describe('bandwidthProfile.video', () => {
     combinationContext([
       [
-        [{ maxSubscriptionBitrate: 0.4, maxSwitchedOnTracks: 0 }, { maxSwitchedOnTracks: 1 }], // maxSwitchedOnTracks=0 specified to disable clientTrackSwitchOffControl.
-        ({ maxSubscriptionBitrate, maxSwitchedOnTracks }) => maxSubscriptionBitrate
+        [{ maxSubscriptionBitrate: 0.4, maxTracks: 0 }, { maxTracks: 1 }], // maxTracks=0 specified to disable clientTrackSwitchOffControl.
+        ({ maxSubscriptionBitrate, maxTracks }) => maxSubscriptionBitrate
           ? `.maxSubscriptionBitrate = ${maxSubscriptionBitrate}`
-          : `.maxSwitchedOnTracks = ${maxSwitchedOnTracks}`
+          : `.maxTracks = ${maxTracks}`
       ],
       [
         [PRIORITY_LOW, PRIORITY_STANDARD, PRIORITY_HIGH],

--- a/test/integration/spec/localtrackpublication.js
+++ b/test/integration/spec/localtrackpublication.js
@@ -375,7 +375,7 @@ describe('LocalTrackPublication', function() {
           testOptions: {
             bandwidthProfile: {
               video: {
-                maxSwitchedOnTracks: 1,
+                maxTracks: 1,
                 dominantSpeakerPriority: 'low'
               }
             },
@@ -520,7 +520,7 @@ describe('LocalTrackPublication', function() {
             aliceOptions: {
               bandwidthProfile: {
                 video: {
-                  maxSwitchedOnTracks: 1,
+                  maxTracks: 1,
                   dominantSpeakerPriority: 'low'
                 }
               },
@@ -575,7 +575,7 @@ describe('LocalTrackPublication', function() {
     });
 
     it('publisher and subscriber priority changes do not mix up', async () => {
-      // Alice and Bob join without tracks, Alice has maxSwitchedOnTracks property set to 1
+      // Alice and Bob join without tracks, Alice has maxTracks property set to 1
       const { roomSid, aliceRoom, bobRoom, bobLocal, bobRemote } = await setupAliceAndBob({
         aliceOptions: { tracks: [] },
         bobOptions: { tracks: [] },
@@ -626,12 +626,12 @@ describe('LocalTrackPublication', function() {
     });
 
     it('publisher can upgrade and downgrade track priorities', async () => {
-      // Alice and Bob join without tracks, Alice has maxSwitchedOnTracks property set to 1
+      // Alice and Bob join without tracks, Alice has maxTracks property set to 1
       const { roomSid, aliceRoom, bobRoom, bobLocal, bobRemote } = await setupAliceAndBob({
         aliceOptions: {
           bandwidthProfile: {
             video: {
-              maxSwitchedOnTracks: 1,
+              maxTracks: 1,
               dominantSpeakerPriority: 'low'
             }
           },

--- a/test/integration/spec/remotetracks.js
+++ b/test/integration/spec/remotetracks.js
@@ -289,7 +289,7 @@ describe('RemoteVideoTrack', function() {
         testOptions: {
           bandwidthProfile: {
             video: {
-              maxSwitchedOnTracks: 1,
+              maxTracks: 1,
               dominantSpeakerPriority: 'low'
             }
           },
@@ -434,7 +434,7 @@ describe('RemoteVideoTrack', function() {
         tracks: [],
         bandwidthProfile: {
           video: {
-            maxSwitchedOnTracks: 1,
+            maxTracks: 1,
             dominantSpeakerPriority: 'low'
           }
         },

--- a/test/integration/spec/room.js
+++ b/test/integration/spec/room.js
@@ -599,7 +599,7 @@ describe('Room', function() {
     before(async () => {
       let thoseRooms;
       [, aliceRoom, thoseRooms] = await setup({
-        testOptions: { tracks: [], bandwidthProfile: { video: { maxSwitchedOnTracks: 1 } } },
+        testOptions: { tracks: [], bandwidthProfile: { video: { maxTracks: 1 } } },
         otherOptions: { tracks: [] },
         participantNames: ['Alice', 'Bob', 'Charlie'],
         nTracks: 0


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

Re-introduce maxTracks for internal testing so that maxSwitchedOnTracks behaves as expected in production.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
