### PR TITLE
[VBLOCKS-4766] Fix document PiP support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 
 **Version 1.x reached End of Life on September 8th, 2021.** See the changelog entry [here](https://www.twilio.com/changelog/end-of-life-complete-for-unsupported-versions-of-the-programmable-video-sdk). Support for the 1.x version ended on December 4th, 2020.
 
+2.32.1 (in progress)
+====================
+
+Bug Fixes
+---------
+- Fixed an issue where video tracks would freeze when the video element was offscreen in a document Picture-in-Picture window.
+
 2.32.0 (in progress)
 ====================
 

--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -73,6 +73,14 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
       _elToPipWindows: {
         value: new WeakMap(),
       },
+      _documentPipWindow: {
+        value: null,
+        writable: true
+      },
+      _documentPipEnterListener: {
+        value: null,
+        writable: true
+      },
       _turnOffTimer: {
         value: new Timeout(() => {
           this._setRenderHint({ enabled: false });
@@ -115,10 +123,6 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
           }
         }, { threshold: 0.25 })
       },
-      _workaroundDocumentPipCleanup: {
-        value: null,
-        writable: true
-      }
     });
   }
 
@@ -235,8 +239,11 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
       this._documentVisibilityTurnOffCleanup = this._documentVisibilityTurnOffCleanup || setupDocumentVisibilityTurnOff(this);
     }
 
-    if (!this._workaroundDocumentPipCleanup && 'documentPictureInPicture' in globalThis) {
-      this._workaroundDocumentPipCleanup = playIfPausedWhileInDocumentPip(this);
+    if (!this._documentPipEnterListener && 'documentPictureInPicture' in globalThis) {
+      this._documentPipEnterListener = event => {
+        this._documentPipWindow = event.window;
+      };
+      globalThis.documentPictureInPicture.addEventListener('enter', this._documentPipEnterListener);
     }
 
     this._observePip(result);
@@ -259,9 +266,10 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
         this._documentVisibilityTurnOffCleanup = null;
       }
 
-      if (this._workaroundDocumentPipCleanup) {
-        this._workaroundDocumentPipCleanup();
-        this._workaroundDocumentPipCleanup = null;
+      if (this._documentPipEnterListener) {
+        globalThis.documentPictureInPicture.removeEventListener('enter', this._documentPipEnterListener);
+        this._documentPipEnterListener = null;
+        this._documentPipWindow = null;
       }
     }
 
@@ -382,6 +390,11 @@ function maybeUpdateEnabledHint(remoteVideoTrack) {
   if (enabled === true) {
     remoteVideoTrack._turnOffTimer.clear();
     remoteVideoTrack._setRenderHint({ enabled: true });
+
+    // Check if videos in document PiP are actually playing
+    if (remoteVideoTrack._documentPipWindow) {
+      ensureDocumentPipVideosPlaying(remoteVideoTrack);
+    }
   } else if (!remoteVideoTrack._turnOffTimer.isSet) {
     // set the track to be turned off after some delay.
     remoteVideoTrack._turnOffTimer.start();
@@ -418,74 +431,31 @@ function setupDocumentVisibilityTurnOff(removeVideoTrack) {
   };
 }
 
-function playIfPausedWhileInDocumentPip(remoteMediaTrack) {
-  const { _log: log } = remoteMediaTrack;
-  let pipWindow = null;
-  let attachedPauseListeners = new Map();
-
-  function onDocumentPipEnter(event) {
-    pipWindow = event.window;
-
-    // Monitor for document pip window close
-    pipWindow.addEventListener('pagehide', () => {
-      cleanupPauseListeners();
-      remoteMediaTrack._workaroundDocumentPipCleanup = null;
-    });
-
-    requestAnimationFrame(playVideosInDocumentPip);
-  }
-
-  function playVideosInDocumentPip() {
-    if (!pipWindow) {
-      return;
-    }
-
-    try {
-      const pipEls = new WeakSet(pipWindow.document.querySelectorAll('video'));
-
-      remoteMediaTrack._attachments.forEach(el => {
-        if (pipEls.has(el) && !attachedPauseListeners.has(el)) {
-          const onPause = () => {
-            el.play().then(() => {
-              log.debug('Successfully played inadvertently paused video element in document PiP window');
-            }).catch(error => {
-              log.debug('Failed to play inadvertently paused video element in document PiP window', error);
-            }).finally(() => {
-              el.removeEventListener('pause', onPause);
-              attachedPauseListeners.delete(el);
-            });
-          };
-
-          el.addEventListener('pause', onPause);
-          attachedPauseListeners.set(el, onPause);
-        }
-      });
-    } catch (error) {
-      log.debug('Error setting up PiP video monitoring:', error);
-    }
-  }
-
-  function cleanupPauseListeners() {
-    attachedPauseListeners.forEach((listener, el) => {
-      el.removeEventListener('pause', listener);
-    });
-    attachedPauseListeners.clear();
+/**
+ * This is a workaround to ensure that videos rendered in a document PIP continue playing after being enabled
+ * by the Intersection Observer. It appears to be a bug in Chrome, and we should revisit this issue once the
+ * Document Picture-in-Picture feature is more reliably supported.
+ */
+function ensureDocumentPipVideosPlaying(remoteVideoTrack) {
+  if (!remoteVideoTrack._documentPipWindow) {
+    return;
   }
 
   try {
-    globalThis.documentPictureInPicture.addEventListener('enter', onDocumentPipEnter);
-  } catch (error) {
-    log.debug('Failed to add document PiP enter listener:', error);
-  }
+    const pipEls = new WeakSet(remoteVideoTrack._documentPipWindow.document.querySelectorAll('video'));
 
-  return () => {
-    try {
-      globalThis.documentPictureInPicture.removeEventListener('enter', onDocumentPipEnter);
-      cleanupPauseListeners();
-    } catch (error) {
-      log.debug('Error during PiP cleanup:', error);
-    }
-  };
+    remoteVideoTrack._attachments.forEach(el => {
+      if (pipEls.has(el) && el.paused) {
+        el.play().then(() => {
+          remoteVideoTrack._log.debug('Successfully played inadvertently paused video element in document PiP window');
+        }).catch(error => {
+          remoteVideoTrack._log.debug('Failed to play inadvertently paused video element in document PiP window', error);
+        });
+      }
+    });
+  } catch (error) {
+    remoteVideoTrack._log.debug('Error checking document PiP video playback:', error);
+  }
 }
 
 /**

--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -115,6 +115,10 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
           }
         }, { threshold: 0.25 })
       },
+      _workaroundDocumentPipCleanup: {
+        value: null,
+        writable: true
+      }
     });
   }
 
@@ -231,6 +235,10 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
       this._documentVisibilityTurnOffCleanup = this._documentVisibilityTurnOffCleanup || setupDocumentVisibilityTurnOff(this);
     }
 
+    if (!this._workaroundDocumentPipCleanup && 'documentPictureInPicture' in globalThis) {
+      this._workaroundDocumentPipCleanup = playIfPausedWhileInDocumentPip(this);
+    }
+
     this._observePip(result);
     return result;
   }
@@ -249,6 +257,11 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
       if (this._documentVisibilityTurnOffCleanup) {
         this._documentVisibilityTurnOffCleanup();
         this._documentVisibilityTurnOffCleanup = null;
+      }
+
+      if (this._workaroundDocumentPipCleanup) {
+        this._workaroundDocumentPipCleanup();
+        this._workaroundDocumentPipCleanup = null;
       }
     }
 
@@ -402,6 +415,76 @@ function setupDocumentVisibilityTurnOff(removeVideoTrack) {
   documentVisibilityMonitor.onVisibilityChange(1, onVisibilityChanged);
   return () => {
     documentVisibilityMonitor.offVisibilityChange(1, onVisibilityChanged);
+  };
+}
+
+function playIfPausedWhileInDocumentPip(remoteMediaTrack) {
+  const { _log: log } = remoteMediaTrack;
+  let pipWindow = null;
+  let attachedPauseListeners = new Map();
+
+  function onDocumentPipEnter(event) {
+    pipWindow = event.window;
+
+    // Monitor for document pip window close
+    pipWindow.addEventListener('pagehide', () => {
+      cleanupPauseListeners();
+      remoteMediaTrack._workaroundDocumentPipCleanup = null;
+    });
+
+    requestAnimationFrame(playVideosInDocumentPip);
+  }
+
+  function playVideosInDocumentPip() {
+    if (!pipWindow) {
+      return;
+    }
+
+    try {
+      const pipEls = new WeakSet(pipWindow.document.querySelectorAll('video'));
+
+      remoteMediaTrack._attachments.forEach(el => {
+        if (pipEls.has(el) && !attachedPauseListeners.has(el)) {
+          const onPause = () => {
+            el.play().then(() => {
+              log.debug('Successfully played inadvertently paused video element in document PiP window');
+            }).catch(error => {
+              log.debug('Failed to play inadvertently paused video element in document PiP window', error);
+            }).finally(() => {
+              el.removeEventListener('pause', onPause);
+              attachedPauseListeners.delete(el);
+            });
+          };
+
+          el.addEventListener('pause', onPause);
+          attachedPauseListeners.set(el, onPause);
+        }
+      });
+    } catch (error) {
+      log.debug('Error setting up PiP video monitoring:', error);
+    }
+  }
+
+  function cleanupPauseListeners() {
+    attachedPauseListeners.forEach((listener, el) => {
+      el.removeEventListener('pause', listener);
+    });
+    attachedPauseListeners.clear();
+  }
+
+  try {
+    globalThis.documentPictureInPicture.addEventListener('enter', onDocumentPipEnter);
+  } catch (error) {
+    log.debug('Failed to add document PiP enter listener:', error);
+  }
+
+  return () => {
+    try {
+      globalThis.documentPictureInPicture.removeEventListener('enter', onDocumentPipEnter);
+      cleanupPauseListeners();
+    } catch (error) {
+      log.debug('Error during PiP cleanup:', error);
+    }
   };
 }
 

--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -244,6 +244,7 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
         globalThis.documentPictureInPicture &&
         typeof globalThis.documentPictureInPicture.addEventListener === 'function') {
       this._documentPipEnterListener = event => {
+        this._log.debug('document pip entered');
         this._documentPipWindow = event.window;
       };
       globalThis.documentPictureInPicture.addEventListener('enter', this._documentPipEnterListener);

--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -239,7 +239,10 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
       this._documentVisibilityTurnOffCleanup = this._documentVisibilityTurnOffCleanup || setupDocumentVisibilityTurnOff(this);
     }
 
-    if (!this._documentPipEnterListener && 'documentPictureInPicture' in globalThis) {
+    // Set up document PiP listener on first attach
+    if (!this._documentPipEnterListener && 'documentPictureInPicture' in globalThis &&
+        globalThis.documentPictureInPicture &&
+        typeof globalThis.documentPictureInPicture.addEventListener === 'function') {
       this._documentPipEnterListener = event => {
         this._documentPipWindow = event.window;
       };
@@ -267,7 +270,9 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
       }
 
       if (this._documentPipEnterListener) {
-        globalThis.documentPictureInPicture.removeEventListener('enter', this._documentPipEnterListener);
+        if (globalThis.documentPictureInPicture && typeof globalThis.documentPictureInPicture.removeEventListener === 'function') {
+          globalThis.documentPictureInPicture.removeEventListener('enter', this._documentPipEnterListener);
+        }
         this._documentPipEnterListener = null;
         this._documentPipWindow = null;
       }


### PR DESCRIPTION
## Pull Request Details

### Description
This PR ensures that video elements rendered in a document PiP play after appearing on the screen when the `clientTrackSwitchOffControl` is set to `auto`, fixing issue #2044.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
