### PR TITLE
[VBLOCKS] feat: add beforeunload monitoring to ApplicationEventPublisher

### DIFF
--- a/lib/insights/applicationeventpublisher.js
+++ b/lib/insights/applicationeventpublisher.js
@@ -31,8 +31,10 @@ class ApplicationEventPublisher {
     this._eventObserver = eventObserver;
     this._log = log;
     this._visibilityChangeHandler = null;
+    this._boundHandleBeforeUnload = this._handleBeforeUnload.bind(this);
 
     this._setupVisibilityMonitoring();
+    this._setupBeforeUnloadMonitoring();
   }
 
   /**
@@ -56,6 +58,19 @@ class ApplicationEventPublisher {
   }
 
   /**
+   * Setup application beforeunload monitoring
+   * @private
+   */
+  _setupBeforeUnloadMonitoring() {
+    try {
+      window.addEventListener('beforeunload', this._boundHandleBeforeUnload);
+      this._log.debug('ApplicationEventPublisher beforeunload monitoring initialized');
+    } catch (error) {
+      this._log.error('Error initializing ApplicationEventPublisher beforeunload monitoring:', error);
+    }
+  }
+
+  /**
    * Cleanup all application event monitors
    */
   cleanup() {
@@ -64,6 +79,10 @@ class ApplicationEventPublisher {
     if (this._visibilityChangeHandler) {
       documentVisibilityMonitor.offVisibilityChange(1, this._visibilityChangeHandler);
       this._visibilityChangeHandler = null;
+    }
+
+    if (this._boundHandleBeforeUnload) {
+      window.removeEventListener('beforeunload', this._boundHandleBeforeUnload);
     }
   }
 
@@ -78,6 +97,15 @@ class ApplicationEventPublisher {
     const eventName = isVisible ? 'resumed' : 'backgrounded';
 
     this._publishEvent(eventName);
+  }
+
+  /**
+   * Handle beforeunload event
+   * @private
+   * @returns {void}
+   */
+  _handleBeforeUnload() {
+    this._publishEvent('terminated');
   }
 
   /**


### PR DESCRIPTION
## Pull Request Details

### Description
Add missing `terminated` event to the ApplicationEventPublisher

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
