### PR TITLE
[VBLOCKS-5721] enable hybrid codec preferences for P2P rooms

### DIFF
--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -26,6 +26,7 @@ const {
   getMediaSections,
   removeSSRCAttributes,
   revertSimulcast,
+  setCodecPreferences,
   setSimulcast
 } = require('../../util/sdp');
 
@@ -120,6 +121,7 @@ class PeerConnectionV2 extends StateMachine {
       offerOptions: {},
       revertSimulcast,
       sessionTimeout: DEFAULT_SESSION_TIMEOUT_SEC * 1000,
+      setCodecPreferences,
       setSimulcast,
       Backoff: DefaultBackoff,
       IceConnectionMonitor: DefaultIceConnectionMonitor,
@@ -328,6 +330,9 @@ class PeerConnectionV2 extends StateMachine {
       },
       _revertSimulcast: {
         value: options.revertSimulcast
+      },
+      _setCodecPreferences: {
+        value: options.setCodecPreferences
       },
       _RTCIceCandidate: {
         value: options.RTCIceCandidate
@@ -1301,6 +1306,11 @@ class PeerConnectionV2 extends StateMachine {
    */
   _setRemoteDescription(description) {
     if (description.sdp) {
+      description.sdp = this._setCodecPreferences(
+        description.sdp,
+        this._preferredAudioCodecs,
+        this._preferredVideoCodecs);
+
       if (this._shouldApplyDtx) {
         description.sdp = enableDtxForOpus(description.sdp);
       } else {

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { difference, flatMap } = require('../');
 const setSimulcastInMediaSection = require('./simulcast');
 
 const ptToFixedBitrateAudioCodecName = {
@@ -401,6 +402,54 @@ function enableDtxForOpus(sdp, mids) {
   })).join('\r\n');
 }
 
+/**
+ * Create the reordered Codec Payload Types based on the preferred Codec Names.
+ * @param {Map<Codec, Array<PT>>} codecMap - Codec Map
+ * @param {Array<AudioCodecSettings|VideoCodecSettings>} preferredCodecs - Preferred Codecs
+ * @returns {Array<PT>} Reordered Payload Types
+ */
+function getReorderedPayloadTypes(codecMap, preferredCodecs) {
+  preferredCodecs = preferredCodecs.map(({ codec }) => codec.toLowerCase());
+  const preferredPayloadTypes = flatMap(preferredCodecs, codecName => codecMap.get(codecName) || []);
+  const remainingCodecs = difference(Array.from(codecMap.keys()), preferredCodecs);
+  const remainingPayloadTypes = flatMap(remainingCodecs, codecName => codecMap.get(codecName));
+  return preferredPayloadTypes.concat(remainingPayloadTypes);
+}
+
+/**
+ * Return a new SDP string with the re-ordered codec preferences.
+ * Used for remote descriptions to enable asymmetric codec support in P2P.
+ * @param {string} sdp
+ * @param {Array<AudioCodec>} preferredAudioCodecs - If empty, the existing order of audio codecs is preserved
+ * @param {Array<VideoCodecSettings>} preferredVideoCodecs - If empty, the existing order of video codecs is preserved
+ * @returns {string} Updated SDP string
+ */
+function setCodecPreferences(sdp, preferredAudioCodecs, preferredVideoCodecs) {
+  const mediaSections = getMediaSections(sdp);
+  const session = sdp.split('\r\nm=')[0];
+  return [session].concat(mediaSections.map(section => {
+    // Codec preferences should not be applied to m=application sections.
+    if (!/^m=(audio|video)/.test(section)) {
+      return section;
+    }
+    const kind = section.match(/^m=(audio|video)/)[1];
+    const codecMap = createCodecMapForMediaSection(section);
+    const preferredCodecs = kind === 'audio' ? preferredAudioCodecs : preferredVideoCodecs;
+    const payloadTypes = getReorderedPayloadTypes(codecMap, preferredCodecs);
+    const newSection = setPayloadTypesInMediaSection(payloadTypes, section);
+
+    const pcmaPayloadTypes = codecMap.get('pcma') || [];
+    const pcmuPayloadTypes = codecMap.get('pcmu') || [];
+    const fixedBitratePayloadTypes = kind === 'audio'
+      ? new Set(pcmaPayloadTypes.concat(pcmuPayloadTypes))
+      : new Set();
+
+    return fixedBitratePayloadTypes.has(payloadTypes[0])
+      ? newSection.replace(/\r\nb=(AS|TIAS):([0-9]+)/g, '')
+      : newSection;
+  })).join('\r\n');
+}
+
 exports.addOrRewriteNewTrackIds = addOrRewriteNewTrackIds;
 exports.addOrRewriteTrackIds = addOrRewriteTrackIds;
 exports.createCodecMapForMediaSection = createCodecMapForMediaSection;
@@ -410,4 +459,5 @@ exports.enableDtxForOpus = enableDtxForOpus;
 exports.getMediaSections = getMediaSections;
 exports.removeSSRCAttributes = removeSSRCAttributes;
 exports.revertSimulcast = revertSimulcast;
+exports.setCodecPreferences = setCodecPreferences;
 exports.setSimulcast = setSimulcast;

--- a/test/integration/spec/connect.js
+++ b/test/integration/spec/connect.js
@@ -1004,40 +1004,18 @@ describe('connect', function() {
 
       before(async () => {
         [sid, thisRoom, thoseRooms, peerConnections] = await setup({ testOptions });
-
-        await Promise.all(peerConnections.map(pc => pc.localDescription ? Promise.resolve() : new Promise(resolve => {
-          pc.addEventListener('signalingstatechange', () => pc.localDescription && resolve());
-        })));
       });
 
-      it('should apply the codec preferences to local descriptions', () => {
+      it('should apply the codec preferences to all remote descriptions', () => {
         flatMap(peerConnections, pc => {
-          assert(pc.localDescription.sdp);
-          // Preferred codecs are only applied to offer descriptions
-          if (pc.localDescription.type !== 'offer') {
-            return [];
-          }
-          return getMediaSections(pc.localDescription.sdp);
+          assert(pc.remoteDescription.sdp);
+          return getMediaSections(pc.remoteDescription.sdp);
         }).forEach(section => {
           const codecMap = createCodecMapForMediaSection(section);
-          const isAudio = /m=audio/.test(section);
-
-          const preferredCodecs = isAudio
-            ? testOptions.preferredAudioCodecs
-            : testOptions.preferredVideoCodecs;
-
-          const supportedPreferredCodecs = preferredCodecs.filter(codec => {
-            const codecName = (codec.codec || codec).toLowerCase();
-            return codecMap.has(codecName);
-          });
-
-          const expectedPayloadTypes = flatMap(supportedPreferredCodecs, codec =>
-            codecMap.get((codec.codec || codec).toLowerCase()) || []
-          );
-          const allPayloadTypes = getPayloadTypes(section);
-          const ptToCodec = createPtToCodecName(section);
-          const actualPayloadTypes = allPayloadTypes.filter(pt => ptToCodec.get(pt) !== 'rtx');
-
+          const expectedPayloadTypes = /m=audio/.test(section)
+            ? flatMap(testOptions.preferredAudioCodecs, codec => codecMap.get(codec.toLowerCase()) || [])
+            : flatMap(testOptions.preferredVideoCodecs, codec => codecMap.get((codec.codec || codec).toLowerCase()) || []);
+          const actualPayloadTypes = getPayloadTypes(section);
           expectedPayloadTypes.forEach((expectedPayloadType, i) => assert.equal(expectedPayloadType, actualPayloadTypes[i]));
         });
       });


### PR DESCRIPTION
## Pull Request Details

### Description
This PR reintroduces the **remote** SDP munging removed in #2180, which is needed to keep send and receive codec preferences independent

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
