### PR TITLE
feat: add support for enumerateDevices option in createLocalTrack

### DIFF
--- a/lib/createlocaltrack.js
+++ b/lib/createlocaltrack.js
@@ -2,6 +2,8 @@
 
 const { DEFAULT_LOG_LEVEL, DEFAULT_LOGGER_NAME } = require('./util/constants');
 
+const WebRTCOverrides = ['getUserMedia', 'enumerateDevices'];
+
 /**
  * Request a {@link LocalAudioTrack} or {@link LocalVideoTrack}.
  * @param {Track.Kind} kind - "audio" or "video"
@@ -18,12 +20,15 @@ function createLocalTrack(kind, options) {
   const createOptions = {};
   createOptions.loggerName = options.loggerName;
   createOptions.logLevel = options.logLevel;
-  if (options.getUserMedia) {
-    createOptions.getUserMedia = options.getUserMedia;
-    delete options.getUserMedia;
-  }
   delete options.loggerName;
   delete options.logLevel;
+
+  WebRTCOverrides.forEach(option => {
+    if (options[option]) {
+      createOptions[option] = options[option];
+      delete options[option];
+    }
+  });
 
   const createLocalTracks = options.createLocalTracks;
   delete options.createLocalTracks;

--- a/lib/createlocaltrack.js
+++ b/lib/createlocaltrack.js
@@ -23,10 +23,10 @@ function createLocalTrack(kind, options) {
   delete options.loggerName;
   delete options.logLevel;
 
-  WebRTCOverrides.forEach(option => {
-    if (options[option]) {
-      createOptions[option] = options[option];
-      delete options[option];
+  WebRTCOverrides.forEach(override => {
+    if (override in options) {
+      createOptions[override] = options[override];
+      delete options[override];
     }
   });
 

--- a/lib/media/track/localaudiotrack.js
+++ b/lib/media/track/localaudiotrack.js
@@ -51,19 +51,24 @@ class LocalAudioTrack extends LocalMediaAudioTrack {
         value: { deviceId: defaultDeviceId, groupId: defaultGroupId, label: defaultDeviceLabel },
         writable: true
       },
+      _enumerateDevices: {
+        value: typeof options.enumerateDevices === 'function'
+          ? options.enumerateDevices
+          : navigator.mediaDevices.enumerateDevices
+      },
       _defaultDeviceCaptureMode: {
         value: (!isIOS() || !!noiseCancellation)
           && this._isCreatedByCreateLocalTracks
           && typeof navigator === 'object'
           && typeof navigator.mediaDevices === 'object'
           && typeof navigator.mediaDevices.addEventListener === 'function'
-          && typeof navigator.mediaDevices.enumerateDevices === 'function'
+          && (typeof options.enumerateDevices === 'function' || typeof navigator.mediaDevices.enumerateDevices === 'function')
           ? options?.defaultDeviceCaptureMode || 'auto'
           : 'manual'
       },
       _onDeviceChange: {
         value: () => {
-          navigator.mediaDevices.enumerateDevices().then(deviceInfos => {
+          this._enumerateDevices().then(deviceInfos => {
             // NOTE(mmalavalli): In Chrome, when the default device changes, and we restart the LocalAudioTrack with
             // device ID "default", it will not switch to the new default device unless all LocalAudioTracks capturing
             // from the old default device are stopped. So, we restart the LocalAudioTrack with the actual device ID of

--- a/lib/media/track/localaudiotrack.js
+++ b/lib/media/track/localaudiotrack.js
@@ -52,7 +52,7 @@ class LocalAudioTrack extends LocalMediaAudioTrack {
         writable: true
       },
       _enumerateDevices: {
-        value: typeof options.enumerateDevices === 'function'
+        value: typeof options?.enumerateDevices === 'function'
           ? options.enumerateDevices
           : navigator.mediaDevices.enumerateDevices
       },
@@ -62,7 +62,7 @@ class LocalAudioTrack extends LocalMediaAudioTrack {
           && typeof navigator === 'object'
           && typeof navigator.mediaDevices === 'object'
           && typeof navigator.mediaDevices.addEventListener === 'function'
-          && (typeof options.enumerateDevices === 'function' || typeof navigator.mediaDevices.enumerateDevices === 'function')
+          && (typeof options?.enumerateDevices === 'function' || typeof navigator.mediaDevices.enumerateDevices === 'function')
           ? options?.defaultDeviceCaptureMode || 'auto'
           : 'manual'
       },

--- a/test/unit/spec/createlocaltrack.js
+++ b/test/unit/spec/createlocaltrack.js
@@ -65,6 +65,16 @@ const {
       })));
     });
 
+    it('should pass the enumerateDevices option to createLocalTracks()', async () => {
+      const enumerateDevices = sinon.spy(() => Promise.resolve([]));
+      const options = {
+        enumerateDevices,
+        createLocalTracks: sinon.spy(() => Promise.resolve([]))
+      };
+      await createLocalTrack(options);
+      assert(options.createLocalTracks.calledWith(sinon.match({ enumerateDevices })));
+    });
+
     if (kind === 'Audio') {
       describe('defaultDeviceCaptureMode', () => {
         [{ defaultDeviceCaptureMode: 'auto' }, { defaultDeviceCaptureMode: 'manual' }, { defaultDeviceCaptureMode: 'foo' }].forEach(options => {

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -244,6 +244,7 @@ export interface CreateLocalTracksOptions {
   tracks?: LocalTrack[];
   video?: boolean | CreateLocalTrackOptions;
   getUserMedia?: (constraints: MediaStreamConstraints) => Promise<MediaStream>;
+  enumerateDevices?: () => Promise<MediaDeviceInfo[]>;
 }
 
 export class TrackStats {


### PR DESCRIPTION
## Pull Request Details

### JIRA link(s):
- [VBLOCKS-3828](https://twilio-engineering.atlassian.net/browse/VBLOCKS-3828)

### Description
- add support for enumerateDevices option in createLocalTrack

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
