### PR TITLE
telemetry: emit room disconnected event

### DIFF
--- a/lib/insights/events/room.js
+++ b/lib/insights/events/room.js
@@ -45,6 +45,17 @@ class RoomEvents {
       name: 'reconnected'
     });
   }
+
+  /**
+   * Emit when room disconnected
+   * @returns {void}
+   */
+  disconnected() {
+    this._telemetry.info({
+      group: 'room',
+      name: 'disconnected'
+    });
+  }
 }
 
 module.exports = RoomEvents;

--- a/lib/room.js
+++ b/lib/room.js
@@ -673,6 +673,7 @@ function handleSignalingEvents(room, signaling) {
     log.info('Transitioned to state:', state);
     switch (state) {
       case 'disconnected':
+        telemetry.room.disconnected();
         room.participants.forEach(participant => {
           participant._unsubscribeTracks();
         });


### PR DESCRIPTION
## Pull Request Details

### Description

This PR adds the new room's `disconnected` event to the telemetry information.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
