### PR TITLE
Fix iOS Safari issues by moving VIDEO-6336 workaround to RemoteAudioTrack.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 
 **Version 1.x reached End of Life on September 8th, 2021.** See the changelog entry [here](https://www.twilio.com/changelog/end-of-life-complete-for-unsupported-versions-of-the-programmable-video-sdk). Support for the 1.x version ended on December 4th, 2020.
 
+2.24.3 (in progress)
+====================
+
+Bug Fixes
+---------
+
+- Fixed a bug where iOS Safari Participant could not hear or see others after switching back from YouTube picture-in-picture mode. (VIDEO-11352)
+- Fixed a bug where iOS Safari Participant could not hear others after switching from recording an audio message in a messenger app. (VIDEO-11354)
+- Fixed a bug where iOS Safari Participant could not hear or see others after watching a video in another browser tab. (VIDEO-11356)
+- Fixed a bug where iOS Safari Participant sometimes could not hear or see others after finishing an incoming call. (VIDEO-11359)
+
 2.24.2 (September 29, 2022)
 ===========================
 

--- a/COMMON_ISSUES.md
+++ b/COMMON_ISSUES.md
@@ -4,7 +4,6 @@ Common Issues
 Are you experiencing an issue with twilio-video.js? Please review this list of known issues and workarounds
 before opening a new issue. We recommend regularly upgrading to the latest version of the SDK, which includes new features, bug fixes and improvements (see [CHANGELOG.md](CHANGELOG.md)).
 
-
 ### Chrome desktop
 <details>
 <summary>Chrome memory leak might cause degraded experience in group rooms</summary>
@@ -32,37 +31,12 @@ before opening a new issue. We recommend regularly upgrading to the latest versi
 </p>
 </details>
 
-
-
 ### Chrome mobile
 <details>
 <summary>Android 11: Participants are unable to connect to a room due to ICE gathering failures on certain devices</summary>
 <p>
 
    Participants are unable to connect to a room on certain Android 11 devices due to a [Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1240237) where the browser is unable to gather ice candidates. Please see this [github issue](https://github.com/twilio/twilio-video.js/issues/1701#issuecomment-1067533348) for more details and a potential solution to mitigate the issue.
-</p>
-</details>
-<details>
-<summary>Android 12: Video distortion on Chrome when hardware acceleration is enabled</summary>
-<p>
-
-   This is a VP8 encoder issue on Android 12. Please see this [github ticket](https://github.com/twilio/twilio-video.js/issues/1627) and this [Chrome bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1237677) for more details.
-</p>
-</details>
-<details>
-<summary>Android Chrome on Pixel 3 receives corrupted video frames with codec VP8</summary>
-<p>
-
-   This is an issue in the hardware VP8 encoder on the Pixel 3 devices. See [WebRTC ticket](https://bugs.chromium.org/p/webrtc/issues/detail?id=11337). To work around this issue, please set H264 as the preferred video codec on Pixel 3. ([Example](https://github.com/twilio/video-quickstart-android/issues/470#issuecomment-623042880)).
-</p>
-</details>
-<details>
-<summary>Android Chrome 81+ Participants fail to subscribe to H264 VideoTracks in Group Rooms</summary>
-<p>
-
-   This happens primarily due to this [Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1074421).
-   We have added a workaround to the SDK in version 2.4.0. For earlier versions of the SDK,
-   please apply the workaround discussed in this [GitHub Issue](https://github.com/twilio/twilio-video.js/issues/966#issuecomment-619212184).
 </p>
 </details>
 
@@ -83,7 +57,6 @@ before opening a new issue. We recommend regularly upgrading to the latest versi
    To fix this issue, please update your adapter.js version to the newer one (^7.7.1) with the [fix](https://github.com/webrtcHacks/adapter/commit/de0348c756b7bda11a700bf7ea9e9393cab16421)
 </p>
 </details>
-
 <details>
 <summary>Echo issues in Safari when using external microphone</summary>
 <p>
@@ -107,14 +80,6 @@ before opening a new issue. We recommend regularly upgrading to the latest versi
 <script src="node_modules/zone.js/dist/zone.js"></script>
 <script src="node_modules/zone.js/dist/webapis-rtc-peer-connection.js"></script>
 ```
-</p>
-</details>
-<details>
-<summary>After unpublishing a Track, Safari 12.1 Participants cannot publish Track(s) of the same kind</summary>
-<p>
-
-   Because of this Safari 12.1 [bug](https://bugs.webkit.org/show_bug.cgi?id=195489),
-   once a Participant unpublishes a MediaTrack of any kind (audio or video), it will not be able to publish another MediaTrack of the same kind.        DataTracks are not affected. We have escalated this bug to the Safari Team and are keeping track of related developments.
 </p>
 </details>
 <details>
@@ -263,16 +228,15 @@ transform: scaleX(-1)
    This issue happened due to regression in Safari's WebKit in iOS version 14.2, the fix got rolled out in iOS 14.3 beta3. Find more details [here](https://github.com/twilio/twilio-video.js/issues/1296) and in this [WebKit bug](https://bugs.webkit.org/show_bug.cgi?id=218762).
 </p>
 </details>
-
-
-### Firefox desktop
 <details>
-<summary>Firefox Participants sometimes fail to subscribe to DataTracks on Peer-to-Peer Rooms</summary>
+<summary>Participant is disconnected from the Room after being backgrounded for 30 seconds due to another audio/video app or incoming phone call</summary>
 <p>
 
-   Because of this Firefox [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1603887) Participants that join a Peer-to-Peer Room after a DataTrack      has been published by a Firefox Participant fail to subscribe to it. You can work around this issue by publishing a DataTrack while connecting to    the Room.
+   This is due to iOS suspending browser sessions that are not capturing audio after 30 seconds, as mentioned in this [Webkit bug comment](https://bugs.webkit.org/show_bug.cgi?id=204681#c5). You can work around this by rejoining the Room once the browser is foregrounded.
 </p>
 </details>
+
+### Firefox desktop
 <details>
 <summary>Firefox Participants cannot constrain their audio bandwidth</summary>
 <p>

--- a/lib/media/track/audiotrack.js
+++ b/lib/media/track/audiotrack.js
@@ -29,18 +29,6 @@ class AudioTrack extends MediaTrack {
   }
 
   /**
-   * @private
-   */
-  _start() {
-    super._start();
-    if (this._dummyEl) {
-      // once started let go of dummy element
-      this._dummyEl.srcObject = null;
-      this._dummyEl = null;
-    }
-  }
-
-  /**
    * Create an HTMLAudioElement and attach the {@link AudioTrack} to it.
    *
    * The HTMLAudioElement's <code>srcObject</code> will be set to a new

--- a/lib/media/track/remoteaudiotrack.js
+++ b/lib/media/track/remoteaudiotrack.js
@@ -40,6 +40,19 @@ class RemoteAudioTrack extends RemoteMediaAudioTrack {
   }
 
   /**
+   * @private
+   */
+  _start() {
+    super._start();
+    if (this._dummyEl) {
+      // NOTE(mpatwardhan): To fix VIDEO-6336, clear dummy element after the
+      // RemoteAudioTrack has started.
+      this._dummyEl.srcObject = null;
+      this._dummyEl = null;
+    }
+  }
+
+  /**
    * Update the subscribe {@link Track.Priority} of the {@link RemoteAudioTrack}.
    * @param {?Track.Priority} priority - the new subscribe {@link Track.Priority};
    *   Currently setPriority has no effect on audio tracks.

--- a/test/unit/spec/media/track/audiotrack.js
+++ b/test/unit/spec/media/track/audiotrack.js
@@ -84,10 +84,6 @@ describe('AudioTrack', () => {
       it('should set the element\'s oncanplay to null', () => {
         assert.equal(dummyElement.oncanplay, null);
       });
-
-      it('should set the element\'s srcObject to null', () => {
-        assert.equal(dummyElement.srcObject, null);
-      });
     });
   });
 


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

Issues fixed:
* VIDEO-11352
* VIDEO-11354
* VIDEO-11356
* VIDEO-11359

Also updated `COMMON_ISSUES.md` to reflect current status.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
