### PR TITLE
feat: support @twilio/krisp-audio-plugin 2.x

### DIFF
--- a/lib/media/track/noisecancellationimpl.ts
+++ b/lib/media/track/noisecancellationimpl.ts
@@ -16,10 +16,18 @@ const Log = require('../../util/log');
  * const { connect, createLocalAudioTrack } = require('twilio-video');
  *
  * // Create a LocalAudioTrack with Krisp noise cancellation enabled.
+ * // Supported plugin versions: @twilio/krisp-audio-plugin 1.x or 2.x.
  * const localAudioTrack = await createLocalAudioTrack({
  *   noiseCancellationOptions: {
- *     sdkAssetsPath: 'path/to/hosted/twilio/krisp/audio/plugin/1.0.0/dist',
+ *     sdkAssetsPath: 'path/to/hosted/twilio/krisp/audio/plugin/{version}/dist',
  *     vendor: 'krisp'
+ *   },
+ *   // Required for @twilio/krisp-audio-plugin 2.x only, so Krisp receives
+ *   // the raw microphone signal. Omit these for 1.x.
+ *   audio: {
+ *     echoCancellation: false,
+ *     noiseSuppression: false,
+ *     autoGainControl: false
  *   }
  * });
  *
@@ -130,7 +138,7 @@ export class NoiseCancellationImpl implements NoiseCancellation {
     const track = await reacquire();
     this._sourceTrack = track;
 
-    const processedTrack = await this._processor.connect(track);
+    const processedTrack = this._processor.connect(track);
     if (processorWasEnabled) {
       this._processor.enable();
     } else {

--- a/lib/media/track/noisecancellationimpl.ts
+++ b/lib/media/track/noisecancellationimpl.ts
@@ -24,11 +24,9 @@ const Log = require('../../util/log');
  *   },
  *   // Required for @twilio/krisp-audio-plugin 2.x only, so Krisp receives
  *   // the raw microphone signal. Omit these for 1.x.
- *   audio: {
- *     echoCancellation: false,
- *     noiseSuppression: false,
- *     autoGainControl: false
- *   }
+ *   echoCancellation: false,
+ *   noiseSuppression: false,
+ *   autoGainControl: false
  * });
  *
  * if (!localAudioTrack.noiseCancellation) {

--- a/lib/noisecancellation/legacy-plugin-adapter.ts
+++ b/lib/noisecancellation/legacy-plugin-adapter.ts
@@ -1,0 +1,53 @@
+import type { NoiseCancellationPlugin } from './plugin';
+
+const AudioContextFactory = require('../webaudio/audiocontext');
+
+// Legacy Krisp 1.x and rnnoise 0.x
+export type LegacyPlugin = {
+  init(options: { rootDir: string }): Promise<void>;
+  isInitialized(): boolean;
+  isConnected(): boolean;
+  isEnabled(): boolean;
+  connect(input: MediaStream): MediaStream;
+  disconnect(): void;
+  enable(): void;
+  disable(): void;
+  destroy(): void;
+  setLogging(enable: boolean): void;
+  isSupported(audioContext: AudioContext): boolean;
+  getVersion(): string;
+}
+
+export class LegacyPluginAdapter implements NoiseCancellationPlugin {
+  private readonly legacy: LegacyPlugin;
+
+  constructor(legacy: LegacyPlugin) {
+    this.legacy = legacy;
+  }
+
+  init(options: { rootDir: string }): Promise<void> { return this.legacy.init(options); }
+  isInitialized(): boolean { return this.legacy.isInitialized(); }
+  isConnected(): boolean { return this.legacy.isConnected(); }
+  isEnabled(): boolean { return this.legacy.isEnabled(); }
+  connect(input: MediaStream): MediaStream { return this.legacy.connect(input); }
+  disconnect(): void { this.legacy.disconnect(); }
+  enable(): void { this.legacy.enable(); }
+  disable(): void { this.legacy.disable(); }
+  setLogging(enable: boolean): void { this.legacy.setLogging(enable); }
+  getVersion(): string { return this.legacy.getVersion(); }
+
+  isSupported(): boolean {
+    const holder = {};
+    const ctx = AudioContextFactory.getOrCreate(holder);
+    try {
+      return this.legacy.isSupported(ctx);
+    } finally {
+      AudioContextFactory.release(holder);
+    }
+  }
+
+  destroy(): Promise<void> {
+    this.legacy.destroy();
+    return Promise.resolve();
+  }
+}

--- a/lib/noisecancellation/legacy-plugin-adapter.ts
+++ b/lib/noisecancellation/legacy-plugin-adapter.ts
@@ -39,11 +39,8 @@ export class LegacyPluginAdapter implements NoiseCancellationPlugin {
   isSupported(): boolean {
     const holder = {};
     const ctx: AudioContext | null = AudioContextFactory.getOrCreate(holder);
-    if (!ctx) {
-      return false;
-    }
     try {
-      return this.legacy.isSupported(ctx);
+      return !!ctx && this.legacy.isSupported(ctx);
     } finally {
       AudioContextFactory.release(holder);
     }

--- a/lib/noisecancellation/legacy-plugin-adapter.ts
+++ b/lib/noisecancellation/legacy-plugin-adapter.ts
@@ -47,7 +47,8 @@ export class LegacyPluginAdapter implements NoiseCancellationPlugin {
   }
 
   destroy(): Promise<void> {
-    this.legacy.destroy();
-    return Promise.resolve();
+    return Promise.resolve().then(() => {
+      this.legacy.destroy();
+    });
   }
 }

--- a/lib/noisecancellation/legacy-plugin-adapter.ts
+++ b/lib/noisecancellation/legacy-plugin-adapter.ts
@@ -38,7 +38,10 @@ export class LegacyPluginAdapter implements NoiseCancellationPlugin {
 
   isSupported(): boolean {
     const holder = {};
-    const ctx = AudioContextFactory.getOrCreate(holder);
+    const ctx: AudioContext | null = AudioContextFactory.getOrCreate(holder);
+    if (!ctx) {
+      return false;
+    }
     try {
       return this.legacy.isSupported(ctx);
     } finally {

--- a/lib/noisecancellation/legacy-plugin-adapter.ts
+++ b/lib/noisecancellation/legacy-plugin-adapter.ts
@@ -16,7 +16,7 @@ export type LegacyPlugin = {
   setLogging(enable: boolean): void;
   isSupported(audioContext: AudioContext): boolean;
   getVersion(): string;
-}
+};
 
 export class LegacyPluginAdapter implements NoiseCancellationPlugin {
   private readonly legacy: LegacyPlugin;

--- a/lib/noisecancellation/plugin.ts
+++ b/lib/noisecancellation/plugin.ts
@@ -1,0 +1,14 @@
+export type NoiseCancellationPlugin = {
+  init(options: { rootDir: string }): Promise<void>;
+  isInitialized(): boolean;
+  isConnected(): boolean;
+  isEnabled(): boolean;
+  connect(input: MediaStream): MediaStream;
+  disconnect(): void;
+  enable(): void;
+  disable(): void;
+  destroy(): Promise<void>;
+  setLogging(enable: boolean): void;
+  isSupported(): boolean;
+  getVersion(): string;
+};

--- a/lib/noisecancellationadapter.ts
+++ b/lib/noisecancellationadapter.ts
@@ -1,65 +1,54 @@
 'use strict';
 
+import { LegacyPlugin, LegacyPluginAdapter } from './noisecancellation/legacy-plugin-adapter';
 import type { AudioProcessor } from '../tsdef/AudioProcessor';
 import type { NoiseCancellationOptions } from '../tsdef/types';
+import type { NoiseCancellationPlugin } from './noisecancellation/plugin';
 
 const dynamicImport = require('./util/dynamicimport');
 const Log = require('./util/log');
 
 const PLUGIN_CONFIG = {
   krisp: {
-    supportedVersion: '1.0.0',
+    supportedVersions: ['1.0.0', '2.0.0'],
     pluginFile: 'krispsdk.mjs'
   },
   rnnoise: {
-    supportedVersion: '0.6.0',
+    supportedVersions: ['0.6.0'],
     pluginFile: 'rnnoise_sdk.mjs'
   }
 };
 
-// AudioProcessor assumes following interface from the Plugin
-interface NoiseCancellationPlugin {
-  init(options: { rootDir: string }): Promise<void>;
-  isInitialized(): boolean;
-  isConnected(): boolean;
-  isEnabled(): boolean
-  connect(input: MediaStream): MediaStream;
-  disconnect(): void;
-  enable(): void;
-  disable(): void;
-  destroy(): void;
-  setLogging(enable: boolean):void;
-  isSupported(audioContext: AudioContext):boolean;
-  getVersion(): string;
-}
+const parseVersion = (version: string): number[] => {
+  const parts = version.split('.').map(v => Number(v));
+  if (parts.length !== 3 || parts.some(Number.isNaN)) {
+    throw new Error(`Unsupported Plugin version format: ${version}`);
+  }
+  return parts;
+};
 
-const ensureVersionSupported = ({ supportedVersion, plugin, log }: { supportedVersion: string, plugin: NoiseCancellationPlugin, log: typeof Log }) : void => {
-  if (!plugin.getVersion || !plugin.isSupported) {
-    throw new Error('Plugin does not export getVersion/isSupported api. Are you using old version of the plugin ?');
+const ensureVersionCompatible = ({ supportedVersions, pluginVersion }: {
+  supportedVersions: string[],
+  pluginVersion: string,
+}): void => {
+  const pluginParts = parseVersion(pluginVersion);
+
+  const match = supportedVersions
+    .map(parseVersion)
+    .find(parts => parts[0] === pluginParts[0]);
+  if (!match) {
+    throw new Error(`Major version mismatch: [Plugin version ${pluginVersion}], [Supported Versions ${supportedVersions.join(', ')}]`);
   }
 
-  const pluginVersion = plugin.getVersion();
-  log.debug(`Plugin Version = ${pluginVersion}`);
-  const supportedVersions = supportedVersion.split('.').map(version => Number(version));
-  const pluginVersions = pluginVersion.split('.').map(version => Number(version));
-  if (supportedVersions.length !== 3 || pluginVersions.length !== 3) {
-    throw new Error(`Unsupported Plugin version format: ${supportedVersion}, ${pluginVersion}`);
+  if (pluginParts[1] < match[1]) {
+    throw new Error(`Minor version mismatch: [Plugin version ${pluginVersion}] < [Supported Version ${match.join('.')}]`);
   }
+};
 
-  if (supportedVersions[0] !== pluginVersions[0]) {
-    throw new Error(`Major version mismatch: [Plugin version ${pluginVersion}],  [Supported Version ${supportedVersion}]`);
-  }
-
-  if (pluginVersions[1] < supportedVersions[1]) {
-    throw new Error(`Minor version mismatch: [Plugin version ${pluginVersion}] < [Supported Version ${supportedVersion}]`);
-  }
-
-  const tempContext = new AudioContext();
-  const isSupported = plugin.isSupported(tempContext);
-  tempContext.close();
-  if (!isSupported) {
-    throw new Error('Noise Cancellation plugin is not supported on your browser');
-  }
+const adaptPlugin = (maybeLegacyPlugin: NoiseCancellationPlugin | LegacyPlugin, major: number): NoiseCancellationPlugin => {
+  return major >= 2
+    ? maybeLegacyPlugin as NoiseCancellationPlugin
+    : new LegacyPluginAdapter(maybeLegacyPlugin as LegacyPlugin);
 };
 
 let audioProcessors = new Map<string, AudioProcessor>();
@@ -74,21 +63,26 @@ export async function createNoiseCancellationAudioProcessor(
       throw new Error(`Unsupported NoiseCancellationOptions.vendor: ${noiseCancellationOptions.vendor}`);
     }
 
-    const { supportedVersion, pluginFile } =  pluginConfig;
-    const  rootDir = noiseCancellationOptions.sdkAssetsPath;
-    const  sdkFilePath = `${rootDir}/${pluginFile}`;
+    const { supportedVersions, pluginFile } = pluginConfig;
+    const rootDir = noiseCancellationOptions.sdkAssetsPath;
+    const sdkFilePath = `${rootDir}/${pluginFile}`;
 
     try {
       log.debug('loading noise cancellation sdk: ', sdkFilePath);
       const dynamicModule = await dynamicImport(sdkFilePath);
       log.debug('Loaded noise cancellation sdk:', dynamicModule);
 
-      const plugin = dynamicModule.default as NoiseCancellationPlugin;
-      ensureVersionSupported({
-        supportedVersion,
-        plugin,
-        log
-      });
+      const maybeLegacyPlugin = dynamicModule.default as NoiseCancellationPlugin | LegacyPlugin;
+      const pluginVersion = maybeLegacyPlugin.getVersion();
+
+      ensureVersionCompatible({ supportedVersions, pluginVersion });
+
+      const major = parseVersion(pluginVersion)[0];
+      const plugin = adaptPlugin(maybeLegacyPlugin, major);
+
+      if (!plugin.isSupported()) {
+        throw new Error('Noise Cancellation plugin is not supported on your browser');
+      }
 
       if (!plugin.isInitialized()) {
         log.debug('initializing noise cancellation sdk: ', rootDir);

--- a/lib/noisecancellationadapter.ts
+++ b/lib/noisecancellationadapter.ts
@@ -73,6 +73,11 @@ export async function createNoiseCancellationAudioProcessor(
       log.debug('Loaded noise cancellation sdk:', dynamicModule);
 
       const maybeLegacyPlugin = dynamicModule.default as NoiseCancellationPlugin | LegacyPlugin;
+
+      if (!maybeLegacyPlugin || typeof maybeLegacyPlugin.getVersion !== 'function') {
+        throw new Error(`Invalid noise cancellation plugin module: ${sdkFilePath}`);
+      }
+
       const pluginVersion = maybeLegacyPlugin.getVersion();
 
       ensureVersionCompatible({ supportedVersions, pluginVersion });

--- a/lib/noisecancellationadapter.ts
+++ b/lib/noisecancellationadapter.ts
@@ -20,7 +20,9 @@ const PLUGIN_CONFIG = {
 };
 
 const parseVersion = (version: string): number[] => {
-  const parts = version.split('.').map(v => Number(v));
+  // Strip semver pre-release suffix (e.g. "2.0.0-rc.1") before parsing.
+  const core = version.split('-')[0];
+  const parts = core.split('.').map(v => Number(v));
   if (parts.length !== 3 || parts.some(Number.isNaN)) {
     throw new Error(`Unsupported Plugin version format: ${version}`);
   }

--- a/lib/noisecancellationadapter.ts
+++ b/lib/noisecancellationadapter.ts
@@ -81,6 +81,7 @@ export async function createNoiseCancellationAudioProcessor(
       }
 
       const pluginVersion = maybeLegacyPlugin.getVersion();
+      log.debug('Plugin Version =', pluginVersion);
 
       ensureVersionCompatible({ supportedVersions, pluginVersion });
 

--- a/lib/noisecancellationadapter.ts
+++ b/lib/noisecancellationadapter.ts
@@ -48,7 +48,7 @@ const ensureVersionCompatible = ({ supportedVersions, pluginVersion }: {
 };
 
 const adaptPlugin = (maybeLegacyPlugin: NoiseCancellationPlugin | LegacyPlugin, major: number): NoiseCancellationPlugin => {
-  return major >= 2
+  return major === 2
     ? maybeLegacyPlugin as NoiseCancellationPlugin
     : new LegacyPluginAdapter(maybeLegacyPlugin as LegacyPlugin);
 };

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -10,12 +10,15 @@ require('./spec/createlocaltrack');
 require('./spec/encodingparameters');
 require('./spec/localparticipant');
 require('./spec/networkqualityconfiguration');
+require('./spec/noisecancellationadapter');
 require('./spec/room');
 require('./spec/remoteparticipant');
 require('./spec/queueingeventemitter');
 require('./spec/statemachine');
 require('./spec/transceiver');
 require('./spec/twilioconnection');
+
+require('./spec/noisecancellation/legacy-plugin-adapter');
 
 require('./spec/data/transceiver');
 require('./spec/data/sender');
@@ -28,6 +31,7 @@ require('./spec/media/track/mediatrack');
 require('./spec/media/track/localdatatrack');
 require('./spec/media/track/localmediatrack');
 require('./spec/media/track/localaudiotrack');
+require('./spec/media/track/noisecancellationimpl');
 require('./spec/media/track/localvideotrack');
 require('./spec/media/track/localtrackpublication');
 require('./spec/media/track/receiver');

--- a/test/unit/spec/media/track/noisecancellationimpl.js
+++ b/test/unit/spec/media/track/noisecancellationimpl.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const assert = require('assert');
+const sinon = require('sinon');
+
+const { NoiseCancellationImpl } = require('../../../../../lib/media/track/noisecancellationimpl');
+
+describe('NoiseCancellationImpl', () => {
+  describe('#reacquireTrack', () => {
+    let processor;
+    let sourceTrack;
+    let reacquiredTrack;
+    let processedTrack;
+    let reacquire;
+    let impl;
+
+    beforeEach(() => {
+      sourceTrack = { id: 'source' };
+      reacquiredTrack = { id: 'reacquired' };
+      processedTrack = { id: 'processed' };
+
+      processor = {
+        vendor: 'krisp',
+        isInitialized: sinon.stub().returns(true),
+        isConnected: sinon.stub().returns(true),
+        isEnabled: sinon.stub().returns(true),
+        disconnect: sinon.spy(),
+        enable: sinon.spy(),
+        disable: sinon.spy(),
+        destroy: sinon.stub().resolves(),
+        setLogging: sinon.spy(),
+        connect: sinon.stub().returns(processedTrack)
+      };
+
+      reacquire = sinon.stub().resolves(reacquiredTrack);
+      impl = new NoiseCancellationImpl(processor, sourceTrack);
+    });
+
+    it('disconnects, reacquires the source, connects the new track, and updates sourceTrack', async () => {
+      const result = await impl.reacquireTrack(reacquire);
+      sinon.assert.calledOnce(processor.disconnect);
+      sinon.assert.calledOnce(reacquire);
+      sinon.assert.calledWith(processor.connect, reacquiredTrack);
+      assert.strictEqual(result, processedTrack);
+      assert.strictEqual(impl.sourceTrack, reacquiredTrack);
+    });
+  });
+});

--- a/test/unit/spec/noisecancellation/legacy-plugin-adapter.js
+++ b/test/unit/spec/noisecancellation/legacy-plugin-adapter.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const assert = require('assert');
+const sinon = require('sinon');
+
+const { LegacyPluginAdapter } = require('../../../../lib/noisecancellation/legacy-plugin-adapter');
+const audioContextFactory = require('../../../../lib/webaudio/audiocontext');
+
+describe('LegacyPluginAdapter', () => {
+  let legacy;
+  let adapter;
+
+  beforeEach(() => {
+    legacy = {
+      init: sinon.stub().resolves(),
+      isInitialized: sinon.stub().returns(true),
+      isConnected: sinon.stub().returns(false),
+      isEnabled: sinon.stub().returns(true),
+      connect: sinon.stub().returns({ id: 'output-stream' }),
+      disconnect: sinon.spy(),
+      enable: sinon.spy(),
+      disable: sinon.spy(),
+      destroy: sinon.spy(),
+      setLogging: sinon.spy(),
+      isSupported: sinon.stub().returns(true),
+      getVersion: sinon.stub().returns('1.0.0')
+    };
+    adapter = new LegacyPluginAdapter(legacy);
+  });
+
+  describe('#isSupported', () => {
+    let getOrCreate;
+    let release;
+
+    beforeEach(() => {
+      getOrCreate = sinon.stub(audioContextFactory, 'getOrCreate');
+      release = sinon.stub(audioContextFactory, 'release');
+    });
+
+    afterEach(() => {
+      getOrCreate.restore();
+      release.restore();
+    });
+
+    it('acquires a context, passes it to legacy.isSupported, and releases the holder', () => {
+      const ctx = { sampleRate: 48000 };
+      getOrCreate.returns(ctx);
+      legacy.isSupported.returns(true);
+
+      const result = adapter.isSupported();
+
+      assert.strictEqual(result, true);
+      sinon.assert.calledOnce(getOrCreate);
+      sinon.assert.calledWith(legacy.isSupported, ctx);
+      sinon.assert.calledOnce(release);
+    });
+
+    it('returns false without calling legacy.isSupported when getOrCreate returns null', () => {
+      getOrCreate.returns(null);
+
+      const result = adapter.isSupported();
+
+      assert.strictEqual(result, false);
+      sinon.assert.notCalled(legacy.isSupported);
+      sinon.assert.calledOnce(release);
+    });
+
+    it('releases the holder even when legacy.isSupported throws', () => {
+      const ctx = { sampleRate: 48000 };
+      getOrCreate.returns(ctx);
+      legacy.isSupported.throws(new Error('boom'));
+
+      assert.throws(() => adapter.isSupported(), /boom/);
+      sinon.assert.calledOnce(release);
+    });
+  });
+
+  describe('#destroy', () => {
+    it('promotes legacy.destroy into an awaitable that propagates errors', async () => {
+      legacy.destroy = sinon.stub()
+        .onFirstCall().returns(undefined)
+        .onSecondCall().throws(new Error('legacy destroy failed'));
+
+      await adapter.destroy();
+      await assert.rejects(adapter.destroy(), /legacy destroy failed/);
+      sinon.assert.calledTwice(legacy.destroy);
+    });
+  });
+});

--- a/test/unit/spec/noisecancellationadapter.js
+++ b/test/unit/spec/noisecancellationadapter.js
@@ -1,0 +1,194 @@
+'use strict';
+
+const assert = require('assert');
+const sinon = require('sinon');
+
+const adapterPath = require.resolve('../../../lib/noisecancellationadapter');
+const dynamicImportPath = require.resolve('../../../lib/util/dynamicimport');
+const audioContextFactory = require('../../../lib/webaudio/audiocontext');
+const log = require('../../lib/fakelog');
+
+function installDynamicImportStub(modulesByPath) {
+  require.cache[dynamicImportPath] = {
+    id: dynamicImportPath,
+    filename: dynamicImportPath,
+    loaded: true,
+    exports: path => {
+      if (path in modulesByPath) {
+        return Promise.resolve(modulesByPath[path]);
+      }
+      return Promise.reject(new Error(`unexpected path: ${path}`));
+    }
+  };
+}
+
+function makeV1Plugin(overrides = {}) {
+  return {
+    init: sinon.stub().resolves(),
+    isInitialized: sinon.stub().returns(true),
+    isConnected: sinon.stub().returns(false),
+    isEnabled: sinon.stub().returns(true),
+    connect: sinon.stub(),
+    disconnect: sinon.spy(),
+    enable: sinon.spy(),
+    disable: sinon.spy(),
+    destroy: sinon.spy(),
+    setLogging: sinon.spy(),
+    isSupported: sinon.stub().returns(true),
+    getVersion: sinon.stub().returns('1.0.0'),
+    ...overrides
+  };
+}
+
+function makeV2Plugin(overrides = {}) {
+  return {
+    init: sinon.stub().resolves(),
+    isInitialized: sinon.stub().returns(true),
+    isConnected: sinon.stub().returns(false),
+    isEnabled: sinon.stub().returns(true),
+    connect: sinon.stub(),
+    disconnect: sinon.spy(),
+    enable: sinon.spy(),
+    disable: sinon.spy(),
+    destroy: sinon.stub().resolves(),
+    setLogging: sinon.spy(),
+    isSupported: sinon.stub().returns(true),
+    getVersion: sinon.stub().returns('2.0.0'),
+    ...overrides
+  };
+}
+
+describe('noisecancellationadapter', () => {
+  let createNoiseCancellationAudioProcessor;
+
+  function loadAdapter() {
+    delete require.cache[adapterPath];
+    ({ createNoiseCancellationAudioProcessor } = require(adapterPath));
+  }
+
+  afterEach(() => {
+    delete require.cache[dynamicImportPath];
+    delete require.cache[adapterPath];
+  });
+
+  describe('createNoiseCancellationAudioProcessor', () => {
+    const sdkPath = '/krisp/krispsdk.mjs';
+    const baseOptions = { vendor: 'krisp', sdkAssetsPath: '/krisp' };
+
+    it('rejects when the vendor is not supported', async () => {
+      installDynamicImportStub({});
+      loadAdapter();
+      await assert.rejects(
+        createNoiseCancellationAudioProcessor({ vendor: 'unknown', sdkAssetsPath: '' }, log),
+        /Unsupported NoiseCancellationOptions\.vendor/
+      );
+    });
+
+    it('rejects when the module has no getVersion()', async () => {
+      installDynamicImportStub({ [sdkPath]: { default: {} } });
+      loadAdapter();
+      await assert.rejects(
+        createNoiseCancellationAudioProcessor(baseOptions, log),
+        /Invalid noise cancellation plugin module/
+      );
+    });
+
+    it('rejects when the plugin major is greater than the supported majors', async () => {
+      const plugin = makeV2Plugin({ getVersion: () => '3.0.0' });
+      installDynamicImportStub({ [sdkPath]: { default: plugin } });
+      loadAdapter();
+      await assert.rejects(
+        createNoiseCancellationAudioProcessor(baseOptions, log),
+        /Major version mismatch/
+      );
+    });
+
+    it('rejects when the plugin minor is below the supported floor', async () => {
+      // rnnoise supportedVersions is ['0.6.0']; a 0.5.x plugin must fail the minor floor.
+      const rnnoisePath = '/rnnoise/rnnoise_sdk.mjs';
+      const plugin = makeV1Plugin({ getVersion: () => '0.5.0' });
+      installDynamicImportStub({ [rnnoisePath]: { default: plugin } });
+      loadAdapter();
+      await assert.rejects(
+        createNoiseCancellationAudioProcessor(
+          { vendor: 'rnnoise', sdkAssetsPath: '/rnnoise' },
+          log
+        ),
+        /Minor version mismatch/
+      );
+    });
+
+    it('rejects when the version string is malformed', async () => {
+      const plugin = makeV2Plugin({ getVersion: () => '2.0' });
+      installDynamicImportStub({ [sdkPath]: { default: plugin } });
+      loadAdapter();
+      await assert.rejects(
+        createNoiseCancellationAudioProcessor(baseOptions, log),
+        /Unsupported Plugin version format/
+      );
+    });
+
+    it('accepts a pre-release version suffix', async () => {
+      const plugin = makeV2Plugin({ getVersion: () => '2.0.0-rc.1' });
+      installDynamicImportStub({ [sdkPath]: { default: plugin } });
+      loadAdapter();
+      const processor = await createNoiseCancellationAudioProcessor(baseOptions, log);
+      assert.strictEqual(processor.vendor, 'krisp');
+    });
+
+    it('rejects when isSupported() returns false', async () => {
+      const plugin = makeV2Plugin({ isSupported: sinon.stub().returns(false) });
+      installDynamicImportStub({ [sdkPath]: { default: plugin } });
+      loadAdapter();
+      await assert.rejects(
+        createNoiseCancellationAudioProcessor(baseOptions, log),
+        /Noise Cancellation plugin is not supported on your browser/
+      );
+    });
+
+    it('routes a 2.x plugin directly (async destroy)', async () => {
+      const plugin = makeV2Plugin();
+      installDynamicImportStub({ [sdkPath]: { default: plugin } });
+      loadAdapter();
+      const processor = await createNoiseCancellationAudioProcessor(baseOptions, log);
+      const destroyResult = processor.destroy();
+      assert.strictEqual(typeof destroyResult.then, 'function');
+      await destroyResult;
+      sinon.assert.calledOnce(plugin.destroy);
+      sinon.assert.calledWithExactly(plugin.isSupported);
+    });
+
+    it('routes a 1.x plugin through LegacyPluginAdapter (sync legacy destroy)', async () => {
+      // LegacyPluginAdapter.isSupported borrows an AudioContext from the factory;
+      // stub it so the legacy probe runs without a real Web Audio environment.
+      const ctx = { sampleRate: 48000 };
+      const getOrCreate = sinon.stub(audioContextFactory, 'getOrCreate').returns(ctx);
+      const release = sinon.stub(audioContextFactory, 'release');
+      try {
+        const plugin = makeV1Plugin();
+        installDynamicImportStub({ [sdkPath]: { default: plugin } });
+        loadAdapter();
+        const processor = await createNoiseCancellationAudioProcessor(baseOptions, log);
+        sinon.assert.calledWith(plugin.isSupported, ctx);
+        const destroyResult = processor.destroy();
+        assert.strictEqual(typeof destroyResult.then, 'function');
+        // Legacy sync destroy must be invoked on a later tick, not synchronously.
+        sinon.assert.notCalled(plugin.destroy);
+        await destroyResult;
+        sinon.assert.calledOnce(plugin.destroy);
+      } finally {
+        getOrCreate.restore();
+        release.restore();
+      }
+    });
+
+    it('caches the processor per vendor on subsequent calls', async () => {
+      const plugin = makeV2Plugin();
+      installDynamicImportStub({ [sdkPath]: { default: plugin } });
+      loadAdapter();
+      const first = await createNoiseCancellationAudioProcessor(baseOptions, log);
+      const second = await createNoiseCancellationAudioProcessor(baseOptions, log);
+      assert.strictEqual(first, second);
+    });
+  });
+});

--- a/tsdef/AudioProcessor.d.ts
+++ b/tsdef/AudioProcessor.d.ts
@@ -50,9 +50,9 @@ export interface AudioProcessor {
 
   /**
    * destroys the processor freeing up any resources
-   * @returns {void}
+   * @returns {Promise<void>}
    */
-  destroy: () => void;
+  destroy: () => Promise<void>;
 
   /**
    * enables/disables logging


### PR DESCRIPTION
## Pull Request Details

### Description

Accepts both `@twilio/krisp-audio-plugin` 1.x and 2.x as the Krisp noise cancellation SDK. Version is detected at load time; 1.x plugins are routed through a legacy adapter, 2.x plugins are used directly.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
