### PR TITLE
[VBLOCKS-5974] update firefox images

### DIFF
--- a/.circleci/images/chrome/beta/Dockerfile
+++ b/.circleci/images/chrome/beta/Dockerfile
@@ -14,11 +14,12 @@ RUN echo "Installing Chrome: $BVER" \
 && echo "Installing xvfb from apt-get" \
 # cypress testing dependencies
 && apt-get install -y xvfb libgbm-dev libgbm1 libgtk-3-0t64 libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth \
+    dbus dbus-x11 \
 && rm -rf /var/lib/apt/lists/*
 
-# start xvfb automatically to avoid needing to express in circle.yml
+# start dbus and xvfb automatically to avoid needing to express in circle.yml
 ENV DISPLAY :99
-RUN printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
+RUN printf '#!/bin/sh\nmkdir -p /run/dbus\ndbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
   && chmod +x /tmp/entrypoint \
         && sudo mv /tmp/entrypoint /docker-entrypoint.sh
 

--- a/.circleci/images/chrome/beta/Dockerfile
+++ b/.circleci/images/chrome/beta/Dockerfile
@@ -17,9 +17,12 @@ RUN echo "Installing Chrome: $BVER" \
     dbus dbus-x11 \
 && rm -rf /var/lib/apt/lists/*
 
+# Pre-create dbus directory at build time (as root)
+RUN mkdir -p /run/dbus && chmod 755 /run/dbus
+
 # start dbus and xvfb automatically to avoid needing to express in circle.yml
 ENV DISPLAY :99
-RUN printf '#!/bin/sh\nmkdir -p /run/dbus\ndbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
+RUN printf '#!/bin/sh\ndbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nsleep 1\nexec "$@"\n' > /tmp/entrypoint \
   && chmod +x /tmp/entrypoint \
         && sudo mv /tmp/entrypoint /docker-entrypoint.sh
 

--- a/.circleci/images/chrome/stable/Dockerfile
+++ b/.circleci/images/chrome/stable/Dockerfile
@@ -31,7 +31,7 @@ USER circleci
 
 # start dbus and xvfb automatically to avoid needing to express in circle.yml
 ENV DISPLAY :99
-RUN printf '#!/bin/sh\nmkdir -p /run/dbus\ndbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
+RUN printf '#!/bin/sh\nsudo mkdir -p /run/dbus\nsudo dbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
   && chmod +x /tmp/entrypoint \
         && sudo mv /tmp/entrypoint /docker-entrypoint.sh
 

--- a/.circleci/images/chrome/stable/Dockerfile
+++ b/.circleci/images/chrome/stable/Dockerfile
@@ -19,7 +19,8 @@ apt-get install -y iproute2 &&\
 echo "Installing google-chrome-$BVER from apt-get" &&\
 apt-get install -y google-chrome-$BVER &&\
 # cypress testing dependencies
-apt-get install -y iptables xvfb libgbm-dev libgbm1 libgtk-3-0t64 libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth &&\
+apt-get install -y iptables xvfb libgbm-dev libgbm1 libgtk-3-0t64 libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth \
+    dbus dbus-x11 &&\
 rm -rf /var/lib/apt/lists/* &&\
 adduser user1 &&\
 adduser user1 sudo &&\
@@ -28,9 +29,9 @@ su - user1
 # Switch back to user - circleci
 USER circleci
 
-# start xvfb automatically to avoid needing to express in circle.yml
+# start dbus and xvfb automatically to avoid needing to express in circle.yml
 ENV DISPLAY :99
-RUN printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
+RUN printf '#!/bin/sh\nmkdir -p /run/dbus\ndbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
   && chmod +x /tmp/entrypoint \
         && sudo mv /tmp/entrypoint /docker-entrypoint.sh
 

--- a/.circleci/images/chrome/stable/Dockerfile
+++ b/.circleci/images/chrome/stable/Dockerfile
@@ -26,12 +26,15 @@ adduser user1 &&\
 adduser user1 sudo &&\
 su - user1
 
+# Pre-create dbus directory at build time (as root)
+RUN mkdir -p /run/dbus && chmod 755 /run/dbus
+
 # Switch back to user - circleci
 USER circleci
 
 # start dbus and xvfb automatically to avoid needing to express in circle.yml
 ENV DISPLAY :99
-RUN printf '#!/bin/sh\nsudo mkdir -p /run/dbus\nsudo dbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
+RUN printf '#!/bin/sh\nsudo dbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nsleep 1\nexec "$@"\n' > /tmp/entrypoint \
   && chmod +x /tmp/entrypoint \
         && sudo mv /tmp/entrypoint /docker-entrypoint.sh
 

--- a/.circleci/images/chrome/unstable/Dockerfile
+++ b/.circleci/images/chrome/unstable/Dockerfile
@@ -14,11 +14,12 @@ RUN echo "Installing Chrome: $BVER" \
 && echo "Installing xvfb from apt-get" \
 # cypress testing dependencies
 && apt-get install -y xvfb libgbm-dev libgbm1 libgtk-3-0t64 libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth \
+    dbus dbus-x11 \
 && rm -rf /var/lib/apt/lists/*
 
-# start xvfb automatically to avoid needing to express in circle.yml
+# start dbus and xvfb automatically to avoid needing to express in circle.yml
 ENV DISPLAY :99
-RUN printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
+RUN printf '#!/bin/sh\nmkdir -p /run/dbus\ndbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
   && chmod +x /tmp/entrypoint \
         && sudo mv /tmp/entrypoint /docker-entrypoint.sh
 

--- a/.circleci/images/chrome/unstable/Dockerfile
+++ b/.circleci/images/chrome/unstable/Dockerfile
@@ -17,9 +17,12 @@ RUN echo "Installing Chrome: $BVER" \
     dbus dbus-x11 \
 && rm -rf /var/lib/apt/lists/*
 
+# Pre-create dbus directory at build time (as root)
+RUN mkdir -p /run/dbus && chmod 755 /run/dbus
+
 # start dbus and xvfb automatically to avoid needing to express in circle.yml
 ENV DISPLAY :99
-RUN printf '#!/bin/sh\nmkdir -p /run/dbus\ndbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
+RUN printf '#!/bin/sh\ndbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nsleep 1\nexec "$@"\n' > /tmp/entrypoint \
   && chmod +x /tmp/entrypoint \
         && sudo mv /tmp/entrypoint /docker-entrypoint.sh
 

--- a/.circleci/images/firefox/beta/Dockerfile
+++ b/.circleci/images/firefox/beta/Dockerfile
@@ -38,12 +38,15 @@ ldconfig &&\
 adduser --disabled-password --gecos "" user1 &&\
 adduser user1 sudo
 
+# Pre-create dbus directory at build time (as root)
+RUN mkdir -p /run/dbus && chmod 755 /run/dbus
+
 # Switch back to user - circleci
 USER circleci
 
 # start dbus and xvfb automatically to avoid needing to express in circle.yml
 ENV DISPLAY :99
-RUN printf '#!/bin/sh\nsudo mkdir -p /run/dbus\nsudo dbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
+RUN printf '#!/bin/sh\nsudo dbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nsleep 1\nexec "$@"\n' > /tmp/entrypoint \
   && chmod +x /tmp/entrypoint \
         && sudo mv /tmp/entrypoint /docker-entrypoint.sh
 

--- a/.circleci/images/firefox/beta/Dockerfile
+++ b/.circleci/images/firefox/beta/Dockerfile
@@ -43,7 +43,7 @@ USER circleci
 
 # start dbus and xvfb automatically to avoid needing to express in circle.yml
 ENV DISPLAY :99
-RUN printf '#!/bin/sh\nmkdir -p /run/dbus\ndbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
+RUN printf '#!/bin/sh\nsudo mkdir -p /run/dbus\nsudo dbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
   && chmod +x /tmp/entrypoint \
         && sudo mv /tmp/entrypoint /docker-entrypoint.sh
 

--- a/.circleci/images/firefox/beta/Dockerfile
+++ b/.circleci/images/firefox/beta/Dockerfile
@@ -1,33 +1,45 @@
 FROM cimg/node:current-browsers
 
 #
-# Install Java 11 LTS / OpenJDK 11
+# Install Java 11 LTS / OpenJDK 11 and dependencies
 #
-RUN if grep -q Debian /etc/os-release && grep -q stretch /etc/os-release; then \
-		echo 'deb http://deb.debian.org/debian stretch-backports main' | sudo tee -a /etc/apt/sources.list.d/stretch-backports.list; \
-	elif grep -q Ubuntu /etc/os-release && grep -q xenial /etc/os-release; then \
-		sudo apt-get update && sudo apt-get install -y software-properties-common && \
-		sudo add-apt-repository -y ppa:openjdk-r/ppa; \
-	fi && \
-	sudo apt-get update && sudo apt-get install -y openjdk-11-jre openjdk-11-jre-headless openjdk-11-jdk openjdk-11-jdk-headless && \
-	sudo apt-get install -y bzip2 libgconf-2-4 xvfb libgbm-dev libgbm1 libgtk-3-0t64 libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth \
-		dbus dbus-x11 # for extracting firefox, running chrome, and cypress testing dependencies
+RUN sudo apt-get update && \
+	sudo apt-get install -y openjdk-11-jre openjdk-11-jre-headless openjdk-11-jdk openjdk-11-jdk-headless && \
+	sudo apt-get install -y bzip2 xvfb libgbm-dev libgbm1 libnotify-dev libnss3 libxss1 libxtst6 xauth \
+		dbus dbus-x11 && \
+	(sudo apt-get install -y libgtk-3-0 libasound2 || sudo apt-get install -y libgtk-3-0t64 libasound2t64) # for extracting firefox, running chrome, and cypress testing dependencies
 
 #
 # install firefox
 #
 RUN FIREFOX_URL="https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=linux64&lang=en-US" \
   && ACTUAL_URL=$(curl -Ls -o /dev/null -w %{url_effective} $FIREFOX_URL) \
-  && curl --silent --show-error --location --fail --retry 3 --output /tmp/firefox.tar.bz2 $ACTUAL_URL \
-  && sudo tar -xvjf /tmp/firefox.tar.bz2 -C /opt \
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/firefox.tar $ACTUAL_URL \
+  && sudo tar -xvf /tmp/firefox.tar -C /opt \
   && sudo ln -s /opt/firefox/firefox /usr/local/bin/firefox \
-  && sudo apt-get install -y libgtk3.0-cil-dev libasound2 libasound2 libdbus-glib-1-2 libdbus-1-3 \
+  && sudo apt-get update \
+  && sudo apt-get install -y libdbus-glib-1-2 libdbus-1-3 \
   && rm -rf /tmp/firefox.* \
   && firefox --version
 
 ENV BROWSER='firefox'
 ENV BVER='beta'
 ENV FIREFOX_BIN=/opt/firefox/firefox
+
+# Switch to user - root
+USER root
+
+# Install and enable iptables
+RUN echo "Setting up iptables..." &&\
+apt-get update &&\
+apt-get install -y iproute2 &&\
+apt-get install -y iptables &&\
+ldconfig &&\
+adduser --disabled-password --gecos "" user1 &&\
+adduser user1 sudo
+
+# Switch back to user - circleci
+USER circleci
 
 # start dbus and xvfb automatically to avoid needing to express in circle.yml
 ENV DISPLAY :99

--- a/.circleci/images/firefox/beta/Dockerfile
+++ b/.circleci/images/firefox/beta/Dockerfile
@@ -10,7 +10,8 @@ RUN if grep -q Debian /etc/os-release && grep -q stretch /etc/os-release; then \
 		sudo add-apt-repository -y ppa:openjdk-r/ppa; \
 	fi && \
 	sudo apt-get update && sudo apt-get install -y openjdk-11-jre openjdk-11-jre-headless openjdk-11-jdk openjdk-11-jdk-headless && \
-	sudo apt-get install -y bzip2 libgconf-2-4 xvfb libgbm-dev libgbm1 libgtk-3-0t64 libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth # for extracting firefox, running chrome, and cypress testing dependencies
+	sudo apt-get install -y bzip2 libgconf-2-4 xvfb libgbm-dev libgbm1 libgtk-3-0t64 libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth \
+		dbus dbus-x11 # for extracting firefox, running chrome, and cypress testing dependencies
 
 #
 # install firefox
@@ -28,9 +29,9 @@ ENV BROWSER='firefox'
 ENV BVER='beta'
 ENV FIREFOX_BIN=/opt/firefox/firefox
 
-# start xvfb automatically to avoid needing to express in circle.yml
+# start dbus and xvfb automatically to avoid needing to express in circle.yml
 ENV DISPLAY :99
-RUN printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
+RUN printf '#!/bin/sh\nmkdir -p /run/dbus\ndbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
   && chmod +x /tmp/entrypoint \
         && sudo mv /tmp/entrypoint /docker-entrypoint.sh
 

--- a/.circleci/images/firefox/stable/Dockerfile
+++ b/.circleci/images/firefox/stable/Dockerfile
@@ -5,7 +5,8 @@ FROM cimg/node:current-browsers
 #
 RUN sudo apt-get update && \
 	sudo apt-get install -y openjdk-11-jre openjdk-11-jre-headless openjdk-11-jdk openjdk-11-jdk-headless && \
-	sudo apt-get install -y bzip2 xvfb libgbm-dev libgbm1 libnotify-dev libnss3 libxss1 libxtst6 xauth && \
+	sudo apt-get install -y bzip2 xvfb libgbm-dev libgbm1 libnotify-dev libnss3 libxss1 libxtst6 xauth \
+		dbus dbus-x11 && \
 	(sudo apt-get install -y libgtk-3-0 libasound2 || sudo apt-get install -y libgtk-3-0t64 libasound2t64) # for extracting firefox, running chrome, and cypress testing dependencies
 
 #
@@ -40,9 +41,9 @@ adduser user1 sudo
 # Switch back to user - circleci
 USER circleci
 
-# start xvfb automatically to avoid needing to express in circle.yml
+# start dbus and xvfb automatically to avoid needing to express in circle.yml
 ENV DISPLAY :99
-RUN printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
+RUN printf '#!/bin/sh\nmkdir -p /run/dbus\ndbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
   && chmod +x /tmp/entrypoint \
         && sudo mv /tmp/entrypoint /docker-entrypoint.sh
 

--- a/.circleci/images/firefox/stable/Dockerfile
+++ b/.circleci/images/firefox/stable/Dockerfile
@@ -38,12 +38,15 @@ ldconfig &&\
 adduser --disabled-password --gecos "" user1 &&\
 adduser user1 sudo
 
+# Pre-create dbus directory at build time (as root)
+RUN mkdir -p /run/dbus && chmod 755 /run/dbus
+
 # Switch back to user - circleci
 USER circleci
 
 # start dbus and xvfb automatically to avoid needing to express in circle.yml
 ENV DISPLAY :99
-RUN printf '#!/bin/sh\nsudo mkdir -p /run/dbus\nsudo dbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
+RUN printf '#!/bin/sh\nsudo dbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nsleep 1\nexec "$@"\n' > /tmp/entrypoint \
   && chmod +x /tmp/entrypoint \
         && sudo mv /tmp/entrypoint /docker-entrypoint.sh
 

--- a/.circleci/images/firefox/stable/Dockerfile
+++ b/.circleci/images/firefox/stable/Dockerfile
@@ -43,7 +43,7 @@ USER circleci
 
 # start dbus and xvfb automatically to avoid needing to express in circle.yml
 ENV DISPLAY :99
-RUN printf '#!/bin/sh\nmkdir -p /run/dbus\ndbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
+RUN printf '#!/bin/sh\nsudo mkdir -p /run/dbus\nsudo dbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
   && chmod +x /tmp/entrypoint \
         && sudo mv /tmp/entrypoint /docker-entrypoint.sh
 

--- a/.circleci/images/firefox/stable/Dockerfile
+++ b/.circleci/images/firefox/stable/Dockerfile
@@ -14,8 +14,8 @@ RUN sudo apt-get update && \
 #
 RUN FIREFOX_URL="https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64&lang=en-US" \
   && ACTUAL_URL=$(curl -Ls -o /dev/null -w %{url_effective} $FIREFOX_URL) \
-  && curl --silent --show-error --location --fail --retry 3 --output /tmp/firefox.tar.xz $ACTUAL_URL \
-  && sudo tar -xvJf /tmp/firefox.tar.xz -C /opt \
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/firefox.tar $ACTUAL_URL \
+  && sudo tar -xvf /tmp/firefox.tar -C /opt \
   && sudo ln -s /opt/firefox/firefox /usr/local/bin/firefox \
   && sudo apt-get update \
   && sudo apt-get install -y libdbus-glib-1-2 libdbus-1-3 \

--- a/.circleci/images/firefox/unstable/Dockerfile
+++ b/.circleci/images/firefox/unstable/Dockerfile
@@ -38,12 +38,15 @@ ldconfig &&\
 adduser --disabled-password --gecos "" user1 &&\
 adduser user1 sudo
 
+# Pre-create dbus directory at build time (as root)
+RUN mkdir -p /run/dbus && chmod 755 /run/dbus
+
 # Switch back to user - circleci
 USER circleci
 
 # start dbus and xvfb automatically to avoid needing to express in circle.yml
 ENV DISPLAY :99
-RUN printf '#!/bin/sh\nsudo mkdir -p /run/dbus\nsudo dbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
+RUN printf '#!/bin/sh\nsudo dbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nsleep 1\nexec "$@"\n' > /tmp/entrypoint \
   && chmod +x /tmp/entrypoint \
         && sudo mv /tmp/entrypoint /docker-entrypoint.sh
 

--- a/.circleci/images/firefox/unstable/Dockerfile
+++ b/.circleci/images/firefox/unstable/Dockerfile
@@ -43,7 +43,7 @@ USER circleci
 
 # start dbus and xvfb automatically to avoid needing to express in circle.yml
 ENV DISPLAY :99
-RUN printf '#!/bin/sh\nmkdir -p /run/dbus\ndbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
+RUN printf '#!/bin/sh\nsudo mkdir -p /run/dbus\nsudo dbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
   && chmod +x /tmp/entrypoint \
         && sudo mv /tmp/entrypoint /docker-entrypoint.sh
 

--- a/.circleci/images/firefox/unstable/Dockerfile
+++ b/.circleci/images/firefox/unstable/Dockerfile
@@ -1,33 +1,45 @@
 FROM cimg/node:current-browsers
 
 #
-# Install Java 11 LTS / OpenJDK 11
+# Install Java 11 LTS / OpenJDK 11 and dependencies
 #
-RUN if grep -q Debian /etc/os-release && grep -q stretch /etc/os-release; then \
-		echo 'deb http://deb.debian.org/debian stretch-backports main' | sudo tee -a /etc/apt/sources.list.d/stretch-backports.list; \
-	elif grep -q Ubuntu /etc/os-release && grep -q xenial /etc/os-release; then \
-		sudo apt-get update && sudo apt-get install -y software-properties-common && \
-		sudo add-apt-repository -y ppa:openjdk-r/ppa; \
-	fi && \
-	sudo apt-get update && sudo apt-get install -y openjdk-11-jre openjdk-11-jre-headless openjdk-11-jdk openjdk-11-jdk-headless && \
-	sudo apt-get install -y bzip2 libgconf-2-4 xvfb libgbm-dev libgbm1 libgtk-3-0t64 libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth \
-		dbus dbus-x11 # for extracting firefox, running chrome, and cypress testing dependencies
+RUN sudo apt-get update && \
+	sudo apt-get install -y openjdk-11-jre openjdk-11-jre-headless openjdk-11-jdk openjdk-11-jdk-headless && \
+	sudo apt-get install -y bzip2 xvfb libgbm-dev libgbm1 libnotify-dev libnss3 libxss1 libxtst6 xauth \
+		dbus dbus-x11 && \
+	(sudo apt-get install -y libgtk-3-0 libasound2 || sudo apt-get install -y libgtk-3-0t64 libasound2t64) # for extracting firefox, running chrome, and cypress testing dependencies
 
 #
 # install firefox
 #
 RUN FIREFOX_URL="https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US" \
   && ACTUAL_URL=$(curl -Ls -o /dev/null -w %{url_effective} $FIREFOX_URL) \
-  && curl --silent --show-error --location --fail --retry 3 --output /tmp/firefox.tar.bz2 $ACTUAL_URL \
-  && sudo tar -xvjf /tmp/firefox.tar.bz2 -C /opt \
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/firefox.tar $ACTUAL_URL \
+  && sudo tar -xvf /tmp/firefox.tar -C /opt \
   && sudo ln -s /opt/firefox/firefox /usr/local/bin/firefox \
-  && sudo apt-get install -y libgtk3.0-cil-dev libasound2 libasound2 libdbus-glib-1-2 libdbus-1-3 \
+  && sudo apt-get update \
+  && sudo apt-get install -y libdbus-glib-1-2 libdbus-1-3 \
   && rm -rf /tmp/firefox.* \
   && firefox --version
 
 ENV BROWSER='firefox'
 ENV BVER='unstable'
 ENV FIREFOX_BIN=/opt/firefox/firefox
+
+# Switch to user - root
+USER root
+
+# Install and enable iptables
+RUN echo "Setting up iptables..." &&\
+apt-get update &&\
+apt-get install -y iproute2 &&\
+apt-get install -y iptables &&\
+ldconfig &&\
+adduser --disabled-password --gecos "" user1 &&\
+adduser user1 sudo
+
+# Switch back to user - circleci
+USER circleci
 
 # start dbus and xvfb automatically to avoid needing to express in circle.yml
 ENV DISPLAY :99

--- a/.circleci/images/firefox/unstable/Dockerfile
+++ b/.circleci/images/firefox/unstable/Dockerfile
@@ -10,7 +10,8 @@ RUN if grep -q Debian /etc/os-release && grep -q stretch /etc/os-release; then \
 		sudo add-apt-repository -y ppa:openjdk-r/ppa; \
 	fi && \
 	sudo apt-get update && sudo apt-get install -y openjdk-11-jre openjdk-11-jre-headless openjdk-11-jdk openjdk-11-jdk-headless && \
-	sudo apt-get install -y bzip2 libgconf-2-4 xvfb libgbm-dev libgbm1 libgtk-3-0t64 libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth # for extracting firefox, running chrome, and cypress testing dependencies
+	sudo apt-get install -y bzip2 libgconf-2-4 xvfb libgbm-dev libgbm1 libgtk-3-0t64 libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth \
+		dbus dbus-x11 # for extracting firefox, running chrome, and cypress testing dependencies
 
 #
 # install firefox
@@ -28,9 +29,9 @@ ENV BROWSER='firefox'
 ENV BVER='unstable'
 ENV FIREFOX_BIN=/opt/firefox/firefox
 
-# start xvfb automatically to avoid needing to express in circle.yml
+# start dbus and xvfb automatically to avoid needing to express in circle.yml
 ENV DISPLAY :99
-RUN printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
+RUN printf '#!/bin/sh\nmkdir -p /run/dbus\ndbus-daemon --system --fork 2>/dev/null || true\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
   && chmod +x /tmp/entrypoint \
         && sudo mv /tmp/entrypoint /docker-entrypoint.sh
 


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

https://twilio-engineering.atlassian.net/browse/VBLOCKS-5974

### Description
  - Fix Cypress startup failures across Chrome and Firefox Docker images caused by missing D-Bus daemon and X server initialization
  - Sync Firefox beta/unstable Dockerfiles with Firefox stable to fix build failures and ensure consistency
    - Firefox Beta is now 148, and Firefox Unstable is now 149
    - [Build workflow](https://app.circleci.com/pipelines/github/twilio/twilio-video.js/12429/workflows/a81bc043-977d-49ba-b626-e0eafe6abf29)
  - Standardize Chrome beta/unstable Dockerfiles with Chrome stable dependencies

#### Note
Look through following thread if need to revisit: https://github.com/puppeteer/puppeteer/issues/8148

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review
