### PR TITLE
[VBLOCKS-6434] feat: add Samsung Internet Browser support

### DIFF
--- a/lib/util/support.js
+++ b/lib/util/support.js
@@ -8,11 +8,13 @@ const SUPPORTED_CHROME_BASED_BROWSERS = [
   'edg',
   'edge',
   'electron',
-  'headlesschrome'
+  'headlesschrome',
+  'samsungbrowser'
 ];
 const SUPPORTED_ANDROID_BROWSERS = [
   'chrome',
-  'firefox'
+  'firefox',
+  'samsungbrowser'
 ];
 const SUPPORTED_IOS_BROWSERS = [
   'chrome',

--- a/lib/util/support.js
+++ b/lib/util/support.js
@@ -13,8 +13,7 @@ const SUPPORTED_CHROME_BASED_BROWSERS = [
 ];
 const SUPPORTED_ANDROID_BROWSERS = [
   'chrome',
-  'firefox',
-  'samsungbrowser'
+  'firefox'
 ];
 const SUPPORTED_IOS_BROWSERS = [
   'chrome',

--- a/test/unit/spec/util/support.js
+++ b/test/unit/spec/util/support.js
@@ -118,6 +118,10 @@ describe('isSupported', () => {
       'Edge on iPhone',
       'Mozilla/5.0 (iPhone; CPU iPhone OS 14_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 EdgiOS/46.3.13 Mobile/15E148 Safari/605.1.15'
     ],
+    [
+      'Samsung Browser on Android',
+      'Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G950U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Mobile Safari/537.36'
+    ],
   ].forEach(([browser, useragent, chrome]) => {
     it('returns true for supported browser: ' + browser, () => {
       navigator.userAgent = useragent;
@@ -193,10 +197,6 @@ describe('isSupported', () => {
     [
       'Opera',
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36 OPR/56.0.3051.52'
-    ],
-    [
-      'Samsung Browser',
-      'Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G950U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Mobile Safari/537.36'
     ]
   ].forEach(([browser, useragent, chrome, brave]) => {
     it('returns false for unsupported browser: ' + browser, () => {


### PR DESCRIPTION
## Pull Request Details

### Description

Add Samsung Internet Browser to the list of supported Chromium-based browsers.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
