### PR TITLE
[VBLOCKS-5005] feat: implement ResourceEventPublisher for CPU pressure insights

### DIFF
--- a/lib/insights/computepressuremonitor.js
+++ b/lib/insights/computepressuremonitor.js
@@ -35,14 +35,14 @@
 class ComputePressureMonitor {
   _lastCpuPressure;
   _cpuPressureObserver;
-  _sampleInterval = 10000; // 10 seconds
+  _sampleInterval = 2000; // 2 seconds
   _cpuPressureChangeListeners = [];
 
   /**
    * @returns {boolean} - True if the Compute Pressure API is supported, false otherwise.
    */
   static isSupported() {
-    return 'PressureObserver' in window;
+    return 'PressureObserver' in globalThis;
   }
 
   /**

--- a/lib/insights/resourceeventpublisher.js
+++ b/lib/insights/resourceeventpublisher.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const computePressureMonitor = require('./computepressuremonitor');
+
+/**
+ * ResourceEventPublisher handles publishing system resource events to the Twilio Video SDK insights.
+ *
+ * @example
+ * const resourceEventPublisher = new ResourceEventPublisher(eventObserver, log);
+ * resourceEventPublisher.cleanup();
+ *
+ * // Any change in resource monitoring will be published to the event observer using the following format:
+ * {
+ *   group: 'cpu',
+ *   name: 'pressure-changed',
+ *   level: 'info',
+ *   payload: {
+ *     state: 'nominal' | 'fair' | 'serious' | 'critical'
+ *   }
+ * }
+ *
+ * // Since CPU pressure will be monitored continuously, it is important to clean up the resource monitors
+ * // when the SDK no longer needs this information.
+ * resourceEventPublisher.cleanup();
+ */
+class ResourceEventPublisher {
+  /**
+   * Create a ResourceEventPublisher
+   * @param {EventObserver} eventObserver - The event observer for publishing insights
+   * @param {Log} log - Logger instance
+   */
+  constructor(eventObserver, log) {
+    this._eventObserver = eventObserver;
+    this._cpuPressureHandler = null;
+    this._log = log;
+
+    this._setupCPUMonitoring();
+  }
+
+  /**
+   * Setup CPU pressure monitoring
+   * @private
+   */
+  _setupCPUMonitoring() {
+    if (!computePressureMonitor.constructor.isSupported()) {
+      this._log.debug('CPU pressure monitoring not supported');
+      return;
+    }
+
+    this._cpuPressureHandler = pressureRecord => {
+      this._log.debug('CPU pressure changed:', pressureRecord);
+      this._publishEvent('cpu', 'pressure-changed', 'info', {
+        state: pressureRecord.state
+      });
+    };
+
+    try {
+      computePressureMonitor.onCpuPressureChange(this._cpuPressureHandler);
+      this._log.debug('CPU pressure monitoring initialized');
+    } catch (error) {
+      this._log.error('Error initializing CPU pressure monitoring:', error);
+    }
+  }
+
+  /**
+   * Publish a resource monitoring event
+   * @param {string} group - Event group
+   * @param {string} name - Event name
+   * @param {string} level - Event level
+   * @param {Object} payload - Event payload
+   * @private
+   */
+  _publishEvent(group, name, level, payload) {
+    this._eventObserver.emit('event', {
+      group,
+      name,
+      level,
+      payload
+    });
+  }
+
+  /**
+   * Cleanup all resource monitors
+   */
+  cleanup() {
+    this._log.debug('Cleaning up resource monitors');
+
+    if (this._cpuPressureHandler) {
+      computePressureMonitor.offCpuPressureChange(this._cpuPressureHandler);
+      this._cpuPressureHandler = null;
+    }
+  }
+}
+
+module.exports = ResourceEventPublisher;

--- a/lib/room.js
+++ b/lib/room.js
@@ -3,6 +3,7 @@
 const EventEmitter = require('./eventemitter');
 const RemoteParticipant = require('./remoteparticipant');
 const StatsReport = require('./stats/statsreport');
+const ResourceEventPublisher = require('./insights/resourceeventpublisher');
 const { flatMap, valueToJSON } = require('./util');
 
 let nInstances = 0;
@@ -87,6 +88,11 @@ class Room extends EventEmitter {
       },
       _signaling: {
         value: signaling
+      },
+      _resourceEventPublisher: {
+        value: options.insights && options.eventObserver
+          ? new ResourceEventPublisher(options.eventObserver, log)
+          : null
       },
       dominantSpeaker: {
         enumerable: true,
@@ -670,6 +676,9 @@ function handleSignalingEvents(room, signaling) {
         room.localParticipant.tracks.forEach(publication => {
           publication.unpublish();
         });
+        if (room._resourceEventPublisher) {
+          room._resourceEventPublisher.cleanup();
+        }
         signaling.removeListener('stateChanged', stateChanged);
         break;
       case 'reconnecting':

--- a/lib/util/eventobserver.js
+++ b/lib/util/eventobserver.js
@@ -9,7 +9,8 @@ const VALID_GROUPS = [
   'media',
   'quality',
   'video-processor',
-  'preflight'
+  'preflight',
+  'cpu'
 ];
 
 const VALID_LEVELS = [

--- a/test/integration/spec/cpupressureevents.js
+++ b/test/integration/spec/cpupressureevents.js
@@ -1,0 +1,253 @@
+'use strict';
+
+const assert = require('assert');
+const { EventEmitter } = require('events');
+
+const { connect } = require('../../../es5');
+const defaults = require('../../lib/defaults');
+const { createRoom, completeRoom } = require('../../lib/rest');
+const getToken = require('../../lib/token');
+const { randomName, waitFor } = require('../../lib/util');
+
+class MockPressureObserver {
+  static instances = [];
+  static activeInstances = [];
+
+  static simulatePressureChange(state) {
+    MockPressureObserver.activeInstances.forEach(instance => {
+      instance._simulatePressureChange(state);
+    });
+  }
+
+  static getActiveCount() {
+    return MockPressureObserver.activeInstances.length;
+  }
+
+  static reset() {
+    MockPressureObserver.instances = [];
+    MockPressureObserver.activeInstances = [];
+  }
+
+  constructor(callback) {
+    this.callback = callback;
+    this.isObserving = false;
+    MockPressureObserver.instances.push(this);
+  }
+
+  observe(source, options) {
+    this.isObserving = true;
+    this.source = source;
+    this.options = options;
+    MockPressureObserver.activeInstances.push(this);
+  }
+
+  disconnect() {
+    this.isObserving = false;
+    const index = MockPressureObserver.activeInstances.indexOf(this);
+    if (index > -1) {
+      MockPressureObserver.activeInstances.splice(index, 1);
+    }
+  }
+
+  _simulatePressureChange(state) {
+    if (this.isObserving) {
+      const mockRecord = {
+        state,
+        source: 'cpu',
+        time: Date.now(),
+        toJSON: () => ({ state, source: 'cpu', time: Date.now() })
+      };
+      this.callback([mockRecord]);
+    }
+  }
+}
+
+describe('CPU Pressure Events', function() {
+
+  let room;
+  let roomName;
+  let token;
+  let originalPressureObserver;
+
+  beforeEach(async () => {
+    roomName = randomName();
+    await createRoom(roomName, defaults.topology);
+    token = getToken(randomName());
+
+    originalPressureObserver = globalThis.PressureObserver;
+    globalThis.PressureObserver = MockPressureObserver;
+  });
+
+  afterEach(async () => {
+    if (room) {
+      room.disconnect();
+      room = null;
+    }
+
+    if (globalThis.PressureObserver && globalThis.PressureObserver.reset) {
+      globalThis.PressureObserver.reset();
+    }
+
+    globalThis.PressureObserver = originalPressureObserver;
+
+    if (roomName) {
+      await completeRoom(roomName);
+    }
+  });
+
+  describe('when PressureObserver is supported', () => {
+    it('should emit CPU pressure events with correct structure', async () => {
+      const eventObserver = new EventEmitter();
+      const cpuEvents = [];
+      eventObserver.on('event', event => {
+        if (event.group === 'cpu') {
+          cpuEvents.push(event);
+        }
+      });
+
+      room = await connect(token, {
+        name: roomName,
+        audio: false,
+        video: false,
+        eventObserver
+      });
+
+      // Wait for pressure monitoring to start
+      await waitFor(() => {
+        return globalThis.PressureObserver.getActiveCount() > 0;
+      }, 'CPU pressure monitoring should start');
+
+      globalThis.PressureObserver.simulatePressureChange('critical');
+
+      await waitFor(() => cpuEvents.length > 0, 'CPU pressure event should be emitted');
+
+      const event = cpuEvents[0];
+      assert.strictEqual(event.group, 'cpu');
+      assert.strictEqual(event.name, 'pressure-changed');
+      assert.strictEqual(event.level, 'info');
+      assert.strictEqual(event.payload.state, 'critical');
+    });
+
+    it('should emit events for all CPU pressure states', async () => {
+      const eventObserver = new EventEmitter();
+      const cpuEvents = [];
+      eventObserver.on('event', event => {
+        if (event.group === 'cpu') {
+          cpuEvents.push(event);
+        }
+      });
+
+      room = await connect(token, {
+        name: roomName,
+        audio: false,
+        video: false,
+        eventObserver
+      });
+
+      await waitFor(() => {
+        return globalThis.PressureObserver.getActiveCount() > 0;
+      }, 'CPU pressure monitoring should start');
+
+      const expectedStates = ['nominal', 'fair', 'serious', 'critical'];
+
+      for (const state of expectedStates) {
+        globalThis.PressureObserver.simulatePressureChange(state);
+      }
+
+      await waitFor(() => cpuEvents.length === expectedStates.length, 'All CPU pressure events should be emitted');
+
+      expectedStates.forEach((state, index) => {
+        const event = cpuEvents[index];
+        assert.strictEqual(event.group, 'cpu');
+        assert.strictEqual(event.name, 'pressure-changed');
+        assert.strictEqual(event.level, 'info');
+        assert.strictEqual(event.payload.state, state);
+      });
+    });
+
+    it('should stop emitting CPU pressure events when Room disconnects', async () => {
+      const eventObserver = new EventEmitter();
+      const cpuEvents = [];
+      eventObserver.on('event', event => {
+        if (event.group === 'cpu') {
+          cpuEvents.push(event);
+        }
+      });
+
+      room = await connect(token, {
+        name: roomName,
+        audio: false,
+        video: false,
+        eventObserver
+      });
+
+      await waitFor(() => {
+        return globalThis.PressureObserver.getActiveCount() > 0;
+      }, 'CPU pressure monitoring should start');
+
+      assert(globalThis.PressureObserver.getActiveCount() > 0, 'Should be observing initially');
+
+      room.disconnect();
+
+      await waitFor(() => globalThis.PressureObserver.getActiveCount() === 0, 'Should stop observing after disconnect');
+
+      // Try to simulate pressure change after disconnect - should not emit events
+      const initialEventCount = cpuEvents.length;
+      globalThis.PressureObserver.simulatePressureChange('critical');
+
+      // Wait a bit to ensure no event is emitted
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      assert.strictEqual(cpuEvents.length, initialEventCount, 'Should not emit events after disconnect');
+    });
+  });
+
+  describe('when PressureObserver is not supported', () => {
+    beforeEach(() => {
+      delete globalThis.PressureObserver;
+    });
+
+    it('should not emit CPU pressure events', async () => {
+      const eventObserver = new EventEmitter();
+      const cpuEvents = [];
+      eventObserver.on('event', event => {
+        if (event.group === 'cpu') {
+          cpuEvents.push(event);
+        }
+      });
+
+      room = await connect(token, {
+        name: roomName,
+        audio: false,
+        video: false,
+        eventObserver
+      });
+
+      assert.strictEqual(cpuEvents.length, 0, 'Should not emit CPU pressure events');
+    });
+  });
+
+  describe('when insights are disabled', () => {
+    it('should not emit CPU pressure events', async () => {
+      const eventObserver = new EventEmitter();
+      const cpuEvents = [];
+      eventObserver.on('event', event => {
+        if (event.group === 'cpu') {
+          cpuEvents.push(event);
+        }
+      });
+
+      room = await connect(token, {
+        name: roomName,
+        audio: false,
+        video: false,
+        insights: false,
+        eventObserver
+      });
+
+      globalThis.PressureObserver.simulatePressureChange('critical');
+      await new Promise(resolve => setTimeout(resolve, 100));
+      assert.strictEqual(cpuEvents.length, 0, 'Should not emit CPU pressure events when insights are disabled');
+    });
+  });
+});


### PR DESCRIPTION
## Pull Request Details

### Description
- Integrate the CPU pressure monitor to the room insights event reporting logic using a ResourceEventPublisher (I'm intentionally choosing a generic name, as we might consider monitoring other sources like GPU down the road to improve the call quality).
- Add integration tests for the ResourceEventPublisher.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
