### PR TITLE
feat: add BufferedEventPublisher for batch event publishing

### DIFF
--- a/lib/insights/bufferedeventpublisher.js
+++ b/lib/insights/bufferedeventpublisher.js
@@ -1,0 +1,172 @@
+'use strict';
+
+/**
+ * BufferedEventPublisher provides a base class for any publisher that needs to
+ * collect events at one frequency but publish them at another frequency.
+ *
+ * @example
+ * const bufferedPublisher = new BufferedEventPublisher(eventObserver, log, { publishIntervalMs: 5000 });
+ * bufferedPublisher._bufferEvent({ group: 'example', name: 'event1', level: 'info', payload: {} });
+ * bufferedPublisher._bufferEvent({ group: 'example', name: 'event2', level: 'info', payload: {} });
+ *
+ * // You can either wait for the next publish interval (5 seconds in this example) or
+ * // immediately publish all buffered events using:
+ * bufferedPublisher.flush();
+ * // Or even disable buffered publishing and start publishing events immediately:
+ * bufferedPublisher.disable(true); // Optional, pass true to flush remaining events before disabling
+ *
+ * // And of course, you can re-enable buffered publishing:
+ * bufferedPublisher.enable();
+ * // or set a different publish interval:
+ * bufferedPublisher.setPublishInterval(2000); // Events will now be published every 2 seconds
+ *
+ * // Finally, when done, you can clean up resources and this will flush any remaining events and clean up timers:
+ * bufferedPublisher.cleanup();
+ */
+class BufferedEventPublisher {
+  /**
+   * Create a BufferedEventPublisher
+   * @param {EventObserver} eventObserver - The event observer for publishing insights
+   * @param {Log} log - Logger instance
+   * @param {Object} [options] - Configuration options
+   * @param {number} [options.publishIntervalMs=10000] - How often to publish buffered events (ms)
+   */
+  constructor(eventObserver, log, options = {}) {
+    const { publishIntervalMs = 10000 } = options;
+
+    this._eventObserver = eventObserver;
+    this._log = log;
+    this._publishIntervalMs = publishIntervalMs;
+    this._pendingEvents = [];
+    this._publishTimer = null;
+    this._enabled = false;
+
+    if (this._publishIntervalMs > 0) {
+      this.enable();
+    }
+  }
+
+  /**
+   * Enable buffered publishing
+   */
+  enable() {
+    if (this._enabled) {
+      return;
+    }
+
+    this._enabled = true;
+    this._scheduleNextPublish();
+  }
+
+  /**
+   * Disable buffered publishing
+   * @param {boolean} [flushRemaining=true] - Whether to flush remaining events
+   */
+  disable(flushRemaining = true) {
+    if (!this._enabled) {
+      return;
+    }
+
+    this._enabled = false;
+    this._clearPublishTimer();
+
+    if (flushRemaining) {
+      this.flush();
+    }
+  }
+
+  /**
+   * Buffer an event for later publishing
+   * @private
+   * @param {Object} event - Event to buffer
+   */
+  _bufferEvent(event) {
+    if (!this._enabled) {
+      // If buffering is disabled, publish new events immediately
+      this._publishEvent(event);
+      return;
+    }
+
+    this._pendingEvents.push(event);
+  }
+
+  /**
+   * Actually publish a single event through the EventObserver
+   * @private
+   * @param {Object} event - Event to publish
+   */
+  _publishEvent(event) {
+    try {
+      this._eventObserver.emit('event', event);
+    } catch (error) {
+      this._log.error(`Error publishing event ${event.name}:`, error);
+    }
+  }
+
+  /**
+   * Immediately publish all buffered events
+   */
+  flush() {
+    if (this._pendingEvents.length === 0) {
+      return;
+    }
+
+    this._log.debug(`Publishing ${this._pendingEvents.length} buffered events`);
+
+    // Create a copy and clear the buffer
+    const events = [...this._pendingEvents];
+    this._pendingEvents = [];
+
+    events.forEach(event => this._publishEvent(event));
+  }
+
+  /**
+   * Schedule the next publish operation
+   * @private
+   */
+  _scheduleNextPublish() {
+    if (!this._enabled || this._publishTimer) {
+      return;
+    }
+
+    this._publishTimer = setTimeout(() => {
+      this._publishTimer = null;
+      this.flush();
+      this._scheduleNextPublish();
+    }, this._publishIntervalMs);
+  }
+
+  /**
+   * Clear the publish timer
+   * @private
+   */
+  _clearPublishTimer() {
+    if (this._publishTimer) {
+      clearTimeout(this._publishTimer);
+      this._publishTimer = null;
+    }
+  }
+
+  /**
+   * Set a new publish interval
+   * @param {number} intervalMs - New interval in milliseconds
+   */
+  setPublishInterval(intervalMs) {
+    this._publishIntervalMs = intervalMs;
+
+    if (this._enabled) {
+      // Restart the timer with the new interval
+      this._clearPublishTimer();
+      this._scheduleNextPublish();
+    }
+  }
+
+  /**
+   * Cleanup resources used by this publisher
+   */
+  cleanup() {
+    this.disable(true);
+  }
+}
+
+module.exports = BufferedEventPublisher;

--- a/lib/insights/qualityeventpublisher.js
+++ b/lib/insights/qualityeventpublisher.js
@@ -1,10 +1,13 @@
 'use strict';
 
+const BufferedEventPublisher = require('./bufferedeventpublisher');
+
 /**
  * QualityEventPublisher handles publishing quality information events to the Twilio Video SDK insights.
+ * Extends BufferedEventPublisher for batch event publishing.
  *
  * @example
- * const qualityEventPublisher = new QualityEventPublisher(eventObserver, log);
+ * const qualityEventPublisher = new QualityEventPublisher(eventObserver, log, { publishIntervalMs: 10000 });
  *
  * // Quality limitation reason changes are published in the following format:
  * {
@@ -20,15 +23,14 @@
  * // Clean up when no longer needed
  * qualityEventPublisher.cleanup();
  */
-class QualityEventPublisher {
+class QualityEventPublisher extends BufferedEventPublisher {
   /**
    * Create a QualityEventPublisher
    * @param {EventObserver} eventObserver - The event observer for publishing insights
    * @param {Log} log - Logger instance
    */
-  constructor(eventObserver, log) {
-    this._eventObserver = eventObserver;
-    this._log = log;
+  constructor(eventObserver, log, options = {}) {
+    super(eventObserver, log, options);
     this._lastQualityLimitationReasonByTrackId = new Map();
   }
 
@@ -75,40 +77,27 @@ class QualityEventPublisher {
    */
   _publishQualityLimitationReasonChanged(trackId, qualityLimitationReason) {
     try {
-      this._publishEvent('quality-limitation-state-changed', 'info', {
-        trackId,
-        qualityLimitationReason,
+      this._bufferEvent({
+        group: 'quality',
+        name: 'quality-limitation-state-changed',
+        level: 'info',
+        payload: {
+          trackId,
+          qualityLimitationReason,
+        }
       });
     } catch (error) {
       this._log.error('Error publishing quality limitation reason change:', error);
     }
   }
 
-  /**
-   * Publish an event through the EventObserver.
-   * @private
-   * @param {string} name - Event name
-   * @param {string} level - Event level (debug, info, warning, error)
-   * @param {Object} payload - Event payload
-   */
-  _publishEvent(name, level, payload) {
-    try {
-      this._eventObserver.emit('event', {
-        group: 'quality',
-        name,
-        level,
-        payload,
-      });
-    } catch (error) {
-      this._log.error(`QualityEventPublisher: Error publishing event ${name}:`, error);
-    }
-  }
 
   /**
    * Cleanup all quality event monitoring
    */
   cleanup() {
     this._lastQualityLimitationReasonByTrackId.clear();
+    super.cleanup();
   }
 }
 

--- a/lib/insights/trackwarningpublisher.js
+++ b/lib/insights/trackwarningpublisher.js
@@ -1,11 +1,14 @@
 'use strict';
 
+const BufferedEventPublisher = require('./bufferedeventpublisher');
+
 /**
  * TrackWarningPublisher handles publishing track warning events to the Twilio Video SDK insights.
  * It monitors video track frame rates from WebRTC stats to detect stalled tracks.
+ * Extends BufferedEventPublisher for batch event publishing.
  *
  * @example
- * const trackWarningPublisher = new TrackWarningPublisher(eventObserver, log);
+ * const trackWarningPublisher = new TrackWarningPublisher(eventObserver, log, { publishIntervalMs: 10000 });
  * trackWarningPublisher.processStats(stats);
  *
  * // Track warning events for stalled tracks are published in the following format:
@@ -36,15 +39,16 @@
  * // Clean up when no longer needed
  * trackWarningPublisher.cleanup();
  */
-class TrackWarningPublisher {
+class TrackWarningPublisher extends BufferedEventPublisher {
   /**
    * Create a TrackWarningPublisher
    * @param {EventObserver} eventObserver - The event observer for publishing insights
    * @param {Log} log - Logger instance
+   * @param {Object} [options] - Configuration options
+   * @param {number} [options.publishIntervalMs=10000] - How often to publish buffered events (ms)
    */
-  constructor(eventObserver, log) {
-    this._eventObserver = eventObserver;
-    this._log = log;
+  constructor(eventObserver, log, options = {}) {
+    super(eventObserver, log, options);
     this._stalledTrackSIDs = new Set();
 
     this._stallThreshold = 0.5;   // Frame rate below this is considered stalled
@@ -99,12 +103,16 @@ class TrackWarningPublisher {
   _publishTrackStalled(trackSID, frameRate, threshold) {
     this._log.debug(`Track ${trackSID} stalled: frame rate ${frameRate} below threshold ${threshold}`);
 
-
-    this._publishEvent('track-warning-raised', 'track-stalled', 'warning', {
-      trackSID,
-      frameRate,
-      threshold,
-      trackType: 'video',
+    this._bufferEvent({
+      group: 'track-warning-raised',
+      name: 'track-stalled',
+      level: 'warning',
+      payload: {
+        trackSID,
+        frameRate,
+        threshold,
+        trackType: 'video',
+      }
     });
   }
 
@@ -118,39 +126,26 @@ class TrackWarningPublisher {
   _publishTrackResumed(trackSID, frameRate, threshold) {
     this._log.debug(`Track ${trackSID} resumed: frame rate ${frameRate} above threshold ${threshold}`);
 
-    this._publishEvent('track-warning-cleared', 'track-stalled', 'info', {
-      trackSID,
-      frameRate,
-      threshold,
-      trackType: 'video',
+    this._bufferEvent({
+      group: 'track-warning-cleared',
+      name: 'track-stalled',
+      level: 'info',
+      payload: {
+        trackSID,
+        frameRate,
+        threshold,
+        trackType: 'video',
+      }
     });
   }
 
-  /**
-   * Publish an event through the EventObserver.
-   * @private
-   * @param {string} name - Event name
-   * @param {string} level - Event level (debug, info, warning, error)
-   * @param {Object} payload - Event payload
-   */
-  _publishEvent(group, name, level, payload) {
-    try {
-      this._eventObserver.emit('event', {
-        group,
-        name,
-        level,
-        payload,
-      });
-    } catch (error) {
-      this._log.error(`TrackWarningPublisher: Error publishing event ${name}:`, error);
-    }
-  }
 
   /**
    * Cleanup all track warning monitoring
    */
   cleanup() {
     this._stalledTrackSIDs.clear();
+    super.cleanup();
   }
 }
 

--- a/lib/room.js
+++ b/lib/room.js
@@ -6,7 +6,6 @@ const StatsReport = require('./stats/statsreport');
 const ResourceEventPublisher = require('./insights/resourceeventpublisher');
 const NetworkEventPublisher = require('./insights/networkeventpublisher');
 const ApplicationEventPublisher = require('./insights/applicationeventpublisher');
-const QualityEventPublisher = require('./insights/qualityeventpublisher');
 const { flatMap, valueToJSON } = require('./util');
 
 let nInstances = 0;
@@ -105,11 +104,6 @@ class Room extends EventEmitter {
       _applicationEventPublisher: {
         value: options.insights && options.eventObserver
           ? new ApplicationEventPublisher(options.eventObserver, log)
-          : null
-      },
-      _qualityEventPublisher: {
-        value: options.insights && options.eventObserver
-          ? new QualityEventPublisher(options.eventObserver, log)
           : null
       },
       dominantSpeaker: {
@@ -702,12 +696,6 @@ function handleSignalingEvents(room, signaling) {
         }
         if (room._applicationEventPublisher) {
           room._applicationEventPublisher.cleanup();
-        }
-        if (room._qualityEventPublisher) {
-          room._qualityEventPublisher.cleanup();
-        }
-        if (room._trackWarningPublisher) {
-          room._trackWarningPublisher.cleanup();
         }
         signaling.removeListener('stateChanged', stateChanged);
         break;

--- a/lib/signaling/v2/room.js
+++ b/lib/signaling/v2/room.js
@@ -7,6 +7,7 @@ const NetworkQualityMonitor = require('./networkqualitymonitor');
 const NetworkQualitySignaling = require('./networkqualitysignaling');
 const RecordingV2 = require('./recording');
 const TrackWarningPublisher = require('../../insights/trackwarningpublisher');
+const QualityEventPublisher = require('../../insights/qualityeventpublisher');
 const RoomSignaling = require('../room');
 const RemoteParticipantV2 = require('./remoteparticipant');
 const StatsReport = require('../../stats/statsreport');
@@ -30,6 +31,7 @@ const MovingAverageDelta = require('../../util/movingaveragedelta');
 const { createTwilioError } = require('../../util/twilio-video-errors');
 
 const STATS_PUBLISH_INTERVAL_MS = 10000;
+const STATS_COLLECTION_INTERVAL_MS = 1000;
 
 /**
  * @extends RoomSignaling
@@ -150,6 +152,16 @@ class RoomV2 extends RoomSignaling {
       _trackWarningPublisher: {
         value: options.eventObserver ? new TrackWarningPublisher(options.eventObserver, log) : null
       },
+      _qualityEventPublisher: {
+        value: options.eventObserver ? new QualityEventPublisher(options.eventObserver, log) : null
+      },
+      _cachedStats: {
+        value: {
+          stats: null,
+          timestamp: 0
+        },
+        writable: true
+      },
       _transport: {
         value: transport
       },
@@ -171,6 +183,7 @@ class RoomV2 extends RoomSignaling {
     handleLocalParticipantEvents(this, localParticipant);
     handlePeerConnectionEvents(this, peerConnectionManager);
     handleTransportEvents(this, transport);
+    periodicallyCollectRoomStats(this);
     periodicallyPublishStats(this, transport, options.statsPublishIntervalMs);
 
     this._update(initialState);
@@ -256,6 +269,10 @@ class RoomV2 extends RoomSignaling {
 
       if (this._trackWarningPublisher) {
         this._trackWarningPublisher.cleanup();
+      }
+
+      if (this._qualityEventPublisher) {
+        this._qualityEventPublisher.cleanup();
       }
 
       this._transport.disconnect();
@@ -730,6 +747,39 @@ function handleTransportEvents(roomV2, transport) {
 }
 
 /**
+ * Collect room stats periodically for processing by {@link QualityEventPublisher} and
+ * {@link TrackWarningPublisher}.
+ * @private
+ * @param {RoomV2} roomV2
+ */
+function periodicallyCollectRoomStats(roomV2) {
+  const interval = setInterval(() => {
+    try {
+      roomV2.getStats().then(stats => {
+        stats.forEach(response => {
+          if (roomV2._qualityEventPublisher) {
+            roomV2._qualityEventPublisher.processStats(response);
+          }
+
+          if (roomV2._trackWarningPublisher) {
+            roomV2._trackWarningPublisher.processStats(response);
+          }
+        });
+      });
+    } catch (error) {
+      roomV2._log.debug('Error collecting room stats:', error);
+    }
+  }, STATS_COLLECTION_INTERVAL_MS);
+
+  roomV2.on('stateChanged', function onStateChanged(state) {
+    if (state === 'disconnected') {
+      clearInterval(interval);
+      roomV2.removeListener('stateChanged', onStateChanged);
+    }
+  });
+}
+
+/**
  * Periodically publish {@link StatsReport}s.
  * @private
  * @param {RoomV2} roomV2
@@ -743,15 +793,6 @@ function periodicallyPublishStats(roomV2, transport, intervalMs) {
     roomV2.getStats().then(stats => {
       oddPublishCount = !oddPublishCount;
       stats.forEach((response, id) => {
-        // Process stats for monitoring quality limitations
-        if (roomV2._qualityEventPublisher) {
-          roomV2._qualityEventPublisher.processStats(response);
-        }
-
-        // Process stats for monitoring track warnings
-        if (roomV2._trackWarningPublisher) {
-          roomV2._trackWarningPublisher.processStats(response);
-        }
         // NOTE(mmalavalli): A StatsReport is used to publish a "stats-report"
         // event instead of using StandardizedStatsResponse directly because
         // StatsReport will add zeros to properties that do not exist.

--- a/test/unit/spec/insights/bufferedeventpublisher.js
+++ b/test/unit/spec/insights/bufferedeventpublisher.js
@@ -1,0 +1,175 @@
+'use strict';
+
+const assert = require('node:assert');
+const { EventEmitter } = require('node:events');
+const sinon = require('sinon');
+
+const fakeLog = require('../../../lib/fakelog');
+const BufferedEventPublisher = require('../../../../lib/insights/bufferedeventpublisher');
+
+describe('BufferedEventPublisher', () => {
+  let eventObserver;
+  let publisher;
+  let emittedEvents;
+  let clock;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
+    eventObserver = new EventEmitter();
+    publisher = new BufferedEventPublisher(eventObserver, fakeLog);
+    emittedEvents = [];
+
+    eventObserver.on('event', event => emittedEvents.push(event));
+  });
+
+  afterEach(() => {
+    clock.restore();
+  });
+
+  it('should initialize with default options', () => {
+    assert(publisher._enabled);
+    assert.strictEqual(publisher._publishIntervalMs, 10000);
+    assert.deepStrictEqual(publisher._pendingEvents, []);
+  });
+
+  it('should initialize with custom options', () => {
+    const customPublisher = new BufferedEventPublisher(eventObserver, fakeLog, {
+      publishIntervalMs: 5000
+    });
+    assert(customPublisher._enabled);
+    assert.strictEqual(customPublisher._publishIntervalMs, 5000);
+  });
+
+  it('should buffer events when enabled', () => {
+    const event = { group: 'test', name: 'buffered', level: 'info' };
+    publisher._bufferEvent(event);
+    assert.strictEqual(emittedEvents.length, 0);
+    assert.strictEqual(publisher._pendingEvents.length, 1);
+    assert.deepStrictEqual(publisher._pendingEvents[0], event);
+  });
+
+  it('should publish events immediately when disabled', () => {
+    publisher.disable();
+    const event = { group: 'test', name: 'immediate', level: 'info' };
+    publisher._bufferEvent(event);
+    assert.strictEqual(emittedEvents.length, 1);
+    assert.strictEqual(publisher._pendingEvents.length, 0);
+    assert.deepStrictEqual(emittedEvents[0], event);
+  });
+
+  it('should flush events when requested', () => {
+    const events = [
+      { group: 'test', name: 'event1', level: 'info' },
+      { group: 'test', name: 'event2', level: 'info' }
+    ];
+
+    events.forEach(event => publisher._bufferEvent(event));
+    assert.strictEqual(emittedEvents.length, 0);
+
+    publisher.flush();
+    assert.strictEqual(emittedEvents.length, 2);
+    assert.deepStrictEqual(emittedEvents, events);
+    assert.strictEqual(publisher._pendingEvents.length, 0);
+  });
+
+  it('should do nothing when flushing with no pending events', () => {
+    publisher.flush();
+    assert.strictEqual(emittedEvents.length, 0);
+  });
+
+  it('should automatically flush events at the publish interval', () => {
+    const events = [
+      { group: 'test', name: 'event1', level: 'info' },
+      { group: 'test', name: 'event2', level: 'info' }
+    ];
+
+    events.forEach(event => publisher._bufferEvent(event));
+    assert.strictEqual(emittedEvents.length, 0);
+
+    // Advance time to trigger flush
+    clock.tick(10000);
+    assert.strictEqual(emittedEvents.length, 2);
+    assert.deepStrictEqual(emittedEvents, events);
+  });
+
+  it('should schedule next publish after flushing', () => {
+    const event = { group: 'test', name: 'event1', level: 'info' };
+
+    publisher._bufferEvent(event);
+    clock.tick(10000);
+    assert.strictEqual(emittedEvents.length, 1);
+
+    // Add new event and verify it gets published in next interval
+    emittedEvents = [];
+    const nextEvent = { group: 'test', name: 'event2', level: 'info' };
+    publisher._bufferEvent(nextEvent);
+
+    clock.tick(10000);
+    assert.strictEqual(emittedEvents.length, 1);
+    assert.deepStrictEqual(emittedEvents[0], nextEvent);
+  });
+
+  it('should disable buffering and flush pending events', () => {
+    const events = [
+      { group: 'test', name: 'event1', level: 'info' },
+      { group: 'test', name: 'event2', level: 'info' }
+    ];
+
+    events.forEach(event => publisher._bufferEvent(event));
+    assert.strictEqual(emittedEvents.length, 0);
+
+    publisher.disable(true);
+    assert.strictEqual(emittedEvents.length, 2);
+    assert.deepStrictEqual(emittedEvents, events);
+    assert.strictEqual(publisher._pendingEvents.length, 0);
+    assert(!publisher._enabled);
+  });
+
+  it('should disable buffering without flushing pending events if specified', () => {
+    const events = [
+      { group: 'test', name: 'event1', level: 'info' },
+      { group: 'test', name: 'event2', level: 'info' }
+    ];
+
+    events.forEach(event => publisher._bufferEvent(event));
+    publisher.disable(false);
+    assert.strictEqual(emittedEvents.length, 0);
+    assert(!publisher._enabled);
+  });
+
+  it('should re-enable buffering after being disabled', () => {
+    publisher.disable();
+    assert(!publisher._enabled);
+
+    publisher.enable();
+    assert(publisher._enabled);
+
+    const event = { group: 'test', name: 'buffered', level: 'info' };
+    publisher._bufferEvent(event);
+    assert.strictEqual(emittedEvents.length, 0);
+    assert.strictEqual(publisher._pendingEvents.length, 1);
+  });
+
+  it('should update publish interval when requested', () => {
+    const event = { group: 'test', name: 'event1', level: 'info' };
+
+    publisher._bufferEvent(event);
+    publisher.setPublishInterval(5000);
+
+    // Advance time to new interval
+    clock.tick(5000);
+    assert.strictEqual(emittedEvents.length, 1);
+    assert.deepStrictEqual(emittedEvents[0], event);
+  });
+
+  it('should clean up resources with cleanup method', () => {
+    const disableSpy = sinon.spy(publisher, 'disable');
+
+    publisher.cleanup();
+
+    assert(disableSpy.calledOnce);
+    assert(disableSpy.calledWith(true));
+
+    disableSpy.restore();
+  });
+});

--- a/test/unit/spec/insights/qualityeventpublisher.js
+++ b/test/unit/spec/insights/qualityeventpublisher.js
@@ -17,7 +17,7 @@ describe('QualityEventPublisher', () => {
       debug: sinon.stub(),
       error: sinon.stub(),
     };
-    publisher = new QualityEventPublisher(eventObserver, mockLog);
+    publisher = new QualityEventPublisher(eventObserver, mockLog, { publishIntervalMs: 0 });
     emittedEvents = [];
 
     eventObserver.on('event', event => {

--- a/test/unit/spec/insights/trackwarningpublisher.js
+++ b/test/unit/spec/insights/trackwarningpublisher.js
@@ -13,7 +13,7 @@ describe('TrackWarningPublisher', () => {
 
   beforeEach(() => {
     eventObserver = new EventEmitter();
-    publisher = new TrackWarningPublisher(eventObserver, fakeLog);
+    publisher = new TrackWarningPublisher(eventObserver, fakeLog, { publishIntervalMs: 0 });
     emittedEvents = [];
 
     eventObserver.on('event', event => emittedEvents.push(event));


### PR DESCRIPTION
## Pull Request Details

### Description
This PR adds a new BufferedEventPublisher class that enables event publishers to define a publishing interval and batching multiple events.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
