### PR TITLE
[RC Fix] Adjust PiP support for Local Participant

### DIFF
--- a/lib/media/track/localvideotrack.js
+++ b/lib/media/track/localvideotrack.js
@@ -52,6 +52,10 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
       _workaroundSilentLocalVideoCleanup: {
         value: null,
         writable: true
+      },
+      _pipIntersectionObserver: {
+        value: null,
+        writable: true
       }
     });
 
@@ -65,6 +69,107 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
 
   toString() {
     return `[LocalVideoTrack #${this._instanceId}: ${this.id}]`;
+  }
+
+  /**
+   * Handle document PiP enter event - set up intersection observer for PiP-specific visibility tracking
+   *
+   * NOTE(lrivas): This is only created if we are in document PiP mode and should be considered deprecated
+   * if Chrome's native PiP fixes the issue in the future.
+   * @private
+   */
+  _onDocumentPipEnter() {
+    this._log.debug('LocalVideoTrack: Setting up PiP intersection observer');
+    this._setupPipIntersectionObserver();
+  }
+
+  /**
+   * Handle document PiP exit event - clean up intersection observer
+   * NOTE(lrivas): This is only created if we are in document PiP mode and should be considered deprecated
+   * if Chrome's native PiP fixes the issue in the future.
+   * @private
+   */
+  _onDocumentPipExit() {
+    this._log.debug('LocalVideoTrack: Cleaning up PiP intersection observer');
+    this._cleanupPipIntersectionObserver();
+  }
+
+  /**
+   * Set up an IntersectionObserver to track visibility of elements attached in document PiP.
+   * This ensures that videos in PiP play when visible.
+   *
+   * NOTE(lrivas): This is only created if we are in document PiP mode and should be considered deprecated
+   * if Chrome's native PiP fixes the issue in the future.
+   * @private
+   */
+  _setupPipIntersectionObserver() {
+    if (!this._pipIntersectionObserver && this._documentPipWindow) {
+      this._log.debug('LocalVideoTrack: Creating PiP intersection observer');
+
+      this._pipIntersectionObserver = new IntersectionObserver(entries => {
+        const hasVisibleElements = entries.some(entry => entry.isIntersecting);
+
+        if (hasVisibleElements) {
+          this._log.debug('LocalVideoTrack: Element visible in PiP, ensuring videos are playing');
+          VideoTrack._ensureDocumentPipVideosPlaying(this);
+        }
+      }, { threshold: 0.25 });
+
+      this._attachments.forEach(el => {
+        this._log.debug('LocalVideoTrack: Observing element for PiP visibility');
+        this._pipIntersectionObserver.observe(el);
+      });
+    }
+  }
+
+  /**
+   * Clean up PiP-specific intersection observer
+   *
+   * NOTE(lrivas): This is only created if we are in document PiP mode and should be considered deprecated
+   * if Chrome's native PiP fixes the issue in the future.
+   * @private
+   */
+  _cleanupPipIntersectionObserver() {
+    if (this._pipIntersectionObserver) {
+      this._log.debug('LocalVideoTrack: Disconnecting PiP intersection observer');
+      this._pipIntersectionObserver.disconnect();
+      this._pipIntersectionObserver = null;
+    }
+  }
+
+  /**
+   * Attach the {@link LocalVideoTrack} to an HTMLMediaElement.
+   * @returns {HTMLMediaElement} mediaElement
+   */
+  attach() {
+    const result = super.attach.apply(this, arguments);
+
+    // If we're in document PiP, new elements should be observed for visibility
+    if (this._pipIntersectionObserver) {
+      this._log.debug('LocalVideoTrack: Observing newly attached element for PiP visibility');
+      this._pipIntersectionObserver.observe(result);
+    }
+
+    return result;
+  }
+
+  /**
+   * Detach the {@link LocalVideoTrack} from HTMLMediaElement(s).
+   * @returns {HTMLMediaElement|Array<HTMLMediaElement>} mediaElement(s)
+   */
+  detach() {
+    const result = super.detach.apply(this, arguments);
+    const elements = Array.isArray(result) ? result : [result];
+
+    // Stop observing detached elements if we're in document PiP
+    if (this._pipIntersectionObserver) {
+      elements.forEach(el => {
+        this._log.debug('LocalVideoTrack: Unobserving detached element from PiP visibility');
+        this._pipIntersectionObserver.unobserve(el);
+      });
+    }
+
+    return result;
   }
 
   /**
@@ -300,6 +405,10 @@ class LocalVideoTrack extends LocalMediaVideoTrack {
       this._workaroundSilentLocalVideoCleanup();
       this._workaroundSilentLocalVideoCleanup = null;
     }
+
+    // Clean up PiP intersection observer when stopping
+    this._cleanupPipIntersectionObserver();
+
     return super.stop.apply(this, arguments);
   }
 }

--- a/lib/media/track/remotevideotrack.js
+++ b/lib/media/track/remotevideotrack.js
@@ -7,7 +7,7 @@ const { NullObserver } = require('../../util/nullobserver.js');
 const Timeout = require('../../util/timeout');
 
 const RemoteMediaVideoTrack = mixinRemoteMediaTrack(VideoTrack);
-const TRACK_TURN_OF_DELAY_MS = 50;
+const TRACK_TURN_OFF_DELAY_MS = 50;
 
 /**
  * A {@link RemoteVideoTrack} represents a {@link VideoTrack} published to a
@@ -73,18 +73,10 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
       _elToPipWindows: {
         value: new WeakMap(),
       },
-      _documentPipWindow: {
-        value: null,
-        writable: true
-      },
-      _documentPipEnterListener: {
-        value: null,
-        writable: true
-      },
       _turnOffTimer: {
         value: new Timeout(() => {
           this._setRenderHint({ enabled: false });
-        }, TRACK_TURN_OF_DELAY_MS, false),
+        }, TRACK_TURN_OFF_DELAY_MS, false),
       },
       _resizeObserver: {
         value: new options.ResizeObserver(entries => {
@@ -239,17 +231,6 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
       this._documentVisibilityTurnOffCleanup = this._documentVisibilityTurnOffCleanup || setupDocumentVisibilityTurnOff(this);
     }
 
-    // Set up document PiP listener on first attach
-    if (!this._documentPipEnterListener && 'documentPictureInPicture' in globalThis &&
-        globalThis.documentPictureInPicture &&
-        typeof globalThis.documentPictureInPicture.addEventListener === 'function') {
-      this._documentPipEnterListener = event => {
-        this._log.debug('document pip entered');
-        this._documentPipWindow = event.window;
-      };
-      globalThis.documentPictureInPicture.addEventListener('enter', this._documentPipEnterListener);
-    }
-
     this._observePip(result);
     return result;
   }
@@ -268,14 +249,6 @@ class RemoteVideoTrack extends RemoteMediaVideoTrack {
       if (this._documentVisibilityTurnOffCleanup) {
         this._documentVisibilityTurnOffCleanup();
         this._documentVisibilityTurnOffCleanup = null;
-      }
-
-      if (this._documentPipEnterListener) {
-        if (globalThis.documentPictureInPicture && typeof globalThis.documentPictureInPicture.removeEventListener === 'function') {
-          globalThis.documentPictureInPicture.removeEventListener('enter', this._documentPipEnterListener);
-        }
-        this._documentPipEnterListener = null;
-        this._documentPipWindow = null;
       }
     }
 
@@ -398,9 +371,7 @@ function maybeUpdateEnabledHint(remoteVideoTrack) {
     remoteVideoTrack._setRenderHint({ enabled: true });
 
     // Check if videos in document PiP are actually playing
-    if (remoteVideoTrack._documentPipWindow) {
-      ensureDocumentPipVideosPlaying(remoteVideoTrack);
-    }
+    VideoTrack._ensureDocumentPipVideosPlaying(remoteVideoTrack);
   } else if (!remoteVideoTrack._turnOffTimer.isSet) {
     // set the track to be turned off after some delay.
     remoteVideoTrack._turnOffTimer.start();
@@ -437,32 +408,6 @@ function setupDocumentVisibilityTurnOff(removeVideoTrack) {
   };
 }
 
-/**
- * This is a workaround to ensure that videos rendered in a document PIP continue playing after being enabled
- * by the Intersection Observer. It appears to be a bug in Chrome, and we should revisit this issue once the
- * Document Picture-in-Picture feature is more reliably supported.
- */
-function ensureDocumentPipVideosPlaying(remoteVideoTrack) {
-  if (!remoteVideoTrack._documentPipWindow) {
-    return;
-  }
-
-  try {
-    const pipEls = new WeakSet(remoteVideoTrack._documentPipWindow.document.querySelectorAll('video'));
-
-    remoteVideoTrack._attachments.forEach(el => {
-      if (pipEls.has(el) && el.paused) {
-        el.play().then(() => {
-          remoteVideoTrack._log.debug('Successfully played inadvertently paused video element in document PiP window');
-        }).catch(error => {
-          remoteVideoTrack._log.debug('Failed to play inadvertently paused video element in document PiP window', error);
-        });
-      }
-    });
-  } catch (error) {
-    remoteVideoTrack._log.debug('Error checking document PiP video playback:', error);
-  }
-}
 
 /**
  * @typedef {object} VideoContentPreferences

--- a/lib/media/track/videotrack.js
+++ b/lib/media/track/videotrack.js
@@ -75,6 +75,18 @@ class VideoTrack extends MediaTrack {
         enumerable: true,
         value: null,
         writable: true
+      },
+      _documentPipWindow: {
+        value: null,
+        writable: true
+      },
+      _documentPipEnterListener: {
+        value: null,
+        writable: true
+      },
+      _documentPipExitListener: {
+        value: null,
+        writable: true
       }
     });
 
@@ -431,6 +443,12 @@ class VideoTrack extends MediaTrack {
    */
   attach() {
     const result = super.attach.apply(this, arguments);
+
+    // Set up document PiP listener on first attach
+    if (this._attachments.size === 1) {
+      setupDocumentPipListener(this);
+    }
+
     if (this.processor) {
       this._captureFrames();
     }
@@ -461,7 +479,14 @@ class VideoTrack extends MediaTrack {
    * videoTrack.detach('#my-video-element').remove();
    */
   detach() {
-    return super.detach.apply(this, arguments);
+    const result = super.detach.apply(this, arguments);
+
+    // Clean up document PiP listener when no attachments remain
+    if (this._attachments.size === 0) {
+      cleanupDocumentPipListener(this);
+    }
+
+    return result;
   }
 
   /**
@@ -521,6 +546,100 @@ VideoTrack.DIMENSIONS_CHANGED = 'dimensionsChanged';
 function dimensionsChanged(track, elem) {
   return track.dimensions.width !== elem.videoWidth
     || track.dimensions.height !== elem.videoHeight;
+}
+
+/**
+ * Set up document PiP listener for a VideoTrack.
+ *
+ * The received VideoTrack can define `_onDocumentPipEnter` and `_onDocumentPipExit`
+ * to handle PiP-specific setup and cleanup.
+ * @param {VideoTrack} videoTrack - The VideoTrack to set up the listener for
+ * @private
+ */
+function setupDocumentPipListener(videoTrack) {
+  if (!videoTrack._documentPipEnterListener && 'documentPictureInPicture' in globalThis &&
+      globalThis.documentPictureInPicture &&
+      typeof globalThis.documentPictureInPicture.addEventListener === 'function') {
+
+    videoTrack._documentPipEnterListener = event => {
+      videoTrack._log.debug('document pip entered');
+      videoTrack._documentPipWindow = event.window;
+
+      // Set up exit listener on the PiP window
+      videoTrack._documentPipExitListener = () => {
+        videoTrack._log.debug('document pip exited');
+        videoTrack._documentPipWindow = null;
+
+        if (typeof videoTrack._onDocumentPipExit === 'function') {
+          videoTrack._onDocumentPipExit();
+        }
+      };
+
+      // Listen for window close on the PiP window
+      if (event.window && typeof event.window.addEventListener === 'function') {
+        event.window.addEventListener('pagehide', videoTrack._documentPipExitListener);
+      }
+
+      // Immediate fix for any paused videos
+      ensureDocumentPipVideosPlaying(videoTrack);
+
+      if (typeof videoTrack._onDocumentPipEnter === 'function') {
+        videoTrack._onDocumentPipEnter(event);
+      }
+    };
+
+    globalThis.documentPictureInPicture.addEventListener('enter', videoTrack._documentPipEnterListener);
+  }
+}
+
+/**
+ * Clean up document PiP listener for VideoTrack
+ * @private
+ */
+function cleanupDocumentPipListener(videoTrack) {
+  if (videoTrack._documentPipEnterListener) {
+    if (globalThis.documentPictureInPicture && typeof globalThis.documentPictureInPicture.removeEventListener === 'function') {
+      globalThis.documentPictureInPicture.removeEventListener('enter', videoTrack._documentPipEnterListener);
+    }
+
+    // Clean up exit listener from PiP window if it exists
+    if (videoTrack._documentPipWindow && videoTrack._documentPipExitListener &&
+        typeof videoTrack._documentPipWindow.removeEventListener === 'function') {
+      videoTrack._documentPipWindow.removeEventListener('pagehide', videoTrack._documentPipExitListener);
+    }
+
+    videoTrack._documentPipEnterListener = null;
+    videoTrack._documentPipExitListener = null;
+    videoTrack._documentPipWindow = null;
+  }
+}
+
+/**
+ * This is a workaround to ensure that videos rendered in a document PIP continue playing after being enabled
+ * by the Intersection Observer. It appears to be a bug in Chrome, and we should revisit this issue once the
+ * Document Picture-in-Picture feature is more reliably supported.
+ * @private
+ */
+function ensureDocumentPipVideosPlaying(videoTrack) {
+  if (!videoTrack._documentPipWindow) {
+    return;
+  }
+
+  try {
+    const pipEls = new WeakSet(videoTrack._documentPipWindow.document.querySelectorAll('video'));
+
+    videoTrack._attachments.forEach(el => {
+      if (pipEls.has(el) && el.paused) {
+        el.play().then(() => {
+          videoTrack._log.debug('Successfully played inadvertently paused video element in document PiP window');
+        }).catch(error => {
+          videoTrack._log.debug('Failed to play inadvertently paused video element in document PiP window', error);
+        });
+      }
+    });
+  } catch (error) {
+    videoTrack._log.debug('Error checking document PiP video playback:', error);
+  }
 }
 
 /**
@@ -616,5 +735,7 @@ function dimensionsChanged(track, elem) {
  * @param {VideoTrack} track - The {@link VideoTrack} that started
  * @event VideoTrack#started
  */
+
+VideoTrack._ensureDocumentPipVideosPlaying = ensureDocumentPipVideosPlaying;
 
 module.exports = VideoTrack;

--- a/test/unit/spec/media/track/remotevideotrack.js
+++ b/test/unit/spec/media/track/remotevideotrack.js
@@ -486,7 +486,7 @@ describe('RemoteVideoTrack', () => {
       originalDocumentPictureInPicture = globalThis.documentPictureInPicture;
       addEventListenerSpy = sinon.spy();
       removeEventListenerSpy = sinon.spy();
-      playSpy = sinon.spy();
+      playSpy = sinon.stub().returns(Promise.resolve());
 
       globalThis.documentPictureInPicture = {
         addEventListener: addEventListenerSpy,
@@ -512,7 +512,7 @@ describe('RemoteVideoTrack', () => {
       globalThis.documentPictureInPicture = originalDocumentPictureInPicture;
     });
 
-    it('should set up document PiP listener on attach', () => {
+    it('should inherit document PiP functionality from VideoTrack', () => {
       track.attach(el);
       sinon.assert.calledOnce(addEventListenerSpy);
       sinon.assert.calledWith(addEventListenerSpy, 'enter', track._documentPipEnterListener);

--- a/test/unit/spec/media/track/videotrack.js
+++ b/test/unit/spec/media/track/videotrack.js
@@ -737,7 +737,7 @@ describe('VideoTrack', () => {
     });
   });
 
-  describe('Document Picture-in-Picture static functions', () => {
+  describe('Document Picture-in-Picture workaround plays inadvertently paused video tracks', () => {
     let mockTrack;
     let el;
     let playSpy;


### PR DESCRIPTION
## Pull Request Details

### Description
- Extends document Picture-in-Picture support from RemoteVideoTrack to LocalVideoTrack.
- LocalVideoTrack now adds intersection observer that only activates when a document PiP is open.
- Fixes issue where local video tracks freeze when displayed in document PiP windows

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
