### PR TITLE
[VBLOCKS-6686] fix: pass module path as an argument to the import function

### DIFF
--- a/lib/util/dynamicimport.js
+++ b/lib/util/dynamicimport.js
@@ -10,13 +10,19 @@ module.exports = (function(scope) {
   scope.__twilioVideoImportedModules = {
     // Imported module map.
   };
+  // NOTE(mmalavalli): Calling import() directly can cause build issues in TypeScript and Webpack
+  // (and probably other frameworks). So, we create a Function that calls import() in its body.
+  // The path arrives only as the `url` argument, so it stays data and never joins the body source.
+  // eslint-disable-next-line no-new-func
+  const importModule = new Function('url', 'return import(url);');
   return function dynamicImport(module) {
     if (module in scope.__twilioVideoImportedModules) {
       return Promise.resolve(scope.__twilioVideoImportedModules[module]);
     }
-    // NOTE(mmalavalli): Calling import() directly can cause build issues in TypeScript and Webpack
-    // (and probably other frameworks). So, we create a Function that calls import() in its body.
-    // eslint-disable-next-line no-new-func
-    return new Function('scope', `return import('${new URL(module, location)}').then(m => scope.__twilioVideoImportedModules['${module}'] = m);`)(scope);
+    return importModule(new URL(module, location).toString())
+      .then(m => {
+        scope.__twilioVideoImportedModules[module] = m;
+        return m;
+      });
   };
 }(globalThis));

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -75,6 +75,7 @@ require('./spec/util/backoff');
 require('./spec/util/browserdetection');
 require('./spec/util/eventobserver');
 require('./spec/util/documentvisibilitymonitor');
+require('./spec/util/dynamicimport');
 require('./spec/util/insightspublisher');
 require('./spec/util/log');
 require('./spec/util/movingaveragedelta');

--- a/test/unit/spec/util/dynamicimport.js
+++ b/test/unit/spec/util/dynamicimport.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const assert = require('assert');
+
+const MODULE_PATH = require.resolve('../../../../lib/util/dynamicimport');
+
+describe('dynamicImport', () => {
+  afterEach(() => {
+    delete global.location;
+    delete global.__twilioVideoImportedModules;
+    delete global.__dynamicImportProbe;
+    delete require.cache[MODULE_PATH];
+  });
+
+  it('treats the module path as data, not code', async () => {
+    global.location = 'https://localhost/';
+    global.__dynamicImportProbe = false;
+
+    const dynamicImport = require(MODULE_PATH);
+    const path = 'a\'+(global.__dynamicImportProbe=true)+\'b.mjs';
+
+    await dynamicImport(path).then(() => {}, () => {});
+
+    assert.strictEqual(global.__dynamicImportProbe, false);
+  });
+});


### PR DESCRIPTION
## Pull Request Details

### Description

Move the module path out of the function source and into a `url` argument.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
