### PR TITLE
ci: pin Docker images by digest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ executors:
       <<: *defaultEnv
   generic-executor:
     docker:
-      - image: alpine:3.21
+      - image: alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
         auth:
           username: $DOCKER_HUB_USERNAME
           password: $DOCKER_HUB_PASSWORD
@@ -280,7 +280,7 @@ jobs:
 
   trigger-qe-tests:
     docker:
-      - image: circleci/node:latest
+      - image: cimg/node:24.15.0@sha256:0a67b6fa151ceac233d469a5915ca75a4a1c9e3854502ed7cc236f18c3a4f5c3
         auth:
           username: $DOCKER_HUB_USERNAME
           password: $DOCKER_HUB_PASSWORD

--- a/.circleci/images/chrome/beta/Dockerfile
+++ b/.circleci/images/chrome/beta/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/node:current-browsers
+FROM cimg/node:24.15.0-browsers@sha256:992b985d8f2f5dc239ced6c2e8008cb83c4763afb57f2e8ec8908095e0ebacfe
 
 USER root
 ENV BROWSER='chrome'

--- a/.circleci/images/chrome/stable/Dockerfile
+++ b/.circleci/images/chrome/stable/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/r/browserless/chrome/dockerfile/
-FROM cimg/node:lts
+FROM cimg/node:24.15.0@sha256:0a67b6fa151ceac233d469a5915ca75a4a1c9e3854502ed7cc236f18c3a4f5c3
 
 # install selected browser / version
 ENV BROWSER='chrome'

--- a/.circleci/images/chrome/unstable/Dockerfile
+++ b/.circleci/images/chrome/unstable/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/node:current-browsers
+FROM cimg/node:24.15.0-browsers@sha256:992b985d8f2f5dc239ced6c2e8008cb83c4763afb57f2e8ec8908095e0ebacfe
 
 USER root
 ENV BROWSER='chrome'

--- a/.circleci/images/firefox/beta/Dockerfile
+++ b/.circleci/images/firefox/beta/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/node:current-browsers
+FROM cimg/node:24.15.0-browsers@sha256:992b985d8f2f5dc239ced6c2e8008cb83c4763afb57f2e8ec8908095e0ebacfe
 
 #
 # Install Java 11 LTS / OpenJDK 11

--- a/.circleci/images/firefox/stable/Dockerfile
+++ b/.circleci/images/firefox/stable/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/node:lts
+FROM cimg/node:24.15.0@sha256:0a67b6fa151ceac233d469a5915ca75a4a1c9e3854502ed7cc236f18c3a4f5c3
 
 #
 # Install Java 11 LTS / OpenJDK 11

--- a/.circleci/images/firefox/unstable/Dockerfile
+++ b/.circleci/images/firefox/unstable/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/node:current-browsers
+FROM cimg/node:24.15.0-browsers@sha256:992b985d8f2f5dc239ced6c2e8008cb83c4763afb57f2e8ec8908095e0ebacfe
 
 #
 # Install Java 11 LTS / OpenJDK 11


### PR DESCRIPTION
## Pull Request Details

### Description

Pin Docker images by SHA256 digest:
- [alpine:3.21](https://hub.docker.com/layers/library/alpine/3.21/images/sha256-48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d)
- [cimg/node:24.15.0](https://hub.docker.com/layers/cimg/node/24.15.0/images/sha256-0a67b6fa151ceac233d469a5915ca75a4a1c9e3854502ed7cc236f18c3a4f5c3)
- [cimg/node:24.15.0-browsers](https://hub.docker.com/layers/cimg/node/24.15.0-browsers/images/sha256-992b985d8f2f5dc239ced6c2e8008cb83c4763afb57f2e8ec8908095e0ebacfe)

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
