### PR TITLE
ci: add prepare-release and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,6 @@ jobs:
             run: |
               npm run build:es5
               npm run test:serversiderender
-          - name: umd-tests
-            run: |
-              npm run build:es5
-              npm run test:umd
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Artifactory OIDC Auth

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
             run: |
               npm run build:es5
               npm run test:serversiderender
+          - name: umd-tests
+            run: |
+              npm run build:es5
+              npm run test:umd
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Artifactory OIDC Auth

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -90,21 +90,18 @@ jobs:
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      # sort -V is not strict semver: it orders 2.36.0-rc.1 after 2.36.0. It still
-      # catches the transposed or stale number this guards against.
+      # Catches the transposed or stale number — this repo once released 2.8.2-rc1
+      # in place of 2.28.2-rc1. Runs before the install, so the script it calls
+      # takes no dependencies.
       - name: Verify the release version moves forward
         env:
           RELEASE_VERSION: ${{ inputs.release_version }}
         run: |
           set -euo pipefail
 
-          CURRENT_VERSION="$(node -p "require('./package.json').version")"
-          HIGHEST_VERSION="$(printf '%s\n%s\n' "$CURRENT_VERSION" "$RELEASE_VERSION" | sort -V | tail -n1)"
-
-          if [ "$RELEASE_VERSION" = "$CURRENT_VERSION" ] || [ "$HIGHEST_VERSION" != "$RELEASE_VERSION" ]; then
-            echo "::error::${RELEASE_VERSION} is not greater than the current version ${CURRENT_VERSION}."
-            exit 1
-          fi
+          node ./scripts/check-version-bump.js \
+            "$(node -p "require('./package.json').version")" \
+            "$RELEASE_VERSION"
 
       - name: Artifactory OIDC Auth
         uses: ./.github/actions/artifactory-oidc

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -61,8 +61,18 @@ jobs:
         env:
           RELEASE_VERSION: ${{ inputs.release_version }}
           DEVELOPMENT_VERSION: ${{ inputs.development_version }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
           set -euo pipefail
+
+          # The dry-run guards match on 'true', so any other string releases for real.
+          case "${DRY_RUN:-false}" in
+            true|false) ;;
+            *)
+              echo "::error::dry_run must be exactly true or false."
+              exit 1
+              ;;
+          esac
 
           SEMVER='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'
           for INPUT_VERSION in "$RELEASE_VERSION" "${DEVELOPMENT_VERSION:-}"
@@ -234,10 +244,46 @@ jobs:
             exit 1
           fi
 
+      # The download overwrites but never deletes, so stale files from a build
+      # still tracked from a previous release would be staged alongside this one.
+      - name: Clear any previously committed build output
+        run: |
+          set -euo pipefail
+
+          git rm -r --quiet --ignore-unmatch --cached dist es5
+          rm -rf dist es5
+
       - name: Download release tree
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-tree
+
+      # The download above overwrites package.json, so check it before tagging.
+      - name: Verify the downloaded tree is the expected package
+        run: |
+          set -euo pipefail
+
+          PACKAGE_NAME="$(node -p "require('./package.json').name")"
+          if [ "$PACKAGE_NAME" != twilio-video ]; then
+            echo "::error::downloaded package.json is for ${PACKAGE_NAME}, not twilio-video."
+            exit 1
+          fi
+
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$PACKAGE_VERSION" != "$RELEASE_VERSION" ]; then
+            echo "::error::downloaded package.json is ${PACKAGE_VERSION}, not ${RELEASE_VERSION}."
+            exit 1
+          fi
+
+          node -e '
+            const scripts = require("./package.json").scripts || {};
+            for (const name of ["install", "preinstall", "postinstall", "prepare", "prepublishOnly"]) {
+              if (scripts[name]) {
+                console.error("::error::downloaded package.json has an unexpected lifecycle script: " + name);
+                process.exit(1);
+              }
+            }
+          '
 
       # Matches the author on the existing release commits.
       - name: Configure git identity

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,223 @@
+name: Prepare Release
+
+# Builds a release: bumps the version, builds the SDK, commits the built tree,
+# and pushes a version tag.
+#
+# Dispatch this FROM the branch you are releasing (normally `develop`) — pick it
+# in the "Run workflow" dropdown. The commits and the tag are pushed back to
+# whatever ref the run was dispatched from, so the branch selected there is the
+# branch that gets the release. Any branch can be released, including a
+# maintenance branch.
+#
+# This workflow does not publish. Pushing the tag is what triggers release.yml,
+# and only a final X.Y.Z tag matches its filter — so a prerelease version stops
+# here.
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: "Version to release (e.g. 2.36.0 or 2.36.0-rc.1)"
+        required: true
+      development_version:
+        description: "Optional: next dev version to commit after the release (e.g. 2.36.1-dev). Leave blank to skip."
+        required: false
+      dry_run:
+        description: "Build and pack only — commit nothing, tag nothing, publish nothing."
+        required: false
+        type: boolean
+        default: false
+
+# No default permissions; each job below declares exactly what it needs.
+permissions: {}
+
+env:
+  ARTIFACTORY_URL: ${{ vars.ARTIFACTORY_URL }}
+
+jobs:
+  # The only job that installs dependencies, and it has no write access.
+  build:
+    name: Build release tree
+    runs-on: ubuntu-latest-large
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      id-token: write # for the OIDC registry exchange below
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # The repo-local action, which reads the ARTIFACTORY_URL env var set above.
+      - name: Artifactory OIDC Auth
+        uses: ./.github/actions/artifactory-oidc
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+
+      # --ignore-scripts is strictly required
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      # Passed as env, referenced as "$VAR" — never interpolated into a run script.
+      - name: Bump version
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
+        run: npm version --no-git-tag-version "$RELEASE_VERSION"
+
+      - name: Build
+        run: npm run build:quick
+
+      # :quick, because build:quick already built es5/. `test:unit` would rebuild
+      # it, discarding the tree this job uploads.
+      - name: Unit tests
+        run: npm run test:unit:quick -- ./test/unit/*
+
+      - name: Server-side render tests
+        run: npm run test:serversiderender
+
+      # The tagged commit is expected to carry the complete built SDK, so an
+      # incomplete tree has to fail here rather than reach a tag.
+      - name: Verify the release tree was built
+        run: |
+          set -euo pipefail
+
+          for RELEASE_FILE in \
+            package.json \
+            package-lock.json \
+            dist/twilio-video.js \
+            dist/twilio-video.min.js
+          do
+            if [ ! -s "$RELEASE_FILE" ]; then
+              echo "::error::${RELEASE_FILE} is missing or empty after the build."
+              exit 1
+            fi
+          done
+
+          for RELEASE_DIR in es5 dist/docs
+          do
+            if [ -z "$(ls -A "$RELEASE_DIR" 2>/dev/null)" ]; then
+              echo "::error::${RELEASE_DIR}/ is missing or empty after the build."
+              exit 1
+            fi
+          done
+
+      # A publish cannot be undone, so this makes it possible to prove the tree
+      # builds and see exactly what would ship without writing anything anywhere.
+      - name: Dry run — pack and preview the publish
+        if: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          echo "::notice::Version: $(node -p "require('./package.json').version")"
+          npm pack --dry-run
+          npm publish --dry-run --registry https://registry.npmjs.org --ignore-scripts --access public
+
+      - name: Upload release tree
+        if: ${{ !inputs.dry_run }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-tree
+          if-no-files-found: error
+          include-hidden-files: false
+          retention-days: 7
+          path: |
+            package.json
+            package-lock.json
+            dist/
+            es5/
+
+  # Holds the push credential; runs no third-party code.
+  commit-tag-push:
+    name: Commit, tag and push
+    needs: build
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest-large
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    # Passed as env, referenced as "$VAR" — never interpolated into a run script.
+    env:
+      RELEASE_VERSION: ${{ inputs.release_version }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Download release tree
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-tree
+
+      # Matches the author on the existing release commits.
+      - name: Configure git identity
+        run: |
+          set -euo pipefail
+
+          git config user.name "twilio-ci"
+          git config user.email "twilio-ci@twilio.com"
+
+      # dist/ and es5/ are gitignored, hence -f. Committing the built output is
+      # intentional: the tagged tree is expected to contain the built SDK, so it
+      # can be consumed directly from the tag.
+      #
+      # --no-verify because pre-commit.sh rejects commits on release branches.
+      # Hooks aren't installed on a fresh checkout, so this only matters if these
+      # steps are ever run by hand.
+      - name: Commit the release
+        run: |
+          set -euo pipefail
+
+          git add package.json package-lock.json
+          git add -f dist es5
+          git commit --no-verify -m "$RELEASE_VERSION"
+          echo "::notice::Release commit: $(git rev-parse HEAD)"
+
+      # Lightweight and un-prefixed, matching the existing tags.
+      - name: Tag the release
+        run: git tag "$RELEASE_VERSION"
+
+      # Explicit refspecs: the checkout may be a detached HEAD rather than on a
+      # named branch, so push back to the ref this run was dispatched from
+      # instead of relying on `HEAD` inferring one.
+      #
+      # Branch first, then tag, so the tag is never briefly unreachable. A final
+      # X.Y.Z tag landing here is what triggers release.yml.
+      - name: Push the release commit and tag
+        run: |
+          set -euo pipefail
+
+          git push origin "HEAD:${GITHUB_REF}"
+          git push origin "refs/tags/${RELEASE_VERSION}"
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        if: ${{ inputs.development_version != '' }}
+        with:
+          node-version: 22
+
+      # The inverse of the release commit: bump to the next -dev version and drop
+      # the built tree again, returning the branch to a clean working state.
+      # Pushed after the tag, so the tag keeps pointing at the built commit.
+      - name: Commit the development version
+        if: ${{ inputs.development_version != '' }}
+        env:
+          DEVELOPMENT_VERSION: ${{ inputs.development_version }}
+        run: |
+          set -euo pipefail
+
+          npm version --no-git-tag-version "$DEVELOPMENT_VERSION"
+          git rm -r --quiet --ignore-unmatch dist es5
+          git add package.json package-lock.json
+          git commit --no-verify -m "$DEVELOPMENT_VERSION"
+          git push origin "HEAD:${GITHUB_REF}"
+          echo "::notice::Development commit: $(git rev-parse HEAD)"
+
+      # A tag that is not reachable from the branch is easy to create by mistake
+      # and hard to notice afterwards.
+      - name: Verify the tag is reachable from the branch
+        run: |
+          set -euo pipefail
+
+          if ! git merge-base --is-ancestor "$RELEASE_VERSION" HEAD; then
+            echo "::error::tag ${RELEASE_VERSION} is not an ancestor of ${GITHUB_REF} — it would be orphaned."
+            exit 1
+          fi
+          echo "::notice::tag ${RELEASE_VERSION} is reachable from ${GITHUB_REF}."

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -90,9 +90,8 @@ jobs:
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      # Catches the transposed or stale number — this repo once released 2.8.2-rc1
-      # in place of 2.28.2-rc1. Runs before the install, so the script it calls
-      # takes no dependencies.
+      # Catches a transposed or stale version number. Runs before the install, so
+      # the script it calls takes no dependencies.
       - name: Verify the release version moves forward
         env:
           RELEASE_VERSION: ${{ inputs.release_version }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -9,9 +9,8 @@ name: Prepare Release
 # branch that gets the release. Any branch can be released, including a
 # maintenance branch.
 #
-# This workflow does not publish. Pushing the tag is what triggers release.yml,
-# and only a final X.Y.Z tag matches its filter — so a prerelease version stops
-# here.
+# This workflow does not publish. To publish, dispatch release.yml from the tag
+# this pushed; it accepts only a final X.Y.Z tag, so a prerelease stops here.
 
 on:
   workflow_dispatch:
@@ -35,7 +34,7 @@ env:
   ARTIFACTORY_URL: ${{ vars.ARTIFACTORY_URL }}
 
 jobs:
-  # The only job that installs dependencies, and it has no write access.
+  # The only job that installs dependencies. Keep it read-only.
   build:
     name: Build release tree
     runs-on: ubuntu-latest-large
@@ -44,6 +43,29 @@ jobs:
       contents: read
       id-token: write # for the OIDC registry exchange below
     steps:
+      # First, so a bad input fails before the install below.
+      #
+      # `npm version` also accepts aliases (patch, minor, from-git), which would
+      # set a package version different from the literal string used below as the
+      # commit message and tag name. Both inputs must be exact versions.
+      #
+      # Passed as env, referenced as "$VAR" — never interpolated into a run script.
+      - name: Validate the version inputs
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
+          DEVELOPMENT_VERSION: ${{ inputs.development_version }}
+        run: |
+          set -euo pipefail
+
+          SEMVER='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'
+          for INPUT_VERSION in "$RELEASE_VERSION" "${DEVELOPMENT_VERSION:-}"
+          do
+            if [ -n "$INPUT_VERSION" ] && ! printf '%s' "$INPUT_VERSION" | grep -qE "$SEMVER"; then
+              echo "::error::${INPUT_VERSION} is not an exact version (expected 2.36.0 or 2.36.0-rc.1)."
+              exit 1
+            fi
+          done
+
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # The repo-local action, which reads the ARTIFACTORY_URL env var set above.
@@ -59,11 +81,11 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
-      # Passed as env, referenced as "$VAR" — never interpolated into a run script.
+      # --ignore-scripts: this bump only rewrites package.json.
       - name: Bump version
         env:
           RELEASE_VERSION: ${{ inputs.release_version }}
-        run: npm version --no-git-tag-version "$RELEASE_VERSION"
+        run: npm version --no-git-tag-version --ignore-scripts "$RELEASE_VERSION"
 
       - name: Build
         run: npm run build:quick
@@ -127,7 +149,7 @@ jobs:
             dist/
             es5/
 
-  # Holds the push credential; runs no third-party code.
+  # Runs git only. Do not add an install or build step here.
   commit-tag-push:
     name: Commit, tag and push
     needs: build
@@ -179,8 +201,7 @@ jobs:
       # named branch, so push back to the ref this run was dispatched from
       # instead of relying on `HEAD` inferring one.
       #
-      # Branch first, then tag, so the tag is never briefly unreachable. A final
-      # X.Y.Z tag landing here is what triggers release.yml.
+      # Branch first, then tag, so the tag is never briefly unreachable.
       - name: Push the release commit and tag
         run: |
           set -euo pipefail
@@ -203,7 +224,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          npm version --no-git-tag-version "$DEVELOPMENT_VERSION"
+          npm version --no-git-tag-version --ignore-scripts "$DEVELOPMENT_VERSION"
           git rm -r --quiet --ignore-unmatch dist es5
           git add package.json package-lock.json
           git commit --no-verify -m "$DEVELOPMENT_VERSION"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -21,11 +21,19 @@ on:
       development_version:
         description: "Optional: next dev version to commit after the release (e.g. 2.36.1-dev). Leave blank to skip."
         required: false
+      # Guards on this read `github.event.inputs.dry_run`, not `inputs.dry_run`:
+      # the event payload is always the string "true"/"false", whereas `inputs`
+      # is a real boolean from the UI but a (truthy) string from the dispatch API.
       dry_run:
         description: "Build and pack only — commit nothing, tag nothing, publish nothing."
         required: false
         type: boolean
         default: false
+
+# Never cancel: two runs would build from the same base and race each other's push.
+concurrency:
+  group: prepare-release-${{ github.ref }}
+  cancel-in-progress: false
 
 # No default permissions; each job below declares exactly what it needs.
 permissions: {}
@@ -43,11 +51,10 @@ jobs:
       contents: read
       id-token: write # for the OIDC registry exchange below
     steps:
-      # First, so a bad input fails before the install below.
-      #
+      # Runs before the install so a bad input fails fast. Exact versions only:
       # `npm version` also accepts aliases (patch, minor, from-git), which would
-      # set a package version different from the literal string used below as the
-      # commit message and tag name. Both inputs must be exact versions.
+      # set a version different from the literal string used below as the commit
+      # message and tag name.
       #
       # Passed as env, referenced as "$VAR" — never interpolated into a run script.
       - name: Validate the version inputs
@@ -60,15 +67,45 @@ jobs:
           SEMVER='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'
           for INPUT_VERSION in "$RELEASE_VERSION" "${DEVELOPMENT_VERSION:-}"
           do
-            if [ -n "$INPUT_VERSION" ] && ! printf '%s' "$INPUT_VERSION" | grep -qE "$SEMVER"; then
+            [ -n "$INPUT_VERSION" ] || continue
+
+            # grep is line-oriented even with -x, so a multi-line input would pass on
+            # one matching line.
+            if [ "$(printf '%s' "$INPUT_VERSION" | wc -l)" -ne 0 ] \
+              || ! printf '%s' "$INPUT_VERSION" | grep -qxE "$SEMVER"; then
               echo "::error::${INPUT_VERSION} is not an exact version (expected 2.36.0 or 2.36.0-rc.1)."
               exit 1
             fi
           done
 
+          # The push steps use GITHUB_REF as a refspec target, so a tag dispatch
+          # would try to push a commit onto a tag.
+          case "$GITHUB_REF" in
+            refs/heads/*) ;;
+            *)
+              echo "::error::Dispatch this workflow from a branch, not ${GITHUB_REF}."
+              exit 1
+              ;;
+          esac
+
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      # The repo-local action, which reads the ARTIFACTORY_URL env var set above.
+      # sort -V is not strict semver: it orders 2.36.0-rc.1 after 2.36.0. It still
+      # catches the transposed or stale number this guards against.
+      - name: Verify the release version moves forward
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
+        run: |
+          set -euo pipefail
+
+          CURRENT_VERSION="$(node -p "require('./package.json').version")"
+          HIGHEST_VERSION="$(printf '%s\n%s\n' "$CURRENT_VERSION" "$RELEASE_VERSION" | sort -V | tail -n1)"
+
+          if [ "$RELEASE_VERSION" = "$CURRENT_VERSION" ] || [ "$HIGHEST_VERSION" != "$RELEASE_VERSION" ]; then
+            echo "::error::${RELEASE_VERSION} is not greater than the current version ${CURRENT_VERSION}."
+            exit 1
+          fi
+
       - name: Artifactory OIDC Auth
         uses: ./.github/actions/artifactory-oidc
 
@@ -82,10 +119,34 @@ jobs:
         run: npm ci --ignore-scripts
 
       # --ignore-scripts: this bump only rewrites package.json.
-      - name: Bump version
+      - name: Set the release version
         env:
           RELEASE_VERSION: ${{ inputs.release_version }}
-        run: npm version --no-git-tag-version --ignore-scripts "$RELEASE_VERSION"
+        run: |
+          set -euo pipefail
+
+          npm version --no-git-tag-version --ignore-scripts "$RELEASE_VERSION"
+
+          # Prereleases neither publish nor become the CDN's advertised version.
+          case "$RELEASE_VERSION" in
+            *-*)
+              echo "::notice::${RELEASE_VERSION} is a prerelease — leaving README.md and CHANGELOG.md alone."
+              exit 0
+              ;;
+          esac
+
+          # `npm version` rewrites package.json only.
+          sed -i -E "s|(releases/)[0-9]+\.[0-9]+\.[0-9]+(/twilio-video)|\1${RELEASE_VERSION}\2|g" README.md
+          if ! grep -qF "releases/${RELEASE_VERSION}/twilio-video" README.md; then
+            echo "::error::README.md has no releases/${RELEASE_VERSION}/ CDN URL after the rewrite."
+            exit 1
+          fi
+
+          # CHANGELOG headings read "2.35.0 (April 29, 2026)".
+          if ! grep -q "^${RELEASE_VERSION} (" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no ${RELEASE_VERSION} entry — add one before releasing."
+            exit 1
+          fi
 
       - name: Build
         run: npm run build:quick
@@ -124,10 +185,10 @@ jobs:
             fi
           done
 
-      # A publish cannot be undone, so this makes it possible to prove the tree
-      # builds and see exactly what would ship without writing anything anywhere.
+      # A publish cannot be undone: this proves the tree builds and shows exactly
+      # what would ship, without writing anything anywhere.
       - name: Dry run — pack and preview the publish
-        if: ${{ inputs.dry_run }}
+        if: ${{ github.event.inputs.dry_run == 'true' }}
         run: |
           set -euo pipefail
 
@@ -136,7 +197,7 @@ jobs:
           npm publish --dry-run --registry https://registry.npmjs.org --ignore-scripts --access public
 
       - name: Upload release tree
-        if: ${{ !inputs.dry_run }}
+        if: ${{ github.event.inputs.dry_run != 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-tree
@@ -146,6 +207,8 @@ jobs:
           path: |
             package.json
             package-lock.json
+            README.md
+            CHANGELOG.md
             dist/
             es5/
 
@@ -153,7 +216,7 @@ jobs:
   commit-tag-push:
     name: Commit, tag and push
     needs: build
-    if: ${{ !inputs.dry_run }}
+    if: ${{ github.event.inputs.dry_run != 'true' }}
     runs-on: ubuntu-latest-large
     timeout-minutes: 15
     permissions:
@@ -163,6 +226,17 @@ jobs:
       RELEASE_VERSION: ${{ inputs.release_version }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # The checkout fetches no tags, so a local `git tag` would not notice a tag that
+      # already exists on origin.
+      - name: Verify the tag does not already exist
+        run: |
+          set -euo pipefail
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${RELEASE_VERSION}" >/dev/null 2>&1; then
+            echo "::error::tag ${RELEASE_VERSION} already exists on origin."
+            exit 1
+          fi
 
       - name: Download release tree
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -188,7 +262,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          git add package.json package-lock.json
+          git add package.json package-lock.json README.md CHANGELOG.md
           git add -f dist es5
           git commit --no-verify -m "$RELEASE_VERSION"
           echo "::notice::Release commit: $(git rev-parse HEAD)"
@@ -201,13 +275,12 @@ jobs:
       # named branch, so push back to the ref this run was dispatched from
       # instead of relying on `HEAD` inferring one.
       #
-      # Branch first, then tag, so the tag is never briefly unreachable.
+      # --atomic: a rejected tag must not leave the release commit pushed alone.
       - name: Push the release commit and tag
         run: |
           set -euo pipefail
 
-          git push origin "HEAD:${GITHUB_REF}"
-          git push origin "refs/tags/${RELEASE_VERSION}"
+          git push --atomic origin "HEAD:${GITHUB_REF}" "refs/tags/${RELEASE_VERSION}"
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: ${{ inputs.development_version != '' }}
@@ -231,14 +304,15 @@ jobs:
           git push origin "HEAD:${GITHUB_REF}"
           echo "::notice::Development commit: $(git rev-parse HEAD)"
 
-      # A tag that is not reachable from the branch is easy to create by mistake
-      # and hard to notice afterwards.
-      - name: Verify the tag is reachable from the branch
+      # Against origin, not local refs: comparing the tag this job just created to
+      # its own HEAD would be true by construction.
+      - name: Verify the tag is reachable from the branch on origin
         run: |
           set -euo pipefail
 
-          if ! git merge-base --is-ancestor "$RELEASE_VERSION" HEAD; then
-            echo "::error::tag ${RELEASE_VERSION} is not an ancestor of ${GITHUB_REF} — it would be orphaned."
+          git fetch --no-tags origin "${GITHUB_REF}"
+          if ! git merge-base --is-ancestor "refs/tags/${RELEASE_VERSION}" FETCH_HEAD; then
+            echo "::error::tag ${RELEASE_VERSION} is not reachable from ${GITHUB_REF} on origin — it is orphaned."
             exit 1
           fi
-          echo "::notice::tag ${RELEASE_VERSION} is reachable from ${GITHUB_REF}."
+          echo "::notice::tag ${RELEASE_VERSION} is reachable from ${GITHUB_REF} on origin."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,19 +8,16 @@ name: Release
 #
 # Dispatch is manual because GitHub suppresses events from a workflow pushing
 # with the default GITHUB_TOKEN, so a tag trigger would never fire.
-#
-# Only a final X.Y.Z tag publishes; the guard below rejects anything else.
 
 on:
   workflow_dispatch:
 
-# Serialize releases. A second run dispatched while one is mid-flight queues
-# behind it rather than racing it for the `latest` dist-tag.
+# Serialize releases: a second run queues rather than racing the first for the
+# `latest` dist-tag.
 concurrency:
   group: release
   cancel-in-progress: false
 
-# No default permissions; the job below declares exactly what it needs.
 permissions: {}
 
 jobs:
@@ -28,10 +25,11 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest-large
     timeout-minutes: 20
+    # Both at job level: `environment:` resolves before any step runs, so a
+    # first-step guard would gate on approval first, and the OIDC token only
+    # carries the environment claim when the job itself asks for the environment
+    # — which is what the npm trusted publisher matches on.
     if: github.repository_owner == 'twilio'
-    # Both a manual-approval gate and a claim the npm trusted publisher matches
-    # on. It must stay declared here: the OIDC token only carries the environment
-    # claim when the job asks for the environment.
     environment:
       name: production
       url: https://www.npmjs.com/package/twilio-video/v/${{ github.ref_name }}
@@ -51,7 +49,34 @@ jobs:
             exit 1
           fi
 
+      # Full commit history for the reachability check below; blob:none skips the
+      # built dist/ and es5/ trees committed on every past release tag.
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          filter: blob:none
+
+      # The check above constrains the tag's name, not where it came from. To
+      # release from a maintenance branch, add it to the refspecs and the loop.
+      - name: Verify the tag is reachable from a release branch
+        run: |
+          set -euo pipefail
+
+          # Explicit refspecs: a tag checkout may leave no origin/* refs.
+          git fetch --no-tags origin \
+            "+refs/heads/master:refs/remotes/origin/master" \
+            "+refs/heads/develop:refs/remotes/origin/develop"
+
+          for RELEASE_BRANCH in origin/master origin/develop
+          do
+            if git merge-base --is-ancestor "$GITHUB_SHA" "$RELEASE_BRANCH"; then
+              echo "::notice::${GITHUB_REF_NAME} is reachable from ${RELEASE_BRANCH}."
+              exit 0
+            fi
+          done
+
+          echo "::error::${GITHUB_REF_NAME} (${GITHUB_SHA}) is not reachable from master or develop."
+          exit 1
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -61,9 +86,7 @@ jobs:
 
       # Used over a plain `npm publish` for two guarantees: the tag must match
       # package.json's version, and the publish runs with --ignore-scripts.
-      #
-      # tag-prefix is empty because this repo's tags are bare versions (1.2.3),
-      # not v-prefixed.
+      # tag-prefix is empty because this repo's tags are bare versions (1.2.3).
       - name: Validate tag and publish to npm
         uses: twilio/sdk-actions/npm-publish@26f95a54e57993c1bf3b26bec2905f395814c23a # v1.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+
+# Publishes a tagged release to npm.
+#
+# Fired by prepare-release.yml pushing a tag. The tagged commit already contains
+# the fully built tree, so this workflow only publishes. The job holding the
+# publishing credential runs no third-party code.
+#
+# The tag pattern matches final releases only. A prerelease version
+# (2.36.0-rc.1, 2.36.0-beta.1) gets its tag and its built tree from
+# prepare-release.yml and stops there.
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+# Serialize releases. A second tag pushed while one is mid-flight queues behind
+# it rather than racing it for the `latest` dist-tag.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+# No default permissions; the job below declares exactly what it needs.
+permissions: {}
+
+jobs:
+  deploy:
+    name: Publish to npm
+    runs-on: ubuntu-latest-large
+    timeout-minutes: 20
+    if: github.repository_owner == 'twilio'
+    # Both a manual-approval gate and a claim the npm trusted publisher matches
+    # on. It must stay declared here: the OIDC token only carries the environment
+    # claim when the job asks for the environment.
+    environment:
+      name: production
+      url: https://www.npmjs.com/package/twilio-video/v/${{ github.ref_name }}
+    permissions:
+      contents: read # the tag already exists
+      id-token: write # required for npm OIDC trusted publishing
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          # npm >= 11.5.1, bundled with Node 24, is required for OIDC trusted
+          # publishing.
+          node-version: 24
+
+      # Used over a plain `npm publish` for two guarantees: the tag must match
+      # package.json's version, and the publish runs with --ignore-scripts.
+      #
+      # tag-prefix is empty because this repo's tags are bare versions (1.2.3),
+      # not v-prefixed.
+      - name: Validate tag and publish to npm
+        uses: twilio/sdk-actions/npm-publish@26f95a54e57993c1bf3b26bec2905f395814c23a # v1.0.0
+        with:
+          registry: https://registry.npmjs.org
+          validate-tag: 'true'
+          tag-prefix: ''
+          access: 'public'
+          provenance: 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,21 +2,20 @@ name: Release
 
 # Publishes a tagged release to npm.
 #
-# Fired by prepare-release.yml pushing a tag. The tagged commit already contains
-# the fully built tree, so this workflow only publishes. The job holding the
-# publishing credential runs no third-party code.
+# Dispatch this FROM the release tag prepare-release.yml pushed — pick the tag in
+# the "Run workflow" dropdown. That commit already contains the built tree, so
+# this workflow only publishes — do not add an install or build step here.
 #
-# The tag pattern matches final releases only. A prerelease version
-# (2.36.0-rc.1, 2.36.0-beta.1) gets its tag and its built tree from
-# prepare-release.yml and stops there.
+# Dispatch is manual because GitHub suppresses events from a workflow pushing
+# with the default GITHUB_TOKEN, so a tag trigger would never fire.
+#
+# Only a final X.Y.Z tag publishes; the guard below rejects anything else.
 
 on:
-  push:
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
 
-# Serialize releases. A second tag pushed while one is mid-flight queues behind
-# it rather than racing it for the `latest` dist-tag.
+# Serialize releases. A second run dispatched while one is mid-flight queues
+# behind it rather than racing it for the `latest` dist-tag.
 concurrency:
   group: release
   cancel-in-progress: false
@@ -40,6 +39,18 @@ jobs:
       contents: read # the tag already exists
       id-token: write # required for npm OIDC trusted publishing
     steps:
+      # Replaces the tag-pattern filter a push trigger would have applied.
+      - name: Verify the run was dispatched from a final release tag
+        run: |
+          set -euo pipefail
+
+          # A branch ref keeps its refs/heads/ prefix here and fails the same check.
+          TAG="${GITHUB_REF#refs/tags/}"
+          if ! printf '%s' "$TAG" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Dispatch this workflow from a final X.Y.Z release tag, not ${GITHUB_REF} — prereleases are not published."
+            exit 1
+          fi
+
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,25 @@ jobs:
           echo "::error::${GITHUB_REF_NAME} (${GITHUB_SHA}) is not reachable from master or develop."
           exit 1
 
+      # The checks above constrain where the tag came from, not what is in it: a
+      # tag missing es5/ would publish a package whose `main` resolves to nothing.
+      - name: Verify the tag carries a built tree
+        run: |
+          set -euo pipefail
+
+          for RELEASE_FILE in dist/twilio-video.js dist/twilio-video.min.js
+          do
+            if [ ! -s "$RELEASE_FILE" ]; then
+              echo "::error::${RELEASE_FILE} is missing or empty at ${GITHUB_REF_NAME}; this tag was not built by prepare-release.yml."
+              exit 1
+            fi
+          done
+
+          if [ ! -s "$(node -p "require('./package.json').main")" ]; then
+            echo "::error::package.json main does not resolve to a file at ${GITHUB_REF_NAME}."
+            exit 1
+          fi
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           # npm >= 11.5.1, bundled with Node 24, is required for OIDC trusted

--- a/scripts/check-version-bump.js
+++ b/scripts/check-version-bump.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+'use strict';
+
+// Semver precedence, hand-rolled: prepare-release.yml runs this before `npm ci`
+// so that a bad input fails in seconds rather than after the install, which
+// means no packages are available to it.
+
+const VERSION = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.]+))?$/;
+
+/**
+ * Split a version into its comparable parts.
+ * @param {string} version - an exact version, e.g. "2.36.0" or "2.36.0-rc.1"
+ * @returns {?{numbers: Array<number>, prerelease: Array<string>}} null if
+ *   `version` is not an exact X.Y.Z[-prerelease]
+ */
+function parse(version) {
+  const match = VERSION.exec(version);
+  if (!match) {
+    return null;
+  }
+  return {
+    numbers: [Number(match[1]), Number(match[2]), Number(match[3])],
+    // Splitting on "." handles both "rc.1" and the dotless "rc1" used before 2.30.
+    prerelease: match[4] ? match[4].split('.') : []
+  };
+}
+
+function comparePrerelease(a, b) {
+  if (!a.length && !b.length) {
+    return 0;
+  }
+  // An absent prerelease outranks any prerelease: 2.34.0 > 2.34.0-rc.5. This is
+  // the rule `sort -V` lacks, and it decides every final release this repo cuts.
+  if (!a.length) {
+    return 1;
+  }
+  if (!b.length) {
+    return -1;
+  }
+
+  const length = Math.max(a.length, b.length);
+  for (let i = 0; i < length; i++) {
+    // A shorter set of identifiers loses when everything before it is equal.
+    if (i >= a.length) {
+      return -1;
+    }
+    if (i >= b.length) {
+      return 1;
+    }
+
+    const x = a[i];
+    const y = b[i];
+    const xIsNumeric = /^\d+$/.test(x);
+    const yIsNumeric = /^\d+$/.test(y);
+
+    if (xIsNumeric && yIsNumeric) {
+      if (Number(x) !== Number(y)) {
+        return Number(x) < Number(y) ? -1 : 1;
+      }
+    } else if (xIsNumeric !== yIsNumeric) {
+      // Numeric identifiers sort below alphanumeric ones.
+      return xIsNumeric ? -1 : 1;
+    } else if (x !== y) {
+      return x < y ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+/**
+ * Order two versions by semver precedence.
+ * @param {string} a
+ * @param {string} b
+ * @returns {number} -1 if a < b, 0 if equal, 1 if a > b
+ * @throws {Error} if either version is not an exact X.Y.Z[-prerelease]
+ */
+function compare(a, b) {
+  const left = parse(a);
+  const right = parse(b);
+
+  for (const [version, parsed] of [[a, left], [b, right]]) {
+    if (!parsed) {
+      throw new Error(`${version} is not an exact version (expected 2.36.0 or 2.36.0-rc.1).`);
+    }
+  }
+
+  for (let i = 0; i < 3; i++) {
+    if (left.numbers[i] !== right.numbers[i]) {
+      return left.numbers[i] < right.numbers[i] ? -1 : 1;
+    }
+  }
+  return comparePrerelease(left.prerelease, right.prerelease);
+}
+
+/**
+ * Whether `next` is a strictly forward move from `current`.
+ * @param {string} current
+ * @param {string} next
+ * @returns {boolean}
+ * @throws {Error} if either version is not an exact X.Y.Z[-prerelease]
+ */
+function isForward(current, next) {
+  return compare(next, current) > 0;
+}
+
+if (require.main === module) {
+  const current = process.argv[2];
+  const next = process.argv[3];
+
+  if (!current || !next) {
+    console.error('::error::usage: check-version-bump.js <current-version> <next-version>');
+    process.exit(1);
+  }
+
+  try {
+    if (!isForward(current, next)) {
+      console.error(`::error::${next} is not greater than the current version ${current}.`);
+      process.exit(1);
+    }
+  } catch (error) {
+    console.error(`::error::${error.message}`);
+    process.exit(1);
+  }
+
+  console.log(`::notice::${next} moves forward from ${current}.`);
+}
+
+module.exports = { compare, isForward, parse };

--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -118,7 +118,9 @@ Object.keys(TwilioErrors).forEach(function(error) {
   privateConstructors.push(error);
 });
 
-spawnSync('node', [
+// Checked because a jsdoc failure is otherwise silent: it leaves an empty docs
+// directory behind while this script still exits 0.
+const jsdoc = spawnSync('node', [
   require.resolve('jsdoc/jsdoc'),
   '-d', docs,
   '-c', './jsdoc.conf',
@@ -127,6 +129,13 @@ spawnSync('node', [
 ].concat(publicClasses), {
   stdio: 'inherit'
 });
+
+if (jsdoc.error || jsdoc.status !== 0) {
+  console.error('jsdoc failed ('
+    + (jsdoc.error ? jsdoc.error.message : 'status ' + jsdoc.status + (jsdoc.signal ? ', signal ' + jsdoc.signal : ''))
+    + '); ' + docs + ' is incomplete.');
+  process.exit(1);
+}
 
 vfs.src(path.join(docs, '*.html'))
   .pipe(map(transform))

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -19,6 +19,7 @@ require('./spec/twilioconnection');
 require('./spec/vendor');
 require('./spec/token');
 require('./spec/rest');
+require('./spec/check-version-bump');
 
 require('./spec/data/transceiver');
 require('./spec/data/sender');

--- a/test/unit/spec/check-version-bump.js
+++ b/test/unit/spec/check-version-bump.js
@@ -83,7 +83,7 @@ describe('check-version-bump', () => {
 
     describe('rejects a version that does not move forward', () => {
       [
-        // The real typo released on 2023-10-03: 2.8.2-rc1 instead of 2.28.2-rc1.
+        // A transposed minor: 2.8.2-rc1 in place of 2.28.2-rc1.
         ['2.28.2-dev', '2.8.2-rc1'],
         ['2.35.0', '2.35.0'],
         ['2.35.1-dev', '2.35.0'],

--- a/test/unit/spec/check-version-bump.js
+++ b/test/unit/spec/check-version-bump.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const assert = require('assert');
+
+const { compare, isForward, parse } = require('../../../scripts/check-version-bump');
+
+describe('check-version-bump', () => {
+  describe('parse', () => {
+    it('splits a final version', () => {
+      assert.deepStrictEqual(parse('2.36.0'), { numbers: [2, 36, 0], prerelease: [] });
+    });
+
+    it('splits a dotted prerelease', () => {
+      assert.deepStrictEqual(parse('2.36.0-rc.1'), { numbers: [2, 36, 0], prerelease: ['rc', '1'] });
+    });
+
+    it('splits the dotless prerelease used before 2.30', () => {
+      assert.deepStrictEqual(parse('2.24.1-rc1'), { numbers: [2, 24, 1], prerelease: ['rc1'] });
+    });
+
+    [' 2.36.0', '2.36', 'v2.36.0', '2.36.0.1', 'patch', '2.36.0\n2.36.0', ''].forEach(version => {
+      it(`returns null for ${JSON.stringify(version)}`, () => {
+        assert.strictEqual(parse(version), null);
+      });
+    });
+  });
+
+  describe('compare', () => {
+    it('orders a final version above its own prerelease', () => {
+      assert.strictEqual(compare('2.34.0', '2.34.0-rc.5'), 1);
+    });
+
+    it('treats identical versions as equal', () => {
+      assert.strictEqual(compare('2.35.0', '2.35.0'), 0);
+    });
+
+    it('orders numeric prerelease identifiers numerically, not lexically', () => {
+      assert.strictEqual(compare('2.34.0-rc.10', '2.34.0-rc.9'), 1);
+    });
+
+    it('orders a numeric identifier below an alphanumeric one', () => {
+      assert.strictEqual(compare('2.34.0-1', '2.34.0-alpha'), -1);
+    });
+
+    it('orders a longer identifier set above its own prefix', () => {
+      assert.strictEqual(compare('2.34.0-rc.1', '2.34.0-rc'), 1);
+    });
+
+    it('throws on a version it cannot parse', () => {
+      assert.throws(() => compare('2.36.0', 'patch'), /not an exact version/);
+    });
+  });
+
+  // Every case below is a transition taken from this repo's git history.
+  describe('isForward', () => {
+    describe('allows the final release, which the branch always cuts from X.Y.Z-dev', () => {
+      [
+        ['2.34.0-dev', '2.34.0'],
+        ['2.33.0-dev', '2.33.0'],
+        ['2.32.1-dev', '2.32.1'],
+        ['2.30.0-dev', '2.30.0'],
+        ['2.35.1-dev', '2.35.1'],
+        ['2.34.0-rc.5', '2.34.0'],
+        ['2.24.1-rc1', '2.24.1']
+      ].forEach(([current, next]) => {
+        it(`${current} -> ${next}`, () => {
+          assert.strictEqual(isForward(current, next), true);
+        });
+      });
+    });
+
+    describe('allows a release candidate', () => {
+      [
+        ['2.34.0-dev', '2.34.0-rc.1'],
+        ['2.34.0-dev', '2.34.0-rc.5'],
+        ['2.35.1-dev', '2.36.0-rc.1']
+      ].forEach(([current, next]) => {
+        it(`${current} -> ${next}`, () => {
+          assert.strictEqual(isForward(current, next), true);
+        });
+      });
+    });
+
+    describe('rejects a version that does not move forward', () => {
+      [
+        // The real typo released on 2023-10-03: 2.8.2-rc1 instead of 2.28.2-rc1.
+        ['2.28.2-dev', '2.8.2-rc1'],
+        ['2.35.0', '2.35.0'],
+        ['2.35.1-dev', '2.35.0'],
+        ['2.34.0-rc.5', '2.34.0-rc.2'],
+        ['2.34.0', '2.34.0-rc.6']
+      ].forEach(([current, next]) => {
+        it(`${current} -> ${next}`, () => {
+          assert.strictEqual(isForward(current, next), false);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Pull Request Details

### Description

Adds the two-workflow release path: `prepare-release.yml` produces the tagged, built commit; `release.yml` is dispatched manually against that tag and publishes it to npm.

The split keeps write access and publishing credentials in jobs that install no dependencies.

Includes a fix to scripts/docs.js, which exited 0 when jsdoc failed and left an empty dist/docs behind.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
