### PR TITLE
telemetry: add events for new ICE candidates and selected candidate pair

### DIFF
--- a/lib/insights/events/peerconnection.js
+++ b/lib/insights/events/peerconnection.js
@@ -105,7 +105,7 @@ class PeerConnectionEvents {
    * @param {boolean} [isRemote = false] - Whether the candidate is remote
    * @returns {void}
    */
-  newIceCandidate(peerConnectionId, iceCandidate, isRemote = false) {
+  iceCandidate(peerConnectionId, iceCandidate, isRemote = false) {
     this._telemetry.debug({
       group: 'ice-candidate',
       name: 'ice-candidate',

--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -560,7 +560,7 @@ class PeerConnectionV2 extends StateMachine {
    */
   _addIceCandidate(candidate) {
     return Promise.resolve().then(() => {
-      telemetry.pc.newIceCandidate(this.id, candidate, true);
+      telemetry.pc.iceCandidate(this.id, candidate, true);
       candidate = new this._RTCIceCandidate(candidate);
       return this._peerConnection.addIceCandidate(candidate);
     }).catch(error => {
@@ -793,7 +793,7 @@ class PeerConnectionV2 extends StateMachine {
       this._didGenerateLocalCandidates = true;
       this._iceGatheringTimeout.clear();
       this._localCandidates.push(event.candidate);
-      telemetry.pc.newIceCandidate(this.id, event.candidate);
+      telemetry.pc.iceCandidate(this.id, event.candidate);
     }
     const peerConnectionState = {
       ice: {


### PR DESCRIPTION
## Pull Request Details

### Description
This PR adds telemetry events for new `ice-candidate` and changes in the `selected-candidate-pair`. Both use a new `IceCandidatePayload` type, which defines the common properties implemented by major engines for the `RTCIceCandidate` object.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
