### PR TITLE
[VBLOCKS-4696] Use a real speech for real-time transcription E2E tests

### DIFF
--- a/test/integration/spec/livetranscription.js
+++ b/test/integration/spec/livetranscription.js
@@ -11,6 +11,7 @@ const {
   waitForEvent,
   waitForSometime,
   waitForNot,
+  createFileAudioMedia,
 } = require('../../lib/util');
 
 describe('LiveTranscription', function() {
@@ -22,14 +23,18 @@ describe('LiveTranscription', function() {
   let roomSid;
 
   beforeEach(async () => {
+    // NOTE:(lrivas) The transcription feature will only return results for speech-like audio tracks,
+    // fake audio tracks without any speech will not return results.
+    const { source, track } = await createFileAudioMedia('/static/speech.m4a');
+
     ({ aliceRoom, bobRoom, roomSid } = await setupAliceAndBob({
       aliceOptions: {
         enableLiveTranscription: true,
-        audio: { fake: true }
+        tracks: [track]
       },
       bobOptions: {
         enableLiveTranscription: true,
-        audio: { fake: true }
+        tracks: [track]
       },
       roomOptions: {
         TranscribeParticipantsOnConnect: true,
@@ -39,6 +44,10 @@ describe('LiveTranscription', function() {
         }
       }
     }));
+
+    // Start playing the speech audio for Alice and Bob
+    source.start();
+
     await waitForSometime(1000); // NOTE(lrivas): Wait for MSP to be ready (1 second)
   });
 

--- a/test/integration/spec/livetranscription.js
+++ b/test/integration/spec/livetranscription.js
@@ -5,6 +5,7 @@ const { connect } = require('../../../es5');
 const defaults = require('../../lib/defaults');
 const getToken = require('../../lib/token');
 const { completeRoom } = require('../../lib/rest');
+const { isFirefox } = require('../../lib/guessbrowser');
 const {
   randomName,
   setupAliceAndBob,
@@ -14,7 +15,9 @@ const {
   createFileAudioMedia,
 } = require('../../lib/util');
 
-(defaults.topology === 'group' ? describe : describe.skip)('LiveTranscription', function() {
+// NOTE(lrivas): Skipping this test in Firefox due to AudioContext issue.
+// Firefox's AudioContext.decodeAudioData() does not complete, causing the test to timeout.
+(defaults.topology === 'group' && !isFirefox ? describe : describe.skip)('LiveTranscription', function() {
   // eslint-disable-next-line no-invalid-this
   this.timeout(15000);
 
@@ -40,7 +43,8 @@ const {
         TranscribeParticipantsOnConnect: true,
         TranscriptionsConfiguration: {
           languageCode: 'en-US',
-          profanityFilter: true
+          profanityFilter: true,
+          partialResults: true
         }
       }
     }));

--- a/test/integration/spec/livetranscription.js
+++ b/test/integration/spec/livetranscription.js
@@ -14,7 +14,7 @@ const {
   createFileAudioMedia,
 } = require('../../lib/util');
 
-describe('LiveTranscription', function() {
+(defaults.topology === 'group' ? describe : describe.skip)('LiveTranscription', function() {
   // eslint-disable-next-line no-invalid-this
   this.timeout(15000);
 


### PR DESCRIPTION
## Pull Request Details

### Description

The transcription feature will only return results for speech-like audio tracks, fake audio tracks without any speech will not return results.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
