### PR TITLE
telemetry: add networkCost to IceCandidatePayload

### DIFF
--- a/lib/insights/events/peerconnection.js
+++ b/lib/insights/events/peerconnection.js
@@ -14,6 +14,7 @@ const { filterObject } = require('../../util');
  * @property {number} [relatedPort]
  * @property {string} [tcpType]
  * @property {string} [transportId] - Alias for RTCIceCandidate.sdpMid
+ * @property {number} [networkCost]
 */
 
 /**
@@ -144,6 +145,9 @@ class PeerConnectionEvents {
    * @returns {IceCandidatePayload} The telemetry payload format
    */
   _toIceCandidatePayload(iceCandidate) {
+    const match = iceCandidate.candidate?.match(/network-cost\s+(\d+)/);
+    const networkCost = match ? parseInt(match[1], 10) : null;
+
     return filterObject({
       'candidateType': iceCandidate.type,
       'ip': iceCandidate.address,
@@ -153,7 +157,8 @@ class PeerConnectionEvents {
       'relatedAddress': iceCandidate.relatedAddress,
       'relatedPort': iceCandidate.relatedPort,
       'tcpType': iceCandidate.tcpType,
-      'transportId': iceCandidate.sdpMid
+      'transportId': iceCandidate.sdpMid,
+      'networkCost': networkCost
     }, null);
   }
 }


### PR DESCRIPTION
## Pull Request Details

### Description
This PR adds an optional `networkCost` to the IceCandidatePayload

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
