### PR TITLE
[VBLOCKS-3826] feat: add support for custom getUserMedia implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,35 +2,8 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 
 **Version 1.x reached End of Life on September 8th, 2021.** See the changelog entry [here](https://www.twilio.com/changelog/end-of-life-complete-for-unsupported-versions-of-the-programmable-video-sdk). Support for the 1.x version ended on December 4th, 2020.
 
-2.30.0 (unreleased)
+2.28.3 (in progress)
 ========================
-
-New Features
-------------
-
-- Added support for passing a custom `getUserMedia` as an option in `connect()`, `createLocalTracks()`, `createLocalAudioTrack()`, and `createLocalVideoTrack()` methods.
-
-```js
-var Video = require('twilio-video');
-
-function getUserMedia(constraints) {
-  // your custom implementation
-}
-
-Video.createLocalTracks({ video: true, audio: true, getUserMedia: getUserMedia }).then(function(localTracks) {
-  // connect to the room using your custom tracks
-  return Video.connect('my-token', {
-    name: 'my-cool-room',
-    tracks: localTracks
-  });
-});
-
-// or using connect directly
-
-Video.connect('token', { name: 'my-cool-room', getUserMedia: getUserMedia }).then((room) => {
-  // Your local tracks will be created using you the provided getUserMedia
-});
-```
 
 
 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,36 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 
 **Version 1.x reached End of Life on September 8th, 2021.** See the changelog entry [here](https://www.twilio.com/changelog/end-of-life-complete-for-unsupported-versions-of-the-programmable-video-sdk). Support for the 1.x version ended on December 4th, 2020.
 
-2.28.3 (in progress)
+2.30.0 (unreleased)
 ========================
+
+New Features
+------------
+
+- Added support for passing a custom `getUserMedia` as an option in `connect()`, `createLocalTracks()`, `createLocalAudioTrack()`, and `createLocalVideoTrack()` methods.
+
+```js
+var Video = require('twilio-video');
+
+function getUserMedia(constraints) {
+  // your custom implementation
+}
+
+Video.createLocalTracks({ video: true, audio: true, getUserMedia: getUserMedia }).then(function(localTracks) {
+  // connect to the room using your custom tracks
+  return Video.connect('my-token', {
+    name: 'my-cool-room',
+    tracks: localTracks
+  });
+});
+
+// or using connect directly
+
+Video.connect('token', { name: 'my-cool-room', getUserMedia: getUserMedia }).then((room) => {
+  // Your local tracks will be created using you the provided getUserMedia
+});
+```
+
 
 Bug Fixes
 ---------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 2.28.3 (in progress)
 ========================
 
+TODO(lrivas): Write public API to support VDI.
 
 Bug Fixes
 ---------

--- a/lib/createlocaltrack.js
+++ b/lib/createlocaltrack.js
@@ -18,6 +18,10 @@ function createLocalTrack(kind, options) {
   const createOptions = {};
   createOptions.loggerName = options.loggerName;
   createOptions.logLevel = options.logLevel;
+  if (options.getUserMedia) {
+    createOptions.getUserMedia = options.getUserMedia;
+    delete options.getUserMedia;
+  }
   delete options.loggerName;
   delete options.logLevel;
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import type { ConnectOptions, CreateLocalTrackOptions, CreateLocalAudioTrackOptions } from '../tsdef/types';
+import type { ConnectOptions, CreateLocalAudioTrackOptions, CreateLocalTrackOptions } from '../tsdef/types';
 import type { LocalAudioTrack as LocalAudioTrackType } from '../tsdef/LocalAudioTrack';
 import type { LocalVideoTrack as LocalVideoTrackType } from '../tsdef/LocalVideoTrack';
 import type { Log } from '../tsdef/loglevel';

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "contributors": [
     "Ryan Rowland <rrowland@twilio.com>",
     "Manjesh Malavalli <mmalavalli@twilio.com>",
-    "Makarand Patwardhan <mpatwardhan@twilio.com>"
+    "Makarand Patwardhan <mpatwardhan@twilio.com>",
+    "Luis Rivas <lrivas@twilio.com>"
   ],
   "keywords": [
     "twilio",

--- a/test/unit/spec/connect.js
+++ b/test/unit/spec/connect.js
@@ -370,6 +370,16 @@ describe('connect', () => {
       assert(createLocalTracks.calledOnce);
     });
 
+    it('passes the getUserMedia option to createLocalTracks()', () => {
+      const createLocalTracks = sinon.spy();
+      const getUserMedia = sinon.spy();
+      connect(token, { createLocalTracks, getUserMedia });
+      assert(createLocalTracks.calledOnce);
+      assert(createLocalTracks.calledWith(sinon.match({
+        getUserMedia
+      })));
+    });
+
     describe('and then immediately canceled by calling .cancel()', () => {
       it('calls .stop() on the LocalTracks', async () => {
         const stream = await fakeGetUserMedia({ audio: true, video: true });

--- a/test/unit/spec/createlocaltrack.js
+++ b/test/unit/spec/createlocaltrack.js
@@ -53,6 +53,18 @@ const {
       });
     });
 
+    it('should pass the getUserMedia option to createLocalTracks()', async () => {
+      const getUserMedia = sinon.spy(() => Promise.resolve(new MediaStream()));
+      const options = {
+        getUserMedia,
+        createLocalTracks: sinon.spy(() => Promise.resolve([]))
+      };
+      await createLocalTrack(options);
+      assert(options.createLocalTracks.calledWith(sinon.match({
+        getUserMedia
+      })));
+    });
+
     if (kind === 'Audio') {
       describe('defaultDeviceCaptureMode', () => {
         [{ defaultDeviceCaptureMode: 'auto' }, { defaultDeviceCaptureMode: 'manual' }, { defaultDeviceCaptureMode: 'foo' }].forEach(options => {

--- a/test/unit/spec/createlocaltracks.ts
+++ b/test/unit/spec/createlocaltracks.ts
@@ -138,6 +138,30 @@ describe('createLocalTracks', () => {
       });
     });
   });
+
+  context('when passing custom WebRTC overrides', () => {
+    it('should use the custom getUserMedia implementation if provided', async () => {
+      const options = makeOptions();
+      const getUserMediaSpy = sinon.spy((options.getUserMedia));
+      const expectedConstraints = {
+        audio: {
+          deviceId: {
+            exact: 'foo'
+          }
+        },
+        video: {
+          deviceId: {
+            exact: 'bar'
+          }
+        },
+      };
+      await createLocalTracks({ ...options, ...expectedConstraints, getUserMedia: getUserMediaSpy });
+      assert(getUserMediaSpy.calledOnce);
+      const callArgs = getUserMediaSpy.getCall(0).args;
+      assert.equal(callArgs.length, 1);
+      assert.deepEqual(callArgs[0], expectedConstraints, 'getUserMedia was not called with the expected constraints');
+    });
+  });
 });
 
 function makeOptions() {

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -238,9 +238,9 @@ export interface CreateLocalTracksOptions {
   audio?: boolean | CreateLocalTrackOptions | CreateLocalAudioTrackOptions;
   /**
    * @deprecated
-  */
- logLevel?: LogLevel | LogLevels;
- loggerName?: string;
+   */
+  logLevel?: LogLevel | LogLevels;
+  loggerName?: string;
   tracks?: LocalTrack[];
   video?: boolean | CreateLocalTrackOptions;
   getUserMedia?: (constraints: MediaStreamConstraints) => Promise<MediaStream>;

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -170,6 +170,7 @@ export interface CreateLocalTrackOptions extends MediaTrackConstraints {
   name?: string;
   workaroundWebKitBug180748?: boolean;
   workaroundWebKitBug1208516?: boolean;
+  getUserMedia?: (constraints: MediaStreamConstraints) => Promise<MediaStream>;
 }
 
 
@@ -230,17 +231,19 @@ export interface ConnectOptions {
 
   tracks?: Array<LocalTrack | MediaStreamTrack>;
   video?: boolean | CreateLocalTrackOptions;
+  getUserMedia?: (constraints: MediaStreamConstraints) => Promise<MediaStream>;
 }
 
 export interface CreateLocalTracksOptions {
   audio?: boolean | CreateLocalTrackOptions | CreateLocalAudioTrackOptions;
   /**
    * @deprecated
-   */
-  logLevel?: LogLevel | LogLevels;
-  loggerName?: string;
+  */
+ logLevel?: LogLevel | LogLevels;
+ loggerName?: string;
   tracks?: LocalTrack[];
   video?: boolean | CreateLocalTrackOptions;
+  getUserMedia?: (constraints: MediaStreamConstraints) => Promise<MediaStream>;
 }
 
 export class TrackStats {


### PR DESCRIPTION
## Pull Request Details

### JIRA link(s):
- [VBLOCKS-3826](https://twilio-engineering.atlassian.net/browse/VBLOCKS-3826)

### Description

- Added support for passing a custom `getUserMedia` as an option in `connect()`, `createLocalTracks()`, `createLocalAudioTrack()`, and `createLocalVideoTrack()` methods.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review
