### PR TITLE
[VBLOCKS-4946] Add daily builds to the CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -466,3 +466,27 @@ workflows:
                 - /^\d+\.\d+\.\d+-beta\d+-rc\.\d+$/
             branches:
               ignore: /.*/
+
+  Daily_Build_Workflow:
+    triggers:
+      - schedule:
+          cron: "0 6 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - Build:
+          context: dockerhub-pulls
+      - UnitTests:
+          context: dockerhub-pulls
+      - run-integration-tests:
+          context: dockerhub-pulls
+          name: << matrix.test_stability >> integration << matrix.topology >> tests on << matrix.browser >>(<< matrix.bver >>)
+          matrix:
+            parameters:
+              browser: ["chrome", "firefox"]
+              bver: ["stable", "unstable", "beta"]
+              topology: ["group", "peer-to-peer"]
+              test_stability: ["stable"]
+          requires: [Build, UnitTests]


### PR DESCRIPTION
## Pull Request Details

### Description
Set up jobs for build, unit tests, and integration tests and configure cron to trigger the workflow daily at 6 AM on the master branch

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
