### PR TITLE
[VBLOCKS-5037] fix: SDP generation with invalid payload types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Bug Fixes
 ---------
 - Fixed an issue where video tracks would freeze when the video element was offscreen in a document Picture-in-Picture window.
 - Fixed an issue where `LocalVideoTrack.restart()` would fail on some devices when a video processor was active.
+- Fixed an issue where Safari would generate invalid SDP with duplicate payload type mappings during track unpublish/republish operations, causing SDP negotiation failures with Chrome 137+.
 
 2.32.0 (in progress)
 ====================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Bug Fixes
 ---------
 - Fixed an issue where video tracks would freeze when the video element was offscreen in a document Picture-in-Picture window.
 - Fixed an issue where `LocalVideoTrack.restart()` would fail on some devices when a video processor was active.
-- Fixed an issue where Safari would generate invalid SDP with duplicate payload type mappings during track unpublish/republish operations, causing SDP negotiation failures with Chrome 137+.
+- Fixed an issue where SDP munging would generate duplicated payload types, causing SDP negotiation failures with Chrome 137+.
 
 2.32.0 (in progress)
 ====================

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1745,14 +1745,6 @@ function filterOutMediaStreamIds(sdp) {
  * @returns {boolean}
  */
 function shouldRecycleTransceiver(transceiver, pcv2) {
-  // NOTE(lrivas): Disable transceiver recycling for Safari to prevent
-  // payload type reuse conflicts during track unpublish/republish scenarios
-  // in P2P rooms. See, https://github.com/twilio/twilio-video.js/issues/2122.
-  // This can be revisited once we remove the SDP munging logic for Safari.
-  if (isSafari) {
-    return false;
-  }
-
   return !transceiver.stopped
     && !pcv2._replaceTrackPromises.has(transceiver)
     && ['inactive', 'recvonly'].includes(transceiver.direction);

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -1745,6 +1745,14 @@ function filterOutMediaStreamIds(sdp) {
  * @returns {boolean}
  */
 function shouldRecycleTransceiver(transceiver, pcv2) {
+  // NOTE(lrivas): Disable transceiver recycling for Safari to prevent
+  // payload type reuse conflicts during track unpublish/republish scenarios
+  // in P2P rooms. See, https://github.com/twilio/twilio-video.js/issues/2122.
+  // This can be revisited once we remove the SDP munging logic for Safari.
+  if (isSafari) {
+    return false;
+  }
+
   return !transceiver.stopped
     && !pcv2._replaceTrackPromises.has(transceiver)
     && ['inactive', 'recvonly'].includes(transceiver.direction);

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -51,6 +51,13 @@ function createMidToMediaSectionMap(sdp) {
  */
 function createPtToCodecName(mediaSection) {
   return getPayloadTypesInMediaSection(mediaSection).reduce((ptToCodecName, pt) => {
+    // NOTE(lrivas): Skip if we already have a mapping for this PT, since Safari
+    // can generate malformed SDP with duplicate PTs. See, https://github.com/twilio/twilio-video.js/issues/2122.
+    // This can be revisited once we remove the SDP munging logic for Safari.
+    if (ptToCodecName.has(pt)) {
+      return ptToCodecName;
+    }
+
     const rtpmapPattern = new RegExp(`a=rtpmap:${pt} ([^/]+)`);
     const matches = mediaSection.match(rtpmapPattern);
     const codecName = matches

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -51,9 +51,8 @@ function createMidToMediaSectionMap(sdp) {
  */
 function createPtToCodecName(mediaSection) {
   return getPayloadTypesInMediaSection(mediaSection).reduce((ptToCodecName, pt) => {
-    // NOTE(lrivas): Skip if we already have a mapping for this PT, since Safari
-    // can generate malformed SDP with duplicate PTs. See, https://github.com/twilio/twilio-video.js/issues/2122.
-    // This can be revisited once we remove the SDP munging logic for Safari.
+    // NOTE(lrivas): Ignore repeated PTs to prevent RFC non‑compliant SDP generation.
+    // See, https://github.com/twilio/twilio-video.js/issues/2122.
     if (ptToCodecName.has(pt)) {
       return ptToCodecName;
     }


### PR DESCRIPTION
## Pull Request Details

### Description
- This PR prevents repeated payload types in the munged SDP section.
- Fixes #2122 

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
