### PR TITLE
fix: update network monitoring and freezeCount on stats handler

### DIFF
--- a/lib/insights/networkeventpublisher.js
+++ b/lib/insights/networkeventpublisher.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const NetworkMonitor = require('../util/networkmonitor');
-
 /**
  * NetworkEventPublisher handles publishing network information events to the Twilio Video SDK insights.
  *
@@ -59,8 +57,19 @@ class NetworkEventPublisher {
     };
 
     try {
-      this._networkMonitor = new NetworkMonitor(networkChangeHandler);
-      this._networkMonitor.start();
+      if (navigator.connection) {
+        ['change', 'typechange'].forEach(eventType => {
+          navigator.connection.addEventListener(eventType, networkChangeHandler);
+        });
+
+        this._networkMonitor = {
+          stop: () => {
+            ['change', 'typechange'].forEach(eventType => {
+              navigator.connection.removeEventListener(eventType, networkChangeHandler);
+            });
+          }
+        };
+      }
     } catch (error) {
       this._log.error('Error initializing network information monitoring:', error);
     }

--- a/lib/webrtc/getstats.js
+++ b/lib/webrtc/getstats.js
@@ -913,6 +913,11 @@ function standardizeChromeOrSafariStats(response, { simulateExceptionWhileStanda
       standardizedStats.jitterBufferEmittedCount = jitterBufferEmittedCount;
     }
 
+    const freezeCount = getStatValue('freezeCount');
+    if (typeof freezeCount === 'number') {
+      standardizedStats.freezeCount = freezeCount;
+    }
+
     stats.push(standardizedStats);
   });
 
@@ -1075,6 +1080,11 @@ function standardizeFirefoxStats(response = new Map(), { isRemote, simulateExcep
     standardizedStats.jitterBufferEmittedCount = jitterBufferEmittedCount;
   }
 
+  const freezeCount = getStatValue('freezeCount');
+  if (typeof freezeCount === 'number') {
+    standardizedStats.freezeCount = freezeCount;
+  }
+
   return standardizedStats;
 }
 
@@ -1152,6 +1162,7 @@ function standardizeFirefoxStats(response = new Map(), { isRemote, simulateExcep
  * @property {number} [frameRateInput] - Captured frames per second of the local video MediaStreamTrack
  * @property {number} [frameRateSent] - Frames per second of the local video MediaStreamTrack's encoded video
  * @property {number} [frameRateReceived] - Frames per second of the remote video MediaStreamTrack's received video
+ * @property {number} [freezeCount] - Number of times the remote video MediaStreamTrack's froze
  * @property {number} [bytesReceived] - Number of bytes of the remote MediaStreamTrack's media received
  * @property {number} [bytesSent] - Number of bytes of the local MediaStreamTrack's media sent
  * @property {number} [packetsLost] - Number of packets of the MediaStreamTrack's media lost

--- a/test/unit/spec/stats/remotevideotrackstats.js
+++ b/test/unit/spec/stats/remotevideotrackstats.js
@@ -23,7 +23,7 @@ describe('RemoteVideoTrackStats', () => {
         height: stats.frameHeightReceived
       });
       assert.equal(trackStats.frameRate, stats.frameRateReceived);
-      assert.equal(trackStats.freezeCount, stats.freezeCount);
+      assert.strictEqual(trackStats.freezeCount, stats.freezeCount);
     });
 
     [


### PR DESCRIPTION
## Pull Request Details

### Description
- Fix the network monitoring logic to replace the `NetworkMonitor` dependency with a more straightforward alternative since `NetworkMonitor` relays on the connection's `type` property to detect changes, which is not supported in most browsers.
- Add the `freezeCount` property to the standardized `getStats` response.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
