### PR TITLE
fix: Firefox setCodecPreferences leaving unreferenced codec attributes

### DIFF
--- a/lib/signaling/v2/peerconnection.js
+++ b/lib/signaling/v2/peerconnection.js
@@ -24,6 +24,7 @@ const {
   disableRtx,
   enableDtxForOpus,
   getMediaSections,
+  removeUnreferencedCodecAttributes,
   removeSSRCAttributes,
   revertSimulcast,
   setCodecPreferences,
@@ -1148,8 +1149,16 @@ class PeerConnectionV2 extends StateMachine {
         // NOTE(mmalavalli): We work around Chromium bug 1106157 by disabling
         // RTX in Firefox 79+. For more details about the bug, please go here:
         // https://bugs.chromium.org/p/chromium/issues/detail?id=1106157
+        let sdp = disableRtx(offer.sdp);
+
+        // NOTE(lrivas): Work around Firefox bug where setCodecPreferences leaves
+        // unreferenced codec attributes (fmtp, rtpmap, rtcp-fb) for payload types not
+        // present in the m= line. For more details about the bug, please go here:
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=1909443
+        sdp = removeUnreferencedCodecAttributes(sdp);
+
         offer = new this._RTCSessionDescription({
-          sdp: disableRtx(offer.sdp),
+          sdp,
           type: offer.type
         });
       } else {

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -350,6 +350,34 @@ function generateFmtpLineFromPtAndAttributes(pt, fmtpAttrs) {
 }
 
 /**
+ * Remove codec-related attributes (fmtp, rtpmap, rtcp-fb) for payload types
+ * that are not present in the m= line. This works around a Firefox bug where
+ * setCodecPreferences leaves unreferenced attributes after filtering codecs.
+ * @param {string} sdp
+ * @returns {string} sdp without unreferenced codec attributes
+ */
+function removeUnreferencedCodecAttributes(sdp) {
+  const mediaSections = getMediaSections(sdp);
+  const session = sdp.split('\r\nm=')[0];
+  return [session].concat(mediaSections.map(mediaSection => {
+    if (!/^m=(audio|video)/.test(mediaSection)) {
+      return mediaSection;
+    }
+
+    const validPts = new Set(getPayloadTypesInMediaSection(mediaSection));
+
+    return mediaSection.split('\r\n').filter(line => {
+      const ptMatch = line.match(/^a=(fmtp|rtpmap|rtcp-fb):(\d+)/);
+      if (!ptMatch) {
+        return true;
+      }
+      const pt = parseInt(ptMatch[2], 10);
+      return validPts.has(pt);
+    }).join('\r\n');
+  })).join('\r\n');
+}
+
+/**
  * Enable DTX for opus in the m= sections for the given MIDs.`
  * @param {string} sdp
  * @param {Array<string>} [mids] - If not specified, enables opus DTX for all
@@ -457,6 +485,7 @@ exports.createPtToCodecName = createPtToCodecName;
 exports.disableRtx = disableRtx;
 exports.enableDtxForOpus = enableDtxForOpus;
 exports.getMediaSections = getMediaSections;
+exports.removeUnreferencedCodecAttributes = removeUnreferencedCodecAttributes;
 exports.removeSSRCAttributes = removeSSRCAttributes;
 exports.revertSimulcast = revertSimulcast;
 exports.setCodecPreferences = setCodecPreferences;

--- a/test/unit/spec/util/sdp/index.js
+++ b/test/unit/spec/util/sdp/index.js
@@ -12,6 +12,7 @@ const {
   getMediaSections,
   setCodecPreferences,
   setSimulcast,
+  removeUnreferencedCodecAttributes,
   removeSSRCAttributes,
   revertSimulcast
 } = require('../../../../../lib/util/sdp');
@@ -501,6 +502,221 @@ a=ssrc-group:FID 2476366320 3143435575`;
              || rtxSSRCAttrRegex.test(line)
              || ssrcGroupRegex.test(line));
             assert.equal(rtxLines.length, 0);
+          }
+        });
+      } else {
+        assert.equal(sdp1, sdp);
+      }
+    });
+  });
+});
+
+describe('removeUnreferencedCodecAttributes', () => {
+  const sdpWithUnreferencedAttributes = `v=0\r
+o=mozilla...THIS_IS_SDPARTA-99.0 3249008904328227516 2 IN IP4 0.0.0.0\r
+s=-\r
+t=0 0\r
+a=fingerprint:sha-256 56:34:8D:F9:03:F8:63:24:58:57:62:2B:0E:AF:E1:B4:F4:22:04:38:2A:BA:FA:B0:16:3A:8C:F5:E4:13:D1:44\r
+a=group:BUNDLE 0 1\r
+a=ice-options:trickle\r
+a=msid-semantic:WMS *\r
+m=audio 9 UDP/TLS/RTP/SAVPF 109 9 0 8 101\r
+c=IN IP4 0.0.0.0\r
+a=sendrecv\r
+a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r
+a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid\r
+a=fmtp:109 maxplaybackrate=48000;stereo=1;useinbandfec=1;usedtx=1\r
+a=fmtp:101 0-15\r
+a=ice-pwd:7a707be15814fdd3047540d288a3f665\r
+a=ice-ufrag:883fb0bb\r
+a=mid:0\r
+a=msid:- {c983e5c7-36a2-4638-b985-7dac62ca643d}\r
+a=rtcp-mux\r
+a=rtpmap:109 opus/48000/2\r
+a=rtpmap:9 G722/8000/1\r
+a=rtpmap:0 PCMU/8000\r
+a=rtpmap:8 PCMA/8000\r
+a=rtpmap:101 telephone-event/8000/1\r
+a=setup:actpass\r
+a=ssrc:3859001979 cname:{da5db090-9171-4294-9f7f-eee36c02fdd7}\r
+m=video 9 UDP/TLS/RTP/SAVPF 120 126 97 105 103\r
+c=IN IP4 0.0.0.0\r
+a=sendrecv\r
+a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid\r
+a=extmap:4 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r
+a=extmap:5 urn:ietf:params:rtp-hdrext:toffset\r
+a=extmap:7 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01\r
+a=fmtp:126 profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1\r
+a=fmtp:97 profile-level-id=42e01f;level-asymmetry-allowed=1\r
+a=fmtp:105 profile-level-id=42001f;level-asymmetry-allowed=1;packetization-mode=1\r
+a=fmtp:103 profile-level-id=42001f;level-asymmetry-allowed=1\r
+a=fmtp:120 max-fs=12288;max-fr=60\r
+a=fmtp:121 max-fs=12288;max-fr=60\r
+a=ice-pwd:7a707be15814fdd3047540d288a3f665\r
+a=ice-ufrag:883fb0bb\r
+a=mid:1\r
+a=msid:- {27d1f953-d806-4c80-88c2-0ad5ce222523}\r
+a=rtcp-fb:120 nack\r
+a=rtcp-fb:120 nack pli\r
+a=rtcp-fb:120 ccm fir\r
+a=rtcp-fb:120 goog-remb\r
+a=rtcp-fb:120 transport-cc\r
+a=rtcp-fb:126 nack\r
+a=rtcp-fb:126 nack pli\r
+a=rtcp-fb:126 ccm fir\r
+a=rtcp-fb:126 goog-remb\r
+a=rtcp-fb:126 transport-cc\r
+a=rtcp-fb:97 nack\r
+a=rtcp-fb:97 nack pli\r
+a=rtcp-fb:97 ccm fir\r
+a=rtcp-fb:97 goog-remb\r
+a=rtcp-fb:97 transport-cc\r
+a=rtcp-fb:105 nack\r
+a=rtcp-fb:105 nack pli\r
+a=rtcp-fb:105 ccm fir\r
+a=rtcp-fb:105 goog-remb\r
+a=rtcp-fb:105 transport-cc\r
+a=rtcp-fb:103 nack\r
+a=rtcp-fb:103 nack pli\r
+a=rtcp-fb:103 ccm fir\r
+a=rtcp-fb:103 goog-remb\r
+a=rtcp-fb:103 transport-cc\r
+a=rtcp-fb:99 nack\r
+a=rtcp-fb:99 nack pli\r
+a=rtcp-fb:99 ccm fir\r
+a=rtcp-fb:99 goog-remb\r
+a=rtcp-fb:99 transport-cc\r
+a=rtcp-fb:121 nack\r
+a=rtcp-fb:121 nack pli\r
+a=rtcp-fb:121 ccm fir\r
+a=rtcp-fb:121 goog-remb\r
+a=rtcp-fb:121 transport-cc\r
+a=rtcp-fb:122 nack\r
+a=rtcp-fb:122 nack pli\r
+a=rtcp-fb:122 ccm fir\r
+a=rtcp-fb:122 goog-remb\r
+a=rtcp-fb:122 transport-cc\r
+a=rtcp-fb:123 nack\r
+a=rtcp-fb:123 nack pli\r
+a=rtcp-fb:123 ccm fir\r
+a=rtcp-fb:123 goog-remb\r
+a=rtcp-fb:123 transport-cc\r
+a=rtcp-mux\r
+a=rtcp-rsize\r
+a=rtpmap:120 VP8/90000\r
+a=rtpmap:126 H264/90000\r
+a=rtpmap:97 H264/90000\r
+a=rtpmap:105 H264/90000\r
+a=rtpmap:103 H264/90000\r
+a=setup:actpass\r
+a=ssrc:2509634557 cname:{da5db090-9171-4294-9f7f-eee36c02fdd7}`;
+
+  const sdpWithoutUnreferencedAttributes = `v=0\r
+o=mozilla...THIS_IS_SDPARTA-99.0 3249008904328227516 2 IN IP4 0.0.0.0\r
+s=-\r
+t=0 0\r
+a=fingerprint:sha-256 56:34:8D:F9:03:F8:63:24:58:57:62:2B:0E:AF:E1:B4:F4:22:04:38:2A:BA:FA:B0:16:3A:8C:F5:E4:13:D1:44\r
+a=group:BUNDLE 0 1\r
+a=ice-options:trickle\r
+a=msid-semantic:WMS *\r
+m=audio 9 UDP/TLS/RTP/SAVPF 109 9 0 8 101\r
+c=IN IP4 0.0.0.0\r
+a=sendrecv\r
+a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r
+a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid\r
+a=fmtp:109 maxplaybackrate=48000;stereo=1;useinbandfec=1;usedtx=1\r
+a=fmtp:101 0-15\r
+a=ice-pwd:7a707be15814fdd3047540d288a3f665\r
+a=ice-ufrag:883fb0bb\r
+a=mid:0\r
+a=msid:- {c983e5c7-36a2-4638-b985-7dac62ca643d}\r
+a=rtcp-mux\r
+a=rtpmap:109 opus/48000/2\r
+a=rtpmap:9 G722/8000/1\r
+a=rtpmap:0 PCMU/8000\r
+a=rtpmap:8 PCMA/8000\r
+a=rtpmap:101 telephone-event/8000/1\r
+a=setup:actpass\r
+a=ssrc:3859001979 cname:{da5db090-9171-4294-9f7f-eee36c02fdd7}\r
+m=video 9 UDP/TLS/RTP/SAVPF 120 126 97 105 103\r
+c=IN IP4 0.0.0.0\r
+a=sendrecv\r
+a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid\r
+a=extmap:4 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r
+a=extmap:5 urn:ietf:params:rtp-hdrext:toffset\r
+a=extmap:7 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01\r
+a=fmtp:126 profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1\r
+a=fmtp:97 profile-level-id=42e01f;level-asymmetry-allowed=1\r
+a=fmtp:105 profile-level-id=42001f;level-asymmetry-allowed=1;packetization-mode=1\r
+a=fmtp:103 profile-level-id=42001f;level-asymmetry-allowed=1\r
+a=fmtp:120 max-fs=12288;max-fr=60\r
+a=ice-pwd:7a707be15814fdd3047540d288a3f665\r
+a=ice-ufrag:883fb0bb\r
+a=mid:1\r
+a=msid:- {27d1f953-d806-4c80-88c2-0ad5ce222523}\r
+a=rtcp-fb:120 nack\r
+a=rtcp-fb:120 nack pli\r
+a=rtcp-fb:120 ccm fir\r
+a=rtcp-fb:120 goog-remb\r
+a=rtcp-fb:120 transport-cc\r
+a=rtcp-fb:126 nack\r
+a=rtcp-fb:126 nack pli\r
+a=rtcp-fb:126 ccm fir\r
+a=rtcp-fb:126 goog-remb\r
+a=rtcp-fb:126 transport-cc\r
+a=rtcp-fb:97 nack\r
+a=rtcp-fb:97 nack pli\r
+a=rtcp-fb:97 ccm fir\r
+a=rtcp-fb:97 goog-remb\r
+a=rtcp-fb:97 transport-cc\r
+a=rtcp-fb:105 nack\r
+a=rtcp-fb:105 nack pli\r
+a=rtcp-fb:105 ccm fir\r
+a=rtcp-fb:105 goog-remb\r
+a=rtcp-fb:105 transport-cc\r
+a=rtcp-fb:103 nack\r
+a=rtcp-fb:103 nack pli\r
+a=rtcp-fb:103 ccm fir\r
+a=rtcp-fb:103 goog-remb\r
+a=rtcp-fb:103 transport-cc\r
+a=rtcp-mux\r
+a=rtcp-rsize\r
+a=rtpmap:120 VP8/90000\r
+a=rtpmap:126 H264/90000\r
+a=rtpmap:97 H264/90000\r
+a=rtpmap:105 H264/90000\r
+a=rtpmap:103 H264/90000\r
+a=setup:actpass\r
+a=ssrc:2509634557 cname:{da5db090-9171-4294-9f7f-eee36c02fdd7}`;
+
+  [sdpWithoutUnreferencedAttributes, sdpWithUnreferencedAttributes].forEach(sdp => {
+    const unreferencedPts = [99, 121, 122, 123];
+    const shouldRemoveUnreferenced = sdp === sdpWithUnreferencedAttributes;
+
+    it(`should ${shouldRemoveUnreferenced ? 'remove unreferenced codec attributes' : 'do nothing when no unreferenced attributes'}`, () => {
+      const sdp1 = removeUnreferencedCodecAttributes(sdp);
+      if (shouldRemoveUnreferenced) {
+        const mediaSections = getMediaSections(sdp);
+        const mediaSections1 = getMediaSections(sdp1);
+        mediaSections.forEach((mediaSection, i) => {
+          if (!/^m=video/.test(mediaSections1[i])) {
+            assert.equal(mediaSections1[i], mediaSection);
+          } else {
+            const lines = mediaSections1[i].split('\r\n');
+            const pts = lines[0].match(/(\d+)/g).slice(1).map(pt => parseInt(pt, 10));
+
+            assert.deepEqual(pts, [120, 126, 97, 105, 103]);
+
+            unreferencedPts.forEach(unreferencedPt => {
+              assert(!pts.includes(unreferencedPt));
+              const unreferencedLines = lines.filter(line =>
+                new RegExp(`^a=(fmtp|rtpmap|rtcp-fb):${unreferencedPt}\\b`).test(line)
+              );
+              assert.equal(unreferencedLines.length, 0, `Found unreferenced attributes for PT ${unreferencedPt}`);
+            });
+
+            const hasUnreferencedFmtp121 = /a=fmtp:121/.test(mediaSections1[i]);
+            assert.equal(hasUnreferencedFmtp121, false);
           }
         });
       } else {


### PR DESCRIPTION
## Pull Request Details

### Description
Fixes Firefox bug where `setCodecPreferences` leaves unreferenced codec attributes (fmtp, rtpmap, rtcp-fb) for filtered payload types, causing other browsers to reject the SDP during negotiation.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
