### PR TITLE
Remove resize and metadata event listeners when the video element is being removed

### DIFF
--- a/lib/media/track/videotrack.js
+++ b/lib/media/track/videotrack.js
@@ -243,6 +243,17 @@ class VideoTrack extends MediaTrack {
   }
 
   /**
+   * @private
+   */
+  _end() {
+    if (this._dummyEl) {
+      this._dummyEl.onloadedmetadata = null;
+      this._dummyEl.onresize = null;
+    }
+    super._end();
+  }
+
+  /**
    * Add a {@link VideoProcessor} to allow for custom processing of video frames belonging to a VideoTrack.
    * @param {VideoProcessor} processor - The {@link VideoProcessor} to use.
    * @param {AddProcessorOptions} [options] - {@link AddProcessorOptions} to provide.


### PR DESCRIPTION
**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

Removed the `onloadedmetadata` and `onresize` callbacks when the video element is being removed. Related to #1786. I can't confirm 100% that this will completely solve the issue as it's been difficult to reproduce locally but it shouldn't cause any side effects.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Included screenshot as PR comment (if needed)
* [x] Ready for review
