### PR TITLE
Prepare 2.36.0 RC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@ The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.o
 
 **Version 1.x reached End of Life on September 8th, 2021.** See the changelog entry [here](https://www.twilio.com/changelog/end-of-life-complete-for-unsupported-versions-of-the-programmable-video-sdk). Support for the 1.x version ended on December 4th, 2020.
 
+2.36.0 (in progress)
+====================
+
+New Features
+------------
+- Added support for `@twilio/krisp-audio-plugin` 2.x. Version 1.x remains supported, so
+  existing applications continue to work without changes.
+
+  The 2.x plugin expects the raw microphone signal, so disable the browser's own audio
+  processing when using it:
+
+  ```js
+  const localAudioTrack = await createLocalAudioTrack({
+    noiseCancellationOptions: {
+      sdkAssetsPath: 'path/to/hosted/twilio/krisp/audio/plugin/{version}/dist',
+      vendor: 'krisp'
+    },
+    // Required for 2.x only — omit these for 1.x.
+    echoCancellation: false,
+    noiseSuppression: false,
+    autoGainControl: false
+  });
+  ```
+
+Bug Fixes
+---------
+- Fixed loading of the noise cancellation plugin when the SDK is bundled by tools that
+  rewrite dynamic imports. The module path is now passed as an argument to the import
+  function instead of being embedded in its body.
+
+Changes
+-------
+- Updated `ws` to address a security advisory. This affects the Node.js build only;
+  browser builds do not include `ws`.
+
 2.35.0 (April 29, 2026)
 ====================
 

--- a/lib/createlocaltrack.js
+++ b/lib/createlocaltrack.js
@@ -58,14 +58,30 @@ function createLocalTrack(kind, options) {
  * @example
  * var Video = require('twilio-video');
  *
- * // Request the LocalAudioTrack with a custom name
- * // and krisp noise cancellation
+ * // Request the LocalAudioTrack with a custom name and noise cancellation
+ * // from @twilio/krisp-audio-plugin 1.x.
  * Video.createLocalAudioTrack({
  *   name: 'microphone',
  *   noiseCancellationOptions: {
  *      vendor: 'krisp',
  *      sdkAssetsPath: '/twilio-krisp-audio-plugin/1.0.0/dist'
  *   }
+ * });
+ * @example
+ * var Video = require('twilio-video');
+ *
+ * // Request the LocalAudioTrack with noise cancellation from
+ * // @twilio/krisp-audio-plugin 2.x, which expects the raw microphone signal,
+ * // so the browser's own audio processing is disabled.
+ * Video.createLocalAudioTrack({
+ *   name: 'microphone',
+ *   noiseCancellationOptions: {
+ *      vendor: 'krisp',
+ *      sdkAssetsPath: '/twilio-krisp-audio-plugin/2.0.0/dist'
+ *   },
+ *   echoCancellation: false,
+ *   noiseSuppression: false,
+ *   autoGainControl: false
  * });
  */
 function createLocalAudioTrack(options) {
@@ -142,7 +158,7 @@ const NoiseCancellationVendor = {
  *   LocalAudioTrack continues to capture from the same audio input device even after the default audio input device changes.
  *   When the property is not specified, it defaults to "auto".
  * @property {NoiseCancellationOptions} [noiseCancellationOptions] - This optional property enables using 3rd party plugins
- *   for noise cancellation.
+ *   for noise cancellation. Supports @twilio/krisp-audio-plugin 1.x and 2.x.
  */
 
 /**

--- a/tsdef/AudioProcessor.d.ts
+++ b/tsdef/AudioProcessor.d.ts
@@ -50,9 +50,9 @@ export interface AudioProcessor {
 
   /**
    * destroys the processor freeing up any resources
-   * @returns {Promise<void>}
+   * @returns {void}
    */
-  destroy: () => Promise<void>;
+  destroy: () => void;
 
   /**
    * enables/disables logging


### PR DESCRIPTION
## Pull Request Details

### Description

- Adds the `2.36.0 (in progress)` CHANGELOG section covering Krisp 2.x support, the dynamic-import fix, and the `ws` bump.
- Reverts `AudioProcessor.destroy` to `() => void`. Consumers implement `AudioProcessor`, so requiring `Promise<void>` breaks any sync `destroy`. Nothing needs it, since the SDK never awaits it.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
