### PR TITLE
refactor: update CPU pressure monitoring to handle errors correctly

### DIFF
--- a/lib/insights/computepressuremonitor.js
+++ b/lib/insights/computepressuremonitor.js
@@ -12,20 +12,22 @@
  * @example
  * const computePressureMonitor = require('./computepressuremonitor');
  *
- *  try {
- *   const cpuPressureHandler = record => {
- *     console.log('New CPU Pressure:', record.state, record.source, record.time);
+ * async function setupMonitoring() {
+ *   try {
+ *     const cpuPressureHandler = record => {
+ *       console.log('New CPU Pressure:', record.state, record.source, record.time);
+ *     }
+ *     await computePressureMonitor.watchCpuPressure(cpuPressureHandler);
+ *     // ...
+ *     // Free resources after the handler once the handler is no longer needed
+ *     computePressureMonitor.unwatchCpuPressure(cpuPressureHandler);
+ *     // ...
+ *     // In case you no longer need the monitor, you can clean up all the resources created by the monitor
+ *     computePressureMonitor.cleanup();
+ *   } catch (error) {
+ *     console.error('Error setting up CPU pressure monitor:', error);
  *   }
- *   computePressureMonitor.onCpuPressureChange(cpuPressureHandler);
- *   // ...
- *   // Free resources after the handler once the handler is no longer needed
- *   computePressureMonitor.offCpuPressureChange(cpuPressureHandler);
- *   // ...
- *   // In case you no longer need the monitor, you can clean up all the resources created by the monitor
- *   computePressureMonitor.cleanup();
- *  } catch (error) {
- *    console.error('Error setting up CPU pressure monitor:', error);
- *  }
+ * }
  */
 
 'use strict';
@@ -54,7 +56,8 @@
 /**
  * @typedef {{
  *   disconnect(): void,
- *   observe(source: PressureSource, options?: PressureObserverOptions): void,
+ *   observe(source: PressureSource, options?: PressureObserverOptions): Promise<void>,
+ *   unobserve(source: PressureSource): void,
  *   takeRecords(): PressureRecord[]
  * }} PressureObserver
  */
@@ -92,10 +95,11 @@ class ComputePressureMonitor {
   }
 
   /**
+   * Start watching CPU pressure changes. This is an asynchronous operation.
    * @param {PressureChangeCallback} callback - The callback function to call when the pressure changes.
-   * @returns {void}
+   * @returns {Promise<void>}
    */
-  onCpuPressureChange(callback) {
+  async watchCpuPressure(callback) {
     if (typeof callback !== 'function') {
       throw new Error('The CPU pressure change callback must be a function');
     }
@@ -107,10 +111,9 @@ class ComputePressureMonitor {
 
     this._cpuPressureChangeListeners.push(callback);
 
-
     if (!this._cpuPressureObserver) {
       this._cpuPressureObserver = new PressureObserver(records => this._handleCpuPressureRecords(records));
-      this._cpuPressureObserver.observe('cpu', {
+      await this._cpuPressureObserver.observe('cpu', {
         sampleInterval: this._sampleInterval,
       });
     }
@@ -124,11 +127,11 @@ class ComputePressureMonitor {
   }
 
   /**
-   * Stop listening to the CPU pressure change.
+   * Stop watching CPU pressure changes for the given callback.
    * @param {PressureChangeCallback} callback - The callback function to stop listening to.
    * @returns {void}
    */
-  offCpuPressureChange(callback) {
+  unwatchCpuPressure(callback) {
     this._cpuPressureChangeListeners = this._cpuPressureChangeListeners.filter(cb => cb !== callback);
     if (this._cpuPressureChangeListeners.length === 0) {
       this.cleanup();

--- a/lib/insights/resourceeventpublisher.js
+++ b/lib/insights/resourceeventpublisher.js
@@ -56,12 +56,13 @@ class ResourceEventPublisher {
       });
     };
 
-    try {
-      computePressureMonitor.onCpuPressureChange(this._cpuPressureHandler);
-      this._log.debug('CPU pressure monitoring initialized');
-    } catch (error) {
-      this._log.error('Error initializing CPU pressure monitoring:', error);
-    }
+    computePressureMonitor.watchCpuPressure(this._cpuPressureHandler)
+      .then(() => {
+        this._log.debug('CPU pressure monitoring initialized');
+      })
+      .catch(error => {
+        this._log.error('Error initializing CPU pressure monitoring:', error);
+      });
   }
 
   /**
@@ -88,7 +89,7 @@ class ResourceEventPublisher {
     this._log.debug('Cleaning up resource monitors');
 
     if (this._cpuPressureHandler) {
-      computePressureMonitor.offCpuPressureChange(this._cpuPressureHandler);
+      computePressureMonitor.unwatchCpuPressure(this._cpuPressureHandler);
       this._cpuPressureHandler = null;
     }
   }


### PR DESCRIPTION
## Pull Request Details

### Description
* Handle async operations correctly for the CPU pressure telemetry events.
* Rename `onCpuPressureChange` to `watchCpuPressure` to be more clear and concise.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
