### PR TITLE
`feat`: Add TypeScript definition tests for Tracks and LocalTrackOptions

### DIFF
--- a/tsdef/twilio-video-tests.ts
+++ b/tsdef/twilio-video-tests.ts
@@ -419,14 +419,13 @@ function trackSubscribed(track: Video.VideoTrack | Video.AudioTrack) {
 
 function trackUnsubscribed(track: Video.VideoTrack | Video.AudioTrack) {
   const element = document.createElement(track.kind);
-  track.detach('#foo').remove();
-  track.detach(element).remove();
-  track.detach().forEach(element => element.remove());
+  track.detach('#foo');
+  track.detach(element);
+  track.detach().forEach(el => el.remove());
 }
 
 function insertDomElement(element: HTMLMediaElement) {
-  document.createElement('div');
-  element.appendChild(element);
+  document.createElement('div').appendChild(element);
 }
 
 function useConnectionOptions() {
@@ -508,3 +507,31 @@ initRoom();
 unpublishTracks();
 runPreflight();
 mediaWarnings();
+
+// New test cases for AudioTrack, VideoTrack, and LocalTrackOptions
+
+const localTrackOptions: Video.LocalTrackOptions = {
+  logLevel: 'info',
+  name: 'my-track'
+};
+
+const audioTrack: Video.AudioTrack = new Video.AudioTrack();
+const videoTrack: Video.VideoTrack = new Video.VideoTrack();
+
+// Test AudioTrack attach method
+const audioElement: HTMLAudioElement = audioTrack.attach();
+audioTrack.attach(document.createElement('audio'));
+
+// Test VideoTrack attach method
+const videoElement: HTMLVideoElement = videoTrack.attach() as HTMLVideoElement;
+videoTrack.attach(document.createElement('video'));
+
+// Test createLocalAudioTrack
+Video.createLocalAudioTrack(localTrackOptions).then((localAudioTrack: Video.LocalAudioTrack) => {
+  const mediaStreamTrack: MediaStreamTrack = localAudioTrack.mediaStreamTrack;
+});
+
+// Test createLocalVideoTrack
+Video.createLocalVideoTrack(localTrackOptions).then((localVideoTrack: Video.LocalVideoTrack) => {
+  const mediaStreamTrack: MediaStreamTrack = localVideoTrack.mediaStreamTrack;
+});


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

This pull request adds new unit tests to `tsdef/twilio-video-tests.ts` to improve the robustness of our TypeScript definitions.

**Description:**

The `CHANGELOG.md` indicates that there have been several fixes related to TypeScript definition errors in the past (e.g., VIDEO-12242, VIDEO-12383). To prevent regressions and ensure the long-term stability of our TypeScript definitions, this PR introduces new unit tests for the following:

  * `AudioTrack`
  * `VideoTrack`
  * `LocalTrackOptions`

These tests will help us catch any incorrect or missing definitions for methods like `AudioTrack.attach()`, `VideoTrack.attach()`, and `createLocalAudioTrack()`. By adding these tests, we can ensure that our TypeScript definitions remain accurate and reliable as the SDK evolves.

**Changes:**

  * Added new test cases to `tsdef/twilio-video-tests.ts` to cover `AudioTrack`, `VideoTrack`, and `LocalTrackOptions`.
  * Corrected minor typing issues in the test file to ensure that the tests build successfully.


## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review
