### PR TITLE
fix: preserve track enabled state during cloning

### DIFF
--- a/lib/signaling/localtrackpublication.js
+++ b/lib/signaling/localtrackpublication.js
@@ -17,7 +17,15 @@ class LocalTrackPublicationSignaling extends TrackSignaling {
    * @param {Track.Priority} priority - initial {@link Track.Priority}
    */
   constructor(trackSender, name, priority) {
-    trackSender = trackSender.clone();
+    /**
+     * Safely clone a media stream track while preserving the original enabled state.
+     * This is needed because Safari 18 incorrectly enables tracks during cloning.
+     * See https://commits.webkit.org/285916@main for more details.
+     */
+    const clonedTrackSender = trackSender.clone();
+    clonedTrackSender.track.enabled = trackSender.track.enabled;
+    trackSender = clonedTrackSender;
+
     const enabled = trackSender.kind === 'data' ? true : trackSender.track.enabled;
     super(name, trackSender.kind, enabled, priority);
     this.setTrackTransceiver(trackSender);


### PR DESCRIPTION
## Pull Request Details

### Description

Ensures track.enabled state is correctly maintained when cloning MediaStreamTracks. Addresses a Safari 18 bug where cloned tracks are incorrectly enabled during cloning. See https://commits.webkit.org/285916@main for more details.


| Cloning a track on Safari 18                                                                                                            | Cloning a track on Chrome 130                                                                                                            |
| --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
| <img width="700" alt="Screenshot from Safari 18" src="https://github.com/user-attachments/assets/457aff57-42a7-4854-937e-bade35a4df5a"> | <img width="700" alt="Screenshot from Chrome 130" src="https://github.com/user-attachments/assets/61e8aef5-9612-4340-ac39-9f07775f7213"> |

[Bug report](https://bugs.webkit.org/show_bug.cgi?id=282465)

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review
