### PR TITLE
VIDEO-11007 - Remove Firefox workaround 1480277

### DIFF
--- a/lib/webrtc/rtcpeerconnection/firefox.js
+++ b/lib/webrtc/rtcpeerconnection/firefox.js
@@ -7,13 +7,6 @@ var inherits = require('../../vendor/inherits');
 var updateTracksToSSRCs = require('../util/sdp').updateUnifiedPlanTrackIdsToSSRCs;
 var util = require('../util');
 
-// NOTE(mroberts): This is a short-lived workaround. Checking the user agent
-// string might not fix every affected Firefox instance, but it should be good
-// enough for this bug.
-var needsWorkaroundForBug1480277 = typeof navigator === 'object'
-  && navigator.userAgent
-  && (navigator.userAgent.match(/Firefox\/61/) || navigator.userAgent.match(/Firefox\/62/));
-
 // NOTE(mroberts): This class wraps Firefox's RTCPeerConnection implementation.
 // It provides some functionality not currently present in Firefox, namely the
 // abilities to
@@ -121,15 +114,6 @@ Object.defineProperty(FirefoxRTCPeerConnection.prototype, 'peerIdentity', {
     name: ''
   })
 });
-
-if (needsWorkaroundForBug1480277) {
-  FirefoxRTCPeerConnection.prototype.addTrack = function addTrack() {
-    var track = arguments[0];
-    var sender = this._peerConnection.addTrack.apply(this._peerConnection, arguments);
-    sender.replaceTrack(track);
-    return sender;
-  };
-}
 
 FirefoxRTCPeerConnection.prototype.createAnswer = function createAnswer() {
   var args = [].slice.call(arguments);

--- a/test/integration/spec/webrtc/rtcpeerconnection.js
+++ b/test/integration/spec/webrtc/rtcpeerconnection.js
@@ -45,7 +45,7 @@ const firefoxVersion = isFirefox && typeof navigator === 'object'
   ? navigator.userAgent.match(/Firefox\/(\d+)\./)[1]
   : null;
 
-describe.only(`RTCPeerConnection(${sdpFormat})`, function() {
+describe(`RTCPeerConnection(${sdpFormat})`, function() {
   after(() => {
     if (typeof gc === 'function') {
       gc();


### PR DESCRIPTION
JIRA: [VIDEO-11007](https://issues.corp.twilio.com/browse/VIDEO-11007)

Removing firefox workaround and the integration test

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

A description of what this PR does.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review
