### PR TITLE
fix: remove unnecessary RegExp construction in enableDtxForOpus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changes
 -------
 - Removed legacy Plan-B SDP support.
 - Removed legacy WebRTC shims for Chrome.
+- Replaced dynamic `RegExp` construction with literal string replacement in `enableDtxForOpus`.
 
 2.34.0 (January 8, 2026)
 ====================

--- a/lib/util/sdp/index.js
+++ b/lib/util/sdp/index.js
@@ -415,7 +415,6 @@ function enableDtxForOpus(sdp, mids) {
 
     // Add usedtx=1 to the a=fmtp: line for opus.
     const origOpusFmtpLine = generateFmtpLineFromPtAndAttributes(opusPt, opusFmtpAttrs);
-    const origOpusFmtpRegex = new RegExp(origOpusFmtpLine);
 
     // If the m= section's MID is in the list of MIDs, then enable dtx. Otherwise disable it.
     const mid = getMidForMediaSection(section);
@@ -426,7 +425,7 @@ function enableDtxForOpus(sdp, mids) {
     }
 
     const opusFmtpLineWithDtx = generateFmtpLineFromPtAndAttributes(opusPt, opusFmtpAttrs);
-    return section.replace(origOpusFmtpRegex, opusFmtpLineWithDtx);
+    return section.replace(origOpusFmtpLine, opusFmtpLineWithDtx);
   })).join('\r\n');
 }
 


### PR DESCRIPTION
## Pull Request Details

### Description

Simplify `enableDtxForOpus` by using `String.prototype.replace()` with a string pattern instead of constructing a `RegExp` at runtime.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
