### PR TITLE
[DEV] Remove the XMLHttpRequest dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
       "dependencies": {
         "events": "^3.3.0",
         "util": "^0.12.4",
-        "ws": "^7.4.6",
-        "xmlhttprequest": "^1.8.0"
+        "ws": "^7.4.6"
       },
       "devDependencies": {
         "@babel/core": "^7.14.2",
@@ -18147,15 +18146,6 @@
       "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha512-58Im/U0mlVBLM38NdZjHyhuMtCqa61469k2YP/AaPbvCoV9aQGUpbJBj1QRm2ytRiVQBD/fsw7L2bJGDVQswBA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -152,11 +152,9 @@
   "dependencies": {
     "events": "^3.3.0",
     "util": "^0.12.4",
-    "ws": "^7.4.6",
-    "xmlhttprequest": "^1.8.0"
+    "ws": "^7.4.6"
   },
   "browser": {
-    "ws": "./src/ws.js",
-    "xmlhttprequest": "./src/xmlhttprequest.js"
+    "ws": "./src/ws.js"
   }
 }

--- a/src/xmlhttprequest.js
+++ b/src/xmlhttprequest.js
@@ -1,1 +1,0 @@
-exports.XMLHttpRequest = XMLHttpRequest;

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -42,15 +42,12 @@ function decodeAudioFromArrayBuffer(arrayBuffer) {
     audioContext.decodeAudioData(arrayBuffer, resolve));
 }
 
-function getArrayBufferForFile(url) {
-  return new Promise(resolve => {
-    const xhr = new XMLHttpRequest();
-    xhr.open('GET', url);
-    xhr.responseType = 'arraybuffer';
-    xhr.onreadystatechange = () =>
-      xhr.readyState === 4 && resolve(xhr.response);
-    xhr.send();
-  });
+async function getArrayBufferForFile(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+  return response.arrayBuffer();
 }
 
 /**


### PR DESCRIPTION
## Pull Request Details

### Description

The Fetch API is finally stable in Node.js

Note: this does not affect the library functionality.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
