### PR TITLE
[VBLOCKS-5148] Publish track warning insights events

### DIFF
--- a/lib/insights/trackwarningpublisher.js
+++ b/lib/insights/trackwarningpublisher.js
@@ -1,0 +1,155 @@
+'use strict';
+
+/**
+ * TrackWarningPublisher handles publishing track warning events to the Twilio Video SDK insights.
+ * It monitors video track frame rates from WebRTC stats to detect stalled tracks.
+ *
+ * @example
+ * const trackWarningPublisher = new TrackWarningPublisher(eventObserver, log);
+ * trackWarningPublisher.processStats(stats);
+ *
+ * // Track warning events for stalled tracks are published in the following format:
+ * {
+ *   group: 'quality',
+ *   name: 'track-warning-raised',
+ *   level: 'warning',
+ *   payload: {
+ *     trackSID: string, // Track SID
+ *     frameRate: number, // Current frame rate
+ *     threshold: number // Frame rate threshold
+ *   }
+ * }
+ *
+ * // Track warning cleared events for resumed tracks are published in the following format:
+ *
+ * {
+ *   group: 'quality',
+ *   name: 'track-warning-cleared',
+ *   level: 'info',
+ *   payload: {
+ *     trackSID: string, // Track SID
+ *     frameRate: number, // Current frame rate
+ *     threshold: number // Frame rate threshold
+ *   }
+ * }
+ *
+ * // Clean up when no longer needed
+ * trackWarningPublisher.cleanup();
+ */
+class TrackWarningPublisher {
+  /**
+   * Create a TrackWarningPublisher
+   * @param {EventObserver} eventObserver - The event observer for publishing insights
+   * @param {Log} log - Logger instance
+   */
+  constructor(eventObserver, log) {
+    this._eventObserver = eventObserver;
+    this._log = log;
+    this._stalledTrackSIDs = new Set();
+
+    this._stallThreshold = 0.5;   // Frame rate below this is considered stalled
+    this._resumeThreshold = 5;  // Frame rate equal or above this is considered resumed
+  }
+
+  /**
+   * Process stats to detect stalled tracks and track resumptions
+   * @param {RTCStatsReport} stats - The RTCStatsReport from getStats()
+   */
+  processStats(stats) {
+    if (!stats || !stats.remoteVideoTrackStats) {
+      return;
+    }
+
+    stats.remoteVideoTrackStats.forEach(trackStat => {
+      if (trackStat.trackSid && typeof trackStat.frameRate === 'number') {
+        this._processTrackFrameRate(
+          trackStat.trackSid,
+          trackStat.frameRate
+        );
+      }
+    });
+  }
+
+  /**
+   * Process track frame rate to detect stalls and resumptions
+   * @private
+   * @param {string} trackSid - The track SID
+   * @param {number} frameRate - Current frame rate
+   */
+  _processTrackFrameRate(trackSid, frameRate) {
+
+    const isStalled = this._stalledTrackSIDs.has(trackSid);
+
+    if (!isStalled && frameRate < this._stallThreshold) {
+      this._stalledTrackSIDs.add(trackSid);
+      this._publishTrackStalled(trackSid, frameRate, this._stallThreshold);
+    } else if (isStalled && frameRate >= this._resumeThreshold) {
+      this._stalledTrackSIDs.delete(trackSid);
+      this._publishTrackResumed(trackSid, frameRate, this._stallThreshold);
+    }
+  }
+
+  /**
+   * Publish a track stalled event
+   * @private
+   * @param {string} trackSID - The Track SID
+   * @param {number} frameRate - Current frame rate
+   * @param {number} threshold - Frame rate threshold
+   */
+  _publishTrackStalled(trackSID, frameRate, threshold) {
+    this._log.debug(`Track ${trackSID} stalled: frame rate ${frameRate} below threshold ${threshold}`);
+
+
+    this._publishEvent('track-warning-raised', 'warning', {
+      trackSID,
+      frameRate,
+      threshold
+    });
+  }
+
+  /**
+   * Publish a track resumed event
+   * @private
+   * @param {string} trackSID - The Track SID
+   * @param {number} frameRate - Current frame rate
+   * @param {number} threshold - Frame rate threshold
+   */
+  _publishTrackResumed(trackSID, frameRate, threshold) {
+    this._log.debug(`Track ${trackSID} resumed: frame rate ${frameRate} above threshold ${threshold}`);
+
+    this._publishEvent('track-warning-cleared', 'info', {
+      trackSID,
+      frameRate,
+      threshold
+    });
+  }
+
+  /**
+   * Publish an event through the EventObserver.
+   * @private
+   * @param {string} name - Event name
+   * @param {string} level - Event level (debug, info, warning, error)
+   * @param {Object} payload - Event payload
+   */
+  _publishEvent(name, level, payload) {
+    try {
+      this._eventObserver.emit('event', {
+        group: 'quality',
+        name,
+        level,
+        payload,
+      });
+    } catch (error) {
+      this._log.error(`TrackWarningPublisher: Error publishing event ${name}:`, error);
+    }
+  }
+
+  /**
+   * Cleanup all track warning monitoring
+   */
+  cleanup() {
+    this._stalledTrackSIDs.clear();
+  }
+}
+
+module.exports = TrackWarningPublisher;

--- a/lib/room.js
+++ b/lib/room.js
@@ -651,6 +651,7 @@ function handleLocalParticipantEvents(room, localParticipant) {
     handler: (...args) => room.emit(event, ...[...args, localParticipant]),
   }));
 
+
   events.forEach(({ eventName, handler }) =>
     localParticipant.on(eventName, handler));
 
@@ -705,6 +706,9 @@ function handleSignalingEvents(room, signaling) {
         }
         if (room._qualityEventPublisher) {
           room._qualityEventPublisher.cleanup();
+        }
+        if (room._trackWarningPublisher) {
+          room._trackWarningPublisher.cleanup();
         }
         signaling.removeListener('stateChanged', stateChanged);
         break;

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -6,7 +6,7 @@ const TranscriptionSignaling = require('./transcriptionsignaling');
 const NetworkQualityMonitor = require('./networkqualitymonitor');
 const NetworkQualitySignaling = require('./networkqualitysignaling');
 const RecordingV2 = require('./recording');
-const QualityEventPublisher = require('../../insights/qualityeventpublisher');
+const TrackWarningPublisher = require('../../insights/trackwarningpublisher');
 const RoomSignaling = require('../room');
 const RemoteParticipantV2 = require('./remoteparticipant');
 const StatsReport = require('../../stats/statsreport');
@@ -147,6 +147,9 @@ class RoomV2 extends RoomSignaling {
       _pendingSwitchOffStates: {
         value: new Map()
       },
+      _trackWarningPublisher: {
+        value: options.eventObserver ? new TrackWarningPublisher(options.eventObserver, log) : null
+      },
       _transport: {
         value: transport
       },
@@ -250,6 +253,11 @@ class RoomV2 extends RoomSignaling {
     const didDisconnect = super._disconnect.call(this, error);
     if (didDisconnect) {
       this._teardownNetworkQualityMonitor();
+
+      if (this._trackWarningPublisher) {
+        this._trackWarningPublisher.cleanup();
+      }
+
       this._transport.disconnect();
       this._peerConnectionManager.close();
     }
@@ -738,6 +746,11 @@ function periodicallyPublishStats(roomV2, transport, intervalMs) {
         // Process stats for monitoring quality limitations
         if (roomV2._qualityEventPublisher) {
           roomV2._qualityEventPublisher.processStats(response);
+        }
+
+        // Process stats for monitoring track warnings
+        if (roomV2._trackWarningPublisher) {
+          roomV2._trackWarningPublisher.processStats(response);
         }
         // NOTE(mmalavalli): A StatsReport is used to publish a "stats-report"
         // event instead of using StandardizedStatsResponse directly because

--- a/test/unit/spec/insights/trackwarningpublisher.js
+++ b/test/unit/spec/insights/trackwarningpublisher.js
@@ -1,0 +1,169 @@
+'use strict';
+
+const assert = require('node:assert');
+const { EventEmitter } = require('node:events');
+
+const fakeLog = require('../../../lib/fakelog');
+const TrackWarningPublisher = require('../../../../lib/insights/trackwarningpublisher');
+
+describe('TrackWarningPublisher', () => {
+  let eventObserver;
+  let publisher;
+  let emittedEvents;
+
+  beforeEach(() => {
+    eventObserver = new EventEmitter();
+    publisher = new TrackWarningPublisher(eventObserver, fakeLog);
+    emittedEvents = [];
+
+    eventObserver.on('event', event => emittedEvents.push(event));
+  });
+
+  function createMockRemoteVideoStats(tracks) {
+    const stats = {
+      remoteVideoTrackStats: tracks.map(({ trackSid, frameRate }) => ({
+        trackSid,
+        frameRate,
+      })),
+    };
+    return stats;
+  }
+
+  it('should detect and publish stalled track events', () => {
+    const stalledStat = {
+      trackSid: 'MT123',
+      frameRate: 0.1,
+    };
+    publisher.processStats(
+      createMockRemoteVideoStats([
+        stalledStat,
+      ])
+    );
+
+    assert.equal(emittedEvents.length, 1);
+    const event = emittedEvents[0];
+
+    assert.equal(event.group, 'quality');
+    assert.equal(event.name, 'track-warning-raised');
+    assert.equal(event.level, 'warning');
+    assert.equal(event.payload.trackSID, stalledStat.trackSid);
+    assert.equal(event.payload.frameRate, stalledStat.frameRate);
+    assert.equal(event.payload.threshold, publisher._stallThreshold);
+  });
+
+  it('should not publish duplicate stalled events for the same track', () => {
+    const trackSid = 'MT123';
+
+    publisher.processStats(createMockRemoteVideoStats([{ trackSid, frameRate: 0.2 }]));
+    publisher.processStats(createMockRemoteVideoStats([{ trackSid, frameRate: 0.1 }]));
+    assert.equal(emittedEvents.length, 1);
+  });
+
+  it('should publish cleared events when frame rate improves', () => {
+    const trackSid = 'MT123';
+
+    publisher.processStats(createMockRemoteVideoStats([{ trackSid, frameRate: 0.2 }]));
+
+    publisher.processStats(
+      createMockRemoteVideoStats([
+        { trackSid, frameRate: 15 },
+      ])
+    );
+    assert.equal(emittedEvents.length, 2);
+    const event = emittedEvents[1];
+
+    assert.equal(event.group, 'quality');
+    assert.equal(event.name, 'track-warning-cleared');
+    assert.equal(event.level, 'info');
+    assert.equal(event.payload.trackSID, trackSid);
+    assert.equal(event.payload.frameRate, 15);
+    assert.equal(event.payload.threshold, publisher._stallThreshold);
+  });
+
+  it('should not publish cleared events for tracks that were not stalled', () => {
+    const trackSid = 'MT123';
+
+    publisher.processStats(createMockRemoteVideoStats([{ trackSid, frameRate: publisher._resumeThreshold }]));
+    assert.equal(emittedEvents.length, 0);
+  });
+
+  it('should not publish events for undefined or null frame rates', () => {
+    const trackSid = 'MT123';
+
+    publisher.processStats(createMockRemoteVideoStats([{ trackSid, frameRate: undefined }]));
+    publisher.processStats(createMockRemoteVideoStats([{ trackSid, frameRate: null }]));
+    assert.equal(emittedEvents.length, 0);
+  });
+
+  it('should handle boundary values correctly', () => {
+    const trackSid = 'MT123';
+
+    publisher.processStats(createMockRemoteVideoStats([{ trackSid, frameRate: publisher._stallThreshold }]));
+    assert.equal(emittedEvents.length, 0);
+
+    publisher.processStats(createMockRemoteVideoStats([{ trackSid, frameRate: publisher._stallThreshold - 0.1 }]));
+    assert.equal(emittedEvents.length, 1);
+    assert.equal(emittedEvents[0].name, 'track-warning-raised');
+
+    publisher.processStats(createMockRemoteVideoStats([{ trackSid, frameRate: publisher._resumeThreshold }]));
+
+    assert.equal(emittedEvents.length, 2);
+    assert.equal(emittedEvents[1].name, 'track-warning-cleared');
+  });
+
+  it('should track multiple tracks independently', () => {
+    const track1 = 'MT123';
+    const track2 = 'MT456';
+
+    publisher.processStats(
+      createMockRemoteVideoStats([
+        { trackSid: track1, frameRate: 0.2 },
+        { trackSid: track2, frameRate: 0.3 },
+      ])
+    );
+    assert.equal(emittedEvents.length, 2);
+
+    publisher.processStats(
+      createMockRemoteVideoStats([
+        { trackSid: track1, frameRate: 30 },
+        { trackSid: track2, frameRate: 0.3 },
+      ])
+    );
+    assert.equal(emittedEvents.length, 3);
+    assert.equal(emittedEvents[2].payload.trackSID, track1);
+    assert.equal(emittedEvents[2].name, 'track-warning-cleared');
+
+    publisher.processStats(
+      createMockRemoteVideoStats([
+        { trackSid: track1, frameRate: 0.2 },
+        { trackSid: track2, frameRate: 0.3 },
+      ])
+    );
+    assert.equal(emittedEvents.length, 4);
+    assert.equal(emittedEvents[3].payload.trackSID, track1);
+    assert.equal(emittedEvents[3].name, 'track-warning-raised');
+  });
+
+  it('should reset the stored state when cleanup is called', () => {
+    const trackSid = 'MT123';
+
+    // Report a stalled track for the first time
+    publisher.processStats(createMockRemoteVideoStats([{ trackSid, frameRate: 0.2 }]));
+    assert.equal(emittedEvents.length, 1);
+
+    publisher.cleanup();
+
+    // After cleanup, reporting the same stalled track should emit the event again
+    publisher.processStats(createMockRemoteVideoStats([{ trackSid, frameRate: 0.2 }]));
+    assert.equal(emittedEvents.length, 2);
+  });
+
+  it('should handle empty stats objects', () => {
+    publisher.processStats({});
+    publisher.processStats({ remoteVideoTrackStats: [] });
+    publisher.processStats(null);
+    publisher.processStats(undefined);
+
+    assert.equal(emittedEvents.length, 0);
+  });
+});


### PR DESCRIPTION
## Pull Request Details

### Description
This PR implements the `TrackWarningPublisher`. It consumes the `stats` information from the `periodicallyPublishStats` for now, but it should be able to `getStats` at a different pace once we define more details about it.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
