### PR TITLE
[VBLOCKS-3827] custom RTCPeerconnection

### DIFF
--- a/test/lib/mockwebrtc.js
+++ b/test/lib/mockwebrtc.js
@@ -258,12 +258,13 @@ URL.createObjectURL = createObjectURL;
 
 URL.revokeObjectURL = revokeObjectURL;
 
-function mockWebRTC(_global) {
-  _global = _global || global;
+function mockWebRTC(_global = globalThis) {
   const _window = _global.window = _global;
   _window.addEventListener = function addEventListener() {};
   _global.Event = Event;
   _global.WebSocket = WebSocket;
+  // Starting Node.js 21 the global object contains a readonly property called 'navigator'
+  if (_global.navigator) { delete _global.navigator; }
   _global.navigator = navigator;
   _global.webkitMediaStream = MediaStream;
   _global.MediaStream = MediaStream;

--- a/test/unit/spec/signaling/v2/peerconnection.js
+++ b/test/unit/spec/signaling/v2/peerconnection.js
@@ -48,6 +48,30 @@ describe('PeerConnectionV2', () => {
     it('sets .id', () => {
       assert.equal(test.pcv2.id, test.id);
     });
+
+    it('uses the provided custom RTCPeerConnection constructor when specified', () => {
+      let wasCustomConstructorCalled = false;
+      class CustomRTCPeerConnection {
+        constructor(configuration) {
+          wasCustomConstructorCalled = true;
+          this.configuration = configuration;
+          this.signalingState = 'stable';
+          this.iceConnectionState = 'new';
+          this.connectionState = 'new';
+          this.senders = [];
+          this.transceivers = [];
+          this.addTrack = () => {};
+          this.addEventListener = () => {};
+        }
+      }
+
+      const test = makeTest({
+        RTCPeerConnection: CustomRTCPeerConnection
+      });
+
+      assert(wasCustomConstructorCalled, 'Custom RTCPeerConnection constructor was not called');
+      assert(test.pcv2._peerConnection instanceof CustomRTCPeerConnection, 'PeerConnectionV2 is not using the custom RTCPeerConnection');
+    });
   });
 
   describe('.connectionState', () => {

--- a/tsdef/twilio-video-tests.ts
+++ b/tsdef/twilio-video-tests.ts
@@ -226,6 +226,40 @@ function LocalParticipant(localParticipant: Video.LocalParticipant) {
   });
 }
 
+function customWebRTCImplementations() {
+  const customRTCPeerConnection = class extends RTCPeerConnection {
+    constructor(configuration?: RTCConfiguration) {
+      super(configuration);
+    }
+  };
+  const getUserMedia = () => {
+    return Promise.resolve(new MediaStream());
+  };
+  const enumerateDevices = () => {
+    return Promise.resolve([]);
+  };
+
+  const localTracks = Video.createLocalTracks({
+    audio: true,
+    video: true,
+    getUserMedia,
+    enumerateDevices
+  });
+  const localAudioTrack = Video.createLocalAudioTrack({
+    getUserMedia,
+    enumerateDevices
+  });
+  const localVideoTrack = Video.createLocalVideoTrack({
+    getUserMedia,
+  });
+  const room = Video.connect('$TOKEN', {
+    RTCPeerConnection: customRTCPeerConnection,
+    getUserMedia,
+    enumerateDevices,
+  });
+}
+
+
 let room: Video.Room | null = null;
 let localVideoTrack: Video.LocalVideoTrack | null = null;
 let localAudioTrack: Video.LocalAudioTrack | null = null;

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -232,6 +232,7 @@ export interface ConnectOptions {
   tracks?: Array<LocalTrack | MediaStreamTrack>;
   video?: boolean | CreateLocalTrackOptions;
   getUserMedia?: (constraints: MediaStreamConstraints) => Promise<MediaStream>;
+  RTCPeerConnection?: any;
 }
 
 export interface CreateLocalTracksOptions {

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -193,6 +193,7 @@ export interface NoiseCancellationOptions {
 export interface CreateLocalAudioTrackOptions extends CreateLocalTrackOptions {
   defaultDeviceCaptureMode?: DefaultDeviceCaptureMode;
   noiseCancellationOptions?: NoiseCancellationOptions;
+  enumerateDevices?: () => Promise<Array<any>>;
 }
 
 export interface ConnectOptions {
@@ -231,8 +232,9 @@ export interface ConnectOptions {
 
   tracks?: Array<LocalTrack | MediaStreamTrack>;
   video?: boolean | CreateLocalTrackOptions;
-  getUserMedia?: (constraints: MediaStreamConstraints) => Promise<MediaStream>;
+  getUserMedia?: (constraints: MediaStreamConstraints) => Promise<any>;
   RTCPeerConnection?: any;
+  enumerateDevices?: () => Promise<Array<any>>;
 }
 
 export interface CreateLocalTracksOptions {
@@ -244,8 +246,8 @@ export interface CreateLocalTracksOptions {
   loggerName?: string;
   tracks?: LocalTrack[];
   video?: boolean | CreateLocalTrackOptions;
-  getUserMedia?: (constraints: MediaStreamConstraints) => Promise<MediaStream>;
-  enumerateDevices?: () => Promise<MediaDeviceInfo[]>;
+  getUserMedia?: (constraints: MediaStreamConstraints) => Promise<any>;
+  enumerateDevices?: () => Promise<Array<any>>;
 }
 
 export class TrackStats {


### PR DESCRIPTION
## Pull Request Details

### JIRA link(s):
- [VBLOCKS-3827](https://twilio-engineering.atlassian.net/browse/VBLOCKS-3827)

### Description
- add support for RTCPeerconnection option in `connectOptions`

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
