### PR TITLE
[VBLOCKS-3977] Polyfill getStats in VDI

### DIFF
--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1639,7 +1639,7 @@ class PeerConnectionV2 extends StateMachine {
    * @returns {Promise<StandardizedStatsResponse>}
    */
   getStats() {
-    return getStatistics(this._peerConnection).then(response => rewriteTrackIds(this, response));
+    return getStatistics(this._peerConnection, { log: this._log }).then(response => rewriteTrackIds(this, response));
   }
 }
 

--- a/lib/webrtc/getstats.js
+++ b/lib/webrtc/getstats.js
@@ -11,7 +11,9 @@ const isFirefox = guess === 'firefox';
 const isSafari = guess === 'safari';
 
 const chromeMajorVersion = isChrome ? guessVersion.major : null;
-const log = new Log('webrtc', null);
+const log = new Log('webrtc', {
+  toString: () => 'getStats'
+});
 
 const CHROME_LEGACY_MAX_AUDIO_LEVEL = 32767;
 

--- a/lib/webrtc/getstats.js
+++ b/lib/webrtc/getstats.js
@@ -621,9 +621,9 @@ function chromeOrSafariGetTrackStats(peerConnection, track, options) {
         .then(stats => {
           log.info('getStats by default successful');
           const isRemote = isRemoteTrack(peerConnection, track);
-          log.info(`Starting filtering stats for ${isRemote ? 'remote' : 'local'} track with id: ${track.id}`);
+          log.info(`Starting filtering stats for ${isRemote ? 'remote' : 'local'} track`);
           const filteredStats = filterStatsByTrack(stats, track, isRemote);
-          log.info(`Completed filtering stats for ${isRemote ? 'remote' : 'local'} track with id: ${track.id}`);
+          log.info(`Completed filtering stats for ${isRemote ? 'remote' : 'local'} track`);
           return standardizeChromeOrSafariStats(filteredStats, options);
         });
     });

--- a/lib/webrtc/getstats.js
+++ b/lib/webrtc/getstats.js
@@ -591,20 +591,6 @@ function getTrackStats(peerConnection, track, options = {}) {
   return Promise.reject(new Error('RTCPeerConnection#getStats() not supported'));
 }
 
-/**
- * Safely logs a message using the provided logger instance.
- * If no logger is provided, this function performs no operation.
- *
- * @param {object} [logger] - Optional logger instance with logging methods (e.g., info, warn, error).
- * @param {string} level - Logging level method name (e.g., 'info', 'warn', 'error').
- * @param {string} message - Message to log.
- * @returns {void}
- */
-function safeLog(logger, level, message) {
-  if (logger) {
-    logger[level](message);
-  }
-}
 
 /**
  * Get the standardized statistics for a particular MediaStreamTrack in Chrome or Safari.
@@ -625,20 +611,20 @@ function chromeOrSafariGetTrackStats(peerConnection, track, options) {
 
   return peerConnection.getStats(track)
     .then(response => {
-      safeLog(log, 'info', 'getStats by track successful');
+      log.info('getStats by track successful');
       return standardizeChromeOrSafariStats(response, options);
     })
     .catch(() => {
       // NOTE(lrivas): Citrix doesn't support track-specific getStats,
       // so this workaround tries getting all stats and filtering by track.
-      safeLog(log, 'warn', 'getStats by track failed. Getting default stats');
+      log.warn('getStats by track failed. Getting default stats');
       return peerConnection.getStats()
         .then(stats => {
-          safeLog(log, 'info', 'getStats by default successful');
+          log.info('getStats by default successful');
           const isRemote = isRemoteTrack(peerConnection, track);
-          safeLog(log, 'info', `Starting filtering stats for ${isRemote ? 'remote' : 'local'} track`);
+          log.info(`Starting filtering stats for ${isRemote ? 'remote' : 'local'} track`);
           const filteredStats = filterStatsByTrack(stats, track, isRemote);
-          safeLog(log, 'info', `Completed filtering stats for ${isRemote ? 'remote' : 'local'} track`);
+          log.info(`Completed filtering stats for ${isRemote ? 'remote' : 'local'} track`);
           return standardizeChromeOrSafariStats(filteredStats, options);
         });
     });

--- a/lib/webrtc/getstats.js
+++ b/lib/webrtc/getstats.js
@@ -11,9 +11,7 @@ const isFirefox = guess === 'firefox';
 const isSafari = guess === 'safari';
 
 const chromeMajorVersion = isChrome ? guessVersion.major : null;
-const log = new Log('webrtc', {
-  toString: () => 'getStats'
-});
+const log = new Log('webrtc', 'getStats');
 
 const CHROME_LEGACY_MAX_AUDIO_LEVEL = 32767;
 

--- a/lib/webrtc/getstats.js
+++ b/lib/webrtc/getstats.js
@@ -14,6 +14,242 @@ const chromeMajorVersion = isChrome ? guessVersion.major : null;
 const CHROME_LEGACY_MAX_AUDIO_LEVEL = 32767;
 
 /**
+ * Helper function to find a specific stat from a report.
+ * Browsers provide the stats report as a Map,
+ * but Citrix provides stats report as an array.
+ * @private
+ */
+function getStatById(report, id) {
+  if (typeof report.get === 'function') {
+    return report.get(id);
+  }
+  return report.find(s => s.id === id);
+}
+
+/**
+ * Filter the RTCStatsReport to only include stats related to a specific track.
+ * This function is designed for use with Citrix, where getStats(track) is not supported.
+ * It includes specific logic to filter the statistics report returned by Citrix and should
+ * only be used when getStats(track) fails.
+ *
+ * @param {RTCStatsReport|Array<RTCStats>} arrayOrMap - Full stats report or array of stats
+ * @param {MediaStreamTrack} track - The track to filter by
+ * @param {boolean} [isRemote=false] - Whether this is a remote track
+ * @returns {RTCStatsReport} Filtered stats
+ * @private
+ */
+function filterStatsByTrack(arrayOrMap, track, isRemote = false) {
+  // Handle different input types
+  let allStats;
+  if (Array.isArray(arrayOrMap)) {
+    allStats = new Map(arrayOrMap.map(stat => [stat.id || String(Math.random()), stat]));
+  } else if (arrayOrMap instanceof Map) {
+    allStats = arrayOrMap;
+  } else if (typeof arrayOrMap === 'object' && arrayOrMap !== null) {
+    // Handle object-style stats (non-standard)
+    const statsMap = new Map();
+    Object.keys(arrayOrMap).forEach(key => {
+      statsMap.set(key, arrayOrMap[key]);
+    });
+    allStats = statsMap;
+  } else {
+    return new Map();
+  }
+
+  if (!allStats || !track) {
+    return new Map();
+  }
+
+  const filteredReport = new Map();
+  const trackId = track.id;
+  const trackKind = track.kind;
+
+  // Step 1: Find the primary track-specific stats
+  let primaryStats = null;
+  let primaryStatsId = null;
+  let ssrc = null;
+
+  // Find the primary stat for this track (inbound-rtp for remote, media-source for local)
+  for (const [id, stat] of allStats) {
+    // For remote tracks, find matching inbound-rtp with matching trackIdentifier
+    if (isRemote && stat.type === 'inbound-rtp' && stat.trackIdentifier === trackId) {
+      primaryStats = stat;
+      primaryStatsId = id;
+      ssrc = stat.ssrc;
+      break;
+    } else if (!isRemote && stat.type === 'media-source' && stat.trackIdentifier === trackId) {
+      // For local tracks, find matching media-source with matching trackIdentifier
+      primaryStats = stat;
+      primaryStatsId = id;
+      break;
+    } else if (stat.type === 'track' && stat.trackIdentifier === trackId) {
+      // Also check for track stats with matching trackIdentifier
+      if (!primaryStats) {
+        primaryStats = stat;
+        primaryStatsId = id;
+      }
+    }
+  }
+
+  // If no primary stat was found using the trackId, try a more lenient approach
+  if (!primaryStats) {
+    // For remote tracks, try to find an inbound-rtp of the correct kind
+    if (isRemote) {
+      // Get all inbound-rtp stats of the right kind
+      const candidateInbounds = [];
+      for (const [id, stat] of allStats) {
+        if (stat.type === 'inbound-rtp' && (stat.kind === trackKind || stat.mediaType === trackKind)) {
+          candidateInbounds.push({ id, stat });
+        }
+      }
+
+      // If there are multiple candidates, we need to be careful
+      if (candidateInbounds.length === 1) {
+        // Only one candidate, use it
+        primaryStats = candidateInbounds[0].stat;
+        primaryStatsId = candidateInbounds[0].id;
+        ssrc = primaryStats.ssrc;
+      } else if (candidateInbounds.length > 1) {
+        // Multiple candidates - if we have the trackId, try to match by mid
+        // otherwise just take the first one
+        primaryStats = candidateInbounds[0].stat;
+        primaryStatsId = candidateInbounds[0].id;
+        ssrc = primaryStats.ssrc;
+      }
+    } else {
+      // For local tracks, try to find a media-source of the correct kind
+      for (const [id, stat] of allStats) {
+        if (stat.type === 'media-source' && stat.kind === trackKind) {
+          primaryStats = stat;
+          primaryStatsId = id;
+          break;
+        }
+      }
+    }
+  }
+
+  // If we still didn't find a primary stat, return an empty report
+  if (!primaryStats) {
+    return filteredReport;
+  }
+
+  // Step 2: Add the primary stat
+  filteredReport.set(primaryStatsId, primaryStats);
+
+  // Step 3: Add related stats using direct references
+  const directlyRelatedIds = new Set();
+
+  // Track different types of related IDs
+  if (isRemote) {
+    // For remote tracks (inbound-rtp is primary)
+    if (primaryStats.codecId) { directlyRelatedIds.add(primaryStats.codecId); }
+    if (primaryStats.transportId) { directlyRelatedIds.add(primaryStats.transportId); }
+    if (primaryStats.remoteId) { directlyRelatedIds.add(primaryStats.remoteId); }
+
+    // Find remote-outbound-rtp based on ssrc
+    if (ssrc) {
+      for (const [id, stat] of allStats) {
+        if (stat.type === 'remote-outbound-rtp' && stat.ssrc === ssrc) {
+          directlyRelatedIds.add(id);
+        }
+      }
+    }
+
+    // Add codec, transport, and remote stats
+    for (const relatedId of directlyRelatedIds) {
+      if (allStats.has(relatedId)) {
+        filteredReport.set(relatedId, allStats.get(relatedId));
+      }
+    }
+
+    // Add the track stats if it exists
+    for (const [id, stat] of allStats) {
+      if (stat.type === 'track' && stat.trackIdentifier === trackId) {
+        filteredReport.set(id, stat);
+      }
+    }
+  } else {
+    // For local tracks (media-source is primary)
+
+    // Find outbound-rtp that references this media source
+    for (const [id, stat] of allStats) {
+      if (stat.type === 'outbound-rtp' && stat.mediaSourceId === primaryStatsId) {
+        filteredReport.set(id, stat);
+
+        // Add codec and transport
+        if (stat.codecId) { directlyRelatedIds.add(stat.codecId); }
+        if (stat.transportId) { directlyRelatedIds.add(stat.transportId); }
+
+        // Find remote-inbound-rtp that references this outbound-rtp
+        const outboundId = id;
+        for (const [remoteId, remoteStat] of allStats) {
+          if (remoteStat.type === 'remote-inbound-rtp' && remoteStat.localId === outboundId) {
+            filteredReport.set(remoteId, remoteStat);
+          }
+        }
+      }
+    }
+
+    // Add codec and transport stats
+    for (const relatedId of directlyRelatedIds) {
+      if (allStats.has(relatedId)) {
+        filteredReport.set(relatedId, allStats.get(relatedId));
+      }
+    }
+  }
+
+  // Step 4: Add candidate pair and certificate info for context
+  // This is useful information that applies to all tracks
+  // but doesn't risk mixing data between tracks
+  let selectedPairId = null;
+  const transportIds = new Set();
+
+  // Find all transport IDs referenced in our filtered stats
+  for (const stat of filteredReport.values()) {
+    if (stat.transportId) {
+      transportIds.add(stat.transportId);
+    }
+  }
+
+  // Add the transports
+  for (const transportId of transportIds) {
+    if (allStats.has(transportId)) {
+      const transport = allStats.get(transportId);
+      filteredReport.set(transportId, transport);
+
+      // Track the selected candidate pair
+      if (transport.selectedCandidatePairId) {
+        selectedPairId = transport.selectedCandidatePairId;
+      }
+
+      // Add certificate info
+      if (transport.localCertificateId && allStats.has(transport.localCertificateId)) {
+        filteredReport.set(transport.localCertificateId, allStats.get(transport.localCertificateId));
+      }
+      if (transport.remoteCertificateId && allStats.has(transport.remoteCertificateId)) {
+        filteredReport.set(transport.remoteCertificateId, allStats.get(transport.remoteCertificateId));
+      }
+    }
+  }
+
+  // Add only the selected candidate pair, not all candidate pairs
+  if (selectedPairId && allStats.has(selectedPairId)) {
+    const selectedPair = allStats.get(selectedPairId);
+    filteredReport.set(selectedPairId, selectedPair);
+
+    // Add the local and remote candidates for the selected pair
+    if (selectedPair.localCandidateId && allStats.has(selectedPair.localCandidateId)) {
+      filteredReport.set(selectedPair.localCandidateId, allStats.get(selectedPair.localCandidateId));
+    }
+    if (selectedPair.remoteCandidateId && allStats.has(selectedPair.remoteCandidateId)) {
+      filteredReport.set(selectedPair.remoteCandidateId, allStats.get(selectedPair.remoteCandidateId));
+    }
+  }
+
+  return filteredReport;
+}
+
+/**
  * Get the standardized {@link RTCPeerConnection} statistics.
  * @param {RTCPeerConnection} peerConnection
  * @param {object} [options] - Used for testing
@@ -103,8 +339,8 @@ function standardizeChromeOrSafariActiveIceCandidatePairStats(stats) {
     return null;
   }
 
-  const activeLocalCandidateStats = stats.get(activeCandidatePairStats.localCandidateId);
-  const activeRemoteCandidateStats = stats.get(activeCandidatePairStats.remoteCandidateId);
+  const activeLocalCandidateStats = getStatById(stats, activeCandidatePairStats.localCandidateId);
+  const activeRemoteCandidateStats = getStatById(stats, activeCandidatePairStats.remoteCandidateId);
 
   const standardizedCandidateStatsKeys = [
     { key: 'candidateType', type: 'string' },
@@ -185,8 +421,8 @@ function standardizeFirefoxActiveIceCandidatePairStats(stats) {
     return null;
   }
 
-  const activeLocalCandidateStats = stats.get(activeCandidatePairStats.localCandidateId);
-  const activeRemoteCandidateStats = stats.get(activeCandidatePairStats.remoteCandidateId);
+  const activeLocalCandidateStats = getStatById(stats, activeCandidatePairStats.localCandidateId);
+  const activeRemoteCandidateStats = getStatById(stats, activeCandidatePairStats.remoteCandidateId);
 
   const standardizedCandidateStatsKeys = [
     { key: 'candidateType', type: 'string' },
@@ -286,6 +522,46 @@ function getTracks(peerConnection, kind, localOrRemote) {
 }
 
 /**
+ * Determine if a track is remote by examining the PeerConnection's receivers.
+ * This function is designed for use with Citrix, where getStats(track) is not supported.
+ * @param {RTCPeerConnection} peerConnection
+ * @param {MediaStreamTrack} track
+ * @returns {boolean} True if the track is a remote track
+ * @private
+ */
+function isRemoteTrack(peerConnection, track) {
+  if (!peerConnection || !track) {
+    return false;
+  }
+
+  // Check if the track belongs to any receiver (remote)
+  if (peerConnection.getReceivers) {
+    const receivers = peerConnection.getReceivers();
+    for (const receiver of receivers) {
+      if (receiver.track && receiver.track.id === track.id) {
+        return true;
+      }
+    }
+  }
+
+  // Check remote streams if getReceivers is not available
+  if (peerConnection.getRemoteStreams) {
+    const remoteStreams = peerConnection.getRemoteStreams();
+    for (const stream of remoteStreams) {
+      const tracks = stream.getTracks();
+      for (const remoteTrack of tracks) {
+        if (remoteTrack.id === track.id) {
+          return true;
+        }
+      }
+    }
+  }
+
+  // The track is not in any remote source, so it's likely local
+  return false;
+}
+
+/**
  * Get the standardized statistics for a particular MediaStreamTrack.
  * @param {RTCPeerConnection} peerConnection
  * @param {MediaStreamTrack} track
@@ -329,9 +605,21 @@ function chromeOrSafariGetTrackStats(peerConnection, track, options) {
       }, null, reject);
     });
   }
-  return peerConnection.getStats(track).then(response => {
-    return standardizeChromeOrSafariStats(response, options);
-  });
+
+  return peerConnection.getStats(track)
+    .then(response => {
+      return standardizeChromeOrSafariStats(response, options);
+    })
+    .catch(() => {
+      // NOTE(lrivas): Citrix doesn't support track-specific getStats,
+      // so this workaround tries getting all stats and filtering by track.
+      return peerConnection.getStats()
+        .then(stats => {
+          const isRemote = isRemoteTrack(peerConnection, track);
+          const filteredStats = filterStatsByTrack(stats, track, isRemote);
+          return standardizeChromeOrSafariStats(filteredStats, options);
+        });
+    });
 }
 
 /**
@@ -346,7 +634,6 @@ function firefoxGetTrackStats(peerConnection, track, options) {
     return [standardizeFirefoxStats(response, options)];
   });
 }
-
 /**
  * Standardize the MediaStreamTrack's legacy statistics in Chrome.
  * @param {RTCStatsResponse} response
@@ -423,7 +710,7 @@ function standardizeChromeLegacyStats(response, track) {
 
 /**
  * Standardize the MediaStreamTrack's statistics in Chrome or Safari.
- * @param {RTCStatsResponse} response
+ * @param {RTCStatsReport} response
  * @param {object} options - Used for testing
  * @returns {Array<StandardizedTrackStatsReport>}
  */
@@ -660,11 +947,11 @@ function standardizeFirefoxStats(response = new Map(), { isRemote, simulateExcep
     switch (type) {
       case 'inbound-rtp':
         inbound = stat;
-        outbound = response.get(remoteId);
+        outbound = getStatById(response, remoteId);
         break;
       case 'outbound-rtp':
         outbound = stat;
-        inbound = response.get(remoteId);
+        inbound = getStatById(response, remoteId);
         break;
     }
   });

--- a/lib/webrtc/getstats.js
+++ b/lib/webrtc/getstats.js
@@ -2,7 +2,6 @@
 
 const { flatMap, guessBrowser, guessBrowserVersion } = require('./util');
 const { getSdpFormat } = require('./util/sdp');
-const Log = require('../util/log');
 
 const guess = guessBrowser();
 const guessVersion = guessBrowserVersion();
@@ -11,7 +10,7 @@ const isFirefox = guess === 'firefox';
 const isSafari = guess === 'safari';
 
 const chromeMajorVersion = isChrome ? guessVersion.major : null;
-const log = new Log('webrtc', 'getStats');
+
 
 const CHROME_LEGACY_MAX_AUDIO_LEVEL = 32767;
 
@@ -593,6 +592,21 @@ function getTrackStats(peerConnection, track, options = {}) {
 }
 
 /**
+ * Safely logs a message using the provided logger instance.
+ * If no logger is provided, this function performs no operation.
+ *
+ * @param {object} [logger] - Optional logger instance with logging methods (e.g., info, warn, error).
+ * @param {string} level - Logging level method name (e.g., 'info', 'warn', 'error').
+ * @param {string} message - Message to log.
+ * @returns {void}
+ */
+function safeLog(logger, level, message) {
+  if (logger) {
+    logger[level](message);
+  }
+}
+
+/**
  * Get the standardized statistics for a particular MediaStreamTrack in Chrome or Safari.
  * @param {RTCPeerConnection} peerConnection
  * @param {MediaStreamTrack} track
@@ -600,6 +614,7 @@ function getTrackStats(peerConnection, track, options = {}) {
  * @returns {Promise.<Array<StandardizedTrackStatsReport>>}
  */
 function chromeOrSafariGetTrackStats(peerConnection, track, options) {
+  const log = options.log;
   if (chromeMajorVersion && chromeMajorVersion < 67) {
     return new Promise((resolve, reject) => {
       peerConnection.getStats(response => {
@@ -610,20 +625,20 @@ function chromeOrSafariGetTrackStats(peerConnection, track, options) {
 
   return peerConnection.getStats(track)
     .then(response => {
-      log.info('getStats by track successful');
+      safeLog(log, 'info', 'getStats by track successful');
       return standardizeChromeOrSafariStats(response, options);
     })
     .catch(() => {
       // NOTE(lrivas): Citrix doesn't support track-specific getStats,
       // so this workaround tries getting all stats and filtering by track.
-      log.warn('getStats by track failed. Getting default stats');
+      safeLog(log, 'warn', 'getStats by track failed. Getting default stats');
       return peerConnection.getStats()
         .then(stats => {
-          log.info('getStats by default successful');
+          safeLog(log, 'info', 'getStats by default successful');
           const isRemote = isRemoteTrack(peerConnection, track);
-          log.info(`Starting filtering stats for ${isRemote ? 'remote' : 'local'} track`);
+          safeLog(log, 'info', `Starting filtering stats for ${isRemote ? 'remote' : 'local'} track`);
           const filteredStats = filterStatsByTrack(stats, track, isRemote);
-          log.info(`Completed filtering stats for ${isRemote ? 'remote' : 'local'} track`);
+          safeLog(log, 'info', `Completed filtering stats for ${isRemote ? 'remote' : 'local'} track`);
           return standardizeChromeOrSafariStats(filteredStats, options);
         });
     });

--- a/lib/webrtc/getstats.js
+++ b/lib/webrtc/getstats.js
@@ -2,6 +2,7 @@
 
 const { flatMap, guessBrowser, guessBrowserVersion } = require('./util');
 const { getSdpFormat } = require('./util/sdp');
+const Log = require('../util/log');
 
 const guess = guessBrowser();
 const guessVersion = guessBrowserVersion();
@@ -10,6 +11,7 @@ const isFirefox = guess === 'firefox';
 const isSafari = guess === 'safari';
 
 const chromeMajorVersion = isChrome ? guessVersion.major : null;
+const log = new Log('webrtc', null);
 
 const CHROME_LEGACY_MAX_AUDIO_LEVEL = 32767;
 
@@ -608,15 +610,20 @@ function chromeOrSafariGetTrackStats(peerConnection, track, options) {
 
   return peerConnection.getStats(track)
     .then(response => {
+      log.info('getStats by track successful');
       return standardizeChromeOrSafariStats(response, options);
     })
     .catch(() => {
       // NOTE(lrivas): Citrix doesn't support track-specific getStats,
       // so this workaround tries getting all stats and filtering by track.
+      log.warn('getStats by track failed. Getting default stats');
       return peerConnection.getStats()
         .then(stats => {
+          log.info('getStats by default successful');
           const isRemote = isRemoteTrack(peerConnection, track);
+          log.info(`Starting filtering stats for ${isRemote ? 'remote' : 'local'} track with id: ${track.id}`);
           const filteredStats = filterStatsByTrack(stats, track, isRemote);
+          log.info(`Completed filtering stats for ${isRemote ? 'remote' : 'local'} track with id: ${track.id}`);
           return standardizeChromeOrSafariStats(filteredStats, options);
         });
     });

--- a/test/integration/spec/webrtc/getstats.js
+++ b/test/integration/spec/webrtc/getstats.js
@@ -26,6 +26,7 @@ const sdpFormat = getSdpFormat();
     let pc2;
     let stats;
     let stream;
+    let logger;
 
     before(async () => {
       stream = await getUserMedia({
@@ -45,6 +46,12 @@ const sdpFormat = getSdpFormat();
           urls: 'stun:stun.l.google.com:19302'
         }]
       });
+
+      logger = {
+        info: () => {},
+        warn: () => {},
+        error: () => {}
+      };
 
       stream.getTracks().forEach(track => pc1.addTrack(track, stream));
       stream.getTracks().forEach(track => pc2.addTrack(track, stream));
@@ -85,7 +92,7 @@ const sdpFormat = getSdpFormat();
       // wait couple of seconds, and get stats
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      stats = await getStats(pc1);
+      stats = await getStats(pc1, { log: logger });
     });
 
     ['localAudioTrackStats', 'localVideoTrackStats', 'remoteAudioTrackStats', 'remoteVideoTrackStats'].forEach(trackType => {

--- a/test/unit/spec/webrtc/getstats.js
+++ b/test/unit/spec/webrtc/getstats.js
@@ -167,8 +167,8 @@ describe('getStats', function() {
     remoteStream.addTrack(new FakeMediaStreamTrack('video'));
     peerConnection._addLocalStream(localStream);
     peerConnection._addRemoteStream(remoteStream);
-
-    return getStats(peerConnection, { testForChrome: true })
+    
+    return getStats(peerConnection, { testForChrome: true, log: new FakeLogger() })
       .then(response => {
         assert.equal(response.localAudioTrackStats.length, 1);
         assert.equal(response.localVideoTrackStats.length, 1);
@@ -279,7 +279,7 @@ describe('getStats', function() {
     peerConnection._addLocalStream(localStream);
     peerConnection._addRemoteStream(remoteStream);
 
-    return getStats(peerConnection, { testForChrome: true })
+    return getStats(peerConnection, { testForChrome: true, log: new FakeLogger() })
       .then(response => {
         assert.equal(response.localAudioTrackStats.length, 1);
         assert.equal(response.localVideoTrackStats.length, 1);
@@ -407,7 +407,7 @@ describe('getStats', function() {
     localStream.addTrack(new FakeMediaStreamTrack('video'));
     peerConnection._addLocalStream(localStream);
 
-    return getStats(peerConnection, { testForChrome: true })
+    return getStats(peerConnection, { testForChrome: true, log: new FakeLogger() })
       .then(response => {
         assert.equal(response.localVideoTrackStats.length, 2);
 
@@ -640,7 +640,7 @@ describe('getStats', function() {
     localStream.addTrack(fakeMediaStreamTrack);
     peerConnection._addLocalStream(localStream);
 
-    return getStats(peerConnection, { testForSafari: true })
+    return getStats(peerConnection, { testForSafari: true, log: new FakeLogger() })
       .then(response => {
         assert.equal(response.localAudioTrackStats.length, 0);
         assert.equal(response.localVideoTrackStats.length, 1);
@@ -1002,7 +1002,7 @@ describe('getStats', function() {
           }))
         };
         const peerConnection = new FakeRTCPeerConnection(options);
-        const { activeIceCandidatePair } = await getStats(peerConnection, { testForChrome: true });
+        const { activeIceCandidatePair } = await getStats(peerConnection, { testForChrome: true, log: new FakeLogger() });
 
         const expectedActiveIceCandidatePair = Array.from(options.chromeFakeStats.values()).find(stat => {
           return stat.nominated;
@@ -1536,4 +1536,13 @@ describe('getStats', function() {
 
 function normalizeAudioLevel(level) {
   return Math.round(level * 32767);
+}
+
+/**
+ * Fake logger for testing with empty info, warn, and error methods.
+ */
+class FakeLogger {
+  info() {}
+  warn() {}
+  error() {}
 }

--- a/test/unit/spec/webrtc/getstats.js
+++ b/test/unit/spec/webrtc/getstats.js
@@ -7,6 +7,15 @@ const { capitalize } = require('../../../lib/util');
 var { FakeRTCPeerConnection } = require('../../../lib/webrtc/fakestats');
 var getStats = require('../../../../lib/webrtc/getstats');
 
+/**
+ * Fake logger for testing with empty info, warn, and error methods.
+ */
+class FakeLogger {
+  info() {}
+  warn() {}
+  error() {}
+}
+
 describe('getStats', function() {
   it('should reject the promise if RTCPeerConnection is not specified', () => {
     return new Promise((resolve, reject) => {
@@ -167,7 +176,7 @@ describe('getStats', function() {
     remoteStream.addTrack(new FakeMediaStreamTrack('video'));
     peerConnection._addLocalStream(localStream);
     peerConnection._addRemoteStream(remoteStream);
-    
+
     return getStats(peerConnection, { testForChrome: true, log: new FakeLogger() })
       .then(response => {
         assert.equal(response.localAudioTrackStats.length, 1);
@@ -1536,13 +1545,4 @@ describe('getStats', function() {
 
 function normalizeAudioLevel(level) {
   return Math.round(level * 32767);
-}
-
-/**
- * Fake logger for testing with empty info, warn, and error methods.
- */
-class FakeLogger {
-  info() {}
-  warn() {}
-  error() {}
 }


### PR DESCRIPTION
## Pull Request Details

### JIRA link(s):
- [VBLOCKS-3977](https://twilio-engineering.atlassian.net/browse/VBLOCKS-3977)

### Description
We require `getStats()` to be able to accept a track as a selector and retrieve only relevant information. Some WebRTC implementations do not support this functionality, so this polyfills it.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
