### PR TITLE
add: set max_auto_reruns for integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,7 @@ commands:
       - run:
           name: Running Integration Tests (environment = << pipeline.parameters.environment >>)
           command: scripts/circleci-run-tests.sh
+          max_auto_reruns: 3
       - save-test-results
   network-tests:
     steps:


### PR DESCRIPTION
## Pull Request Details

### Description

Automatically retry failed integration test executions up to 3 times.
Reference: https://circleci.com/docs/guides/orchestrate/automatic-reruns/

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review
