### PR TITLE
[VBLOCKS-3978] Handling custom AudioContext

### DIFF
--- a/lib/createlocaltracks.ts
+++ b/lib/createlocaltracks.ts
@@ -11,6 +11,7 @@ import {
 } from '../tsdef';
 
 import { applyNoiseCancellation } from './media/track/noisecancellationimpl';
+const AudioContextFactory = require('./webaudio/audiocontext');
 
 const { buildLogLevels } = require('./util');
 const { getUserMedia, MediaStreamTrack } = require('./webrtc');
@@ -161,6 +162,16 @@ export async function createLocalTracks(options?: CreateLocalTracksOptions): Pro
   if (typeof fullOptions.audio === 'object') {
     if (typeof fullOptions.audio.workaroundWebKitBug1208516 === 'boolean') {
       extraLocalTrackOptions.audio.workaroundWebKitBug1208516 = fullOptions.audio.workaroundWebKitBug1208516;
+    }
+
+    if ('audioContext' in fullOptions.audio) {
+      if (fullOptions.audio.audioContext === null) {
+        log.warn('AudioContext is disabled by user preference. Features that depend on AudioContext like silence detection and noise cancellation will not be available.');
+        AudioContextFactory.disable();
+      } else {
+        log.info('Using custom AudioContext implementation:', fullOptions.audio.audioContext);
+        AudioContextFactory.setAudioContext(fullOptions.audio.audioContext);
+      }
     }
 
     if ('noiseCancellationOptions' in fullOptions.audio) {

--- a/lib/webaudio/audiocontext.js
+++ b/lib/webaudio/audiocontext.js
@@ -40,8 +40,49 @@ class AudioContextFactory {
       AudioContextFactory: {
         enumerable: true,
         value: AudioContextFactory
+      },
+      _enabled: {
+        value: true,
+        writable: true
       }
     });
+  }
+
+  /**
+   * Disables audio context functionality
+   * @returns {void}
+   */
+  disable() {
+    if (this._holders.size > 0) {
+      throw new Error('Cannot disable while AudioContext has active holders');
+    }
+    this._enabled = false;
+    if (this._audioContext) {
+      this._audioContext.close();
+      this._audioContext = null;
+    }
+  }
+
+  /**
+   * @returns {boolean} Whether audio context functionality is enabled
+   */
+  isEnabled() {
+    return this._enabled;
+  }
+
+  /**
+   * Sets a custom AudioContext instance
+   * @param {AudioContext} customContext - The AudioContext instance to use
+   * @returns {void}
+   */
+  setAudioContext(customContext) {
+    if (!this._enabled) {
+      throw new Error('Cannot set AudioContext while it is disabled');
+    }
+    if (this._holders.size > 0) {
+      throw new Error('Cannot change AudioContext while it has active holders');
+    }
+    this._audioContext = customContext;
   }
 
   /**
@@ -52,6 +93,9 @@ class AudioContextFactory {
    * @returns {?AudioContext}
    */
   getOrCreate(holder) {
+    if (!this._enabled) {
+      throw new Error('Cannot use AudioContext while it is disabled');
+    }
     if (!this._holders.has(holder)) {
       this._holders.add(holder);
       if (this._AudioContext && !this._audioContext) {

--- a/test/unit/spec/webaudio/audiocontext.js
+++ b/test/unit/spec/webaudio/audiocontext.js
@@ -186,4 +186,32 @@ describe('AudioContextFactory', () => {
       });
     });
   });
+
+  describe('#setAudioContext', () => {
+    it('sets and uses the custom audio context', () => {
+      const mockAudioContext = { close: sinon.spy() };
+      const factory = new AudioContextFactory();
+      factory.setAudioContext(mockAudioContext);
+      let holder = {};
+      const result = factory.getOrCreate(holder);
+      assert.equal(result, mockAudioContext);
+      factory.release(holder);
+      sinon.assert.calledOnce(mockAudioContext.close);
+    });
+
+    it('throws an error if the audio context is disabled', () => {
+      const factory = new AudioContextFactory();
+      factory.disable();
+      assert.throws(() => factory.setAudioContext({}), Error);
+    });
+  });
+
+  describe('#disable', () => {
+    it('disables the audio context', () => {
+      const factory = new AudioContextFactory();
+      assert.equal(factory.isEnabled(), true);
+      factory.disable();
+      assert.equal(factory.isEnabled(), false);
+    });
+  });
 });

--- a/tsdef/twilio-video-tests.ts
+++ b/tsdef/twilio-video-tests.ts
@@ -239,20 +239,26 @@ function customWebRTCImplementations() {
     return Promise.resolve([]);
   };
 
+  const audioContext = new AudioContext();
+
   const localTracks = Video.createLocalTracks({
     audio: true,
     video: true,
     getUserMedia,
-    enumerateDevices
+    enumerateDevices,
   });
   const localAudioTrack = Video.createLocalAudioTrack({
     getUserMedia,
-    enumerateDevices
+    enumerateDevices,
+    audioContext
   });
   const localVideoTrack = Video.createLocalVideoTrack({
     getUserMedia,
   });
   const room = Video.connect('$TOKEN', {
+    audio: {
+      audioContext
+    },
     RTCPeerConnection: customRTCPeerConnection,
     getUserMedia,
     enumerateDevices,

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -194,6 +194,12 @@ export interface CreateLocalAudioTrackOptions extends CreateLocalTrackOptions {
   defaultDeviceCaptureMode?: DefaultDeviceCaptureMode;
   noiseCancellationOptions?: NoiseCancellationOptions;
   enumerateDevices?: () => Promise<Array<any>>;
+  /**
+   * AudioContext to use for audio processing features. Set to null to disable AudioContext usage.
+   * When null, features that depend on AudioContext like silence detection and noise cancellation will not be available.
+   * @default The default AudioContext implementation
+   */
+  audioContext?: AudioContext | null;
 }
 
 export interface ConnectOptions {


### PR DESCRIPTION
## Pull Request Details

### JIRA link(s):
- [VBLOCKS-3978](https://twilio-engineering.atlassian.net/browse/VBLOCKS-3978)

### Description
- Added a new custom audioContext option. Users can now provide an AudioContext instance or completely disable audio processing by passing `null`.  While turning off audio processing can be a valid use case, features that depend on AudioContext like silence detection and noise cancellation will not be available.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
