### PR TITLE
[VBLOCKS-4208] add: custom rtcConfiguration to ConnectOptions

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -499,7 +499,7 @@ function connect(token, options) {
  *   than <code style="padding:0 0">gll</code> bypasses routing and guarantees that signaling traffic will be
  *   terminated in the region that you prefer. Please refer to this <a href="https://www.twilio.com/docs/video/ip-address-whitelisting#signaling-communication" target="_blank">table</a>
  *   for the list of supported signaling regions.
- * @property {RTCConfiguration} [rtcConfiguration] - An optional RTCConfiguration to pass to the RTCPeerConnection constructor.
+ * @property {RTCConfiguration} [rtcConfiguration] - An optional RTCConfiguration to pass to the RTCPeerConnection constructor.
  * This allows you to configure the WebRTC connection between your local machine and the remote peer.
  * @property {Array<AudioCodec|AudioCodecSettings>} [preferredAudioCodecs=[]] - Preferred audio codecs;
  *  An empty array preserves the current audio codec preference order.

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -499,6 +499,8 @@ function connect(token, options) {
  *   than <code style="padding:0 0">gll</code> bypasses routing and guarantees that signaling traffic will be
  *   terminated in the region that you prefer. Please refer to this <a href="https://www.twilio.com/docs/video/ip-address-whitelisting#signaling-communication" target="_blank">table</a>
  *   for the list of supported signaling regions.
+ * @property {RTCConfiguration} [rtcConfiguration] - An optional RTCConfiguration to pass to the RTCPeerConnection constructor.
+ * This allows you to configure the WebRTC connection between your local machine and the remote peer.
  * @property {Array<AudioCodec|AudioCodecSettings>} [preferredAudioCodecs=[]] - Preferred audio codecs;
  *  An empty array preserves the current audio codec preference order.
  * @property {Array<VideoCodec|VideoCodecSettings>|VideoEncodingMode} [preferredVideoCodecs=[]] -

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -134,7 +134,10 @@ class PeerConnectionV2 extends StateMachine {
       Timeout: DefaultTimeout
     }, options);
 
-    const configuration = getConfiguration(options);
+    // NOTE(lrivas): We intentionally include the options object for backward compatibility.
+    // The ConnectOptions 'iceServers' and 'iceTransportPolicy' are part of the 'RTCConfiguration' interface and should be passed
+    // as 'rtcConfiguration.iceServers' and 'rtcConfiguration.iceTransportPolicy' respectively.
+    const configuration = getConfiguration(Object.assign({}, options, options.rtcConfiguration));
     const logLevels = buildLogLevels(options.logLevel);
     const RTCPeerConnection = options.RTCPeerConnection;
 
@@ -1697,7 +1700,15 @@ function getUfrag(description) {
   return null;
 }
 
-function getConfiguration(configuration) {
+/**
+ * Construct a {@link RTCConfiguration} for the {@link PeerConnectionV2} combining the provided configuration object with the default values.
+ * Default values are:
+ * - bundlePolicy: 'max-bundle'
+ * - rtcpMuxPolicy: 'require'
+ * @param {RTCConfiguration} [configuration={}] - Optional RTCConfiguration object
+ * @returns {RTCConfiguration}
+ */
+function getConfiguration(configuration = {}) {
   return Object.assign({
     bundlePolicy: 'max-bundle',
     rtcpMuxPolicy: 'require'

--- a/tsdef/twilio-video-tests.ts
+++ b/tsdef/twilio-video-tests.ts
@@ -257,7 +257,12 @@ function customWebRTCImplementations() {
       super();
     }
   };
+  const customRTCConfiguration: RTCConfiguration = {
+    bundlePolicy: 'max-bundle',
+    rtcpMuxPolicy: 'require',
+  };
   const room = Video.connect('$TOKEN', {
+    rtcConfiguration: customRTCConfiguration,
     RTCPeerConnection: customRTCPeerConnection,
     getUserMedia,
     enumerateDevices,

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -220,7 +220,13 @@ export interface ConnectOptions {
    */
   loggerName?: string;
   eventListener?: EventListener;
+  /**
+   * @deprecated use ConnectOptions.rtcConfiguration.iceServers
+   */
   iceServers?: Array<RTCIceServer>;
+  /**
+   * @deprecated use ConnectOptions.rtcConfiguration.iceTransportPolicy
+   */
   iceTransportPolicy?: RTCIceTransportPolicy;
   insights?: boolean;
   maxAudioBitrate?: number | null;
@@ -240,6 +246,7 @@ export interface ConnectOptions {
   tracks?: Array<LocalTrack | MediaStreamTrack>;
   video?: boolean | CreateLocalTrackOptions;
   getUserMedia?: (constraints: MediaStreamConstraints) => Promise<any>;
+  rtcConfiguration?: RTCConfiguration;
   RTCPeerConnection?: any;
   enumerateDevices?: () => Promise<Array<any>>;
   MediaStream?: any;


### PR DESCRIPTION
## Pull Request Details

### JIRA link(s):
- [VBLOCKS-4208](https://twilio-engineering.atlassian.net/browse/VBLOCKS-4208)

### Description
This PR introduces a new property to the `ConnectOptions` called `rtcConfiguration`, allowing users to define the configuration passed to `RTCPeerConnection`.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
