### PR TITLE
[VBLOCKS-5149] Publish room insights events

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -21,6 +21,7 @@ const SignalingV2 = require('./signaling/v2');
 const {
   asLocalTrack,
   buildLogLevels,
+  createRoomConnectedEventPayload,
   filterObject,
   isNonArrayObject
 } = require('./util');
@@ -409,6 +410,10 @@ function connect(token, options) {
 
   cancelableRoomPromise.then(room => {
     eventPublisher.connect(room.sid, room.localParticipant.sid);
+
+    const connectedEventPayload = createRoomConnectedEventPayload(options);
+    options.eventObserver.emit('event', connectedEventPayload);
+
     log.info('Connected to Room:', room.toString());
     log.info('Room name:', room.name);
     log.debug('Room:', room);

--- a/lib/signaling/v2/cancelableroomsignalingpromise.js
+++ b/lib/signaling/v2/cancelableroomsignalingpromise.js
@@ -10,7 +10,7 @@ const {
   SignalingIncomingMessageInvalidError
 } = require('../../util/twilio-video-errors');
 
-const { flatMap, createRoomConnectEventPayload } = require('../../util');
+const { flatMap, createRoomConnectingEventPayload } = require('../../util');
 
 function createCancelableRoomSignalingPromise(token, wsServer, localParticipant, encodingParameters, preferredCodecs, options) {
   options = Object.assign({
@@ -112,8 +112,8 @@ function createCancelableRoomSignalingPromise(token, wsServer, localParticipant,
       wsServer,
       transportOptions);
 
-    const connectEventPayload = createRoomConnectEventPayload(options);
-    eventObserver.emit('event', connectEventPayload);
+    const connectingEventPayload = createRoomConnectingEventPayload(options);
+    eventObserver.emit('event', connectingEventPayload);
 
     transport.once('connected', initialState => {
       log.debug('Transport connected:', initialState);

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -569,7 +569,13 @@ function valueToJSON(value) {
   return value;
 }
 
-function createRoomConnectEventPayload(connectOptions) {
+/**
+ * Create base payload for room connection events.
+ * @private
+ * @param {ConnectOptions} connectOptions
+ * @returns {object} Base payload
+ */
+function createRoomConnectionBasePayload(connectOptions) {
   function boolToString(val) {
     return val ? 'true' : 'false';
   }
@@ -656,11 +662,34 @@ function createRoomConnectEventPayload(connectOptions) {
     payload[insightName] = boolToString(typeof connectOptions[optionName] !== 'undefined');
   });
 
+  return payload;
+}
+
+/**
+ * Create the payload for the 'connecting' event.
+ * @param {ConnectOptions} connectOptions
+ * @returns {object} Connecting event payload
+ */
+function createRoomConnectingEventPayload(connectOptions) {
   return {
     group: 'room',
-    name: 'connect',
+    name: 'connecting',
     level: 'info',
-    payload
+    payload: createRoomConnectionBasePayload(connectOptions)
+  };
+}
+
+/**
+ * Create the payload for the 'connected' event.
+ * @param {ConnectOptions} connectOptions
+ * @returns {object} Connected event payload
+ */
+function createRoomConnectedEventPayload(connectOptions) {
+  return {
+    group: 'room',
+    name: 'connected',
+    level: 'info',
+    payload: createRoomConnectionBasePayload(connectOptions)
   };
 }
 
@@ -867,7 +896,9 @@ exports.constants = constants;
 exports.createBandwidthProfilePayload = createBandwidthProfilePayload;
 exports.createMediaSignalingPayload = createMediaSignalingPayload;
 exports.createMediaWarningsPayload = createMediaWarningsPayload;
-exports.createRoomConnectEventPayload = createRoomConnectEventPayload;
+exports.createRoomConnectionBasePayload = createRoomConnectionBasePayload;
+exports.createRoomConnectingEventPayload = createRoomConnectingEventPayload;
+exports.createRoomConnectedEventPayload = createRoomConnectedEventPayload;
 exports.createSubscribePayload = createSubscribePayload;
 exports.asLocalTrack = asLocalTrack;
 exports.asLocalTrackPublication = asLocalTrackPublication;

--- a/test/unit/spec/util/index.js
+++ b/test/unit/spec/util/index.js
@@ -12,10 +12,44 @@ const {
   promiseFromEvents,
   isChromeScreenShareTrack,
   createRoomConnectionBasePayload,
+  createRoomConnectingEventPayload,
+  createRoomConnectedEventPayload,
 } = require('../../../../lib/util');
 
 const { sessionSID } = require('../../../../lib/util/sid');
 describe('util', () => {
+  describe('createRoomConnectingEventPayload', () => {
+    it('should create a proper connecting event payload', () => {
+      const connectOptions = {
+        audio: true,
+        video: true
+      };
+
+      const event = createRoomConnectingEventPayload(connectOptions);
+
+      assert.equal(event.group, 'room');
+      assert.equal(event.name, 'connecting');
+      assert.equal(event.level, 'info');
+      assert.deepStrictEqual(event.payload, createRoomConnectionBasePayload(connectOptions));
+    });
+  });
+
+  describe('createRoomConnectedEventPayload', () => {
+    it('should create a proper connected event payload', () => {
+      const connectOptions = {
+        audio: true,
+        video: true
+      };
+
+      const event = createRoomConnectedEventPayload(connectOptions);
+
+      assert.equal(event.group, 'room');
+      assert.equal(event.name, 'connected');
+      assert.equal(event.level, 'info');
+      assert.deepStrictEqual(event.payload, createRoomConnectionBasePayload(connectOptions));
+    });
+  });
+
   describe('createRoomConnectionBasePayload', () => {
     [
       {

--- a/test/unit/spec/util/index.js
+++ b/test/unit/spec/util/index.js
@@ -213,7 +213,7 @@ describe('util', () => {
       },
     ].forEach(({ testCase, connectOptions, expectedPayload }) => {
       it(testCase, () => {
-        const event = createRoomConnectionBasePayload(connectOptions);
+        const payload = createRoomConnectionBasePayload(connectOptions);
         const defaultOptions = {
           sessionSID,
           'audio': 'false',
@@ -233,7 +233,7 @@ describe('util', () => {
           'videoTracks': 0
         };
         const expectedOutput = Object.assign(defaultOptions, expectedPayload);
-        assert.deepStrictEqual(event.payload, expectedOutput);
+        assert.deepStrictEqual(payload, expectedOutput);
       });
     });
   });

--- a/test/unit/spec/util/index.js
+++ b/test/unit/spec/util/index.js
@@ -11,12 +11,12 @@ const {
   makeUUID,
   promiseFromEvents,
   isChromeScreenShareTrack,
-  createRoomConnectEventPayload,
+  createRoomConnectionBasePayload,
 } = require('../../../../lib/util');
 
 const { sessionSID } = require('../../../../lib/util/sid');
 describe('util', () => {
-  describe('createRoomConnectEventPayload', () => {
+  describe('createRoomConnectionBasePayload', () => {
     [
       {
         testCase: 'empty options',
@@ -213,7 +213,7 @@ describe('util', () => {
       },
     ].forEach(({ testCase, connectOptions, expectedPayload }) => {
       it(testCase, () => {
-        const event = createRoomConnectEventPayload(connectOptions);
+        const event = createRoomConnectionBasePayload(connectOptions);
         const defaultOptions = {
           sessionSID,
           'audio': 'false',
@@ -233,7 +233,6 @@ describe('util', () => {
           'videoTracks': 0
         };
         const expectedOutput = Object.assign(defaultOptions, expectedPayload);
-        assert.strictEqual(event.name, 'connect');
         assert.strictEqual(event.level, 'info');
         assert.strictEqual(event.group, 'room');
         assert.deepStrictEqual(event.payload, expectedOutput);

--- a/test/unit/spec/util/index.js
+++ b/test/unit/spec/util/index.js
@@ -233,8 +233,6 @@ describe('util', () => {
           'videoTracks': 0
         };
         const expectedOutput = Object.assign(defaultOptions, expectedPayload);
-        assert.strictEqual(event.level, 'info');
-        assert.strictEqual(event.group, 'room');
         assert.deepStrictEqual(event.payload, expectedOutput);
       });
     });


### PR DESCRIPTION
## Pull Request Details

### Description
This PR separates "connecting" and "connected" events to replace the single "connect" insight event

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
