### PR TITLE
[VBLOCKS-4111] feat: validate MediaStream constructor in MediaTrack

### DIFF
--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -45,6 +45,10 @@ class MediaTrack extends Track {
       MediaStream
     }, options);
 
+    if (typeof options.MediaStream !== 'function') {
+      throw new Error('MediaTrack received an invalid MediaStream constructor: ' + options.MediaStream);
+    }
+
     /* istanbul ignore next */
     Object.defineProperties(this, {
       _attachments: {

--- a/lib/participant.js
+++ b/lib/participant.js
@@ -340,7 +340,10 @@ class Participant extends EventEmitter {
         return;
       }
 
-      const options = { log, name, clientTrackSwitchOffControl, contentPreferencesMode, MediaStream };
+      const options = { log, name, clientTrackSwitchOffControl, contentPreferencesMode };
+      if (MediaStream) {
+        options.MediaStream = MediaStream;
+      }
       const setPriority = newPriority => participantSignaling.updateSubscriberTrackPriority(sid, newPriority);
       const setRenderHint = renderHint => {
         if (signaling.isSubscribed) {

--- a/test/unit/spec/media/track/mediatrack.js
+++ b/test/unit/spec/media/track/mediatrack.js
@@ -45,6 +45,13 @@ describe('MediaTrack', () => {
     it('should return the mediaTrackTransceiver.track as the mediaStreamTrack if unprocessedTrack does not exists', () => {
       assert.equal(track.mediaStreamTrack, track.tranceiver.track);
     });
+
+    it.only('should throw an error if an invalid MediaStream is provided', () => {
+      assert.throws(
+        () =>  createMediaTrack('1', 'audio', { MediaStream: null }),
+        /MediaTrack received an invalid MediaStream constructor/
+      );
+    });
   });
 
   describe('_initialize', () => {


### PR DESCRIPTION
## Pull Request Details

### JIRA link(s):
- [VBLOCKS-4111](https://twilio-engineering.atlassian.net/browse/VBLOCKS-4111)

### Description
- Validate MediaStream constructor in MediaTrack

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
