### PR TITLE
[VBLOCKS-4179] [VBLOCKS-4191] fix: MediaTrack lifecycle on Citrix

### DIFF
--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -45,7 +45,7 @@ class MediaTrack extends Track {
       MediaStream
     }, options);
 
-    if (typeof options.MediaStream !== 'function') {
+    if (typeof options.MediaStream !== 'function' && typeof options.MediaStream?.createMediaStream !== 'function') {
       throw new Error('MediaTrack received an invalid MediaStream constructor: ' + options.MediaStream);
     }
 
@@ -132,7 +132,7 @@ class MediaTrack extends Track {
         self._end();
         self.mediaStreamTrack.removeEventListener('ended', onended);
       });
-    } else if (this.mediaStreamTrack && this.mediaStreamTrack.onended) {
+    } else if (this.mediaStreamTrack) {
       this.mediaStreamTrack.onended = function onended() {
         self._end();
         self.mediaStreamTrack.onended = null;
@@ -190,10 +190,7 @@ class MediaTrack extends Track {
    * @private
    */
   _attach(el, mediaStreamTrack = this.processedTrack || this.mediaStreamTrack) {
-    let mediaStream = el.srcObject;
-    if (!(mediaStream instanceof this._MediaStream)) {
-      mediaStream = new this._MediaStream();
-    }
+    let mediaStream = this._getOrCreateMediaStream(el);
 
     const getTracks = mediaStreamTrack.kind === 'audio'
       ? 'getAudioTracks'
@@ -204,9 +201,13 @@ class MediaTrack extends Track {
     });
     mediaStream.addTrack(mediaStreamTrack);
 
+    // NOTE(lrivas): This is a workaround for Citrix, which requires the element
+    // to be mapped before attaching the media stream
+    if (this._MediaStream.mapElement) {
+      this._prepareCustomMediaElement(el);
+    }
     // NOTE(mpatwardhan): resetting `srcObject` here, causes flicker (JSDK-2641), but it lets us
     // to sidestep the a chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1052353
-    //
     el.srcObject = mediaStream;
     el.autoplay = true;
     el.playsInline = true;
@@ -216,6 +217,59 @@ class MediaTrack extends Track {
     }
 
     return el;
+  }
+
+  /**
+   * @private
+   * This method is used to get or create a MediaStream for the given element
+   * NOTE(lrivas): Citrix has a custom implementation of MediaStream,
+   * so we need to handle it differently.
+   */
+  _getOrCreateMediaStream(el) {
+    let mediaStream = el.srcObject;
+    const hasCreateMethod =
+      typeof this._MediaStream.createMediaStream === 'function';
+
+    if (hasCreateMethod) {
+      if (!mediaStream) {
+        this._log.debug('Creating new MediaStream using custom MediaStream.createMediaStream');
+        return this._MediaStream.createMediaStream();
+      }
+    } else if (!(mediaStream instanceof this._MediaStream)) {
+      return new this._MediaStream();
+    }
+
+    return mediaStream;
+  }
+
+  /**
+   * @private
+   * This method is used to prepare the custom Element for Citrix
+   * NOTE(lrivas): Citrix requires a custom implementation of MediaStream,
+   * so we need to let Citrix map the element before attaching the media stream
+   * @param {HTMLMediaElement} el
+   * @returns {void}
+   */
+  _prepareCustomMediaElement(el) {
+    // NOTE(lrivas): Since 'canplay' event is not fired automatically in Citrix,
+    // we need to fire it manually after loadedmetadata event is fired since this
+    // is the only event that is fired in Citrix.
+    const conditions = [waitForEvent(el, 'loadedmetadata')];
+
+    // NOTE(lrivas): Citrix 4.x does not trigger the 'loadedmetadata' event for audio elements.
+    // If the audioLoadingTimeout property is present in the custom MediaStream,
+    // we wait for the specified timeout to ensure the element is ready.
+    if (this._MediaStream.audioLoadingTimeout && this.mediaStreamTrack.kind === 'audio') {
+      conditions.push(waitForSometime(this._MediaStream.audioLoadingTimeout));
+    }
+
+    Promise.race(conditions).then(() => {
+      this._log.debug('Firing canplay event manually since it is not fired automatically in Citrix');
+      el.dispatchEvent(new Event('canplay'));
+    });
+
+    this._log.debug('Using Custom MediaStream.mapElement to attach media to element');
+    this._MediaStream.mapElement(el);
   }
 
   /**
@@ -278,10 +332,7 @@ class MediaTrack extends Track {
     if (!this._attachments.has(el)) {
       return el;
     }
-    const mediaStream = el.srcObject;
-    if (mediaStream instanceof this._MediaStream) {
-      mediaStream.removeTrack(this.processedTrack || this.mediaStreamTrack);
-    }
+    this._removeMediaStream(el);
     this._attachments.delete(el);
 
     if (this._shouldShimAttachedElements && this._elShims.has(el)) {
@@ -291,6 +342,27 @@ class MediaTrack extends Track {
     }
 
     return el;
+  }
+
+  /**
+   * @private
+   * This method is used to remove the MediaStream from the given element
+   * NOTE(lrivas): Citrix has a custom implementation of MediaStream,
+   * so we need to handle it differently.
+   */
+  _removeMediaStream(el) {
+    const mediaStream = el.srcObject;
+    const hasDisposeElementMethod =
+      typeof this._MediaStream.disposeElement === 'function';
+
+    if (hasDisposeElementMethod) {
+      if (mediaStream) {
+        this._log.debug('Disposing element using custom MediaStream.disposeElement');
+        this._MediaStream.disposeElement(el);
+      }
+    } else if (mediaStream instanceof this._MediaStream) {
+      mediaStream.removeTrack(this.processedTrack || this.mediaStreamTrack);
+    }
   }
 
   /**

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -229,7 +229,6 @@ class MediaTrack extends Track {
     return el;
   }
 
-
   /**
    * @private
    */
@@ -308,7 +307,6 @@ class MediaTrack extends Track {
 
     return el;
   }
-
 
   /**
    * @private

--- a/lib/media/track/mediatrack.js
+++ b/lib/media/track/mediatrack.js
@@ -45,7 +45,7 @@ class MediaTrack extends Track {
       MediaStream
     }, options);
 
-    if (typeof options.MediaStream !== 'function' && typeof options.MediaStream?.createMediaStream !== 'function') {
+    if (typeof options.MediaStream !== 'function') {
       throw new Error('MediaTrack received an invalid MediaStream constructor: ' + options.MediaStream);
     }
 
@@ -82,6 +82,12 @@ class MediaTrack extends Track {
       },
       _MediaStream: {
         value: options.MediaStream
+      },
+      _mapMediaElement: {
+        value: options.mapMediaElement
+      },
+      _disposeMediaElement: {
+        value: options.disposeMediaElement
       },
       isStarted: {
         enumerable: true,
@@ -190,7 +196,10 @@ class MediaTrack extends Track {
    * @private
    */
   _attach(el, mediaStreamTrack = this.processedTrack || this.mediaStreamTrack) {
-    let mediaStream = this._getOrCreateMediaStream(el);
+    let mediaStream = el.srcObject;
+    if (!(mediaStream instanceof this._MediaStream)) {
+      mediaStream = new this._MediaStream();
+    }
 
     const getTracks = mediaStreamTrack.kind === 'audio'
       ? 'getAudioTracks'
@@ -201,11 +210,12 @@ class MediaTrack extends Track {
     });
     mediaStream.addTrack(mediaStreamTrack);
 
-    // NOTE(lrivas): This is a workaround for Citrix, which requires the element
-    // to be mapped before attaching the media stream
-    if (this._MediaStream.mapElement) {
-      this._prepareCustomMediaElement(el);
+    // Map the element if a custom mapping function is provided
+    if (this._mapMediaElement) {
+      this._log.debug('Mapping element using mapMediaElement before attaching media to element');
+      this._mapMediaElement(el);
     }
+
     // NOTE(mpatwardhan): resetting `srcObject` here, causes flicker (JSDK-2641), but it lets us
     // to sidestep the a chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1052353
     el.srcObject = mediaStream;
@@ -219,58 +229,6 @@ class MediaTrack extends Track {
     return el;
   }
 
-  /**
-   * @private
-   * This method is used to get or create a MediaStream for the given element
-   * NOTE(lrivas): Citrix has a custom implementation of MediaStream,
-   * so we need to handle it differently.
-   */
-  _getOrCreateMediaStream(el) {
-    let mediaStream = el.srcObject;
-    const hasCreateMethod =
-      typeof this._MediaStream.createMediaStream === 'function';
-
-    if (hasCreateMethod) {
-      if (!mediaStream) {
-        this._log.debug('Creating new MediaStream using custom MediaStream.createMediaStream');
-        return this._MediaStream.createMediaStream();
-      }
-    } else if (!(mediaStream instanceof this._MediaStream)) {
-      return new this._MediaStream();
-    }
-
-    return mediaStream;
-  }
-
-  /**
-   * @private
-   * This method is used to prepare the custom Element for Citrix
-   * NOTE(lrivas): Citrix requires a custom implementation of MediaStream,
-   * so we need to let Citrix map the element before attaching the media stream
-   * @param {HTMLMediaElement} el
-   * @returns {void}
-   */
-  _prepareCustomMediaElement(el) {
-    // NOTE(lrivas): Since 'canplay' event is not fired automatically in Citrix,
-    // we need to fire it manually after loadedmetadata event is fired since this
-    // is the only event that is fired in Citrix.
-    const conditions = [waitForEvent(el, 'loadedmetadata')];
-
-    // NOTE(lrivas): Citrix 4.x does not trigger the 'loadedmetadata' event for audio elements.
-    // If the audioLoadingTimeout property is present in the custom MediaStream,
-    // we wait for the specified timeout to ensure the element is ready.
-    if (this._MediaStream.audioLoadingTimeout && this.mediaStreamTrack.kind === 'audio') {
-      conditions.push(waitForSometime(this._MediaStream.audioLoadingTimeout));
-    }
-
-    Promise.race(conditions).then(() => {
-      this._log.debug('Firing canplay event manually since it is not fired automatically in Citrix');
-      el.dispatchEvent(new Event('canplay'));
-    });
-
-    this._log.debug('Using Custom MediaStream.mapElement to attach media to element');
-    this._MediaStream.mapElement(el);
-  }
 
   /**
    * @private
@@ -332,7 +290,14 @@ class MediaTrack extends Track {
     if (!this._attachments.has(el)) {
       return el;
     }
-    this._removeMediaStream(el);
+    const mediaStream = el.srcObject;
+    if (mediaStream instanceof this._MediaStream) {
+      mediaStream.removeTrack(this.processedTrack || this.mediaStreamTrack);
+    }
+    if (this._disposeMediaElement) {
+      this._log.debug('Disposing element using disposeMediaElement after removing media from element');
+      this._disposeMediaElement(el);
+    }
     this._attachments.delete(el);
 
     if (this._shouldShimAttachedElements && this._elShims.has(el)) {
@@ -344,26 +309,6 @@ class MediaTrack extends Track {
     return el;
   }
 
-  /**
-   * @private
-   * This method is used to remove the MediaStream from the given element
-   * NOTE(lrivas): Citrix has a custom implementation of MediaStream,
-   * so we need to handle it differently.
-   */
-  _removeMediaStream(el) {
-    const mediaStream = el.srcObject;
-    const hasDisposeElementMethod =
-      typeof this._MediaStream.disposeElement === 'function';
-
-    if (hasDisposeElementMethod) {
-      if (mediaStream) {
-        this._log.debug('Disposing element using custom MediaStream.disposeElement');
-        this._MediaStream.disposeElement(el);
-      }
-    } else if (mediaStream instanceof this._MediaStream) {
-      mediaStream.removeTrack(this.processedTrack || this.mediaStreamTrack);
-    }
-  }
 
   /**
    * @private

--- a/lib/participant.js
+++ b/lib/participant.js
@@ -170,6 +170,12 @@ class Participant extends EventEmitter {
       },
       _MediaStream: {
         value: options.MediaStream
+      },
+      _mapMediaElement: {
+        value: options.mapMediaElement
+      },
+      _disposeMediaElement: {
+        value: options.disposeMediaElement
       }
     });
 
@@ -265,7 +271,7 @@ class Participant extends EventEmitter {
    * @private
    */
   _handleTrackSignalingEvents() {
-    const { _log: log, _clientTrackSwitchOffControl: clientTrackSwitchOffControl, _contentPreferencesMode: contentPreferencesMode, _MediaStream: MediaStream } = this;
+    const { _log: log, _clientTrackSwitchOffControl: clientTrackSwitchOffControl, _contentPreferencesMode: contentPreferencesMode, _MediaStream: MediaStream, _mapMediaElement: mapMediaElement, _disposeMediaElement: disposeMediaElement } = this;
     const self = this;
 
     if (this.state === 'disconnected') {
@@ -340,7 +346,7 @@ class Participant extends EventEmitter {
         return;
       }
 
-      const options = { log, name, clientTrackSwitchOffControl, contentPreferencesMode };
+      const options = { log, name, clientTrackSwitchOffControl, contentPreferencesMode, mapMediaElement, disposeMediaElement };
       if (MediaStream) {
         options.MediaStream = MediaStream;
       }

--- a/lib/room.js
+++ b/lib/room.js
@@ -548,8 +548,8 @@ function rewriteLocalTrackIds(room, trackStats) {
  */
 
 function connectParticipant(room, participantSignaling) {
-  const { _log: log, _clientTrackSwitchOffControl: clientTrackSwitchOffControl, _contentPreferencesMode: contentPreferencesMode, _options: { MediaStream } } = room;
-  const participant = new RemoteParticipant(participantSignaling, { log, clientTrackSwitchOffControl, contentPreferencesMode, MediaStream });
+  const { _log: log, _clientTrackSwitchOffControl: clientTrackSwitchOffControl, _contentPreferencesMode: contentPreferencesMode, _options: { MediaStream, mapMediaElement, disposeMediaElement } } = room;
+  const participant = new RemoteParticipant(participantSignaling, { log, clientTrackSwitchOffControl, contentPreferencesMode, MediaStream, mapMediaElement, disposeMediaElement });
 
   log.info('A new RemoteParticipant connected:', participant);
   room._participants.set(participant.sid, participant);

--- a/test/unit/spec/media/track/mediatrack.js
+++ b/test/unit/spec/media/track/mediatrack.js
@@ -472,20 +472,17 @@ describe('MediaTrack', () => {
         sinon.assert.calledWithExactly(el1.srcObject.removeTrack, track.processedTrack);
       });
 
-      it('should call disposeElement if the custom MediaStream has the disposeElement property (Citrix)', () => {
-        const disposeElementSpy = sinon.spy();
+      it('should call disposeMediaElement if the option is provided', () => {
+        const disposeMediaElementSpy = sinon.spy();
         let customTrack = createMediaTrack('1', 'audio', {
-          MediaStream: {
-            createMediaStream: () => new MediaStream(),
-            disposeElement: disposeElementSpy
-          }
+          disposeMediaElement: disposeMediaElementSpy
         });
         const customElement = document.createElement('audio');
         customElement.srcObject = new MediaStream();
         customTrack._attachments.add(customElement);
         customTrack._detachElement(customElement);
-        assert(disposeElementSpy.calledOnce);
-        assert(disposeElementSpy.calledWith(customElement));
+        assert(disposeMediaElementSpy.calledOnce);
+        assert(disposeMediaElementSpy.calledWith(customElement));
       });
     });
 
@@ -642,52 +639,27 @@ describe('MediaTrack', () => {
       });
     });
 
-    context('when MediaStream has a createMediaStream factory method (Citrix)', () => {
-      const factoryCreateStreamSpy = sinon.stub();
-      let factoryMediaStream;
-      let customTrack;
-      let customElement;
-
-      beforeEach(() => {
-        factoryMediaStream = new MediaStream();
-        customTrack = createMediaTrack('1', 'audio', {
-          MediaStream: {
-            createMediaStream: factoryCreateStreamSpy.returns(factoryMediaStream)
-          }
-        });
-        customElement = document.createElement('audio');
+    it('should use the custom MediaStream constructor if the option is provided', () => {
+      const CustomMediaStream = sinon.spy(() => new MediaStream());
+      const customTrack = createMediaTrack('1', 'audio', {
+        MediaStream: CustomMediaStream
       });
 
-      afterEach(() => {
-        factoryCreateStreamSpy.reset();
-      });
+      const element = document.createElement('audio');
+      customTrack._attach(element);
 
-      it('should use createMediaStream when available and no srcObject exists', () => {
-        customTrack._attach(customElement);
-        assert(factoryCreateStreamSpy.calledOnce);
-        assert.equal(customElement.srcObject, factoryMediaStream);
-      });
-
-      it('should not use createMediaStream when srcObject already exists', () => {
-        const existingMediaStream = new MediaStream();
-        customElement.srcObject = existingMediaStream;
-        customTrack._attach(customElement);
-        assert(!factoryCreateStreamSpy.called);
-      });
+      assert(CustomMediaStream.calledOnce);
     });
 
-    it('should call mapElement if the custom MediaStream has the mapElement property (Citrix)', () => {
-      const mapElementSpy = sinon.spy();
+    it('should call mapMediaElement if the option is provided', () => {
+      const mapMediaElementSpy = sinon.spy();
       const customElement = document.createElement('audio');
       const track = createMediaTrack('1', 'audio', {
-        MediaStream: {
-          createMediaStream: () => new MediaStream(),
-          mapElement: mapElementSpy
-        }
+        mapMediaElement: mapMediaElementSpy
       });
       track._attach(customElement);
-      assert(mapElementSpy.calledOnce);
-      assert(mapElementSpy.calledWith(customElement));
+      assert(mapMediaElementSpy.calledOnce);
+      assert(mapMediaElementSpy.calledWith(customElement));
     });
   });
 });


### PR DESCRIPTION
## Pull Request Details

### JIRA link(s):
- [VBLOCKS-4179](https://twilio-engineering.atlassian.net/browse/VBLOCKS-4179)
- [VBLOCKS-4191](https://twilio-engineering.atlassian.net/browse/VBLOCKS-4191)

### Description
This PR removes the burden of manually attaching and detaching MediaStream to elements on Citrix by extracting that logic from the consumer and putting it in the SDK. After this change, customers using Citrix should be able to call `track.attach(element)` or `track.detach(element)`, maintaining the same API.


### Changes
- Added support for [trackStarted](https://sdk.twilio.com/js/video/releases/2.29.0/docs/Room.html#event:trackStarted) event on Citrix  environments.
- Updated MediaTrack to validate `MediaStream` constructor with an additional check for `createMediaStream` method.
- Introduced `_prepareCustomMediaElement` and `_removeMediaStream` methods to handle custom MediaStream mapping and disposal for Citrix.

The property names chosen for this `MediaStream` custom constructor are still under active development and can be changed.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
