### PR TITLE
[VBLOCKS-5150] QualityEventPublisher for tracking video quality limitations

### DIFF
--- a/lib/insights/qualityeventpublisher.js
+++ b/lib/insights/qualityeventpublisher.js
@@ -1,0 +1,115 @@
+'use strict';
+
+/**
+ * QualityEventPublisher handles publishing quality information events to the Twilio Video SDK insights.
+ *
+ * @example
+ * const qualityEventPublisher = new QualityEventPublisher(eventObserver, log);
+ *
+ * // Quality limitation reason changes are published in the following format:
+ * {
+ *   group: 'quality',
+ *   name: 'quality-limitation-state-changed',
+ *   level: 'info',
+ *   payload: {
+ *     trackId: string, // MediaStreamTrack ID
+ *     qualityLimitationReason: string // 'none', 'cpu', 'bandwidth', or 'other'
+ *   }
+ * }
+ *
+ * // Clean up when no longer needed
+ * qualityEventPublisher.cleanup();
+ */
+class QualityEventPublisher {
+  /**
+   * Create a QualityEventPublisher
+   * @param {EventObserver} eventObserver - The event observer for publishing insights
+   * @param {Log} log - Logger instance
+   */
+  constructor(eventObserver, log) {
+    this._eventObserver = eventObserver;
+    this._log = log;
+    this._lastQualityLimitationReasonByTrackId = new Map();
+  }
+
+  /**
+   * Process outbound-rtp stats to detect quality limitation reason changes
+   * @param {RTCStatsReport} stats - The RTCStatsReport from getStats()
+   */
+  processStats(stats) {
+    if (!stats) {
+      return;
+    }
+
+    const outboundStats = [];
+    stats.forEach(stat => {
+      if (stat.type === 'outbound-rtp' && !stat.isRemote) {
+        outboundStats.push(stat);
+      }
+    });
+
+    outboundStats.forEach(stat => {
+      if (!stat.trackId || typeof stat.qualityLimitationReason !== 'string') {
+        return;
+      }
+
+      const qualityLimitationReason = stat.qualityLimitationReason;
+      const trackId = stat.trackId;
+      const lastReason = this._lastQualityLimitationReasonByTrackId.get(trackId);
+
+      if (lastReason !== qualityLimitationReason) {
+        this._log.debug(`Quality limitation reason changed for track ${trackId}: ${lastReason || 'none'} -> ${qualityLimitationReason}`);
+
+        this._lastQualityLimitationReasonByTrackId.set(trackId, qualityLimitationReason);
+
+        this._publishQualityLimitationReasonChanged(trackId, qualityLimitationReason);
+      }
+    });
+  }
+
+  /**
+   * Publish a quality limitation reason change event
+   * @private
+   * @param {string} trackId - The MediaStreamTrack ID
+   * @param {string} qualityLimitationReason - The quality limitation reason
+   */
+  _publishQualityLimitationReasonChanged(trackId, qualityLimitationReason) {
+    try {
+      this._publishEvent('quality-limitation-state-changed', 'info', {
+        trackId,
+        qualityLimitationReason,
+      });
+    } catch (error) {
+      this._log.error('Error publishing quality limitation reason change:', error);
+    }
+  }
+
+  /**
+   * Publish an event through the EventObserver.
+   * @private
+   * @param {string} name - Event name
+   * @param {string} level - Event level (debug, info, warning, error)
+   * @param {Object} payload - Event payload
+   */
+  _publishEvent(name, level, payload) {
+    try {
+      this._eventObserver.emit('event', {
+        group: 'quality',
+        name,
+        level,
+        payload,
+      });
+    } catch (error) {
+      this._log.error(`QualityEventPublisher: Error publishing event ${name}:`, error);
+    }
+  }
+
+  /**
+   * Cleanup all quality event monitoring
+   */
+  cleanup() {
+    this._lastQualityLimitationReasonByTrackId.clear();
+  }
+}
+
+module.exports = QualityEventPublisher;

--- a/lib/room.js
+++ b/lib/room.js
@@ -6,6 +6,7 @@ const StatsReport = require('./stats/statsreport');
 const ResourceEventPublisher = require('./insights/resourceeventpublisher');
 const NetworkEventPublisher = require('./insights/networkeventpublisher');
 const ApplicationEventPublisher = require('./insights/applicationeventpublisher');
+const QualityEventPublisher = require('./insights/qualityeventpublisher');
 const { flatMap, valueToJSON } = require('./util');
 
 let nInstances = 0;
@@ -104,6 +105,11 @@ class Room extends EventEmitter {
       _applicationEventPublisher: {
         value: options.insights && options.eventObserver
           ? new ApplicationEventPublisher(options.eventObserver, log)
+          : null
+      },
+      _qualityEventPublisher: {
+        value: options.insights && options.eventObserver
+          ? new QualityEventPublisher(options.eventObserver, log)
           : null
       },
       dominantSpeaker: {
@@ -696,6 +702,9 @@ function handleSignalingEvents(room, signaling) {
         }
         if (room._applicationEventPublisher) {
           room._applicationEventPublisher.cleanup();
+        }
+        if (room._qualityEventPublisher) {
+          room._qualityEventPublisher.cleanup();
         }
         signaling.removeListener('stateChanged', stateChanged);
         break;

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -6,6 +6,7 @@ const TranscriptionSignaling = require('./transcriptionsignaling');
 const NetworkQualityMonitor = require('./networkqualitymonitor');
 const NetworkQualitySignaling = require('./networkqualitysignaling');
 const RecordingV2 = require('./recording');
+const QualityEventPublisher = require('../../insights/qualityeventpublisher');
 const RoomSignaling = require('../room');
 const RemoteParticipantV2 = require('./remoteparticipant');
 const StatsReport = require('../../stats/statsreport');
@@ -734,6 +735,10 @@ function periodicallyPublishStats(roomV2, transport, intervalMs) {
     roomV2.getStats().then(stats => {
       oddPublishCount = !oddPublishCount;
       stats.forEach((response, id) => {
+        // Process stats for quality limitation reason monitoring
+        if (roomV2._qualityEventPublisher) {
+          roomV2._qualityEventPublisher.processStats(response);
+        }
         // NOTE(mmalavalli): A StatsReport is used to publish a "stats-report"
         // event instead of using StandardizedStatsResponse directly because
         // StatsReport will add zeros to properties that do not exist.

--- a/test/unit/spec/insights/qualityeventpublisher.js
+++ b/test/unit/spec/insights/qualityeventpublisher.js
@@ -1,0 +1,132 @@
+'use strict';
+
+const assert = require('assert');
+const sinon = require('sinon');
+const { EventEmitter } = require('events');
+const QualityEventPublisher = require('../../../../lib/insights/qualityeventpublisher');
+
+describe('QualityEventPublisher', () => {
+  let eventObserver;
+  let mockLog;
+  let publisher;
+  let emittedEvents;
+
+  beforeEach(() => {
+    eventObserver = new EventEmitter();
+    mockLog = {
+      debug: sinon.stub(),
+      error: sinon.stub(),
+    };
+    publisher = new QualityEventPublisher(eventObserver, mockLog);
+    emittedEvents = [];
+
+    eventObserver.on('event', event => {
+      emittedEvents.push(event);
+    });
+  });
+
+  function createMockStats(tracks) {
+    const stats = new Map();
+
+    tracks.forEach(({ trackId, qualityLimitationReason }) => {
+      const statId = `outbound-rtp-${trackId}`;
+      stats.set(statId, {
+        type: 'outbound-rtp',
+        trackId,
+        qualityLimitationReason,
+        isRemote: false,
+      });
+    });
+
+    return stats;
+  }
+
+  it('should publish an event when a quality limitation reason is first detected', () => {
+    const trackId = 'track1';
+    const qualityLimitationReason = 'cpu';
+
+    const stats = createMockStats([{ trackId, qualityLimitationReason }]);
+
+    publisher.processStats(stats);
+
+    assert.strictEqual(emittedEvents.length, 1);
+    const event = emittedEvents[0];
+
+    assert.strictEqual(event.group, 'quality');
+    assert.strictEqual(event.name, 'quality-limitation-state-changed');
+    assert.strictEqual(event.level, 'info');
+    assert.deepStrictEqual(event.payload, {
+      trackId,
+      qualityLimitationReason,
+    });
+  });
+
+  it('should not publish an event when the quality limitation reason stays the same', () => {
+    const trackId = 'track1';
+    const qualityLimitationReason = 'cpu';
+    const stats = createMockStats([{ trackId, qualityLimitationReason }]);
+
+    publisher.processStats(stats);
+    publisher.processStats(stats);
+
+    assert.strictEqual(emittedEvents.length, 1);
+  });
+
+  it('should publish an event when the quality limitation reason changes', () => {
+    const trackId = 'track1';
+    const initialReason = 'cpu';
+    const newReason = 'bandwidth';
+
+    publisher.processStats(createMockStats([{ trackId, qualityLimitationReason: initialReason }]));
+
+    publisher.processStats(createMockStats([{ trackId, qualityLimitationReason: newReason }]));
+
+    assert.strictEqual(emittedEvents.length, 2);
+
+    const changeEvent = emittedEvents[1];
+    assert.deepStrictEqual(changeEvent.payload, {
+      trackId,
+      qualityLimitationReason: newReason,
+    });
+  });
+
+  it('should handle multiple tracks independently', () => {
+    const track1 = 'track1';
+    const track2 = 'track2';
+
+    publisher.processStats(
+      createMockStats([
+        { trackId: track1, qualityLimitationReason: 'cpu' },
+        { trackId: track2, qualityLimitationReason: 'bandwidth' },
+      ])
+    );
+
+    assert.strictEqual(emittedEvents.length, 2);
+
+    publisher.processStats(
+      createMockStats([
+        { trackId: track1, qualityLimitationReason: 'other' },
+        { trackId: track2, qualityLimitationReason: 'bandwidth' },
+      ])
+    );
+
+    assert.strictEqual(emittedEvents.length, 3);
+
+    const changeEvent = emittedEvents[2];
+    assert.strictEqual(changeEvent.payload.trackId, track1);
+    assert.strictEqual(changeEvent.payload.qualityLimitationReason, 'other');
+  });
+
+  it('should reset the stored state when cleanup is called', () => {
+    const trackId = 'track1';
+    const qualityLimitationReason = 'cpu';
+    const stats = createMockStats([{ trackId, qualityLimitationReason }]);
+
+    publisher.processStats(stats);
+    assert.strictEqual(emittedEvents.length, 1);
+
+    publisher.cleanup();
+    publisher.processStats(stats);
+    assert.strictEqual(emittedEvents.length, 2);
+  });
+});


### PR DESCRIPTION
## Pull Request Details

### Description

This PR implements QualityEventPublisher to detect and report video quality limitation reasons (CPU, bandwidth) from WebRTC stats to Insights.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
