### PR TITLE
fix: adjust the insights events payload to comply with the spec

### DIFF
--- a/lib/insights/qualityeventpublisher.js
+++ b/lib/insights/qualityeventpublisher.js
@@ -19,7 +19,7 @@
  *   name: 'quality-limitation-state-changed',
  *   level: 'info',
  *   payload: {
- *     trackId: string, // MediaStreamTrack ID
+ *     trackSid: string, // Track Sid
  *     qualityLimitationReason: string // 'none', 'cpu', 'bandwidth', or 'other'
  *   }
  * }
@@ -36,7 +36,7 @@ class QualityEventPublisher {
   constructor(eventObserver, log) {
     this._eventObserver = eventObserver;
     this._log = log;
-    this._lastQualityLimitationReasonByTrackId = new Map();
+    this._lastQualityLimitationReasonByTrackSid = new Map();
   }
 
   /**
@@ -47,40 +47,40 @@ class QualityEventPublisher {
     if (!Array.isArray(localVideoTrackStats)) {
       return;
     }
-    localVideoTrackStats.forEach(({ trackId, qualityLimitationReason }) => {
-      this._maybePublish(trackId, qualityLimitationReason);
+    localVideoTrackStats.forEach(({ trackSid, qualityLimitationReason }) => {
+      this._maybePublish(trackSid, qualityLimitationReason);
     });
   }
 
   /**
    * Check and publish if quality limitation reason changed.
    * @private
-   * @param {LocalVideoTrackStats['trackId']} trackId
+   * @param {LocalVideoTrackStats['trackSid']} trackSid
    * @param {LocalVideoTrackStats['qualityLimitationReason']} qualityLimitationReason
    */
-  _maybePublish(trackId, qualityLimitationReason) {
-    if (!trackId || typeof qualityLimitationReason !== 'string') {
+  _maybePublish(trackSid, qualityLimitationReason) {
+    if (!trackSid || typeof qualityLimitationReason !== 'string') {
       return;
     }
 
-    const lastQualityLimitationReason = this._lastQualityLimitationReasonByTrackId.get(trackId);
+    const lastQualityLimitationReason = this._lastQualityLimitationReasonByTrackSid.get(trackSid);
     if (lastQualityLimitationReason !== qualityLimitationReason) {
-      this._log.debug(`Quality limitation reason changed for track ${trackId}: ${lastQualityLimitationReason || 'none'} -> ${qualityLimitationReason}`);
-      this._lastQualityLimitationReasonByTrackId.set(trackId, qualityLimitationReason);
-      this._publishQualityLimitationReasonChanged(trackId, qualityLimitationReason);
+      this._log.debug(`Quality limitation reason changed for track ${trackSid}: ${lastQualityLimitationReason || 'none'} -> ${qualityLimitationReason}`);
+      this._lastQualityLimitationReasonByTrackSid.set(trackSid, qualityLimitationReason);
+      this._publishQualityLimitationReasonChanged(trackSid, qualityLimitationReason);
     }
   }
 
   /**
    * Publish a quality limitation reason change event
    * @private
-   * @param {string} trackId - The MediaStreamTrack ID
+   * @param {string} trackSid - The Track SID
    * @param {string} qualityLimitationReason - The quality limitation reason
    */
-  _publishQualityLimitationReasonChanged(trackId, qualityLimitationReason) {
+  _publishQualityLimitationReasonChanged(trackSid, qualityLimitationReason) {
     try {
       this._publishEvent('quality-limitation-state-changed', 'info', {
-        trackId,
+        trackSid,
         qualityLimitationReason,
       });
     } catch (error) {
@@ -112,7 +112,7 @@ class QualityEventPublisher {
    * Cleanup all quality event monitoring
    */
   cleanup() {
-    this._lastQualityLimitationReasonByTrackId.clear();
+    this._lastQualityLimitationReasonByTrackSid.clear();
   }
 }
 

--- a/lib/insights/resourceeventpublisher.js
+++ b/lib/insights/resourceeventpublisher.js
@@ -11,10 +11,11 @@ const computePressureMonitor = require('./computepressuremonitor');
  *
  * // Any change in resource monitoring will be published to the event observer using the following format:
  * {
- *   group: 'cpu',
- *   name: 'pressure-changed',
+ *   group: 'system',
+ *   name: 'cpu-pressure-changed',
  *   level: 'info',
  *   payload: {
+ *     resourceType: 'cpu',
  *     pressure: 'nominal' | 'fair' | 'serious' | 'critical'
  *   }
  * }
@@ -49,7 +50,8 @@ class ResourceEventPublisher {
 
     this._cpuPressureHandler = pressureRecord => {
       this._log.debug('CPU pressure changed:', pressureRecord);
-      this._publishEvent('cpu', 'pressure-changed', 'info', {
+      this._publishEvent('system', 'cpu-pressure-changed', 'info', {
+        resourceType: 'cpu',
         pressure: pressureRecord.state
       });
     };

--- a/lib/util/eventobserver.js
+++ b/lib/util/eventobserver.js
@@ -10,7 +10,7 @@ const VALID_GROUPS = [
   'quality',
   'video-processor',
   'preflight',
-  'cpu',
+  'system',
   'network',
   'application',
   'get-user-media',

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -570,32 +570,32 @@ function valueToJSON(value) {
 }
 
 /**
- * Create base payload for room connection events.
- * @private
+ * Create the payload for the 'connecting' event.
+ * @internal
  * @param {ConnectOptions} connectOptions
- * @returns {object} Base payload
+ * @returns {object} Connecting event payload
  */
-function createRoomConnectionBasePayload(connectOptions) {
+function createRoomConnectingEventPayload(connectOptions) {
   function boolToString(val) {
     return val ? 'true' : 'false';
   }
+
   const payload = {
     sessionSID,
-
-    // arrays props converted to lengths.
+    // Arrays props converted to lengths.
     iceServers: (connectOptions.iceServers || []).length,
     audioTracks: (connectOptions.tracks || []).filter(track => track.kind === 'audio').length,
     videoTracks: (connectOptions.tracks || []).filter(track => track.kind === 'video').length,
     dataTracks: (connectOptions.tracks || []).filter(track => track.kind === 'data').length,
   };
 
-  // boolean properties.
+  // boolean properties
   [['audio'], ['automaticSubscription'], ['enableDscp'], ['eventListener'], ['preflight'], ['video'], ['dominantSpeaker', 'enableDominantSpeaker']].forEach(([prop, eventProp]) => {
     eventProp = eventProp || prop;
     payload[eventProp] = boolToString(!!connectOptions[prop]);
   });
 
-  // numbers properties.
+  // number properties
   [['maxVideoBitrate'], ['maxAudioBitrate']].forEach(([prop, eventProp]) => {
     eventProp = eventProp || prop;
     if (typeof connectOptions[prop] === 'number') {
@@ -605,7 +605,7 @@ function createRoomConnectionBasePayload(connectOptions) {
     }
   });
 
-  // string properties.
+  // string properties
   [['iceTransportPolicy'], ['region'], ['name', 'roomName']].forEach(([prop, eventProp]) => {
     eventProp = eventProp || prop;
     if (typeof connectOptions[prop] === 'string') {
@@ -615,13 +615,14 @@ function createRoomConnectionBasePayload(connectOptions) {
     }
   });
 
-  // array props stringified.
+  // array properties as JSON strings
   ['preferredAudioCodecs', 'preferredVideoCodecs'].forEach(prop => {
     if (prop in connectOptions) {
       payload[prop] = JSON.stringify(connectOptions[prop]);
     }
   });
 
+  // network quality configuration
   if ('networkQuality' in connectOptions) {
     payload.networkQualityConfiguration = {};
     if (isNonArrayObject(connectOptions.networkQuality)) {
@@ -636,6 +637,7 @@ function createRoomConnectionBasePayload(connectOptions) {
     }
   }
 
+  // bandwidth profile options
   if (connectOptions.bandwidthProfile && connectOptions.bandwidthProfile.video) {
     const videoBPOptions = connectOptions.bandwidthProfile.video || {};
     payload.bandwidthProfileOptions = {};
@@ -650,7 +652,7 @@ function createRoomConnectionBasePayload(connectOptions) {
     });
   }
 
-  // WebRTC Redirections
+  // WebRTC redirections
   const webRTCRedirectionsInsightsMap = {
     'RTCPeerConnection': 'customRTCPeerConnectionImpl',
     'MediaStream': 'customMediaStreamImpl',
@@ -662,34 +664,23 @@ function createRoomConnectionBasePayload(connectOptions) {
     payload[insightName] = boolToString(typeof connectOptions[optionName] !== 'undefined');
   });
 
-  return payload;
-}
-
-/**
- * Create the payload for the 'connecting' event.
- * @param {ConnectOptions} connectOptions
- * @returns {object} Connecting event payload
- */
-function createRoomConnectingEventPayload(connectOptions) {
   return {
     group: 'room',
     name: 'connecting',
     level: 'info',
-    payload: createRoomConnectionBasePayload(connectOptions)
+    payload
   };
 }
 
 /**
  * Create the payload for the 'connected' event.
- * @param {ConnectOptions} connectOptions
  * @returns {object} Connected event payload
  */
-function createRoomConnectedEventPayload(connectOptions) {
+function createRoomConnectedEventPayload() {
   return {
     group: 'room',
     name: 'connected',
-    level: 'info',
-    payload: createRoomConnectionBasePayload(connectOptions)
+    level: 'info'
   };
 }
 
@@ -896,7 +887,6 @@ exports.constants = constants;
 exports.createBandwidthProfilePayload = createBandwidthProfilePayload;
 exports.createMediaSignalingPayload = createMediaSignalingPayload;
 exports.createMediaWarningsPayload = createMediaWarningsPayload;
-exports.createRoomConnectionBasePayload = createRoomConnectionBasePayload;
 exports.createRoomConnectingEventPayload = createRoomConnectingEventPayload;
 exports.createRoomConnectedEventPayload = createRoomConnectedEventPayload;
 exports.createSubscribePayload = createSubscribePayload;

--- a/test/unit/spec/util/index.js
+++ b/test/unit/spec/util/index.js
@@ -11,46 +11,24 @@ const {
   makeUUID,
   promiseFromEvents,
   isChromeScreenShareTrack,
-  createRoomConnectionBasePayload,
   createRoomConnectingEventPayload,
   createRoomConnectedEventPayload,
 } = require('../../../../lib/util');
 
 const { sessionSID } = require('../../../../lib/util/sid');
 describe('util', () => {
-  describe('createRoomConnectingEventPayload', () => {
-    it('should create a proper connecting event payload', () => {
-      const connectOptions = {
-        audio: true,
-        video: true
-      };
-
-      const event = createRoomConnectingEventPayload(connectOptions);
-
-      assert.equal(event.group, 'room');
-      assert.equal(event.name, 'connecting');
-      assert.equal(event.level, 'info');
-      assert.deepStrictEqual(event.payload, createRoomConnectionBasePayload(connectOptions));
-    });
-  });
-
   describe('createRoomConnectedEventPayload', () => {
     it('should create a proper connected event payload', () => {
-      const connectOptions = {
-        audio: true,
-        video: true
-      };
-
-      const event = createRoomConnectedEventPayload(connectOptions);
+      const event = createRoomConnectedEventPayload();
 
       assert.equal(event.group, 'room');
       assert.equal(event.name, 'connected');
       assert.equal(event.level, 'info');
-      assert.deepStrictEqual(event.payload, createRoomConnectionBasePayload(connectOptions));
+      assert.equal(event.payload, undefined);
     });
   });
 
-  describe('createRoomConnectionBasePayload', () => {
+  describe('createRoomConnectingEventPayload', () => {
     [
       {
         testCase: 'empty options',
@@ -247,7 +225,7 @@ describe('util', () => {
       },
     ].forEach(({ testCase, connectOptions, expectedPayload }) => {
       it(testCase, () => {
-        const payload = createRoomConnectionBasePayload(connectOptions);
+        const event = createRoomConnectingEventPayload(connectOptions);
         const defaultOptions = {
           sessionSID,
           'audio': 'false',
@@ -267,7 +245,10 @@ describe('util', () => {
           'videoTracks': 0
         };
         const expectedOutput = Object.assign(defaultOptions, expectedPayload);
-        assert.deepStrictEqual(payload, expectedOutput);
+        assert.equal(event.name, 'connecting');
+        assert.equal(event.level, 'info');
+        assert.equal(event.group, 'room');
+        assert.deepStrictEqual(event.payload, expectedOutput);
       });
     });
   });


### PR DESCRIPTION
## Pull Request Details

### Description

- Renamed event `pressure-changed` to `cpu-pressure-changed`.
- Moved event from `cpu` group to `system` group.
- Added required `resourceType: "cpu"` property to the `cpu-pressure-changed` event.
- Updated the `connected` event to simplify it payload.
- Track warning events now use `trackSid` instead of `trackSID`.
- Quality limitation reason now includes `trackSid`.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
