### PR TITLE
[VBLOCKS-5387] telemetry: add PeerConnection telemetry events

### DIFF
--- a/lib/insights/events/peerconnection.js
+++ b/lib/insights/events/peerconnection.js
@@ -1,0 +1,73 @@
+'use strict';
+
+/**
+ * PeerConnection telemetry events
+ * @internal
+ */
+class PeerConnectionEvents {
+  /**
+   * @param {import('../telemetry')} telemetry - The telemetry instance
+   */
+  constructor(telemetry) {
+    this._telemetry = telemetry;
+  }
+
+  /**
+   * Emit connection state change event
+   * @param {string} peerConnectionId - Peer connection identifier
+   * @param {('new'|'connecting'|'connected'|'disconnected'|'failed'|'closed')} state - Connection state
+   * @returns {void}
+   */
+  connectionState(peerConnectionId, state) {
+    this._telemetry.debug({
+      group: 'pc-connection-state',
+      name: state,
+      payload: { peerConnectionId }
+    });
+  }
+
+  /**
+   * Emit signaling state change event
+   * @param {string} peerConnectionId - Peer connection identifier
+   * @param {('stable'|'have-local-offer'|'have-remote-offer'|'have-local-pranswer'|'have-remote-pranswer'|'closed')} state - Signaling state
+   * @returns {void}
+   */
+  signalingState(peerConnectionId, state) {
+    this._telemetry.debug({
+      group: 'pc-signaling-state',
+      name: state,
+      payload: { peerConnectionId }
+    });
+  }
+
+  /**
+   * Emit ice gathering state change event
+   * @param {string} peerConnectionId - Peer connection identifier
+   * @param {('new'|'gathering'|'complete')} state - Ice gathering state
+   * @returns {void}
+   */
+  iceGatheringState(peerConnectionId, state) {
+    this._telemetry.debug({
+      group: 'ice-gathering-state',
+      name: state,
+      payload: { peerConnectionId }
+    });
+  }
+
+  /**
+   * Emit ice connection state change event
+   * @param {string} peerConnectionId - Peer connection identifier
+   * @param {('new'|'checking'|'connected'|'completed'|'disconnected'|'failed'|'closed')} state - Ice connection state
+   * @returns {void}
+   */
+  iceConnectionState(peerConnectionId, state) {
+    const level = state === 'failed' ? 'error' : 'debug';
+    this._telemetry[level]({
+      group: 'ice-connection-state',
+      name: state,
+      payload: { peerConnectionId }
+    });
+  }
+}
+
+module.exports = PeerConnectionEvents;

--- a/lib/insights/telemetry.js
+++ b/lib/insights/telemetry.js
@@ -6,6 +6,7 @@ const QualityEvents = require('./events/quality');
 const TrackEvents = require('./events/track');
 const ApplicationEvents = require('./events/application');
 const SystemEvents = require('./events/system');
+const PeerConnectionEvents = require('./events/peerconnection');
 
 /**
  * @typedef {Object} InsightsPublisher
@@ -53,6 +54,8 @@ class Telemetry {
     this.application = new ApplicationEvents(this);
     /** @type {SystemEvents} */
     this.system = new SystemEvents(this);
+    /** @type {PeerConnectionEvents} */
+    this.pc = new PeerConnectionEvents(this);
   }
 
   /**
@@ -165,6 +168,16 @@ class Telemetry {
    */
   error({ group, name, payload }) {
     return this._emit(group, name, 'error', payload);
+  }
+
+  /**
+   * Emit a debug-level telemetry event.
+   *
+   * @param {TelemetryEventOptions} options - Event options
+   * @returns {void}
+   */
+  debug({ group, name, payload }) {
+    return this._emit(group, name, 'debug', payload);
   }
 
 }

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -54,6 +54,7 @@ const StateMachine = require('../../statemachine');
 const Log = require('../../util/log');
 const TrackMatcher = require('../../util/sdp/trackmatcher');
 const workaroundIssue8329 = require('../../util/sdp/issue8329');
+const telemetry = require('../../insights/telemetry');
 
 const guess = util.guessBrowser();
 const platform = getPlatform();
@@ -721,6 +722,7 @@ class PeerConnectionV2 extends StateMachine {
    * @returns {void}
    */
   _handleConnectionStateChange() {
+    telemetry.pc.connectionState(this.id, this.connectionState);
     this.emit('connectionStateChanged');
   }
 
@@ -814,6 +816,7 @@ class PeerConnectionV2 extends StateMachine {
     const log = this._log;
 
     log.debug(`ICE connection state is "${iceConnectionState}"`);
+    telemetry.pc.iceConnectionState(this.id, iceConnectionState);
     if (isIceConnectedOrComplete) {
       this._iceReconnectTimeout.clear();
       this._iceRestartBackoff.reset();
@@ -872,6 +875,8 @@ class PeerConnectionV2 extends StateMachine {
    */
   _handleIceGatheringStateChange() {
     const { iceGatheringState } = this._peerConnection;
+    telemetry.pc.iceGatheringState(this.id, iceGatheringState);
+
     const log = this._log;
     log.debug(`ICE gathering state is "${iceGatheringState}"`);
 
@@ -892,6 +897,8 @@ class PeerConnectionV2 extends StateMachine {
    * @returns {void}
    */
   _handleSignalingStateChange() {
+    telemetry.pc.signalingState(this.id, this._peerConnection.signalingState);
+
     if (this._peerConnection.signalingState === 'stable') {
       this._appliedTrackIdsToAttributes = new Map(this._trackIdsToAttributes);
     }

--- a/test/unit/spec/insights/telemetry.js
+++ b/test/unit/spec/insights/telemetry.js
@@ -299,5 +299,73 @@ describe('Telemetry', () => {
         }));
       });
     });
+
+    describe('RTCPeerConnection events', () => {
+      describe('connectionState', () => {
+        ['new', 'connecting', 'connected', 'disconnected', 'failed', 'closed'].forEach(state => {
+          it(`should publish ${state} event`, () => {
+            telemetry.pc.connectionState('PC123', state);
+
+            sinon.assert.calledOnce(mockPublisher.publish);
+            sinon.assert.calledWith(mockPublisher.publish, 'pc-connection-state', state, sinon.match({
+              level: 'debug',
+              peerConnectionId: 'PC123'
+            }));
+          });
+        });
+      });
+
+      describe('signalingState', () => {
+        ['stable', 'have-local-offer', 'have-remote-offer', 'have-local-pranswer', 'have-remote-pranswer', 'closed'].forEach(state => {
+          it(`should publish ${state} event`, () => {
+            telemetry.pc.signalingState('PC123', state);
+
+            sinon.assert.calledOnce(mockPublisher.publish);
+            sinon.assert.calledWith(mockPublisher.publish, 'pc-signaling-state', state, sinon.match({
+              level: 'debug',
+              peerConnectionId: 'PC123'
+            }));
+          });
+        });
+      });
+
+      describe('iceGatheringState', () => {
+        ['new', 'gathering', 'complete'].forEach(state => {
+          it(`should publish ${state} event`, () => {
+            telemetry.pc.iceGatheringState('PC123', state);
+
+            sinon.assert.calledOnce(mockPublisher.publish);
+            sinon.assert.calledWith(mockPublisher.publish, 'ice-gathering-state', state, sinon.match({
+              level: 'debug',
+              peerConnectionId: 'PC123'
+            }));
+          });
+        });
+      });
+
+      describe('iceConnectionState', () => {
+        ['new', 'checking', 'connected', 'completed', 'disconnected', 'closed'].forEach(state => {
+          it(`should publish ${state} event with debug level`, () => {
+            telemetry.pc.iceConnectionState('PC123', state);
+
+            sinon.assert.calledOnce(mockPublisher.publish);
+            sinon.assert.calledWith(mockPublisher.publish, 'ice-connection-state', state, sinon.match({
+              level: 'debug',
+              peerConnectionId: 'PC123'
+            }));
+          });
+        });
+
+        it('should publish failed event with error level', () => {
+          telemetry.pc.iceConnectionState('PC123', 'failed');
+
+          sinon.assert.calledOnce(mockPublisher.publish);
+          sinon.assert.calledWith(mockPublisher.publish, 'ice-connection-state', 'failed', sinon.match({
+            level: 'error',
+            peerConnectionId: 'PC123'
+          }));
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
## Pull Request Details

### Description

This PR adds telemetry events for the following states:
* [RTCPeerConnectionState](https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnectionstate)
* [RTCSignalingState](https://w3c.github.io/webrtc-pc/#dom-rtcsignalingstate)
* [RTCIceGatheringState](https://w3c.github.io/webrtc-pc/#dom-rtcicegatheringstate)
* [RTCIceConnectionState](https://w3c.github.io/webrtc-pc/#dom-rtciceconnectionstate)

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
