### PR TITLE
[VBLOCKS-5078] fix: resolve payload type conflicts in issue8329 workaround

### DIFF
--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -300,10 +300,14 @@ function filterCodecsInMediaSection(section, peerMidsToMediaSections, codecsToRe
   // Payload Type if present.
   const rtxPts = codecsToPts.get('rtx') || [];
   // In "a=fmtp:<rtxPt> apt=<apt>", extract the codec PT <apt> associated with rtxPt.
-  pts = pts.concat(rtxPts.filter(rtxPt => {
+  const additionalRtxPts = rtxPts.filter(rtxPt => {
     const fmtpAttrs = getFmtpAttributesForPt(rtxPt, section);
     return fmtpAttrs && pts.includes(fmtpAttrs.apt);
-  }));
+  });
+
+  // NOTE(lrivas): Retain rtx Payload Types that reference a codec already in `pts`.
+  // Using an intermediate Set to prevent duplicates from being reintroduced after concatenation.
+  pts = Array.from(new Set([...pts, ...additionalRtxPts]));
 
   // Filter out the below mentioned attribute lines in the m= section that do not
   // belong to one of the Payload Types that are to be retained.
@@ -318,7 +322,11 @@ function filterCodecsInMediaSection(section, peerMidsToMediaSections, codecsToRe
 
   // Filter the list of Payload Types in the first line of the m= section.
   const orderedPts = getPayloadTypesInMediaSection(section).filter(pt => pts.includes(pt));
-  return setPayloadTypesInMediaSection(orderedPts, lines.join('\r\n'));
+
+  // Ensure only unique Payload Types are retained.
+  const uniquePayloadTypes = Array.from(new Set(orderedPts));
+
+  return setPayloadTypesInMediaSection(uniquePayloadTypes, lines.join('\r\n'));
 }
 
 /**

--- a/lib/util/sdp/issue8329.js
+++ b/lib/util/sdp/issue8329.js
@@ -51,6 +51,7 @@ function sdpWorkaround(sdp) {
 function mediaSectionWorkaround(mediaSection) {
   const ptToCodecName = createPtToCodecName(mediaSection);
   mediaSection = deleteDuplicateRtxPts(mediaSection, ptToCodecName);
+  mediaSection = resolvePayloadTypeConflicts(mediaSection);
   const codecNameToPts = createCodecNameToPts(ptToCodecName);
   const rtxPts = codecNameToPts.get('rtx') || new Set();
 
@@ -86,6 +87,48 @@ function mediaSectionWorkaround(mediaSection) {
 
   return mediaSection;
 }
+
+/**
+ * Resolve payload type conflicts where same PT maps to different codecs
+ * @param {string} mediaSection
+ * @returns {string} resolvedMediaSection
+ */
+function resolvePayloadTypeConflicts(mediaSection) {
+  const lines = mediaSection.split('\r\n');
+  const seenPts = new Map(); // PT -> first codec seen
+  let nextAvailablePt = 96; // Start from 96, which is the first dynamic PT. See https://datatracker.ietf.org/doc/html/rfc3551#section-3
+
+  for (let i = 0; i < lines.length; i++) {
+    const rtpmapMatch = lines[i].match(/^a=rtpmap:(\d+) ([^/]+)/);
+    if (rtpmapMatch) {
+      const pt = parseInt(rtpmapMatch[1], 10);
+      const codec = rtpmapMatch[2].toLowerCase();
+
+      if (seenPts.has(pt) && seenPts.get(pt) !== codec) {
+        // Conflict detected - reassign this PT
+        while (seenPts.has(nextAvailablePt) || nextAvailablePt === pt) {
+          nextAvailablePt++;
+        }
+        const newPt = nextAvailablePt;
+        seenPts.set(newPt, codec);
+
+        lines[i] = lines[i].replace(`a=rtpmap:${pt}`, `a=rtpmap:${newPt}`);
+
+        for (let j = i + 1; j < lines.length; j++) {
+          // eslint-disable-next-line max-depth
+          if (lines[j].match(new RegExp(`^a=(fmtp|rtcp-fb):${pt}\\b`))) {
+            lines[j] = lines[j].replace(new RegExp(`^a=(fmtp|rtcp-fb):${pt}\\b`), `a=$1:${newPt}`);
+          }
+        }
+      } else {
+        seenPts.set(pt, codec);
+      }
+    }
+  }
+
+  return lines.join('\r\n');
+}
+
 
 /**
  * @param {string} mediaSection


### PR DESCRIPTION
## Pull Request Details

### Description
- Added PT conflict detection and reassignment in Issue 8329 workaround.
  Implementation details:
   - Detect duplicate PTs mapped to different codecs in malformed SDP
   - Reassign conflicting PTs to next available numbers (96-127 range)
   - Update all related SDP lines (rtpmap, fmtp, rtcp-fb) consistently
- Added a new unit test to validate the functionality

Fixes #2122  

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
