### PR TITLE
FirefoxRTCPeerConnection es6 syntax

### DIFF
--- a/lib/webrtc/rtcpeerconnection/firefox.js
+++ b/lib/webrtc/rtcpeerconnection/firefox.js
@@ -1,11 +1,10 @@
 /* globals RTCPeerConnection */
 'use strict';
 
-var EventTarget = require('../util/eventtarget');
-var FirefoxRTCSessionDescription = require('../rtcsessiondescription/firefox');
-var inherits = require('../../vendor/inherits');
-var updateTracksToSSRCs = require('../util/sdp').updateUnifiedPlanTrackIdsToSSRCs;
-var util = require('../util');
+const EventTarget = require('../../eventtarget');
+const FirefoxRTCSessionDescription = require('../rtcsessiondescription/firefox');
+const updateTracksToSSRCs = require('../util/sdp').updateUnifiedPlanTrackIdsToSSRCs;
+const { delegateMethods, interceptEvent, legacyPromise, proxyProperties } = require('../util');
 
 // NOTE(mroberts): This class wraps Firefox's RTCPeerConnection implementation.
 // It provides some functionality not currently present in Firefox, namely the
@@ -27,230 +26,221 @@ var util = require('../util');
 //
 //     https://bugzilla.mozilla.org/show_bug.cgi?id=1240897
 //
-function FirefoxRTCPeerConnection(configuration) {
-  if (!(this instanceof FirefoxRTCPeerConnection)) {
-    return new FirefoxRTCPeerConnection(configuration);
-  }
+class FirefoxRTCPeerConnection extends EventTarget {
+  constructor(configuration) {
+    super();
 
-  EventTarget.call(this);
+    interceptEvent(this, 'signalingstatechange');
 
-  util.interceptEvent(this, 'signalingstatechange');
+    /* eslint new-cap:0 */
+    const peerConnection = new RTCPeerConnection(configuration);
 
-  /* eslint new-cap:0 */
-  var peerConnection = new RTCPeerConnection(configuration);
-
-  Object.defineProperties(this, {
-    _initiallyNegotiatedDtlsRole: {
-      value: null,
-      writable: true
-    },
-    _isClosed: {
-      value: false,
-      writable: true
-    },
-    _peerConnection: {
-      value: peerConnection
-    },
-    _rollingBack: {
-      value: false,
-      writable: true
-    },
-    _tracksToSSRCs: {
-      value: new Map()
-    },
-    iceGatheringState: {
-      enumerable: true,
-      get: function() {
-        return this._isClosed ? 'complete' : this._peerConnection.iceGatheringState;
+    Object.defineProperties(this, {
+      _initiallyNegotiatedDtlsRole: {
+        value: null,
+        writable: true
+      },
+      _isClosed: {
+        value: false,
+        writable: true
+      },
+      _peerConnection: {
+        value: peerConnection
+      },
+      _rollingBack: {
+        value: false,
+        writable: true
+      },
+      _tracksToSSRCs: {
+        value: new Map()
+      },
+      iceGatheringState: {
+        enumerable: true,
+        get: function() {
+          return this._isClosed ? 'complete' : this._peerConnection.iceGatheringState;
+        }
+      },
+      localDescription: {
+        enumerable: true,
+        get: function() {
+          return overwriteWithInitiallyNegotiatedDtlsRole(this._peerConnection.localDescription, this._initiallyNegotiatedDtlsRole);
+        }
+      },
+      signalingState: {
+        enumerable: true,
+        get: function() {
+          return this._isClosed ? 'closed' : this._peerConnection.signalingState;
+        }
+      },
+      peerIdentity: {
+        enumerable: true,
+        value: Promise.resolve({
+          idp: '',
+          name: ''
+        })
       }
-    },
-    localDescription: {
-      enumerable: true,
-      get: function() {
-        return overwriteWithInitiallyNegotiatedDtlsRole(this._peerConnection.localDescription, this._initiallyNegotiatedDtlsRole);
-      }
-    },
-    signalingState: {
-      enumerable: true,
-      get: function() {
-        return this._isClosed ? 'closed' : this._peerConnection.signalingState;
-      }
-    }
-  });
-
-  var self = this;
-  var previousSignalingState;
-
-  peerConnection.addEventListener('signalingstatechange', function onsignalingstatechange() {
-    if (!self._rollingBack && self.signalingState !== previousSignalingState) {
-      previousSignalingState = self.signalingState;
-
-      // NOTE(mmalavalli): In Firefox, 'signalingstatechange' event is
-      // triggered synchronously in the same tick after
-      // RTCPeerConnection#close() is called. So we mimic Chrome's behavior
-      // by triggering 'signalingstatechange' on the next tick.
-      var dispatchEventToSelf = self.dispatchEvent.apply.bind(self.dispatchEvent, self, arguments);
-      if (self._isClosed) {
-        setTimeout(dispatchEventToSelf);
-      } else {
-        dispatchEventToSelf();
-      }
-    }
-  });
-
-  util.proxyProperties(RTCPeerConnection.prototype, this, peerConnection);
-}
-
-inherits(FirefoxRTCPeerConnection, EventTarget);
-
-// NOTE(mmalavalli): Firefox throws a TypeError when the PeerConnection's
-// prototype's "peerIdentity" property is accessed. In order to overcome
-// this, we ignore this property while delegating methods.
-// Reference: https://bugzilla.mozilla.org/show_bug.cgi?id=1363815
-Object.defineProperty(FirefoxRTCPeerConnection.prototype, 'peerIdentity', {
-  enumerable: true,
-  value: Promise.resolve({
-    idp: '',
-    name: ''
-  })
-});
-
-FirefoxRTCPeerConnection.prototype.createAnswer = function createAnswer() {
-  var args = [].slice.call(arguments);
-  var promise;
-  var self = this;
-
-  promise = this._peerConnection.createAnswer().then(function createAnswerSucceeded(answer) {
-    saveInitiallyNegotiatedDtlsRole(self, answer);
-    return overwriteWithInitiallyNegotiatedDtlsRole(answer, self._initiallyNegotiatedDtlsRole);
-  });
-
-  return typeof args[0] === 'function'
-    ? util.legacyPromise(promise, args[0], args[1])
-    : promise;
-};
-
-// NOTE(mroberts): The WebRTC spec allows you to call createOffer from any
-// signalingState other than "closed"; however, Firefox has not yet implemented
-// this (https://bugzilla.mozilla.org/show_bug.cgi?id=1072388). We workaround
-// this by rolling back if we are in state "have-local-offer" or
-// "have-remote-offer". This is acceptable for our use case because we will
-// apply the newly-created offer almost immediately; however, this may be
-// unacceptable for other use cases.
-FirefoxRTCPeerConnection.prototype.createOffer = function createOffer() {
-  var args = [].slice.call(arguments);
-  var options = (args.length > 1 ? args[2] : args[0]) || {};
-  var promise;
-  var self = this;
-
-  if (this.signalingState === 'have-local-offer' ||
-      this.signalingState === 'have-remote-offer') {
-    var local = this.signalingState === 'have-local-offer';
-    promise = rollback(this, local, function rollbackSucceeded() {
-      return self.createOffer(options);
     });
-  } else {
-    promise = self._peerConnection.createOffer(options);
-  }
 
-  promise = promise.then(function(offer) {
-    return new FirefoxRTCSessionDescription({
-      type: offer.type,
-      sdp: updateTracksToSSRCs(self._tracksToSSRCs, offer.sdp)
+    let previousSignalingState;
+
+    peerConnection.addEventListener('signalingstatechange', (...args) => {
+      if (!this._rollingBack && this.signalingState !== previousSignalingState) {
+        previousSignalingState = this.signalingState;
+
+        // NOTE(mmalavalli): In Firefox, 'signalingstatechange' event is
+        // triggered synchronously in the same tick after
+        // RTCPeerConnection#close() is called. So we mimic Chrome's behavior
+        // by triggering 'signalingstatechange' on the next tick.
+        const dispatchEventToSelf = this.dispatchEvent.apply.bind(this.dispatchEvent, this, args);
+        if (this._isClosed) {
+          setTimeout(dispatchEventToSelf);
+        } else {
+          dispatchEventToSelf();
+        }
+      }
     });
-  });
 
-  return args.length > 1
-    ? util.legacyPromise(promise, args[0], args[1])
-    : promise;
-};
+    proxyProperties(RTCPeerConnection.prototype, this, peerConnection);
 
-// NOTE(mroberts): While Firefox will reject the Promise returned by
-// setLocalDescription when called from signalingState "have-local-offer" with
-// an answer, it still updates the .localDescription property. We workaround
-// this by explicitly handling this case.
-FirefoxRTCPeerConnection.prototype.setLocalDescription = function setLocalDescription() {
-  var args = [].slice.call(arguments);
-  var description = args[0];
-  var promise;
-
-  if (description && description.type === 'answer' && this.signalingState === 'have-local-offer') {
-    promise = Promise.reject(new Error('Cannot set local answer in state have-local-offer'));
+    // NOTE(mmalavalli): Firefox throws a TypeError when the PeerConnection's
+    // prototype's "peerIdentity" property is accessed. In order to overcome
+    // this, we ignore this property while delegating methods.
+    // Reference: https://bugzilla.mozilla.org/show_bug.cgi?id=1363815
   }
 
-  if (promise) {
-    return args.length > 1
-      ? util.legacyPromise(promise, args[1], args[2])
+  createAnswer(...args) {
+    const [arg1, arg2] = args;
+    let promise;
+
+    promise = this._peerConnection.createAnswer().then(answer => {
+      saveInitiallyNegotiatedDtlsRole(this, answer);
+      return overwriteWithInitiallyNegotiatedDtlsRole(answer, this._initiallyNegotiatedDtlsRole);
+    });
+
+    return typeof track === 'function'
+      ? legacyPromise(promise, arg1, arg2)
       : promise;
   }
 
-  return this._peerConnection.setLocalDescription.apply(this._peerConnection, args);
-};
+  // NOTE(mroberts): The WebRTC spec allows you to call createOffer from any
+  // signalingState other than "closed"; however, Firefox has not yet implemented
+  // this (https://bugzilla.mozilla.org/show_bug.cgi?id=1072388). We workaround
+  // this by rolling back if we are in state "have-local-offer" or
+  // "have-remote-offer". This is acceptable for our use case because we will
+  // apply the newly-created offer almost immediately; however, this may be
+  // unacceptable for other use cases.
+  createOffer(...args) {
+    const [arg1, arg2, arg3] = args;
+    const options = (args.length > 1 ? arg3 : arg1) || {};
+    let promise;
 
-// NOTE(mroberts): The WebRTC spec allows you to call setRemoteDescription with
-// an offer multiple times in signalingState "have-remote-offer"; however,
-// Firefox has not yet implemented this (https://bugzilla.mozilla.org/show_bug.cgi?id=1072388).
-// We workaround this by rolling back if we are in state "have-remote-offer".
-// This is acceptable for our use case; however, this may be unacceptable for
-// other use cases.
-//
-// While Firefox will reject the Promise returned by setRemoteDescription when
-// called from signalingState "have-remote-offer" with an answer, it sill
-// updates the .remoteDescription property. We workaround this by explicitly
-// handling this case.
-FirefoxRTCPeerConnection.prototype.setRemoteDescription = function setRemoteDescription() {
-  var args = [].slice.call(arguments);
-  var description = args[0];
-  var promise;
-  var self = this;
-
-  if (description && this.signalingState === 'have-remote-offer') {
-    if (description.type === 'answer') {
-      promise = Promise.reject(new Error('Cannot set remote answer in state have-remote-offer'));
-    } else if (description.type === 'offer') {
-      promise = rollback(this, false, function rollbackSucceeded() {
-        return self._peerConnection.setRemoteDescription(description);
+    if (this.signalingState === 'have-local-offer' ||
+      this.signalingState === 'have-remote-offer') {
+      const local = this.signalingState === 'have-local-offer';
+      promise = rollback(this, local, () => {
+        return this.createOffer(options);
       });
+    } else {
+      promise = this._peerConnection.createOffer(options);
+    }
+
+    promise = promise.then(offer => {
+      return new FirefoxRTCSessionDescription({
+        type: offer.type,
+        sdp: updateTracksToSSRCs(this._tracksToSSRCs, offer.sdp)
+      });
+    });
+
+    return args.length > 1
+      ? legacyPromise(promise, arg1, arg2)
+      : promise;
+  }
+
+  // NOTE(mroberts): While Firefox will reject the Promise returned by
+  // setLocalDescription when called from signalingState "have-local-offer" with
+  // an answer, it still updates the .localDescription property. We workaround
+  // this by explicitly handling this case.
+  setLocalDescription(...args) {
+    const [description, arg1, arg2] = args;
+    let promise;
+
+    if (description && description.type === 'answer' && this.signalingState === 'have-local-offer') {
+      promise = Promise.reject(new Error('Cannot set local answer in state have-local-offer'));
+    }
+
+    if (promise) {
+      return args.length > 1
+        ? legacyPromise(promise, arg1, arg2)
+        : promise;
+    }
+
+    return this._peerConnection.setLocalDescription.apply(this._peerConnection, args);
+  }
+
+  // NOTE(mroberts): The WebRTC spec allows you to call setRemoteDescription with
+  // an offer multiple times in signalingState "have-remote-offer"; however,
+  // Firefox has not yet implemented this (https://bugzilla.mozilla.org/show_bug.cgi?id=1072388).
+  // We workaround this by rolling back if we are in state "have-remote-offer".
+  // This is acceptable for our use case; however, this may be unacceptable for
+  // other use cases.
+  //
+  // While Firefox will reject the Promise returned by setRemoteDescription when
+  // called from signalingState "have-remote-offer" with an answer, it sill
+  // updates the .remoteDescription property. We workaround this by explicitly
+  // handling this case.
+  setRemoteDescription(...args) {
+    const [description, arg1, arg2] = args;
+
+    let promise;
+
+    if (description && this.signalingState === 'have-remote-offer') {
+      if (description.type === 'answer') {
+        promise = Promise.reject(new Error('Cannot set remote answer in state have-remote-offer'));
+      } else if (description.type === 'offer') {
+        promise = rollback(this, false, () => {
+          return this._peerConnection.setRemoteDescription(description);
+        });
+      }
+    }
+
+    if (!promise) {
+      promise = this._peerConnection.setRemoteDescription(description);
+    }
+
+    promise = promise.then(() => {
+      saveInitiallyNegotiatedDtlsRole(this, description, true);
+    });
+
+    return args.length > 1
+      ? legacyPromise(promise, arg1, arg2)
+      : promise;
+  }
+
+  // NOTE(mroberts): The WebRTC spec specifies that the PeerConnection's internal
+  // isClosed slot should immediately be set to true; however, in Firefox it
+  // occurs in the next tick. We workaround this by tracking isClosed manually.
+  close() {
+    if (this.signalingState !== 'closed') {
+      this._isClosed = true;
+      this._peerConnection.close();
     }
   }
+}
 
-  if (!promise) {
-    promise = this._peerConnection.setRemoteDescription(description);
-  }
-
-  promise = promise.then(function setRemoteDescriptionSucceeded() {
-    saveInitiallyNegotiatedDtlsRole(self, description, true);
-  });
-
-  return args.length > 1
-    ? util.legacyPromise(promise, args[1], args[2])
-    : promise;
-};
-
-// NOTE(mroberts): The WebRTC spec specifies that the PeerConnection's internal
-// isClosed slot should immediately be set to true; however, in Firefox it
-// occurs in the next tick. We workaround this by tracking isClosed manually.
-FirefoxRTCPeerConnection.prototype.close = function close() {
-  if (this.signalingState !== 'closed') {
-    this._isClosed = true;
-    this._peerConnection.close();
-  }
-};
-
-util.delegateMethods(
+delegateMethods(
   RTCPeerConnection.prototype,
   FirefoxRTCPeerConnection.prototype,
   '_peerConnection');
 
 function rollback(peerConnection, local, onceRolledBack) {
-  var setLocalDescription = local ? 'setLocalDescription' : 'setRemoteDescription';
+  const setLocalDescription = local ? 'setLocalDescription' : 'setRemoteDescription';
   peerConnection._rollingBack = true;
   return peerConnection._peerConnection[setLocalDescription](new FirefoxRTCSessionDescription({
     type: 'rollback'
-  })).then(onceRolledBack).then(function onceRolledBackSucceeded(result) {
+  })).then(onceRolledBack).then(result => {
     peerConnection._rollingBack = false;
     return result;
-  }, function rollbackOrOnceRolledBackFailed(error) {
+  }, error => {
     peerConnection._rollingBack = false;
     throw error;
   });
@@ -278,12 +268,12 @@ function saveInitiallyNegotiatedDtlsRole(peerConnection, description, remote) {
     return;
   }
 
-  var match = description.sdp.match(/a=setup:([a-z]+)/);
+  const match = description.sdp.match(/a=setup:([a-z]+)/);
   if (!match) {
     return;
   }
 
-  var dtlsRole = match[1];
+  const dtlsRole = match[1];
   peerConnection._initiallyNegotiatedDtlsRole = remote ? {
     active: 'passive',
     passive: 'active'

--- a/lib/webrtc/rtcpeerconnection/firefox.js
+++ b/lib/webrtc/rtcpeerconnection/firefox.js
@@ -54,24 +54,6 @@ class FirefoxRTCPeerConnection extends EventTarget {
       _tracksToSSRCs: {
         value: new Map()
       },
-      iceGatheringState: {
-        enumerable: true,
-        get: function() {
-          return this._isClosed ? 'complete' : this._peerConnection.iceGatheringState;
-        }
-      },
-      localDescription: {
-        enumerable: true,
-        get: function() {
-          return overwriteWithInitiallyNegotiatedDtlsRole(this._peerConnection.localDescription, this._initiallyNegotiatedDtlsRole);
-        }
-      },
-      signalingState: {
-        enumerable: true,
-        get: function() {
-          return this._isClosed ? 'closed' : this._peerConnection.signalingState;
-        }
-      },
       peerIdentity: {
         enumerable: true,
         value: Promise.resolve({
@@ -108,6 +90,18 @@ class FirefoxRTCPeerConnection extends EventTarget {
     // Reference: https://bugzilla.mozilla.org/show_bug.cgi?id=1363815
   }
 
+  get iceGatheringState() {
+    return this._isClosed ? 'complete' : this._peerConnection.iceGatheringState;
+  }
+
+  get localDescription() {
+    return overwriteWithInitiallyNegotiatedDtlsRole(this._peerConnection.localDescription, this._initiallyNegotiatedDtlsRole);
+  }
+
+  get signalingState() {
+    return this._isClosed ? 'closed' : this._peerConnection.signalingState;
+  }
+
   createAnswer(...args) {
     const [arg1, arg2] = args;
     let promise;
@@ -131,15 +125,13 @@ class FirefoxRTCPeerConnection extends EventTarget {
   // unacceptable for other use cases.
   createOffer(...args) {
     const [arg1, arg2, arg3] = args;
-    const options = (args.length > 1 ? arg3 : arg1) || {};
+    const options = (arg3 || arg1) || {};
     let promise;
 
     if (this.signalingState === 'have-local-offer' ||
       this.signalingState === 'have-remote-offer') {
       const local = this.signalingState === 'have-local-offer';
-      promise = rollback(this, local, () => {
-        return this.createOffer(options);
-      });
+      promise = rollback(this, local, () => this.createOffer(options));
     } else {
       promise = this._peerConnection.createOffer(options);
     }
@@ -197,9 +189,7 @@ class FirefoxRTCPeerConnection extends EventTarget {
       if (description.type === 'answer') {
         promise = Promise.reject(new Error('Cannot set remote answer in state have-remote-offer'));
       } else if (description.type === 'offer') {
-        promise = rollback(this, false, () => {
-          return this._peerConnection.setRemoteDescription(description);
-        });
+        promise = rollback(this, false, () => this._peerConnection.setRemoteDescription(description));
       }
     }
 
@@ -207,9 +197,7 @@ class FirefoxRTCPeerConnection extends EventTarget {
       promise = this._peerConnection.setRemoteDescription(description);
     }
 
-    promise = promise.then(() => {
-      saveInitiallyNegotiatedDtlsRole(this, description, true);
-    });
+    promise = promise.then(() => saveInitiallyNegotiatedDtlsRole(this, description, true));
 
     return args.length > 1
       ? legacyPromise(promise, arg1, arg2)

--- a/lib/webrtc/rtcpeerconnection/firefox.js
+++ b/lib/webrtc/rtcpeerconnection/firefox.js
@@ -3,7 +3,7 @@
 
 const EventTarget = require('../../eventtarget');
 const FirefoxRTCSessionDescription = require('../rtcsessiondescription/firefox');
-const updateTracksToSSRCs = require('../util/sdp').updateUnifiedPlanTrackIdsToSSRCs;
+const { updateUnifiedPlanTrackIdsToSSRCs: updateTracksToSSRCs } = require('../util/sdp');
 const { delegateMethods, interceptEvent, legacyPromise, proxyProperties } = require('../util');
 
 // NOTE(mroberts): This class wraps Firefox's RTCPeerConnection implementation.
@@ -54,6 +54,11 @@ class FirefoxRTCPeerConnection extends EventTarget {
       _tracksToSSRCs: {
         value: new Map()
       },
+
+      // NOTE(mmalavalli): Firefox throws a TypeError when the PeerConnection's
+      // prototype's "peerIdentity" property is accessed. In order to overcome
+      // this, we ignore this property while delegating methods.
+      // Reference: https://bugzilla.mozilla.org/show_bug.cgi?id=1363815
       peerIdentity: {
         enumerable: true,
         value: Promise.resolve({
@@ -73,21 +78,15 @@ class FirefoxRTCPeerConnection extends EventTarget {
         // triggered synchronously in the same tick after
         // RTCPeerConnection#close() is called. So we mimic Chrome's behavior
         // by triggering 'signalingstatechange' on the next tick.
-        const dispatchEventToSelf = this.dispatchEvent.apply.bind(this.dispatchEvent, this, args);
         if (this._isClosed) {
-          setTimeout(dispatchEventToSelf);
+          setTimeout(() => this.dispatchEvent(...args));
         } else {
-          dispatchEventToSelf();
+          this.dispatchEvent(...args);
         }
       }
     });
 
     proxyProperties(RTCPeerConnection.prototype, this, peerConnection);
-
-    // NOTE(mmalavalli): Firefox throws a TypeError when the PeerConnection's
-    // prototype's "peerIdentity" property is accessed. In order to overcome
-    // this, we ignore this property while delegating methods.
-    // Reference: https://bugzilla.mozilla.org/show_bug.cgi?id=1363815
   }
 
   get iceGatheringState() {
@@ -103,7 +102,6 @@ class FirefoxRTCPeerConnection extends EventTarget {
   }
 
   createAnswer(...args) {
-    const [arg1, arg2] = args;
     let promise;
 
     promise = this._peerConnection.createAnswer().then(answer => {
@@ -111,8 +109,8 @@ class FirefoxRTCPeerConnection extends EventTarget {
       return overwriteWithInitiallyNegotiatedDtlsRole(answer, this._initiallyNegotiatedDtlsRole);
     });
 
-    return typeof track === 'function'
-      ? legacyPromise(promise, arg1, arg2)
+    return typeof args[0] === 'function'
+      ? legacyPromise(promise, ...args)
       : promise;
   }
 
@@ -125,7 +123,7 @@ class FirefoxRTCPeerConnection extends EventTarget {
   // unacceptable for other use cases.
   createOffer(...args) {
     const [arg1, arg2, arg3] = args;
-    const options = (arg3 || arg1) || {};
+    const options = arg3 || arg1 || {};
     let promise;
 
     if (this.signalingState === 'have-local-offer' ||
@@ -153,7 +151,7 @@ class FirefoxRTCPeerConnection extends EventTarget {
   // an answer, it still updates the .localDescription property. We workaround
   // this by explicitly handling this case.
   setLocalDescription(...args) {
-    const [description, arg1, arg2] = args;
+    const [description, ...rest] = args;
     let promise;
 
     if (description && description.type === 'answer' && this.signalingState === 'have-local-offer') {
@@ -162,11 +160,11 @@ class FirefoxRTCPeerConnection extends EventTarget {
 
     if (promise) {
       return args.length > 1
-        ? legacyPromise(promise, arg1, arg2)
+        ? legacyPromise(promise, ...rest)
         : promise;
     }
 
-    return this._peerConnection.setLocalDescription.apply(this._peerConnection, args);
+    return this._peerConnection.setLocalDescription(...args);
   }
 
   // NOTE(mroberts): The WebRTC spec allows you to call setRemoteDescription with
@@ -181,7 +179,7 @@ class FirefoxRTCPeerConnection extends EventTarget {
   // updates the .remoteDescription property. We workaround this by explicitly
   // handling this case.
   setRemoteDescription(...args) {
-    const [description, arg1, arg2] = args;
+    const [description, ...rest] = args;
 
     let promise;
 
@@ -200,7 +198,7 @@ class FirefoxRTCPeerConnection extends EventTarget {
     promise = promise.then(() => saveInitiallyNegotiatedDtlsRole(this, description, true));
 
     return args.length > 1
-      ? legacyPromise(promise, arg1, arg2)
+      ? legacyPromise(promise, ...rest)
       : promise;
   }
 


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

ES6 syntax changes for FirefoxRTCPeerConnection

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
